### PR TITLE
feat: Quick Jump mode and right-click context menu

### DIFF
--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		P10000050000000000000001 /* HookHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = P10000060000000000000001 /* HookHandler.swift */; };
 		P10000070000000000000001 /* HookLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = P10000080000000000000001 /* HookLogger.swift */; };
 		P10000090000000000000001 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000020000000000000001 /* Session.swift */; };
+		JM0000010000000000000001 /* JumpModeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = JM0000020000000000000001 /* JumpModeController.swift */; };
 		PM0000010000000000000001 /* PluginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = PM0000020000000000000001 /* PluginManager.swift */; };
 		Q10000010000000000000001 /* QASnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = Q10000020000000000000001 /* QASnapshotTests.swift */; };
 		SN0000010000000000000001 /* SessionNameLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = SN0000020000000000000001 /* SessionNameLookup.swift */; };
@@ -97,6 +98,7 @@
 		P10000040000000000000001 /* HookInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInput.swift; sourceTree = "<group>"; };
 		P10000060000000000000001 /* HookHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookHandler.swift; sourceTree = "<group>"; };
 		P10000080000000000000001 /* HookLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookLogger.swift; sourceTree = "<group>"; };
+		JM0000020000000000000001 /* JumpModeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpModeController.swift; sourceTree = "<group>"; };
 		PM0000020000000000000001 /* PluginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginManager.swift; sourceTree = "<group>"; };
 		Q10000020000000000000001 /* QASnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QASnapshotTests.swift; sourceTree = "<group>"; };
 		SN0000020000000000000001 /* SessionNameLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNameLookup.swift; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 				E10000020000000000000001 /* FocusTerminal.swift */,
 				SP0000020000000000000001 /* SparkleUpdater.swift */,
 				PM0000020000000000000001 /* PluginManager.swift */,
+				JM0000020000000000000001 /* JumpModeController.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -374,6 +377,7 @@
 				L10000010000000000000001 /* EmptyStateView.swift in Sources */,
 				SP0000010000000000000001 /* SparkleUpdater.swift in Sources */,
 				PM0000010000000000000001 /* PluginManager.swift in Sources */,
+				JM0000010000000000000001 /* JumpModeController.swift in Sources */,
 				N10000010000000000000001 /* SessionStatus+UI.swift in Sources */,
 				N10000030000000000000001 /* HookEvent.swift in Sources */,
 				N10000050000000000000001 /* Config.swift in Sources */,

--- a/menubar/CctopMenubar/Models/AppSettings.swift
+++ b/menubar/CctopMenubar/Models/AppSettings.swift
@@ -13,4 +13,5 @@ enum AppearanceMode: String, CaseIterable {
 
 extension KeyboardShortcuts.Name {
     static let togglePanel = Self("togglePanel")
+    static let quickJump = Self("quickJump")
 }

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -244,6 +244,12 @@ struct Session: Codable, Identifiable {
         return nil
     }
 
+    static func sorted(_ sessions: [Session]) -> [Session] {
+        sessions.sorted {
+            ($0.status.sortOrder, $1.lastActivity) < ($1.status.sortOrder, $0.lastActivity)
+        }
+    }
+
     static func extractProjectName(_ path: String) -> String {
         URL(fileURLWithPath: path).lastPathComponent
     }

--- a/menubar/CctopMenubar/Services/JumpModeController.swift
+++ b/menubar/CctopMenubar/Services/JumpModeController.swift
@@ -1,0 +1,38 @@
+import AppKit
+import Combine
+
+class JumpModeController: ObservableObject {
+    @Published var isActive = false
+    /// Sorted session snapshot captured when jump mode activates.
+    /// Prevents reordering while badges are visible.
+    private(set) var frozenSessions: [Session] = []
+    var previousApp: NSRunningApplication?
+    var panelWasClosedBeforeJump = false
+    private var timeoutWork: DispatchWorkItem?
+
+    func activate(sessions: [Session]) {
+        frozenSessions = Session.sorted(sessions)
+        isActive = true
+    }
+
+    func deactivate() {
+        isActive = false
+        frozenSessions = []
+        cancelTimeout()
+    }
+
+    func startTimeout(duration: TimeInterval = 5, onTimeout: @escaping () -> Void) {
+        cancelTimeout()
+        let work = DispatchWorkItem { [weak self] in
+            guard self?.isActive == true else { return }
+            onTimeout()
+        }
+        timeoutWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: work)
+    }
+
+    func cancelTimeout() {
+        timeoutWork?.cancel()
+        timeoutWork = nil
+    }
+}

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -76,6 +76,24 @@ struct SettingsSection: View {
 
             Divider().padding(.horizontal, 14)
 
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("Quick Jump Shortcut")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Color.textSecondary)
+                    Spacer()
+                    KeyboardShortcuts.Recorder("", name: .quickJump)
+                }
+                Text("Focus the panel and jump to sessions by number.")
+                    .font(.system(size: 10))
+                    .foregroundStyle(Color.textMuted)
+            }
+            .padding(.horizontal, 14)
+            .padding(.top, 10)
+            .padding(.bottom, 10)
+
+            Divider().padding(.horizontal, 14)
+
             Toggle(isOn: $launchAtLogin) {
                 Text("Launch at Login")
                     .font(.system(size: 11, weight: .semibold))
@@ -296,24 +314,36 @@ private struct MonitoredToolsView: View {
         HStack(spacing: 8) {
             toolLabel(name)
             Spacer()
-            if installed { connectedBadge } else {
-                Text("Not installed").font(.system(size: 10)).foregroundStyle(Color.textMuted)
+            if installed {
+                connectedBadge
+            } else {
+                Text("Not installed")
+                    .font(.system(size: 10))
+                    .foregroundStyle(Color.textMuted)
             }
         }
     }
 
     private func toolLabel(_ name: String) -> some View {
         HStack(spacing: 8) {
-            Image(systemName: "terminal").font(.system(size: 12))
-                .foregroundStyle(Color.textSecondary).frame(width: 16, height: 16)
-            Text(name).font(.system(size: 12, weight: .medium)).foregroundStyle(.primary)
+            Image(systemName: "terminal")
+                .font(.system(size: 12))
+                .foregroundStyle(Color.textSecondary)
+                .frame(width: 16, height: 16)
+            Text(name)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.primary)
         }
     }
 
     private var connectedBadge: some View {
         HStack(spacing: 4) {
-            Circle().fill(Color.statusGreen).frame(width: 6, height: 6)
-            Text("Connected").font(.system(size: 10)).foregroundStyle(Color.textMuted)
+            Circle()
+                .fill(Color.statusGreen)
+                .frame(width: 6, height: 6)
+            Text("Connected")
+                .font(.system(size: 10))
+                .foregroundStyle(Color.textMuted)
         }
     }
 }
