### PR TITLE
fix: restore panel closed state after jump mode

### DIFF
--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		FK0000010000000000000001 /* ForkSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FK0000020000000000000001 /* ForkSessionTests.swift */; };
 		FT0000010000000000000001 /* WorkspaceFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT0000020000000000000001 /* WorkspaceFileTests.swift */; };
 		FT0000010000000000000002 /* FocusTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT0000020000000000000002 /* FocusTerminalTests.swift */; };
+		JMT000010000000000000001 /* JumpModeControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = JMT000020000000000000001 /* JumpModeControllerTests.swift */; };
 		G10000010000000000000001 /* FloatingPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = G10000020000000000000001 /* FloatingPanel.swift */; };
 		G10000030000000000000001 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = G10000040000000000000001 /* AppDelegate.swift */; };
 		H10000010000000000000001 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = H10000020000000000000001 /* AppSettings.swift */; };
@@ -82,6 +83,7 @@
 		FK0000020000000000000001 /* ForkSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForkSessionTests.swift; sourceTree = "<group>"; };
 		FT0000020000000000000001 /* WorkspaceFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFileTests.swift; sourceTree = "<group>"; };
 		FT0000020000000000000002 /* FocusTerminalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusTerminalTests.swift; sourceTree = "<group>"; };
+		JMT000020000000000000001 /* JumpModeControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpModeControllerTests.swift; sourceTree = "<group>"; };
 		G10000020000000000000001 /* FloatingPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanel.swift; sourceTree = "<group>"; };
 		G10000040000000000000001 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		H10000020000000000000001 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
@@ -247,6 +249,7 @@
 				FK0000020000000000000001 /* ForkSessionTests.swift */,
 				FT0000020000000000000001 /* WorkspaceFileTests.swift */,
 				FT0000020000000000000002 /* FocusTerminalTests.swift */,
+				JMT000020000000000000001 /* JumpModeControllerTests.swift */,
 			);
 			path = CctopMenubarTests;
 			sourceTree = "<group>";
@@ -415,6 +418,7 @@
 				FK0000010000000000000001 /* ForkSessionTests.swift in Sources */,
 				FT0000010000000000000001 /* WorkspaceFileTests.swift in Sources */,
 				FT0000010000000000000002 /* FocusTerminalTests.swift in Sources */,
