### PR TITLE
Dismiss panel when jumping to a session

### DIFF
--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -98,6 +98,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             self?.handleEvent(.headerClicked)
         }
         nc.addObserver(
+            forName: .sessionJumped, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.handleEvent(.menubarIconClicked(appIsActive: true))
+        }
+        nc.addObserver(
             forName: NSApplication.didResignActiveNotification, object: nil, queue: .main
         ) { [weak self] _ in
             self?.handleEvent(.appLostFocus)

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 extension Notification.Name {
     static let layoutChanged = Notification.Name("layoutChanged")
     static let panelHeaderClicked = Notification.Name("panelHeaderClicked")
+    static let sessionJumped = Notification.Name("sessionJumped")
 }
 
 enum PopupTab {
@@ -312,7 +313,10 @@ extension PopupView {
         return Session.sorted(sessions)
     }
 
-    private func focusSession(_ session: Session) { focusTerminal(session: session); NSApp.deactivate() }
+    private func focusSession(_ session: Session) {
+        focusTerminal(session: session)
+        NotificationCenter.default.post(name: .sessionJumped, object: nil)
+    }
 
     private func toggleOverlay(_ overlay: Overlay) {
         if activeOverlay == overlay {


### PR DESCRIPTION
## Summary

- Clicking a session card now properly dismisses the floating panel
- Previously, `NSApp.deactivate()` was called but the panel remained visible because `panelMode` stayed in `.normal`
- This required pressing the shortcut twice to reopen the panel

## How it works

Instead of calling `NSApp.deactivate()` directly, `focusSession()` posts a `.sessionJumped` notification. `AppDelegate` handles it via the existing `PanelCoordinator` state machine, which transitions `panelMode` to `.hidden` and runs the `.dismissPanel` action.

## Test plan

- [ ] Click a session card in the panel
- [ ] Panel should disappear and focus should move to the target app
- [ ] Press the panel shortcut once — panel should reopen immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)