### PR TITLE
Defer git branch and session name lookups to menubar app

### DIFF
--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		PC0000010000000000000001 /* PanelCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = PC0000020000000000000001 /* PanelCoordinator.swift */; };
 		PM0000010000000000000001 /* PluginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = PM0000020000000000000001 /* PluginManager.swift */; };
 		Q10000010000000000000001 /* QASnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = Q10000020000000000000001 /* QASnapshotTests.swift */; };
+		SE0000010000000000000001 /* SessionEnricher.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE0000020000000000000001 /* SessionEnricher.swift */; };
 		SN0000010000000000000001 /* SessionNameLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = SN0000020000000000000001 /* SessionNameLookup.swift */; };
 		SN0000030000000000000001 /* SessionNameLookupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SN0000040000000000000001 /* SessionNameLookupTests.swift */; };
 		SN0000050000000000000001 /* SessionNameLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = SN0000020000000000000001 /* SessionNameLookup.swift */; };
@@ -136,6 +137,7 @@
 		PC0000020000000000000001 /* PanelCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelCoordinator.swift; sourceTree = "<group>"; };
 		PM0000020000000000000001 /* PluginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginManager.swift; sourceTree = "<group>"; };
 		Q10000020000000000000001 /* QASnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QASnapshotTests.swift; sourceTree = "<group>"; };
+		SE0000020000000000000001 /* SessionEnricher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEnricher.swift; sourceTree = "<group>"; };
 		SN0000020000000000000001 /* SessionNameLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNameLookup.swift; sourceTree = "<group>"; };
 		SN0000040000000000000001 /* SessionNameLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNameLookupTests.swift; sourceTree = "<group>"; };
 		SP0000020000000000000001 /* SparkleUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdater.swift; sourceTree = "<group>"; };
@@ -202,6 +204,7 @@
 				JM0000020000000000000001 /* RefocusController.swift */,
 				PC0000020000000000000001 /* PanelCoordinator.swift */,
 				NSC000020000000000000001 /* NotchStatusController.swift */,
+				SE0000020000000000000001 /* SessionEnricher.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -461,6 +464,7 @@
 				N10000010000000000000001 /* SessionStatus+UI.swift in Sources */,
 				N10000030000000000000001 /* HookEvent.swift in Sources */,
 				N10000050000000000000001 /* Config.swift in Sources */,
