### PR TITLE
fix: harden input sanitization and file permissions

### DIFF
--- a/menubar/CctopMenubar/Hook/HookLogger.swift
+++ b/menubar/CctopMenubar/Hook/HookLogger.swift
@@ -42,15 +42,19 @@ enum HookLogger {
     }
 
     private static func appendLine(_ line: String, to path: String) {
+        let fm = FileManager.default
         let dir = (path as NSString).deletingLastPathComponent
-        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try? fm.createDirectory(
+            atPath: dir, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
 
         if let handle = FileHandle(forWritingAtPath: path) {
             handle.seekToEndOfFile()
             handle.write(Data(line.utf8))
             handle.closeFile()
         } else {
-            FileManager.default.createFile(atPath: path, contents: Data(line.utf8))
+            fm.createFile(atPath: path, contents: Data(line.utf8), attributes: [.posixPermissions: 0o600])
         }
     }
 

--- a/menubar/CctopMenubar/Models/Config.swift
+++ b/menubar/CctopMenubar/Models/Config.swift
@@ -17,7 +17,10 @@ enum Config {
     private static func ensureDirectoryExists(_ path: String) {
         let fm = FileManager.default
         if !fm.fileExists(atPath: path) {
-            try? fm.createDirectory(atPath: path, withIntermediateDirectories: true)
+            try? fm.createDirectory(
+                atPath: path, withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
         }
     }
 }

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -30,7 +30,9 @@ func extractITermGUID(from sessionId: String?) -> String? {
 }
 
 private func focusITerm2Session(sessionId: String?) -> Bool {
-    guard let guid = extractITermGUID(from: sessionId) else { return false }
+    guard let guid = extractITermGUID(from: sessionId),
+          guid.range(of: #"^[0-9a-fA-F-]+$"#, options: .regularExpression) != nil
+    else { return false }
 
     let script = """
     tell application "iTerm2"

--- a/menubar/CctopMenubarTests/HookEventTests.swift
+++ b/menubar/CctopMenubarTests/HookEventTests.swift
@@ -177,7 +177,7 @@ final class HookEventTests: XCTestCase {
     }
 
     func testSanitizeRemovesDoubleDot() {
-        XCTAssertEqual(Session.sanitizeSessionId(raw: "../../.bashrc"), ".bashrc")
+        XCTAssertEqual(Session.sanitizeSessionId(raw: "../../.bashrc"), "bashrc")
     }
 
     func testSanitizePathTraversal() {
@@ -186,6 +186,11 @@ final class HookEventTests: XCTestCase {
 
     func testSanitizeDoubleDotOnly() {
         XCTAssertEqual(Session.sanitizeSessionId(raw: ".."), "")
+    }
+
+    func testSanitizeCapsLength() {
+        let long = String(repeating: "a", count: 100)
+        XCTAssertEqual(Session.sanitizeSessionId(raw: long).count, 64)
     }
 
     func testSanitizeNormalIdUnchanged() {

--- a/plugins/cctop/hooks/run-hook.sh
+++ b/plugins/cctop/hooks/run-hook.sh
@@ -4,6 +4,7 @@
 # Buffers stdin, logs a SHIM entry to the per-session log, then dispatches to cctop-hook.
 
 EVENT="$1"
+umask 077
 LOGS_DIR="$HOME/.cctop/logs"
 mkdir -p "$LOGS_DIR"
 
@@ -13,6 +14,7 @@ INPUT=$(cat)
 # Extract session ID and label for logging
 CWD=$(echo "$INPUT" | sed -n 's/.*"cwd" *: *"\([^"]*\)".*/\1/p' | head -1)
 SID=$(echo "$INPUT" | sed -n 's/.*"session_id" *: *"\([^"]*\)".*/\1/p' | head -1)
+SID=$(echo "$SID" | tr -cd 'a-zA-Z0-9_-')
 PROJECT=$(basename "$CWD")
 LABEL="${PROJECT:-unknown}:$(echo "$SID" | cut -c1-8)"
 LOG="$LOGS_DIR/${SID}.log"


### PR DESCRIPTION
## Summary

- Fix AppleScript injection via unsanitized iTerm2 GUID interpolation (`FocusTerminal.swift`, `HookHandler.swift`)
- Replace session ID sanitization with allowlist regex + 64-char cap (`Session.swift`, `run-hook.sh`)
- Restrict file permissions to 0700 dirs / 0600 files (`Config.swift`, `Session.swift`, `HookLogger.swift`, `run-hook.sh`)

## Test plan

- [x] All 121 tests pass (including new `testSanitizeCapsLength`)
- [x] Lint clean (0 violations)
- [x] Verify session files created after update have `0600` permissions
- [x] Verify jump-to-session still works with iTerm2

🤖 Generated with [Claude Code](https://claude.com/claude-code)