### PR TITLE
Auto-select session matching the previously focused app

### DIFF
--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -286,6 +286,14 @@ extension AppDelegate {
                 previousApp = NSWorkspace.shared.frontmostApplication
                 if let prev = previousApp, prev != NSRunningApplication.current {
                     lastExternalApp = prev
+                    let bundleID = prev.bundleIdentifier ?? ""
+                    DispatchQueue.main.async {
+                        NotificationCenter.default.post(
+                            name: .panelOpened,
+                            object: nil,
+                            userInfo: ["bundleID": bundleID]
+                        )
+                    }
                 }
             case .startRefocusMode(let panelWasClosed):
                 refocusController.activate(

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 extension Notification.Name {
     static let layoutChanged = Notification.Name("layoutChanged")
     static let panelHeaderClicked = Notification.Name("panelHeaderClicked")
+    static let panelOpened = Notification.Name("panelOpened")
 }
 
 enum PopupTab {
@@ -91,6 +92,17 @@ struct PopupView: View {
         }
         .onChange(of: selectedTab) { _ in selectedIndex = nil }
         .onAppear { selectedTab = initialTab }
+        .onReceive(NotificationCenter.default.publisher(for: .panelOpened)) { notification in
+            guard selectedTab == .active else { return }
+            guard let bundleID = notification.userInfo?["bundleID"] as? String else { return }
+            if let idx = sortedSessions.firstIndex(where: { session in
+                guard let program = session.terminal?.program, !program.isEmpty else { return false }
+                let hostApp = HostApp.from(editorName: program)
+                return hostApp.bundleID == bundleID || program == bundleID
+            }) {
+                selectedIndex = idx
+            }
+        }
     }
 
     // MARK: - Tab picker


### PR DESCRIPTION
## Summary

- When the panel opens, the session corresponding to the previously focused app is automatically highlighted
- Matches by comparing the previous app's bundle ID against `HostApp.bundleID` or the raw `terminal.program` value
- Makes it easy to jump back to the session you were just working in

## How it works

1. `AppDelegate` captures the previous app's bundle ID during `.captureApps`
2. Posts a `.panelOpened` notification asynchronously (after `.reset` clears `selectedIndex`)
3. `PopupView` receives the notification and finds the matching session by bundle ID

## Test plan

- [ ] Open iTerm, then open the cctop panel — iTerm session should be highlighted
- [ ] Open VS Code, then open the cctop panel — VS Code session should be highlighted
- [ ] Open an app with no session — no session should be highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)