### PR TITLE
Remove focus ring from tab picker buttons

### DIFF
--- a/menubar/CctopMenubar/Views/PopupViewHelpers.swift
+++ b/menubar/CctopMenubar/Views/PopupViewHelpers.swift
@@ -85,6 +85,7 @@ struct TabButtonView: View {
             .contentShape(RoundedRectangle(cornerRadius: 6))
         }
         .buttonStyle(.plain)
+        .focusable(false)
         .onHover { isHovered = $0 }
     }
 }


### PR DESCRIPTION
## Summary

- The Active/Recent tab buttons showed a blue focus ring when the panel opened
- Add `.focusable(false)` to `TabButtonView` to prevent the distracting highlight

## Test plan

- [ ] Open the cctop panel — no blue focus ring should appear on the Active tab
- [ ] Tab switching should still work via click and keyboard shortcuts

🤖 Generated with [Claude Code](https://claude.com/claude-code)