### PR TITLE
Display the session's custom name

### DIFF
--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		P10000030000000000000001 /* HookInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = P10000040000000000000001 /* HookInput.swift */; };
 		P10000050000000000000001 /* HookHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = P10000060000000000000001 /* HookHandler.swift */; };
 		P10000070000000000000001 /* HookLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = P10000080000000000000001 /* HookLogger.swift */; };
+		SN0000010000000000000001 /* SessionNameLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = SN0000020000000000000001 /* SessionNameLookup.swift */; };
 		P10000090000000000000001 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000020000000000000001 /* Session.swift */; };
 		P1000000A000000000000001 /* SessionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000040000000000000001 /* SessionStatus.swift */; };
 		P1000000B000000000000001 /* HookEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = N10000040000000000000001 /* HookEvent.swift */; };
@@ -89,6 +90,7 @@
 		P10000040000000000000001 /* HookInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInput.swift; sourceTree = "<group>"; };
 		P10000060000000000000001 /* HookHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookHandler.swift; sourceTree = "<group>"; };
 		P10000080000000000000001 /* HookLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookLogger.swift; sourceTree = "<group>"; };
+		SN0000020000000000000001 /* SessionNameLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNameLookup.swift; sourceTree = "<group>"; };
 		P1000000D000000000000001 /* cctop-hook */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "cctop-hook"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -143,6 +145,7 @@
 				P10000040000000000000001 /* HookInput.swift */,
 				P10000060000000000000001 /* HookHandler.swift */,
 				P10000080000000000000001 /* HookLogger.swift */,
+				SN0000020000000000000001 /* SessionNameLookup.swift */,
 			);
 			path = Hook;
 			sourceTree = "<group>";
@@ -352,6 +355,7 @@
 				P10000030000000000000001 /* HookInput.swift in Sources */,
 				P10000050000000000000001 /* HookHandler.swift in Sources */,
 				P10000070000000000000001 /* HookLogger.swift in Sources */,
+				SN0000010000000000000001 /* SessionNameLookup.swift in Sources */,
 				P10000090000000000000001 /* Session.swift in Sources */,
 				P1000000A000000000000001 /* SessionStatus.swift in Sources */,
 				P1000000B000000000000001 /* HookEvent.swift in Sources */,

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -39,6 +39,9 @@ enum HookHandler {
         session.lastActivity = Date()
         session.branch = branch
         session.terminal = terminal
+        if event == .sessionStart || event == .userPromptSubmit {
+            session.sessionName = SessionNameLookup.lookupSessionName(transcriptPath: input.transcriptPath, sessionId: input.sessionId)
+        }
 
         applySideEffects(event: event, session: &session, input: input, sessionsDir: sessionsDir, safeId: safeId)
 

--- a/menubar/CctopMenubar/Hook/SessionNameLookup.swift
+++ b/menubar/CctopMenubar/Hook/SessionNameLookup.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Looks up a session's custom name from Claude Code's local data.
+enum SessionNameLookup {
+    /// Look up the session name from Claude Code's transcript JSONL or sessions-index.json.
+    /// The transcript contains `{"type":"custom-title","customTitle":"..."}` entries in real-time.
+    /// Falls back to sessions-index.json for older sessions.
+    static func lookupSessionName(transcriptPath: String?, sessionId: String) -> String? {
+        guard let transcriptPath, !transcriptPath.isEmpty else { return nil }
+
+        let expanded = NSString(string: transcriptPath).expandingTildeInPath
+
+        // Primary: scan transcript JSONL for the latest custom-title entry
+        if let name = lookupNameFromTranscript(path: expanded) {
+            return name
+        }
+
+        // Fallback: check sessions-index.json
+        let dir = (expanded as NSString).deletingLastPathComponent
+        let indexPath = (dir as NSString).appendingPathComponent("sessions-index.json")
+        return lookupNameFromIndex(indexPath: indexPath, sessionId: sessionId)
+    }
+
+    /// Scan the transcript JSONL for the last `custom-title` entry.
+    private static func lookupNameFromTranscript(path: String) -> String? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let content = String(data: data, encoding: .utf8)
+        else { return nil }
+
+        for line in content.components(separatedBy: "\n").reversed() {
+            guard line.contains("\"custom-title\"") else { continue }
+            guard let lineData = line.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let type = json["type"] as? String, type == "custom-title",
+                  let title = json["customTitle"] as? String, !title.isEmpty
+            else { continue }
+            return title
+        }
+        return nil
+    }
+
+    private static func lookupNameFromIndex(indexPath: String, sessionId: String) -> String? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: indexPath)),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let entries = json["entries"] as? [[String: Any]]
+        else { return nil }
+
+        for entry in entries {
+            guard let entryId = entry["sessionId"] as? String, entryId == sessionId else { continue }
+            if let title = entry["customTitle"] as? String, !title.isEmpty {
+                return title
+            }
+            return nil
+        }
+        return nil
+    }
+}