+				SE0000010000000000000001 /* SessionEnricher.swift in Sources */,
 				SN0000050000000000000001 /* SessionNameLookup.swift in Sources */,
 				RP0000010000000000000001 /* RecentProject.swift in Sources */,
 				RV0000010000000000000001 /* RecentProjectCardView.swift in Sources */,

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -20,7 +20,6 @@ enum HookHandler {
         let label = HookLogger.sessionLabel(cwd: input.cwd, sessionId: safeId)
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("\(pid).json")
 
-        let branch = getCurrentBranch(cwd: input.cwd)
         let terminal = captureTerminalInfo()
         let startTime = Session.processStartTime(pid: pid)
 
@@ -29,7 +28,7 @@ enum HookHandler {
         // firing simultaneously) race: both read the old file, apply changes
         // independently, and the last writer wins — clobbering the first writer's changes.
         try withSessionLock(sessionPath: sessionPath) {
-            let freshSession = Session(sessionId: safeId, projectPath: input.cwd, branch: branch, terminal: terminal)
+            let freshSession = Session(sessionId: safeId, projectPath: input.cwd, branch: "unknown", terminal: terminal)
             var session = loadOrCreateSession(
                 path: sessionPath, event: event, startTime: startTime, fresh: freshSession
             )
@@ -37,7 +36,7 @@ enum HookHandler {
             session.pid = pid
             session.pidStartTime = startTime
 
-            let (oldStatus, newStatus) = applyTransition(&session, event: event, input: input, branch: branch, terminal: terminal)
+            let (oldStatus, newStatus) = applyTransition(&session, event: event, input: input, terminal: terminal)
             applySideEffects(event: event, session: &session, input: input, sessionsDir: sessionsDir, safeId: safeId)
 
             let suffix = newStatus == nil ? " (preserved)" : ""
@@ -83,7 +82,7 @@ enum HookHandler {
     /// Apply status transition and update session metadata. Returns (oldStatus, newStatus).
     private static func applyTransition(
         _ session: inout Session, event: HookEvent, input: HookInput,
-        branch: String, terminal: TerminalInfo
+        terminal: TerminalInfo
     ) -> (String, SessionStatus?) {
         let oldStatus = session.status.rawValue
         let newStatus = Transition.forEvent(session.status, event: event)
@@ -92,12 +91,9 @@ enum HookHandler {
         // already set it, and we need the original timestamp for child-process-start-time
         // comparison in the menubar app.
         if event != .notificationPermission { session.lastActivity = Date() }
-        session.branch = branch
         session.terminal = terminal
         if event == .sessionStart || event == .userPromptSubmit {
-            session.sessionName = SessionNameLookup.lookupSessionName(
-                transcriptPath: input.transcriptPath, sessionId: input.sessionId
-            )
+            session.transcriptPath = input.transcriptPath
         }
         return (oldStatus, newStatus)
     }
@@ -346,31 +342,6 @@ func withSessionLock(sessionPath: String, body: () throws -> Void) throws {
     }
     defer { flock(fd, LOCK_UN) }
     try body()
-}
-
-// MARK: - Git Branch
-
-func getCurrentBranch(cwd: String) -> String {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
-    process.arguments = ["branch", "--show-current"]
-    process.currentDirectoryURL = URL(fileURLWithPath: cwd)
-
-    let pipe = Pipe()
-    process.standardOutput = pipe
-    process.standardError = FileHandle.nullDevice
-
-    do {
-        try process.run()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else { return "unknown" }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        let branch = String(data: data, encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return branch.isEmpty ? "unknown" : branch
-    } catch {
-        return "unknown"
-    }
 }
 
 // MARK: - Tool Detail Extraction

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -91,6 +91,7 @@ struct Session: Codable, Identifiable {
     var lastToolDetail: String?
     var notificationMessage: String?
     var sessionName: String?
+    var transcriptPath: String?
     var workspaceFile: String?
     var source: String?
     var endedAt: Date?
@@ -124,6 +125,7 @@ struct Session: Codable, Identifiable {
         case lastToolDetail = "last_tool_detail"
         case notificationMessage = "notification_message"
         case sessionName = "session_name"
+        case transcriptPath = "transcript_path"
         case workspaceFile = "workspace_file"
         case source
         case endedAt = "ended_at"
@@ -149,6 +151,7 @@ struct Session: Codable, Identifiable {
         lastToolDetail: String?,
         notificationMessage: String?,
         sessionName: String? = nil,
+        transcriptPath: String? = nil,
         workspaceFile: String? = nil,
         source: String? = nil,
         endedAt: Date? = nil,
@@ -169,6 +172,7 @@ struct Session: Codable, Identifiable {
         self.lastToolDetail = lastToolDetail
         self.notificationMessage = notificationMessage
         self.sessionName = sessionName
+        self.transcriptPath = transcriptPath
         self.workspaceFile = workspaceFile
         self.source = source
         self.endedAt = endedAt
@@ -192,6 +196,7 @@ struct Session: Codable, Identifiable {
         self.lastToolDetail = nil
         self.notificationMessage = nil
         self.sessionName = nil
+        self.transcriptPath = nil
         self.workspaceFile = nil
         self.source = nil
         self.endedAt = nil
@@ -256,6 +261,7 @@ struct Session: Codable, Identifiable {
             lastToolDetail: lastToolDetail,
             notificationMessage: notificationMessage,
             sessionName: sessionName,
+            transcriptPath: transcriptPath,
             workspaceFile: workspaceFile,
             source: source,
             endedAt: endedAt,

--- a/menubar/CctopMenubar/Services/SessionEnricher.swift
+++ b/menubar/CctopMenubar/Services/SessionEnricher.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Enriches sessions with git branch and session name data in-memory.
+/// Runs in the menubar app, replacing lookups previously done in cctop-hook.
+/// Skips opencode sessions (they provide their own branch/name via plugin.js).
+class SessionEnricher {
+    // Cache: projectPath → (branch, timestamp)
+    private var branchCache: [String: (branch: String, fetchedAt: Date)] = [:]
+    // Cache: sessionId → sessionName (nil value = already looked up, not found)
+    private var nameCache: [String: String?] = [:]
+
+    private static let branchMaxAge: TimeInterval = 30
+
+    /// Enrich session with branch and session name (in-memory only).
+    func enrich(_ session: inout Session) {
+        guard session.source != "opencode" else { return }
+        enrichBranch(&session)
+        enrichSessionName(&session)
+    }
+
+    private func enrichBranch(_ session: inout Session) {
+        let path = session.projectPath
+        if let cached = branchCache[path],
+           -cached.fetchedAt.timeIntervalSinceNow < Self.branchMaxAge {
+            session.branch = cached.branch
+            return
+        }
+        let branch = Self.getCurrentBranch(cwd: path)
+        branchCache[path] = (branch, Date())
+        session.branch = branch
+    }
+
+    private func enrichSessionName(_ session: inout Session) {
+        let sid = session.sessionId
+        if let cached = nameCache[sid] {
+            session.sessionName = cached
+            return
+        }
+        guard let transcriptPath = session.transcriptPath else { return }
+        let name = SessionNameLookup.lookupSessionName(
+            transcriptPath: transcriptPath, sessionId: sid
+        )
+        nameCache[sid] = name
+        session.sessionName = name
+    }
+
+    /// Invalidate session name cache so the next enrich() re-reads the transcript.
+    func invalidateSessionName(_ sessionId: String) {
+        nameCache.removeValue(forKey: sessionId)
+    }
+
+    /// Invalidate branch cache so the next enrich() re-runs git.
+    func invalidateBranch(projectPath: String) {
+        branchCache.removeValue(forKey: projectPath)
+    }
+
+    /// Remove cache entries for sessions/projects that are no longer active.
+    func pruneCache(
+        activeSessionIds: Set<String>,
+        activeProjectPaths: Set<String>
+    ) {
+        nameCache = nameCache.filter { activeSessionIds.contains($0.key) }
+        branchCache = branchCache.filter {
+            activeProjectPaths.contains($0.key)
+        }
+    }
+
+    /// Spawn `git branch --show-current` and return the branch name.
+    static func getCurrentBranch(cwd: String) -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = ["branch", "--show-current"]
+        process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return "unknown" }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let branch = String(
+                data: data, encoding: .utf8
+            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return branch.isEmpty ? "unknown" : branch
+        } catch {
+            return "unknown"
+        }
+    }
+}

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -10,6 +10,7 @@ class SessionManager: ObservableObject {
     @Published var sessions: [Session] = []
 
     let historyManager: HistoryManager
+    private let enricher = SessionEnricher()
 
     private let sessionsDir: URL
     private var source: DispatchSourceFileSystemObject?
@@ -59,9 +60,13 @@ class SessionManager: ObservableObject {
         let dead = allDecoded.filter { !$0.1.isAlive }
         logger.info("loadSessions: \(jsonFiles.count) files, \(allDecoded.count) decoded, \(alive.count) alive, \(dead.count) dead")
         let oldCount = sessions.count
-        sessions = alive.map(\.1).map { session in
-            adjustDisplayStatus(session)
-        }
+
+        invalidateCachesOnTransitions(alive: alive, oldStatuses: oldStatuses)
+        sessions = alive.map(\.1).map { enrichAndAdjust($0) }
+        enricher.pruneCache(
+            activeSessionIds: Set(sessions.map(\.sessionId)),
+            activeProjectPaths: Set(sessions.map(\.projectPath))
+        )
         if sessions.count != oldCount {
             logger.info("loadSessions: session count changed \(oldCount) -> \(self.sessions.count)")
         }
@@ -107,6 +112,32 @@ class SessionManager: ObservableObject {
                 try? FileManager.default.removeItem(at: url)
             }
         }
+    }
+
+    /// Invalidate session name cache when a session transitions to working
+    /// (user sent a new prompt, session name may change).
+    private func invalidateCachesOnTransitions(
+        alive: [(URL, Session)],
+        oldStatuses: [String: SessionStatus]
+    ) {
+        for (_, session) in alive {
+            guard let old = oldStatuses[session.id] else { continue }
+            // User sent a new prompt → session name may change
+            if old != .working, session.status == .working {
+                enricher.invalidateSessionName(session.sessionId)
+            }
+            // Stopped working → may have switched branches
+            if old == .working, session.status != .working {
+                enricher.invalidateBranch(projectPath: session.projectPath)
+            }
+        }
+    }
+
+    /// Apply display-side status adjustments and enrich with branch/session name.
+    private func enrichAndAdjust(_ session: Session) -> Session {
+        var result = adjustDisplayStatus(session)
+        enricher.enrich(&result)
+        return result
     }
 
     /// Apply display-side status adjustments. The session file on disk is NOT modified.


### PR DESCRIPTION
## Summary

- Move `getCurrentBranch()` and `SessionNameLookup` calls from `cctop-hook` to the menubar app via a new `SessionEnricher` service
- Hook now writes `transcriptPath` to session JSON instead of performing lookups itself — simplifies hook to a thin status writer
- Branch cache (30s TTL, invalidated when sessions stop working) and session name cache (invalidated when sessions start working) keep the UI responsive
- Opencode sessions are skipped (they provide their own branch/name via plugin.js)

## Test plan

- [x] `make build` — both targets compile
- [x] `make lint` — 0 violations
- [x] `make test` — 257 tests pass
- [ ] Start a CC session, verify branch appears in menubar within ~2s
- [ ] Verify session name appears after first prompt
- [ ] Switch git branches mid-session, verify menubar updates when session stops working
- [ ] Verify opencode sessions still show their own branch/name

🤖 Generated with [Claude Code](https://claude.com/claude-code)