@@ -327,7 +357,9 @@ private struct MonitoredToolsView: View {
     cc: Bool = true, oc: Bool = false, ocConfig: Bool = false
 ) -> PluginManager {
     let pm = PluginManager()
-    pm.ccInstalled = cc; pm.ocInstalled = oc; pm.ocConfigExists = ocConfig
+    pm.ccInstalled = cc
+    pm.ocInstalled = oc
+    pm.ocConfigExists = ocConfig
     return pm
 }
 #Preview("Default") {


### PR DESCRIPTION
## Summary

- **Quick Jump mode**: a configurable global hotkey that temporarily grabs keyboard focus to the floating panel, showing numbered badges (1-9) on session cards. Press a number to jump directly to that session via `focusTerminal`. Escape, any non-number key, toggling the panel, or a 5-second timeout exits the mode and restores focus to the previously active app.
- **Right-click context menu** on session cards: Jump to Terminal, Open in Finder, Copy Project Path.
- **Settings**: new "Quick Jump Shortcut" recorder row with descriptive label, footer hint showing the configured shortcut.

### New files
- `JumpModeController.swift` — Observable state machine (active/inactive, frozen session list, timeout, previous app tracking)

### Changed files
- `AppDelegate.swift` — hotkey registration, focus grab via `NSApp.activate()` + `panel.makeKey()`, `NSEvent.addLocalMonitorForEvents` key capture, enter/exit jump mode
- `SessionCardView.swift` — fixed 16x16 container for status indicator, numbered badges during jump mode
- `PopupView.swift` — context menu, jump mode plumbing with frozen session ordering, auto-collapse settings on jump mode, footer hint
- `SettingsSection.swift` — Quick Jump shortcut recorder
- `Session.swift` — `Session.sorted()` static method for consistent sort order
- `AppSettings.swift` — `.quickJump` shortcut name

## Test plan

- [x] Set a Quick Jump shortcut in Settings
- [x] Focus another app, press the shortcut — panel grabs focus, numbered badges appear
- [x] Press a number key — jumps to that session, focus moves to terminal/editor
- [x] Press Escape — exits jump mode, restores focus to previous app
- [x] Press a non-number key — exits jump mode
- [x] Toggle panel (icon or shortcut) while in jump mode — exits jump mode
- [x] 5-second timeout — auto-exits jump mode
- [x] Right-click a session card — context menu with 3 actions
- [x] Verify footer shows shortcut hint after configuring

🤖 Generated with [Claude Code](https://claude.com/claude-code)