### PR TITLE
Fix pi source mislabel in Raycast detail pane

### DIFF
--- a/raycast/src/sessions.ts
+++ b/raycast/src/sessions.ts
@@ -147,6 +147,15 @@ export function sourceLabel(session: CctopSession): string {
 }
 
 /**
+ * Human-readable source name for detail panes.
+ */
+export function sourceDisplayName(session: CctopSession): string {
+  if (session.source === "opencode") return "opencode";
+  if (session.source === "pi") return "pi";
+  return "Claude Code";
+}
+
+/**
  * Format tool display matching Session.swift formatToolDisplay.
  * Case-insensitive matching (opencode sends lowercase, Claude Code sends capitalized).
  */

--- a/raycast/src/show-sessions.tsx
+++ b/raycast/src/show-sessions.tsx
@@ -19,6 +19,7 @@ import {
   contextLine,
   relativeTime,
   sourceLabel,
+  sourceDisplayName,
   statusGroup,
   groupSessions,
   needsAttention,
@@ -120,7 +121,7 @@ function SessionDetail({ session }: { session: CctopSession }) {
           />
           <List.Item.Detail.Metadata.Label
             title="Source"
-            text={session.source === "opencode" ? "opencode" : "Claude Code"}
+            text={sourceDisplayName(session)}
           />
           <List.Item.Detail.Metadata.Separator />
           <List.Item.Detail.Metadata.Label


### PR DESCRIPTION
The detail pane hard-coded a two-way check (`opencode` vs `Claude Code`) so pi sessions were shown as "Claude Code". Extracts `sourceDisplayName()` to handle all sources.

One-liner fix, no new dependencies.