+				JMT000010000000000000001 /* JumpModeControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -172,11 +172,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             keyMonitor = nil
         }
 
+        if panelWasClosed {
+            panel.orderOut(nil)
+        }
         if restoreFocus {
             previousApp?.activate()
-            if panelWasClosed {
-                panel.orderOut(nil)
-            }
         }
         NSApp.deactivate()
     }

--- a/menubar/CctopMenubarTests/JumpModeControllerTests.swift
+++ b/menubar/CctopMenubarTests/JumpModeControllerTests.swift
@@ -1,0 +1,245 @@
+import XCTest
+@testable import CctopMenubar
+
+final class JumpModeControllerTests: XCTestCase {
+    private var sut: JumpModeController!
+
+    override func setUp() {
+        super.setUp()
+        sut = JumpModeController()
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initial state
+
+    func testInitialState() {
+        XCTAssertFalse(sut.isActive)
+        XCTAssertTrue(sut.frozenSessions.isEmpty)
+        XCTAssertNil(sut.previousApp)
+        XCTAssertFalse(sut.panelWasClosedBeforeJump)
+    }
+
+    // MARK: - Activate
+
+    func testActivateSetsIsActive() {
+        sut.activate(sessions: [])
+        XCTAssertTrue(sut.isActive)
+    }
+
+    func testActivateFreezesSessions() {
+        let sessions = [
+            Session.mock(id: "1", project: "alpha", status: .idle),
+            Session.mock(id: "2", project: "beta", status: .working),
+        ]
+        sut.activate(sessions: sessions)
+        XCTAssertEqual(sut.frozenSessions.count, 2)
+    }
+
+    func testActivateSortsSessions() {
+        var idle = Session.mock(id: "1", project: "alpha", status: .idle)
+        idle.lastActivity = Date().addingTimeInterval(-60)
+        let working = Session.mock(id: "2", project: "beta", status: .working)
+
+        sut.activate(sessions: [idle, working])
+
+        // Working sessions sort before idle
+        XCTAssertEqual(sut.frozenSessions[0].projectName, "beta")
+        XCTAssertEqual(sut.frozenSessions[1].projectName, "alpha")
+    }
+
+    func testActivateWithEmptySessions() {
+        sut.activate(sessions: [])
+        XCTAssertTrue(sut.isActive)
+        XCTAssertTrue(sut.frozenSessions.isEmpty)
+    }
+
+    // MARK: - Deactivate
+
+    func testDeactivateClearsIsActive() {
+        sut.activate(sessions: [.mock()])
+        sut.deactivate()
+        XCTAssertFalse(sut.isActive)
+    }
+
+    func testDeactivateClearsFrozenSessions() {
+        sut.activate(sessions: [.mock(), .mock(id: "2")])
+        sut.deactivate()
+        XCTAssertTrue(sut.frozenSessions.isEmpty)
+    }
+
+    func testDeactivateCancelsTimeout() {
+        let expectation = expectation(description: "timeout should not fire")
+        expectation.isInverted = true
+
+        sut.activate(sessions: [])
+        sut.startTimeout(duration: 0.05) { expectation.fulfill() }
+        sut.deactivate()
+
+        waitForExpectations(timeout: 0.2)
+    }
+
+    func testDeactivateFromInactiveStateIsNoOp() {
+        sut.deactivate()
+        XCTAssertFalse(sut.isActive)
+        XCTAssertTrue(sut.frozenSessions.isEmpty)
+    }
+
+    // MARK: - Frozen sessions are a snapshot
+
+    func testFrozenSessionsAreSnapshot() {
+        var sessions = [
+            Session.mock(id: "1", project: "alpha", status: .working),
+        ]
+        sut.activate(sessions: sessions)
+
+        // Mutating the original array shouldn't affect frozen sessions
+        sessions.append(.mock(id: "2", project: "beta", status: .idle))
+        XCTAssertEqual(sut.frozenSessions.count, 1)
+    }
+
+    // MARK: - Timeout
+
+    func testTimeoutFiresWhenActive() {
+        let expectation = expectation(description: "timeout fires")
+
+        sut.activate(sessions: [])
+        sut.startTimeout(duration: 0.05) { expectation.fulfill() }
+
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testTimeoutDoesNotFireWhenDeactivatedBeforeExpiry() {
+        let expectation = expectation(description: "timeout should not fire")
+        expectation.isInverted = true
+
+        sut.activate(sessions: [])
+        sut.startTimeout(duration: 0.1) { expectation.fulfill() }
+        sut.deactivate()
+
+        waitForExpectations(timeout: 0.3)
+    }
+
+    func testTimeoutDoesNotFireIfManuallyDeactivated() {
+        let expectation = expectation(description: "timeout should not fire")
+        expectation.isInverted = true
+
+        sut.activate(sessions: [])
+        sut.startTimeout(duration: 0.05) {
+            expectation.fulfill()
+        }
+        // Deactivate before timeout — the guard inside the work item checks isActive
+        sut.isActive = false
+
+        waitForExpectations(timeout: 0.2)
+    }
+
+    func testCancelTimeoutPreventsCallback() {
+        let expectation = expectation(description: "timeout should not fire")
+        expectation.isInverted = true
+
+        sut.activate(sessions: [])
+        sut.startTimeout(duration: 0.05) { expectation.fulfill() }
+        sut.cancelTimeout()
+
+        waitForExpectations(timeout: 0.2)
+    }
+
+    func testCancelTimeoutWhenNoneScheduledIsNoOp() {
+        // Should not crash
+        sut.cancelTimeout()
+    }
+
+    func testStartTimeoutReplacesExistingTimeout() {
+        let first = expectation(description: "first timeout should not fire")
+        first.isInverted = true
+        let second = expectation(description: "second timeout fires")
+
+        sut.activate(sessions: [])
+        sut.startTimeout(duration: 0.05) { first.fulfill() }
+        // Starting a new timeout cancels the previous one
+        sut.startTimeout(duration: 0.05) { second.fulfill() }
+
+        waitForExpectations(timeout: 1.0)
+    }
+
+    // MARK: - Panel state tracking
+
+    func testPanelWasClosedBeforeJumpDefaultsFalse() {
+        XCTAssertFalse(sut.panelWasClosedBeforeJump)
+    }
+
+    func testPanelWasClosedBeforeJumpTracksState() {
+        sut.panelWasClosedBeforeJump = true
+        XCTAssertTrue(sut.panelWasClosedBeforeJump)
+    }
+
+    // MARK: - Activate → Deactivate cycle
+
+    func testFullActivateDeactivateCycle() {
+        let sessions = [
+            Session.mock(id: "1", status: .working),
+            Session.mock(id: "2", status: .idle),
+        ]
+
+        // Activate
+        sut.previousApp = nil
+        sut.panelWasClosedBeforeJump = true
+        sut.activate(sessions: sessions)
+
+        XCTAssertTrue(sut.isActive)
+        XCTAssertEqual(sut.frozenSessions.count, 2)
+        XCTAssertTrue(sut.panelWasClosedBeforeJump)
+
+        // Deactivate
+        sut.deactivate()
+
+        XCTAssertFalse(sut.isActive)
+        XCTAssertTrue(sut.frozenSessions.isEmpty)
+        // panelWasClosedBeforeJump is managed by AppDelegate, not by deactivate()
+        XCTAssertTrue(sut.panelWasClosedBeforeJump)
+    }
+
+    func testMultipleActivateDeactivateCycles() {
+        for i in 0..<3 {
+            let sessions = [Session.mock(id: "\(i)", status: .working)]
+            sut.activate(sessions: sessions)
+            XCTAssertTrue(sut.isActive)
+            XCTAssertEqual(sut.frozenSessions.count, 1)
+
+            sut.deactivate()
+            XCTAssertFalse(sut.isActive)
+            XCTAssertTrue(sut.frozenSessions.isEmpty)
+        }
+    }
+
+    // MARK: - Sort order in frozen sessions
+
+    func testFrozenSessionsSortAttentionBeforeWorking() {
+        var idle = Session.mock(id: "1", status: .idle)
+        idle.lastActivity = Date().addingTimeInterval(-60)
+        let attention = Session.mock(id: "2", status: .waitingPermission)
+        let working = Session.mock(id: "3", status: .working)
+
+        sut.activate(sessions: [idle, attention, working])
+
+        XCTAssertEqual(sut.frozenSessions[0].status, .waitingPermission)
+        XCTAssertEqual(sut.frozenSessions[1].status, .working)
+        XCTAssertEqual(sut.frozenSessions[2].status, .idle)
+    }
+
+    func testFrozenSessionsSortByRecencyWithinSameStatus() {
+        var older = Session.mock(id: "1", project: "older", status: .working)
+        older.lastActivity = Date().addingTimeInterval(-120)
+        var newer = Session.mock(id: "2", project: "newer", status: .working)
+        newer.lastActivity = Date()
+
+        sut.activate(sessions: [older, newer])
+
+        XCTAssertEqual(sut.frozenSessions[0].projectName, "newer")
+        XCTAssertEqual(sut.frozenSessions[1].projectName, "older")
+    }
+}


### PR DESCRIPTION
## Summary

- If the panel was closed when entering jump mode, it now closes again after jumping to a session (previously it stayed open)
- Panel stays open after jump if it was already open before entering jump mode
- Adds 22 tests for `JumpModeController` covering state transitions, timeouts, frozen session snapshots, and sort order

## Test plan

- [x] All 143 tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] Manual test: panel closed → jump mode → select session → panel closes
- [x] Manual test: panel open → jump mode → select session → panel stays open
- [x] Manual test: cancel/timeout still restores panel state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)