### PR TITLE
feat: add terminal multiplexer focus support

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,9 @@ cyclomatic_complexity:
 type_body_length:
   warning: 300
 
+file_length:
+  warning: 500
+
 identifier_name:
   min_length:
     warning: 2

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ When you click a session card (or jump via Navigate mode), cctop focuses the hos
 > Kitty requires `allow_remote_control socket-only` and `listen_on` in your `kitty.conf`.
 > Without remote control enabled, Kitty falls back to app activation (same as Warp/Ghostty).
 
+### Terminal Multiplexers
+
+When running inside a multiplexer, cctop additionally focuses the specific pane.
+This composes with any terminal emulator above.
+
+| Multiplexer | How it focuses |
+|-------------|----------------|
+| Zellij | `zellij --session <name> action focus-pane-id <paneId>` — targets the exact pane |
+| tmux | `tmux select-window` + `select-pane` — targets the exact window and pane |
+
 ## Installation
 
 ### Step 1: Install the app

--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		PLT000010000000000000001 /* PanelLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PLT000020000000000000001 /* PanelLifecycleTests.swift */; };
 		PPT000010000000000000001 /* PanelPositioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PPT000020000000000000001 /* PanelPositioningTests.swift */; };
 		FST000010000000000000001 /* FocusStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FST000020000000000000001 /* FocusStrategyTests.swift */; };
+		MFT000010000000000000001 /* MultiplexerFocusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MFT000020000000000000001 /* MultiplexerFocusTests.swift */; };
 		TMT000010000000000000001 /* ThemeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TMT000020000000000000001 /* ThemeManagerTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -185,6 +186,7 @@
 		PLT000020000000000000001 /* PanelLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelLifecycleTests.swift; sourceTree = "<group>"; };
 		PPT000020000000000000001 /* PanelPositioningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelPositioningTests.swift; sourceTree = "<group>"; };
 		FST000020000000000000001 /* FocusStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusStrategyTests.swift; sourceTree = "<group>"; };
+		MFT000020000000000000001 /* MultiplexerFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiplexerFocusTests.swift; sourceTree = "<group>"; };
 		TMT000020000000000000001 /* ThemeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManagerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -360,6 +362,7 @@
 				PLT000020000000000000001 /* PanelLifecycleTests.swift */,
 				PPT000020000000000000001 /* PanelPositioningTests.swift */,
 				FST000020000000000000001 /* FocusStrategyTests.swift */,
+				MFT000020000000000000001 /* MultiplexerFocusTests.swift */,
 				TMT000020000000000000001 /* ThemeManagerTests.swift */,
 			);
 			path = CctopMenubarTests;
@@ -576,6 +579,7 @@
 				PLT000010000000000000001 /* PanelLifecycleTests.swift in Sources */,
 				PPT000010000000000000001 /* PanelPositioningTests.swift in Sources */,
 				FST000010000000000000001 /* FocusStrategyTests.swift in Sources */,
