### PR TITLE
Add JetBrains IDE support for session focusing

### DIFF
--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -182,7 +182,11 @@ enum HookHandler {
     }
 
     static func captureTerminalInfo() -> TerminalInfo {
-        let program = ProcessInfo.processInfo.environment["TERM_PROGRAM"] ?? ""
+        var program = ProcessInfo.processInfo.environment["TERM_PROGRAM"] ?? ""
+        // JetBrains IDEs don't set TERM_PROGRAM; fall back to __CFBundleIdentifier
+        if program.isEmpty {
+            program = ProcessInfo.processInfo.environment["__CFBundleIdentifier"] ?? ""
+        }
         let sessionId = sanitizeTerminalSessionId(
             ProcessInfo.processInfo.environment["ITERM_SESSION_ID"]
             ?? ProcessInfo.processInfo.environment["KITTY_WINDOW_ID"]

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -10,6 +10,7 @@ enum HostApp {
     case iterm2
     case warp
     case terminal
+    case jetbrains
     case unknown
 
     /// Match program name to a HostApp.
@@ -24,6 +25,7 @@ enum HostApp {
         if lower.contains("code") { return .vscode }
         if lower.contains("iterm") { return .iterm2 }
         if lower.contains("warp") { return .warp }
+        if lower.contains("jetbrains") { return .jetbrains }
         if lower.contains("terminal") { return .terminal }
         return .unknown
     }
@@ -37,6 +39,7 @@ enum HostApp {
         case .iterm2: return "com.googlecode.iterm2"
         case .warp: return "dev.warp.Warp-Stable"
         case .terminal: return "com.apple.Terminal"
+        case .jetbrains: return nil  // varies per IDE; handled via terminal.program
         case .unknown: return nil
         }
     }
@@ -51,6 +54,7 @@ enum HostApp {
         case .iterm2: return "iterm2"
         case .warp: return "warp"
         case .terminal: return "terminal"
+        case .jetbrains: return nil  // activated by bundle ID in focusTerminal
         case .unknown: return nil
         }
     }
@@ -59,7 +63,7 @@ enum HostApp {
         switch self {
         case .vscode, .cursor, .windsurf, .zed:
             return "chevron.left.forwardslash.chevron.right"
-        case .iterm2, .warp, .terminal, .unknown:
+        case .iterm2, .warp, .terminal, .jetbrains, .unknown:
             return "terminal"
         }
     }
@@ -68,7 +72,7 @@ enum HostApp {
     var usesWorkspaceFile: Bool {
         switch self {
         case .vscode, .cursor, .windsurf, .zed: return true
-        case .iterm2, .warp, .terminal, .unknown: return false
+        case .iterm2, .warp, .terminal, .jetbrains, .unknown: return false
         }
     }
 

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -18,6 +18,11 @@ func focusTerminal(session: Session) {
         if !focusITerm2Session(sessionId: terminal.sessionId) {
             if let name = hostApp.activationName { activateAppByName(name) }
         }
+    } else if hostApp == .jetbrains {
+        // terminal.program contains the bundle ID (e.g., "com.jetbrains.WebStorm")
+        if !activateAppByBundleID(terminal.program) {
+            NSWorkspace.shared.open(URL(fileURLWithPath: session.projectPath))
+        }
     } else if let name = hostApp.activationName, activateAppByName(name) {
         // activated successfully
     } else {
@@ -101,6 +106,17 @@ func openInEditor(project: RecentProject) {
 
     // Final fallback: open in Finder
     NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: project.projectPath)
+}
+
+@discardableResult
+private func activateAppByBundleID(_ bundleID: String) -> Bool {
+    guard let app = NSWorkspace.shared.runningApplications.first(where: {
+        $0.bundleIdentifier == bundleID
+    }) else {
+        return false
+    }
+    app.activate()
+    return true
 }
 
 @discardableResult


### PR DESCRIPTION
## Summary

- JetBrains IDEs (WebStorm, PyCharm, RubyMine, IntelliJ, GoLand, DataGrip, etc.) don't set `$TERM_PROGRAM`, so cctop couldn't identify them and fell back to opening the project folder
- Fall back to `$__CFBundleIdentifier` when `$TERM_PROGRAM` is empty (e.g. `com.jetbrains.WebStorm`)
- Add `.jetbrains` case to `HostApp` enum, matching `"jetbrains"` in the bundle ID string
- Add `activateAppByBundleID()` to activate the correct IDE dynamically

## How it works

1. **Hook** (`HookHandler.swift`): When `TERM_PROGRAM` is empty, reads `__CFBundleIdentifier` instead (set by macOS for all apps)
2. **Matching** (`HostApp.swift`): `"com.jetbrains.WebStorm"` contains `"jetbrains"` → matched as `.jetbrains`
3. **Activation** (`FocusTerminal.swift`): Uses the stored bundle ID to find and activate the running app via `NSWorkspace`

All JetBrains IDEs are covered automatically since they all share the `com.jetbrains.*` bundle ID prefix.

## Test plan

- [ ] Run Claude Code in a JetBrains IDE terminal (e.g. WebStorm)
- [ ] Verify session file shows `terminal.program` = `"com.jetbrains.WebStorm"` (or equivalent)
- [ ] Click the session in cctop menubar → should focus the JetBrains IDE window
- [ ] Verify iTerm and VS Code sessions still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)