### PR TITLE
chore(actions): bump deprecated actions to Node.js 24 + add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(actions)"
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Swift Lint
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install SwiftLint
         run: brew install swiftlint
       - name: SwiftLint
@@ -20,7 +20,7 @@ jobs:
     name: Swift Build & Test
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_16.3.app
       - name: Cache DerivedData

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           - arch: x86_64
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_16.3.app
@@ -74,13 +74,13 @@ jobs:
         run: ./scripts/create-dmg.sh --arch ${{ matrix.arch }}
 
       - name: Upload zip artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cctop-macOS-${{ matrix.arch }}
           path: dist/cctop-macOS-${{ matrix.arch }}.zip
 
       - name: Upload DMG artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cctop-macOS-${{ matrix.arch }}-dmg
           path: dist/cctop-macOS-${{ matrix.arch }}.dmg
@@ -90,10 +90,10 @@ jobs:
     needs: build-macos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 
@@ -165,13 +165,13 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
           fetch-depth: 0
 
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 
@@ -216,10 +216,10 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary

The `v0.14.1` release run surfaced a deprecation annotation: `actions/checkout` and `actions/upload-artifact` were running on Node.js 20, which GitHub is removing from Actions runners on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

This PR bumps every deprecated action to its Node.js 24-native pin and adds Dependabot so the next deprecation cycle lands as a PR automatically.

## Action bumps

| Action | Old pin | New pin | Reason |
|---|---|---|---|
| `actions/checkout` | v4 (`34e1148`) | [v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2) (`de0fac2`) | Node.js 24 native since [v5.0.0](https://github.com/actions/checkout/releases/tag/v5.0.0); v6 added improved tag handling |
| `actions/upload-artifact` | v4 (`ea165f8`) | [v7.0.1](https://github.com/actions/upload-artifact/releases/tag/v7.0.1) (`043fb46`) | Node.js 24 became default in [v6.0.0](https://github.com/actions/upload-artifact/releases/tag/v6.0.0); v7 adds optional direct-upload mode (opt-in via `archive: false`, default behavior unchanged) |
| `actions/download-artifact` | v4 (`d3f86a1`) | [v8.0.1](https://github.com/actions/download-artifact/releases/tag/v8.0.1) (`3e5f45b`) | Node.js 24 became default in [v7.0.0](https://github.com/actions/download-artifact/releases/tag/v7.0.0); v8 enforces hash-mismatch errors by default |

### Compatibility check

- **`download-artifact` v5.0.0 changed single-by-ID download paths** ([breaking note](https://github.com/actions/download-artifact/releases/tag/v5.0.0)). All three usages in `release.yml` download by `path:` (no `name:` or `artifact-ids:`), so this does not apply.
- **`download-artifact` v8 errors on hash mismatch** by default. Our artifacts come from `upload-artifact` in the same workflow run, so hashes will match.
- **`upload-artifact` v7's `archive: false` direct-upload mode** is opt-in. We don't set it, so existing zip behavior is preserved.

## Dependabot

New `.github/dependabot.yml` enables monthly grouped GitHub Actions updates ([docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)). Grouping all actions into one PR per month keeps churn low while still catching deprecations early.

## Test plan

- [ ] CI workflow passes on this branch (lint + Swift build/test)
- [ ] Verify `release.yml` is structurally valid (will only run on tag push, but YAML/SHA correctness is checked by Actions on PR)
- [ ] Confirm Dependabot picks up `.github/dependabot.yml` after merge (visible under repo Insights > Dependency graph > Dependabot)