### PR TITLE
Fix keyboard navigation digits not working with non-English IME

### DIFF
--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -454,6 +454,14 @@ private let navKeyMap: [UInt16: PanelNavAction] = [
     124: .nextTab       // right arrow
 ]
 
+// Hardware key codes for digit row (1-9). Using keyCode instead of
+// event.characters so digit navigation works with non-English input
+// methods (e.g. Zhuyin where "1" produces "ㄅ").
+private let digitKeyCodeMap: [UInt16: Int] = [
+    18: 1, 19: 2, 20: 3, 21: 4, 23: 5,
+    22: 6, 26: 7, 28: 8, 25: 9
+]
+
 extension AppDelegate {
     @MainActor @discardableResult
     func handleEvent(_ event: PanelEvent) -> Bool {
@@ -536,9 +544,9 @@ extension AppDelegate {
         navKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self, self.panel.isVisible else { return event }
 
-            // Navigate: digit keys jump to session
+            // Navigate: digit keys jump to session (use keyCode for IME compatibility)
             if self.navigateController.isActive,
-               let char = event.characters, let digit = Int(char), digit >= 1, digit <= 9 {
+               let digit = digitKeyCodeMap[event.keyCode] {
                 DispatchQueue.main.async { self.jumpToSession(index: digit - 1) }
                 return nil
             }


### PR DESCRIPTION
## Summary

- Navigate mode digit keys (1-9) used `event.characters` which returns IME-mapped characters (e.g. "ㄅ" instead of "1" with zh-tw Zhuyin), causing digit presses to exit navigate mode instead of jumping to sessions
- Switched to `event.keyCode` (hardware key codes) which are input-method independent — matching how arrow/escape/tab keys were already handled

## Test plan

- [ ] Switch input method to zh-tw (Zhuyin/Bopomofo)
- [ ] Open panel, trigger navigate mode (Cmd+Ctrl+N)
- [ ] Press 1-9 — should jump to the corresponding session
- [ ] Verify arrow keys, Escape, Tab, Return still work
- [ ] Switch back to English and verify everything still works