### PR TITLE
feat: add Kitty terminal support with remote control focus

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,9 @@ line_length:
 cyclomatic_complexity:
   warning: 15
 
+type_body_length:
+  warning: 300
+
 identifier_name:
   min_length:
     warning: 2

--- a/README.md
+++ b/README.md
@@ -63,11 +63,15 @@ When you click a session card (or jump via Navigate mode), cctop focuses the hos
 |-----|-------------|
 | VS Code, Cursor, Windsurf, Zed | Opens the project (workspace file if present) |
 | iTerm2 | Targets the specific window, tab, and pane |
+| Kitty | Targets the specific window via remote control |
 | Warp, Terminal, Ghostty | Activates the app (no per-tab targeting) |
 | Other | Falls back to opening the project folder in Finder |
 
 > [!NOTE]
 > iTerm2 requires macOS Automation permission. You'll be prompted to grant it on first use.
+>
+> Kitty requires `allow_remote_control socket-only` and `listen_on` in your `kitty.conf`.
+> Without remote control enabled, Kitty falls back to app activation (same as Warp/Ghostty).
 
 ## Installation
 

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -221,7 +221,9 @@ enum HookHandler {
         )
         let tty = env["TTY"] ?? findTTY()
         let bundleId = env["__CFBundleIdentifier"]
-        return TerminalInfo(program: program, sessionId: sessionId, tty: tty, bundleId: bundleId)
+        // Only Kitty exposes a remote-control socket for now (KITTY_LISTEN_ON).
+        let socket = env["KITTY_LISTEN_ON"]
+        return TerminalInfo(program: program, sessionId: sessionId, tty: tty, bundleId: bundleId, socket: socket)
     }
 
     /// Validate terminal session IDs to prevent injection via env vars.

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -11,6 +11,7 @@ enum HostApp {
     case warp
     case terminal
     case ghostty
+    case kitty
     case unknown
 
     /// Match a bundle identifier to a HostApp. Preferred over program name matching
@@ -33,6 +34,7 @@ enum HostApp {
         if lower.contains("iterm") { return .iterm2 }
         if lower.contains("warp") { return .warp }
         if lower.contains("ghostty") { return .ghostty }
+        if lower.contains("kitty") { return .kitty }
         if lower.contains("terminal") { return .terminal }
         return .unknown
     }
@@ -47,6 +49,7 @@ enum HostApp {
         case .warp: return "dev.warp.Warp-Stable"
         case .terminal: return "com.apple.Terminal"
         case .ghostty: return "com.mitchellh.ghostty"
+        case .kitty: return "net.kovidgoyal.kitty"
         case .unknown: return nil
         }
     }
@@ -62,6 +65,7 @@ enum HostApp {
         case .warp: return "warp"
         case .terminal: return "terminal"
         case .ghostty: return "ghostty"
+        case .kitty: return "kitty"
         case .unknown: return nil
         }
     }
@@ -70,7 +74,7 @@ enum HostApp {
         switch self {
         case .vscode, .cursor, .windsurf, .zed:
             return "chevron.left.forwardslash.chevron.right"
-        case .iterm2, .warp, .terminal, .ghostty, .unknown:
+        case .iterm2, .warp, .terminal, .ghostty, .kitty, .unknown:
             return "terminal"
         }
     }