+				MFT000010000000000000001 /* MultiplexerFocusTests.swift in Sources */,
 				TMT000010000000000000001 /* ThemeManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -235,14 +235,16 @@ enum HookHandler {
         // zellij: ZELLIJ_SESSION_NAME + ZELLIJ_PANE_ID
         if let sessionName = sanitizeTerminalSessionId(env["ZELLIJ_SESSION_NAME"]),
            let paneId = sanitizeTerminalSessionId(env["ZELLIJ_PANE_ID"]) {
-            return .zellij(sessionName: sessionName, paneId: paneId)
+            let path = resolveBinaryPath(env: env, name: "zellij")
+            return .zellij(sessionName: sessionName, paneId: paneId, binaryPath: path)
         }
         // tmux: $TMUX = "socket_path,pid,session_index", $TMUX_PANE = "%N"
         if let tmux = env["TMUX"],
            let paneId = sanitizeTerminalSessionId(env["TMUX_PANE"]),
            let socket = tmux.split(separator: ",").first.map(String.init),
            !socket.isEmpty {
-            return .tmux(socket: socket, paneId: paneId)
+            let path = resolveBinaryPath(env: env, name: "tmux")
+            return .tmux(socket: socket, paneId: paneId, binaryPath: path)
         }
         return nil
     }
@@ -254,6 +256,19 @@ enum HookHandler {
               value.range(of: #"^[0-9a-zA-Z:.@_%-]+$"#, options: .regularExpression) != nil
         else { return nil }
         return value
+    }
+
+    /// Resolve absolute path for a CLI binary by searching $PATH.
+    private static func resolveBinaryPath(env: [String: String], name: String) -> String? {
+        guard let pathEnv = env["PATH"] else { return nil }
+        let fm = FileManager.default
+        for dir in pathEnv.split(separator: ":") {
+            let fullPath = URL(fileURLWithPath: String(dir)).appendingPathComponent(name).path
+            if fm.isExecutableFile(atPath: fullPath) {
+                return fullPath
+            }
+        }
+        return nil
     }
 
     /// Walk up the process tree to find the first ancestor with a controlling terminal.

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -223,14 +223,35 @@ enum HookHandler {
         let bundleId = env["__CFBundleIdentifier"]
         // Only Kitty exposes a remote-control socket for now (KITTY_LISTEN_ON).
         let socket = env["KITTY_LISTEN_ON"]
-        return TerminalInfo(program: program, sessionId: sessionId, tty: tty, bundleId: bundleId, socket: socket)
+        let multiplexer = captureMultiplexerInfo(env: env)
+        return TerminalInfo(
+            program: program, sessionId: sessionId, tty: tty,
+            bundleId: bundleId, socket: socket, multiplexer: multiplexer
+        )
+    }
+
+    /// Detect zellij or tmux from env vars. Checks zellij first, then tmux.
+    private static func captureMultiplexerInfo(env: [String: String]) -> MultiplexerInfo? {
+        // zellij: ZELLIJ_SESSION_NAME + ZELLIJ_PANE_ID
+        if let sessionName = sanitizeTerminalSessionId(env["ZELLIJ_SESSION_NAME"]),
+           let paneId = sanitizeTerminalSessionId(env["ZELLIJ_PANE_ID"]) {
+            return .zellij(sessionName: sessionName, paneId: paneId)
+        }
+        // tmux: $TMUX = "socket_path,pid,session_index", $TMUX_PANE = "%N"
+        if let tmux = env["TMUX"],
+           let paneId = sanitizeTerminalSessionId(env["TMUX_PANE"]),
+           let socket = tmux.split(separator: ",").first.map(String.init),
+           !socket.isEmpty {
+            return .tmux(socket: socket, paneId: paneId)
+        }
+        return nil
     }
 
     /// Validate terminal session IDs to prevent injection via env vars.
-    /// Only allows alphanumeric, hyphens, colons, and periods (covers iTerm2 and Kitty formats).
+    /// Only allows alphanumeric, hyphens, colons, periods, at-signs, underscores, and percent (covers iTerm2, Kitty, and tmux formats).
     private static func sanitizeTerminalSessionId(_ value: String?) -> String? {
         guard let value, !value.isEmpty,
-              value.range(of: #"^[0-9a-zA-Z:.@_-]+$"#, options: .regularExpression) != nil
+              value.range(of: #"^[0-9a-zA-Z:.@_%-]+$"#, options: .regularExpression) != nil
         else { return nil }
         return value
     }

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -77,30 +77,34 @@ struct TerminalInfo: Codable {
 /// Each variant carries exactly the fields needed for its focus command.
 enum MultiplexerInfo: Codable, Equatable {
     /// zellij --session $sessionName action focus-pane-id $paneId
-    case zellij(sessionName: String, paneId: String)
+    case zellij(sessionName: String, paneId: String, binaryPath: String?)
     /// tmux -S $socket select-window -t $paneId && tmux -S $socket select-pane -t $paneId
-    case tmux(socket: String, paneId: String)
+    case tmux(socket: String, paneId: String, binaryPath: String?)
 
     private enum CodingKeys: String, CodingKey {
         case name
         case sessionName = "session_name"
         case paneId = "pane_id"
         case socket
+        case binaryPath = "binary_path"
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let name = try container.decode(String.self, forKey: .name)
+        let binaryPath = try container.decodeIfPresent(String.self, forKey: .binaryPath)
         switch name {
         case "zellij":
             self = .zellij(
                 sessionName: try container.decode(String.self, forKey: .sessionName),
-                paneId: try container.decode(String.self, forKey: .paneId)
+                paneId: try container.decode(String.self, forKey: .paneId),
+                binaryPath: binaryPath
             )
         case "tmux":
             self = .tmux(
                 socket: try container.decode(String.self, forKey: .socket),
-                paneId: try container.decode(String.self, forKey: .paneId)
+                paneId: try container.decode(String.self, forKey: .paneId),
+                binaryPath: binaryPath
             )
         default:
             throw DecodingError.dataCorruptedError(
@@ -113,14 +117,16 @@ enum MultiplexerInfo: Codable, Equatable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
-        case .zellij(let sessionName, let paneId):
+        case .zellij(let sessionName, let paneId, let binaryPath):
             try container.encode("zellij", forKey: .name)
             try container.encode(sessionName, forKey: .sessionName)
             try container.encode(paneId, forKey: .paneId)
-        case .tmux(let socket, let paneId):
+            try container.encodeIfPresent(binaryPath, forKey: .binaryPath)
+        case .tmux(let socket, let paneId, let binaryPath):
             try container.encode("tmux", forKey: .name)
             try container.encode(socket, forKey: .socket)
             try container.encode(paneId, forKey: .paneId)
+            try container.encodeIfPresent(binaryPath, forKey: .binaryPath)
         }
     }
 }

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -51,6 +51,7 @@ struct TerminalInfo: Codable {
     let tty: String?
     let bundleId: String?
     let socket: String? // Remote-control socket (e.g. KITTY_LISTEN_ON)
+    let multiplexer: MultiplexerInfo?
 
     enum CodingKeys: String, CodingKey {
         case program
@@ -58,15 +59,69 @@ struct TerminalInfo: Codable {
         case tty
         case bundleId = "bundle_id"
         case socket
+        case multiplexer
     }
 
     init(program: String = "", sessionId: String? = nil, tty: String? = nil,
-         bundleId: String? = nil, socket: String? = nil) {
+         bundleId: String? = nil, socket: String? = nil, multiplexer: MultiplexerInfo? = nil) {
         self.program = program
         self.sessionId = sessionId
         self.tty = tty
         self.bundleId = bundleId
         self.socket = socket
+        self.multiplexer = multiplexer
+    }
+}
+
+/// Identifies a terminal multiplexer (zellij, tmux) hosting the session.
+/// Each variant carries exactly the fields needed for its focus command.
+enum MultiplexerInfo: Codable, Equatable {
+    /// zellij --session $sessionName action focus-pane-id $paneId
+    case zellij(sessionName: String, paneId: String)
+    /// tmux -S $socket select-window -t $paneId && tmux -S $socket select-pane -t $paneId
+    case tmux(socket: String, paneId: String)
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case sessionName = "session_name"
+        case paneId = "pane_id"
+        case socket
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let name = try container.decode(String.self, forKey: .name)
+        switch name {
+        case "zellij":
+            self = .zellij(
+                sessionName: try container.decode(String.self, forKey: .sessionName),
+                paneId: try container.decode(String.self, forKey: .paneId)
+            )
+        case "tmux":
+            self = .tmux(
+                socket: try container.decode(String.self, forKey: .socket),
+                paneId: try container.decode(String.self, forKey: .paneId)
+            )
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .name, in: container,
+                debugDescription: "Unknown multiplexer: \(name)"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .zellij(let sessionName, let paneId):
+            try container.encode("zellij", forKey: .name)
+            try container.encode(sessionName, forKey: .sessionName)
+            try container.encode(paneId, forKey: .paneId)
+        case .tmux(let socket, let paneId):
+            try container.encode("tmux", forKey: .name)
+            try container.encode(socket, forKey: .socket)
+            try container.encode(paneId, forKey: .paneId)
+        }
     }
 }
 

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -94,7 +94,9 @@ func focusTerminal(session: Session) {
     let muxStrategy = resolveMultiplexerFocus(session: session)
     executeFocusStrategy(strategy)
     if let mux = muxStrategy {
-        executeMultiplexerFocus(mux)
+        DispatchQueue.global(qos: .userInitiated).async {
+            executeMultiplexerFocus(mux)
+        }
     }
     NSApp.deactivate()
 }

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -70,9 +70,9 @@ func resolveFocusStrategy(session: Session) -> FocusStrategy {
 /// Describes how to focus a specific pane inside a terminal multiplexer.
 enum MultiplexerFocusStrategy: Equatable {
     /// zellij --session $sessionName action focus-pane-id $paneId
-    case zellij(sessionName: String, paneId: String)
+    case zellij(sessionName: String, paneId: String, binaryPath: String)
     /// tmux -S $socket select-window -t $paneId && tmux -S $socket select-pane -t $paneId
-    case tmux(socket: String, paneId: String)
+    case tmux(socket: String, paneId: String, binaryPath: String)
 }
 
 /// Resolve multiplexer focus from session info. Returns nil when no multiplexer is present.
@@ -80,10 +80,12 @@ enum MultiplexerFocusStrategy: Equatable {
 func resolveMultiplexerFocus(session: Session) -> MultiplexerFocusStrategy? {
     guard let mux = session.terminal?.multiplexer else { return nil }
     switch mux {
-    case .zellij(let sessionName, let paneId):
-        return .zellij(sessionName: sessionName, paneId: paneId)
-    case .tmux(let socket, let paneId):
-        return .tmux(socket: socket, paneId: paneId)
+    case .zellij(let sessionName, let paneId, let binaryPath):
+        guard let binaryPath else { return nil }
+        return .zellij(sessionName: sessionName, paneId: paneId, binaryPath: binaryPath)
+    case .tmux(let socket, let paneId, let binaryPath):
+        guard let binaryPath else { return nil }
+        return .tmux(socket: socket, paneId: paneId, binaryPath: binaryPath)
     }
 }
 
@@ -265,18 +267,18 @@ private func activateAppByName(_ program: String) -> Bool {
 
 private func executeMultiplexerFocus(_ strategy: MultiplexerFocusStrategy) {
     switch strategy {
-    case .zellij(let sessionName, let paneId):
-        executeZellijFocus(sessionName: sessionName, paneId: paneId)
-    case .tmux(let socket, let paneId):
-        executeTmuxFocus(socket: socket, paneId: paneId)
+    case .zellij(let sessionName, let paneId, let binaryPath):
+        executeZellijFocus(binaryPath: binaryPath, sessionName: sessionName, paneId: paneId)
+    case .tmux(let socket, let paneId, let binaryPath):
+        executeTmuxFocus(binaryPath: binaryPath, socket: socket, paneId: paneId)
     }
 }
 
 // https://zellij.dev/documentation/controlling-zellij-through-cli
-private func executeZellijFocus(sessionName: String, paneId: String) {
+private func executeZellijFocus(binaryPath: String, sessionName: String, paneId: String) {
     let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    process.arguments = ["zellij", "--session", sessionName, "action", "focus-pane-id", paneId]
+    process.executableURL = URL(fileURLWithPath: binaryPath)
+    process.arguments = ["--session", sessionName, "action", "focus-pane-id", paneId]
     process.standardOutput = FileHandle.nullDevice
     process.standardError = FileHandle.nullDevice
     do {
@@ -288,11 +290,11 @@ private func executeZellijFocus(sessionName: String, paneId: String) {
 // https://man.openbsd.org/tmux.1
 // select-window switches to the window containing the pane;
 // select-pane then activates the specific pane within that window.
-private func executeTmuxFocus(socket: String, paneId: String) {
+private func executeTmuxFocus(binaryPath: String, socket: String, paneId: String) {
     for cmd in [["select-window", "-t", paneId], ["select-pane", "-t", paneId]] {
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = ["tmux", "-S", socket] + cmd
+        process.executableURL = URL(fileURLWithPath: binaryPath)
+        process.arguments = ["-S", socket] + cmd
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
         do {

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -65,11 +65,37 @@ func resolveFocusStrategy(session: Session) -> FocusStrategy {
     return .openInFinder(session.projectPath)
 }
 
+// MARK: - Multiplexer focus (independent of emulator focus)
+
+/// Describes how to focus a specific pane inside a terminal multiplexer.
+enum MultiplexerFocusStrategy: Equatable {
+    /// zellij --session $sessionName action focus-pane-id $paneId
+    case zellij(sessionName: String, paneId: String)
+    /// tmux -S $socket select-window -t $paneId && tmux -S $socket select-pane -t $paneId
+    case tmux(socket: String, paneId: String)
+}
+
+/// Resolve multiplexer focus from session info. Returns nil when no multiplexer is present.
+/// Pure function — no side effects, fully testable.
+func resolveMultiplexerFocus(session: Session) -> MultiplexerFocusStrategy? {
+    guard let mux = session.terminal?.multiplexer else { return nil }
+    switch mux {
+    case .zellij(let sessionName, let paneId):
+        return .zellij(sessionName: sessionName, paneId: paneId)
+    case .tmux(let socket, let paneId):
+        return .tmux(socket: socket, paneId: paneId)
+    }
+}
+
 // MARK: - Execution (AppKit side effects)
 
 func focusTerminal(session: Session) {
     let strategy = resolveFocusStrategy(session: session)
+    let muxStrategy = resolveMultiplexerFocus(session: session)
     executeFocusStrategy(strategy)
+    if let mux = muxStrategy {
+        executeMultiplexerFocus(mux)
+    }
     NSApp.deactivate()
 }
 
@@ -229,4 +255,47 @@ private func activateAppByName(_ program: String) -> Bool {
     }
     app.activate()
     return true
+}
+
+// MARK: - Multiplexer focus execution
+// Failures are silently ignored — the emulator was already focused,
+// which is better than nothing.
+
+private func executeMultiplexerFocus(_ strategy: MultiplexerFocusStrategy) {
+    switch strategy {
+    case .zellij(let sessionName, let paneId):
+        executeZellijFocus(sessionName: sessionName, paneId: paneId)
+    case .tmux(let socket, let paneId):
+        executeTmuxFocus(socket: socket, paneId: paneId)
+    }
+}
+
+// https://zellij.dev/documentation/controlling-zellij-through-cli
+private func executeZellijFocus(sessionName: String, paneId: String) {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["zellij", "--session", sessionName, "action", "focus-pane-id", paneId]
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    do {
+        try process.run()
+        process.waitUntilExit()
+    } catch {}
+}
+
+// https://man.openbsd.org/tmux.1
+// select-window switches to the window containing the pane;
+// select-pane then activates the specific pane within that window.
+private func executeTmuxFocus(socket: String, paneId: String) {
+    for cmd in [["select-window", "-t", paneId], ["select-pane", "-t", paneId]] {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["tmux", "-S", socket] + cmd
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {}
+    }
 }

--- a/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
+++ b/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import CctopMenubar
+
+final class MultiplexerFocusTests: XCTestCase {
+
+    // MARK: - resolveMultiplexerFocus
+
+    func testZellijReturnsStrategy() {
+        let session = Session.mock(
+            terminal: TerminalInfo(
+                program: "Ghostty",
+                multiplexer: .zellij(sessionName: "dev", paneId: "terminal_3")
+            )
+        )
+        let strategy = resolveMultiplexerFocus(session: session)
+        XCTAssertEqual(strategy, .zellij(sessionName: "dev", paneId: "terminal_3"))
+    }
+
+    func testTmuxReturnsStrategy() {
+        let session = Session.mock(
+            terminal: TerminalInfo(
+                program: "Ghostty",
+                multiplexer: .tmux(socket: "/tmp/tmux-501/default", paneId: "%3")
+            )
+        )
+        let strategy = resolveMultiplexerFocus(session: session)
+        XCTAssertEqual(strategy, .tmux(socket: "/tmp/tmux-501/default", paneId: "%3"))
+    }
+
+    func testNoMultiplexerReturnsNil() {
+        let session = Session.mock(
+            terminal: TerminalInfo(program: "Ghostty")
+        )
+        let strategy = resolveMultiplexerFocus(session: session)
+        XCTAssertNil(strategy)
+    }
+
+    func testNoTerminalReturnsNil() {
+        let session = Session.mock(terminal: nil)
+        let strategy = resolveMultiplexerFocus(session: session)
+        XCTAssertNil(strategy)
+    }
+
+    // MARK: - MultiplexerInfo Codable round-trip
+
+    func testZellijCodableRoundTrip() throws {
+        let info = MultiplexerInfo.zellij(sessionName: "amzn", paneId: "42")
+        let data = try JSONEncoder().encode(info)
+        let decoded = try JSONDecoder().decode(MultiplexerInfo.self, from: data)
+        XCTAssertEqual(decoded, info)
+    }
+
+    func testTmuxCodableRoundTrip() throws {
+        let info = MultiplexerInfo.tmux(socket: "/tmp/tmux-501/default", paneId: "%3")
+        let data = try JSONEncoder().encode(info)
+        let decoded = try JSONDecoder().decode(MultiplexerInfo.self, from: data)
+        XCTAssertEqual(decoded, info)
+    }
+
+    func testZellijJSONShape() throws {
+        let info = MultiplexerInfo.zellij(sessionName: "dev", paneId: "terminal_1")
+        let data = try JSONEncoder().encode(info)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: String]
+        XCTAssertEqual(json?["name"], "zellij")
+        XCTAssertEqual(json?["session_name"], "dev")
+        XCTAssertEqual(json?["pane_id"], "terminal_1")
+        XCTAssertNil(json?["socket"])
+    }
+
+    func testTmuxJSONShape() throws {
+        let info = MultiplexerInfo.tmux(socket: "/tmp/tmux-501/default", paneId: "%3")
+        let data = try JSONEncoder().encode(info)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: String]
+        XCTAssertEqual(json?["name"], "tmux")
+        XCTAssertEqual(json?["socket"], "/tmp/tmux-501/default")
+        XCTAssertEqual(json?["pane_id"], "%3")
+        XCTAssertNil(json?["session_name"])
+    }
+
+    func testUnknownMultiplexerFailsDecode() {
+        let json = #"{"name":"screen","pane_id":"1"}"#
+        let data = json.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(MultiplexerInfo.self, from: data))
+    }
+
+    // MARK: - Multiplexer focus is independent of emulator focus
+
+    func testEmulatorStrategyUnaffectedByMultiplexer() {
+        // zellij inside Ghostty — emulator strategy should still be activateByName
+        let session = Session.mock(
+            terminal: TerminalInfo(
+                program: "Ghostty",
+                multiplexer: .zellij(sessionName: "dev", paneId: "terminal_1")
+            )
+        )
+        let emulatorStrategy = resolveFocusStrategy(session: session)
+        XCTAssertEqual(emulatorStrategy, .activateByName("ghostty"))
+
+        let muxStrategy = resolveMultiplexerFocus(session: session)
+        XCTAssertEqual(muxStrategy, .zellij(sessionName: "dev", paneId: "terminal_1"))
+    }
+}

--- a/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
+++ b/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
@@ -9,22 +9,36 @@ final class MultiplexerFocusTests: XCTestCase {
         let session = Session.mock(
             terminal: TerminalInfo(
                 program: "Ghostty",
-                multiplexer: .zellij(sessionName: "dev", paneId: "terminal_3")
+                multiplexer: .zellij(sessionName: "dev", paneId: "terminal_3", binaryPath: "/usr/bin/zellij")
             )
         )
         let strategy = resolveMultiplexerFocus(session: session)
-        XCTAssertEqual(strategy, .zellij(sessionName: "dev", paneId: "terminal_3"))
+        XCTAssertEqual(strategy, .zellij(sessionName: "dev", paneId: "terminal_3", binaryPath: "/usr/bin/zellij"))
     }
 
     func testTmuxReturnsStrategy() {
         let session = Session.mock(
             terminal: TerminalInfo(
                 program: "Ghostty",
-                multiplexer: .tmux(socket: "/tmp/tmux-501/default", paneId: "%3")
+                multiplexer: .tmux(socket: "/tmp/tmux-501/default", paneId: "%3", binaryPath: "/opt/homebrew/bin/tmux")
             )
         )
         let strategy = resolveMultiplexerFocus(session: session)
-        XCTAssertEqual(strategy, .tmux(socket: "/tmp/tmux-501/default", paneId: "%3"))
+        XCTAssertEqual(
+            strategy,
+            .tmux(socket: "/tmp/tmux-501/default", paneId: "%3", binaryPath: "/opt/homebrew/bin/tmux")
+        )
+    }
+
+    func testNoBinaryPathReturnsNil() {
+        let session = Session.mock(
+            terminal: TerminalInfo(
+                program: "Ghostty",
+                multiplexer: .zellij(sessionName: "dev", paneId: "terminal_3", binaryPath: nil)
+            )
+        )
+        let strategy = resolveMultiplexerFocus(session: session)
+        XCTAssertNil(strategy)
     }
 
     func testNoMultiplexerReturnsNil() {
@@ -44,36 +58,45 @@ final class MultiplexerFocusTests: XCTestCase {
     // MARK: - MultiplexerInfo Codable round-trip
 
     func testZellijCodableRoundTrip() throws {
-        let info = MultiplexerInfo.zellij(sessionName: "amzn", paneId: "42")
+        let info = MultiplexerInfo.zellij(sessionName: "amzn", paneId: "42", binaryPath: "/usr/bin/zellij")
         let data = try JSONEncoder().encode(info)
         let decoded = try JSONDecoder().decode(MultiplexerInfo.self, from: data)
         XCTAssertEqual(decoded, info)
     }
 
     func testTmuxCodableRoundTrip() throws {
-        let info = MultiplexerInfo.tmux(socket: "/tmp/tmux-501/default", paneId: "%3")
+        let info = MultiplexerInfo.tmux(socket: "/tmp/tmux-501/default", paneId: "%3", binaryPath: "/opt/homebrew/bin/tmux")
+        let data = try JSONEncoder().encode(info)
+        let decoded = try JSONDecoder().decode(MultiplexerInfo.self, from: data)
+        XCTAssertEqual(decoded, info)
+    }
+
+    func testNilBinaryPathCodableRoundTrip() throws {
+        let info = MultiplexerInfo.zellij(sessionName: "dev", paneId: "1", binaryPath: nil)
         let data = try JSONEncoder().encode(info)
         let decoded = try JSONDecoder().decode(MultiplexerInfo.self, from: data)
         XCTAssertEqual(decoded, info)
     }
 
     func testZellijJSONShape() throws {
-        let info = MultiplexerInfo.zellij(sessionName: "dev", paneId: "terminal_1")
+        let info = MultiplexerInfo.zellij(sessionName: "dev", paneId: "terminal_1", binaryPath: "/usr/bin/zellij")
         let data = try JSONEncoder().encode(info)
         let json = try JSONSerialization.jsonObject(with: data) as? [String: String]
         XCTAssertEqual(json?["name"], "zellij")
         XCTAssertEqual(json?["session_name"], "dev")
         XCTAssertEqual(json?["pane_id"], "terminal_1")
+        XCTAssertEqual(json?["binary_path"], "/usr/bin/zellij")
         XCTAssertNil(json?["socket"])
     }
 
     func testTmuxJSONShape() throws {
-        let info = MultiplexerInfo.tmux(socket: "/tmp/tmux-501/default", paneId: "%3")
+        let info = MultiplexerInfo.tmux(socket: "/tmp/tmux-501/default", paneId: "%3", binaryPath: "/opt/homebrew/bin/tmux")
         let data = try JSONEncoder().encode(info)
         let json = try JSONSerialization.jsonObject(with: data) as? [String: String]
         XCTAssertEqual(json?["name"], "tmux")
         XCTAssertEqual(json?["socket"], "/tmp/tmux-501/default")
         XCTAssertEqual(json?["pane_id"], "%3")
+        XCTAssertEqual(json?["binary_path"], "/opt/homebrew/bin/tmux")
         XCTAssertNil(json?["session_name"])
     }
 
@@ -90,13 +113,13 @@ final class MultiplexerFocusTests: XCTestCase {
         let session = Session.mock(
             terminal: TerminalInfo(
                 program: "Ghostty",
-                multiplexer: .zellij(sessionName: "dev", paneId: "terminal_1")
+                multiplexer: .zellij(sessionName: "dev", paneId: "terminal_1", binaryPath: "/usr/bin/zellij")
             )
         )
         let emulatorStrategy = resolveFocusStrategy(session: session)
         XCTAssertEqual(emulatorStrategy, .activateByName("ghostty"))
 
         let muxStrategy = resolveMultiplexerFocus(session: session)
-        XCTAssertEqual(muxStrategy, .zellij(sessionName: "dev", paneId: "terminal_1"))
+        XCTAssertEqual(muxStrategy, .zellij(sessionName: "dev", paneId: "terminal_1", binaryPath: "/usr/bin/zellij"))
     }
 }

--- a/site/index.html
+++ b/site/index.html
@@ -543,6 +543,8 @@
         <div class="chips">
           <span class="chip">iTerm2</span>
           <span class="chip">Kitty<sup>*</sup></span>
+          <span class="chip">Zellij</span>
+          <span class="chip">tmux</span>
         </div>
       </div>
       <div class="tier-row reveal" style="--rd:80ms">


### PR DESCRIPTION
When running inside a multiplexer, cctop additionally focuses the specific pane.
This composes with any terminal emulator above.

I tested it end-to-end locally. I am not really a tmux users anymore, it worked but can't guarantee it works for every case.