### PR TITLE
fix: use last session name from index instead of first

### DIFF
--- a/menubar/CctopMenubar/Hook/SessionNameLookup.swift
+++ b/menubar/CctopMenubar/Hook/SessionNameLookup.swift
@@ -45,13 +45,13 @@ enum SessionNameLookup {
               let entries = json["entries"] as? [[String: Any]]
         else { return nil }
 
+        var lastName: String?
         for entry in entries {
             guard let entryId = entry["sessionId"] as? String, entryId == sessionId else { continue }
             if let title = entry["customTitle"] as? String, !title.isEmpty {
-                return title
+                lastName = title
             }
-            return nil
         }
-        return nil
+        return lastName
     }
 }

--- a/menubar/CctopMenubarTests/SessionNameLookupTests.swift
+++ b/menubar/CctopMenubarTests/SessionNameLookupTests.swift
@@ -145,6 +145,26 @@ final class SessionNameLookupTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    func testIndexReturnsLastTitleWhenMultipleEntries() {
+        let transcriptPath = tmpDir + "/transcript.jsonl"
+        try! "{\"type\":\"system\"}\n".write(toFile: transcriptPath, atomically: true, encoding: .utf8)
+
+        let indexPath = tmpDir + "/sessions-index.json"
+        let index = """
+        {"entries":[
+            {"sessionId":"s1","customTitle":"first name"},
+            {"sessionId":"other","customTitle":"unrelated"},
+            {"sessionId":"s1","customTitle":"renamed"}
+        ]}
+        """
+        try! index.write(toFile: indexPath, atomically: true, encoding: .utf8)
+
+        let result = SessionNameLookup.lookupSessionName(
+            transcriptPath: transcriptPath, sessionId: "s1"
+        )
+        XCTAssertEqual(result, "renamed")
+    }
+
     func testTranscriptTakesPriorityOverIndex() {
         let transcriptPath = tmpDir + "/transcript.jsonl"
         let content = """


### PR DESCRIPTION
## Summary
- Fixed `lookupNameFromIndex` to return the **last** matching title for a session instead of early-returning on the first match
- When `sessions-index.json` has multiple entries for the same session (e.g. after a rename), the most recent name is now used

Fixes #11

## Test plan
- [x] Added `testIndexReturnsLastTitleWhenMultipleEntries` test
- [x] All 90 existing tests pass
- [x] SwiftLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)