@@ -79,13 +83,13 @@ enum HostApp {
     var usesWorkspaceFile: Bool {
         switch self {
         case .vscode, .cursor, .windsurf, .zed: return true
-        case .iterm2, .warp, .terminal, .ghostty, .unknown: return false
+        case .iterm2, .warp, .terminal, .ghostty, .kitty, .unknown: return false
         }
     }
 
     /// Reverse lookup: bundle ID → HostApp.
     static let allByBundleID: [String: HostApp] = {
-        let all: [HostApp] = [.vscode, .cursor, .windsurf, .zed, .iterm2, .warp, .terminal, .ghostty]
+        let all: [HostApp] = [.vscode, .cursor, .windsurf, .zed, .iterm2, .warp, .terminal, .ghostty, .kitty]
         return Dictionary(uniqueKeysWithValues: all.compactMap { app in
             app.bundleID.map { ($0, app) }
         })

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -50,19 +50,23 @@ struct TerminalInfo: Codable {
     let sessionId: String?
     let tty: String?
     let bundleId: String?
+    let socket: String? // Remote-control socket (e.g. KITTY_LISTEN_ON)
 
     enum CodingKeys: String, CodingKey {
         case program
         case sessionId = "session_id"
         case tty
         case bundleId = "bundle_id"
+        case socket
     }
 
-    init(program: String = "", sessionId: String? = nil, tty: String? = nil, bundleId: String? = nil) {
+    init(program: String = "", sessionId: String? = nil, tty: String? = nil,
+         bundleId: String? = nil, socket: String? = nil) {
         self.program = program
         self.sessionId = sessionId
         self.tty = tty
         self.bundleId = bundleId
+        self.socket = socket
     }
 }
 

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -8,6 +8,8 @@ enum FocusStrategy: Equatable {
     case openWithApp(bundleID: String, target: String)
     /// Focus an iTerm2 session by its unique GUID, with a bundle ID fallback.
     case iTerm2(guid: String)
+    /// Focus a Kitty window via remote control socket, with bundle ID fallback.
+    case kitty(socket: String, windowId: String)
     /// Activate a running app by its localized name.
     case activateByName(String)
     /// Activate a running app by its bundle identifier.
@@ -46,6 +48,13 @@ func resolveFocusStrategy(session: Session) -> FocusStrategy {
         return .iTerm2(guid: guid)
     }
 
+    // Kitty → remote control to focus the specific window (pane in Kitty's terms)
+    if hostApp == .kitty,
+       let socket = terminal.socket,
+       let windowId = terminal.sessionId {
+        return .kitty(socket: socket, windowId: windowId)
+    }
+
     // Try activation by name, then bundle ID, then Finder
     if let name = hostApp.activationName {
         return .activateByName(name)
@@ -81,6 +90,13 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
     case .iTerm2(let guid):
         if !executeITerm2Script(guid: guid) {
             if let bundleID = HostApp.iterm2.bundleID {
+                activateAppByBundleID(bundleID)
+            }
+        }
+
+    case .kitty(let socket, let windowId):
+        if !executeKittyFocusWindow(socket: socket, windowId: windowId) {
+            if let bundleID = HostApp.kitty.bundleID {
                 activateAppByBundleID(bundleID)
             }
         }
@@ -130,6 +146,24 @@ private func executeITerm2Script(guid: String) -> Bool {
     var error: NSDictionary?
     NSAppleScript(source: script)?.executeAndReturnError(&error)
     return error == nil
+}
+
+// MARK: - Kitty Remote Control
+// https://sw.kovidgoyal.net/kitty/remote-control/
+
+private func executeKittyFocusWindow(socket: String, windowId: String) -> Bool {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["kitty", "@", "--to", socket, "focus-window", "--match", "id:\(windowId)"]
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    do {
+        try process.run()
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    } catch {
+        return false
+    }
 }
 
 // MARK: - Open recent project in editor

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -7,12 +7,17 @@ final class FocusStrategyTests: XCTestCase {
 
     private func makeSession(
         program: String,
-        sessionId: String? = nil
+        sessionId: String? = nil,
+        bundleId: String? = nil,
+        socket: String? = nil
     ) -> Session {
         Session.mock(
             id: "test",
             project: "myapp",
-            terminal: TerminalInfo(program: program, sessionId: sessionId, tty: nil)
+            terminal: TerminalInfo(
+                program: program, sessionId: sessionId, tty: nil,
+                bundleId: bundleId, socket: socket
+            )
         )
     }
 
@@ -91,6 +96,44 @@ final class FocusStrategyTests: XCTestCase {
         )
         let strategy = resolveFocusStrategy(session: session)
         XCTAssertEqual(strategy, .activateByName("iterm2"))
+    }
+
+    // MARK: - Kitty uses remote control with socket
+
+    func testKittyWithSocketUsesRemoteControl() {
+        let session = makeSession(
+            program: "kitty", sessionId: "1",
+            bundleId: "net.kovidgoyal.kitty", socket: "unix:/tmp/kitty-1234"
+        )
+        let strategy = resolveFocusStrategy(session: session)
+        XCTAssertEqual(strategy, .kitty(socket: "unix:/tmp/kitty-1234", windowId: "1"))
+    }
+
+    func testKittyWithoutSocketFallsBackToActivate() {
+        let session = makeSession(
+            program: "kitty", sessionId: "1",
+            bundleId: "net.kovidgoyal.kitty"
+        )
+        let strategy = resolveFocusStrategy(session: session)
+        XCTAssertEqual(strategy, .activateByName("kitty"))
+    }
+
+    func testKittyWithoutWindowIdFallsBackToActivate() {
+        let session = makeSession(
+            program: "kitty",
+            bundleId: "net.kovidgoyal.kitty", socket: "unix:/tmp/kitty-1234"
+        )
+        let strategy = resolveFocusStrategy(session: session)
+        XCTAssertEqual(strategy, .activateByName("kitty"))
+    }
+
+    func testKittyDetectedByBundleIdWhenProgramDiffers() {
+        let session = makeSession(
+            program: "zellij", sessionId: "1",
+            bundleId: "net.kovidgoyal.kitty", socket: "unix:/tmp/kitty-1234"
+        )
+        let strategy = resolveFocusStrategy(session: session)
+        XCTAssertEqual(strategy, .kitty(socket: "unix:/tmp/kitty-1234", windowId: "1"))
     }
 
     // MARK: - Other terminals use activate

--- a/site/index.html
+++ b/site/index.html
@@ -542,6 +542,7 @@
         </div>
         <div class="chips">
           <span class="chip">iTerm2</span>
+          <span class="chip">Kitty<sup>*</sup></span>
         </div>
       </div>
       <div class="tier-row reveal" style="--rd:80ms">
@@ -567,6 +568,9 @@
           <span class="chip">Ghostty</span>
         </div>
       </div>
+      <p class="tier-footnote" style="font-size:.85rem;color:var(--c-muted);margin-top:8px">
+        *&thinsp;Kitty targets the exact window when <a href="https://sw.kovidgoyal.net/kitty/remote-control/" target="_blank" rel="noopener noreferrer"><code>remote control</code></a> is enabled in kitty.conf. Without it, falls back to app activation.
+      </p>
     </div>
 
   </div>


### PR DESCRIPTION
This adds kitty support by checking the remote control socket (can jump to the right pane), with a fallback to `__CFBundleIdentifier` of `net.kovidgoyal.kitty` (like other terminals).


Kitty remote control requires user opt-in these configruation:

```config
allow_remote_control socket-only
listen_on unix:/path/to/socket
```


See

* https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.allow_remote_control
* https://sw.kovidgoyal.net/kitty/glossary/#envvar-KITTY_LISTEN_ON

I've tested locally and it worked.
