### PR TITLE
Prioritize direct release download in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,18 @@ Switch themes in Settings > Appearance > Color.
 
 ### Step 1: Install the app
 
-**Homebrew:**
+[**Download the latest release**](https://github.com/st0012/cctop/releases/latest) — the app is signed and notarized by Apple. Unzip it and drag `cctop.app` into `/Applications/`.
+
+Once installed, cctop updates itself automatically via Sparkle — you'll be prompted when a new version is available.
+
+<details>
+<summary>Alternative: Homebrew</summary>
 
 ```bash
 brew install --cask st0012/cctop/cctop
 ```
 
-Or [download the latest release](https://github.com/st0012/cctop/releases/latest) — the app is signed and notarized by Apple.
+</details>
 
 ### Step 2: Connect your tools
 


### PR DESCRIPTION
Lead with the GitHub release download (the supported path that
enables Sparkle auto-updates) and move Homebrew to a collapsed
alternative. Call out that updates happen automatically after
install so users know they don't need to track new versions.

https://claude.ai/code/session_01S2i2eaE2V7nsWgqTeaW1Tj