--- a/menubar/CctopMenubar/Models/Session+Mock.swift
+++ b/menubar/CctopMenubar/Models/Session+Mock.swift
@@ -5,13 +5,14 @@ extension Session {
         id: String = "test-123",
         project: String = "cctop",
         branch: String = "main",
+        sessionName: String? = nil,
         status: SessionStatus = .idle,
         lastPrompt: String? = nil,
         lastTool: String? = nil,
         lastToolDetail: String? = nil,
         notificationMessage: String? = nil
     ) -> Session {
-        Session(
+        var session = Session(
             sessionId: id,
             projectPath: "/Users/test/projects/\(project)",
             projectName: project,
@@ -26,11 +27,13 @@ extension Session {
             lastToolDetail: lastToolDetail,
             notificationMessage: notificationMessage
         )
+        session.sessionName = sessionName
+        return session
     }
 
     static let mockSessions: [Session] = [
         .mock(id: "1", project: "cctop", branch: "main", status: .waitingPermission, notificationMessage: "Allow Bash: npm test"),
-        .mock(id: "2", project: "my-app", branch: "feature/auth", status: .working, lastTool: "Edit", lastToolDetail: "/src/auth.ts"),
+        .mock(id: "2", project: "my-app", branch: "feature/auth", sessionName: "refactor auth flow", status: .working, lastTool: "Edit", lastToolDetail: "/src/auth.ts"),
         .mock(id: "3", project: "api-server", branch: "fix/timeout", status: .waitingInput, lastPrompt: "Should I also update the retry logic?"),
         .mock(id: "4", project: "docs", branch: "main", status: .idle),
     ]

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -64,8 +64,13 @@ struct Session: Codable, Identifiable {
     var lastTool: String?
     var lastToolDetail: String?
     var notificationMessage: String?
+    var sessionName: String?
 
     var id: String { sessionId }
+
+    var displayName: String {
+        sessionName ?? projectName
+    }
 
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"
@@ -79,6 +84,7 @@ struct Session: Codable, Identifiable {
         case lastTool = "last_tool"
         case lastToolDetail = "last_tool_detail"
         case notificationMessage = "notification_message"
+        case sessionName = "session_name"
     }
 
     // MARK: - Constructors
@@ -97,7 +103,8 @@ struct Session: Codable, Identifiable {
         pid: UInt32?,
         lastTool: String?,
         lastToolDetail: String?,
-        notificationMessage: String?
+        notificationMessage: String?,
+        sessionName: String? = nil
     ) {
         self.sessionId = sessionId
         self.projectPath = projectPath
@@ -112,6 +119,7 @@ struct Session: Codable, Identifiable {
         self.lastTool = lastTool
         self.lastToolDetail = lastToolDetail
         self.notificationMessage = notificationMessage
+        self.sessionName = sessionName
     }
 
     /// Convenience init for creating new sessions (used by cctop-hook).
@@ -129,6 +137,7 @@ struct Session: Codable, Identifiable {
         self.lastTool = nil
         self.lastToolDetail = nil
         self.notificationMessage = nil
+        self.sessionName = nil
     }
 
     // MARK: - File I/O

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -123,7 +123,7 @@ class SessionManager: ObservableObject {
 
     private func postNotification(for session: Session) {
         let content = UNMutableNotificationContent()
-        content.title = session.projectName
+        content.title = session.displayName
         switch session.status {
         case .waitingPermission:
             content.body = session.notificationMessage ?? "Permission needed"

--- a/menubar/CctopMenubar/Views/SessionCardView.swift
+++ b/menubar/CctopMenubar/Views/SessionCardView.swift
@@ -21,7 +21,7 @@ struct SessionCardView: View {
 
             VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 6) {
-                    Text(session.projectName)
+                    Text(session.displayName)
                         .font(.system(size: 13))
                         .foregroundStyle(.primary)
                     Text(session.branch)
@@ -31,6 +31,11 @@ struct SessionCardView: View {
                         .padding(.vertical, 1)
                         .background(Color.primary.opacity(0.06))
                         .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
+                if session.sessionName != nil {
+                    Text(session.projectName)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
                 }
                 if let context = session.contextLine {
                     Text(context)
@@ -58,7 +63,7 @@ struct SessionCardView: View {
                     }
                     .buttonStyle(.plain)
                     .onHover { resetHovered = $0 }
-                    .accessibilityLabel("Reset \(session.projectName) to idle")
+                    .accessibilityLabel("Reset \(session.displayName) to idle")
                     .help("Reset status to idle")
                 } else {
                     Text(session.relativeTime)
@@ -89,7 +94,7 @@ struct SessionCardView: View {
     }
 
     private var cardAccessibilityLabel: String {
-        var parts = [session.projectName, "on branch", session.branch, session.status.accessibilityDescription]
+        var parts = [session.displayName, "on branch", session.branch, session.status.accessibilityDescription]
         if let context = session.contextLine {
             parts.append(context)
         }
@@ -121,5 +126,9 @@ struct SessionCardView: View {
 }
 #Preview("Compacting") {
     SessionCardView(session: .mock(status: .compacting))
+        .frame(width: 300).padding()
+}
+#Preview("Named Session") {
+    SessionCardView(session: .mock(sessionName: "refactor auth flow", status: .working, lastTool: "Edit", lastToolDetail: "/src/auth.ts"))
         .frame(width: 300).padding()
 }

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -71,6 +71,53 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.contextLine, "Compacting context...")
     }
 
+    func testDecodesSessionName() throws {
+        let json = """
+        {
+            "session_id": "named-1",
+            "project_path": "/Users/test/projects/myapp",
+            "project_name": "myapp",
+            "branch": "main",
+            "status": "working",
+            "last_activity": "2026-02-08T12:00:00Z",
+            "started_at": "2026-02-08T11:00:00Z",
+            "terminal": {"program": "Code"},
+            "session_name": "refactor auth"
+        }
+        """
+        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        XCTAssertEqual(session.sessionName, "refactor auth")
+        XCTAssertEqual(session.displayName, "refactor auth")
+    }
+
+    func testDecodesWithoutSessionName() throws {
+        let json = """
+        {
+            "session_id": "no-name-1",
+            "project_path": "/Users/test/projects/myapp",
+            "project_name": "myapp",
+            "branch": "main",
+            "status": "idle",
+            "last_activity": "2026-02-08T12:00:00Z",
+            "started_at": "2026-02-08T11:00:00Z",
+            "terminal": {"program": "Code"}
+        }
+        """
+        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        XCTAssertNil(session.sessionName)
+        XCTAssertEqual(session.displayName, "myapp")
+    }
+
+    func testDisplayNameReturnsSessionNameWhenSet() {
+        let session = Session.mock(sessionName: "my task")
+        XCTAssertEqual(session.displayName, "my task")
+    }
+
+    func testDisplayNameFallsBackToProjectName() {
+        let session = Session.mock(project: "myapp")
+        XCTAssertEqual(session.displayName, "myapp")
+    }
+
     func testOldJsonWithContextCompactedStillDecodes() throws {
         let json = """
         {


### PR DESCRIPTION
## Summary
- When a Claude Code session is renamed via `/rename`, display that name as the primary label in the session card
- Project directory name shown as smaller secondary text underneath when a custom name is set
- Session name is looked up from the transcript JSONL (real-time) with fallback to `sessions-index.json`

<img width="323" height="166" alt="Screenshot 2026-02-12 at 1 02 34 PM" src="https://github.com/user-attachments/assets/e2c3e312-c6ff-4daa-92d5-e42ff942d98c" />

Closes #4

## Changes
- **Session.swift** — Added `sessionName: String?` field and `displayName` computed property
- **HookHandler.swift** — Reads session name from transcript JSONL (`custom-title` entries) with fallback to `sessions-index.json`
- **SessionCardView.swift** — Uses `displayName` as primary label; shows `projectName` as secondary when custom name is set
- **SessionManager.swift** — Notifications use `displayName`
- **Session+Mock.swift** — Updated mock factory with `sessionName` parameter
- **SessionTests.swift** — 4 new tests for encoding/decoding and `displayName` logic

## Test plan
- [x] `make build` passes (both targets)
- [x] `make test` passes (68 tests, 0 failures)
- [x] Verified locally: `/rename cctop-new-feat` shows in menubar immediately
- [ ] Verify with resumed session that already has a name in `sessions-index.json`
- [ ] Verify session without a name still displays project directory as before