### PR TITLE
feat: target a specific Ghostty terminal by working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,19 @@ When you click a session card (or jump via Navigate mode), cctop focuses the hos
 | VS Code, Cursor, Windsurf, Zed | Opens the project (workspace file if present) |
 | iTerm2 | Targets the specific window, tab, and pane |
 | Kitty | Targets the specific window via remote control |
-| Warp, Terminal, Ghostty | Activates the app (no per-tab targeting) |
+| Ghostty | Targets a terminal whose working directory matches the project (best-effort) |
+| Warp, Terminal | Activates the app (no per-tab targeting) |
 | Other | Falls back to opening the project folder in Finder |
 
 > [!NOTE]
-> iTerm2 requires macOS Automation permission. You'll be prompted to grant it on first use.
+> iTerm2 and Ghostty require macOS Automation permission. You'll be prompted to grant it on first use.
 >
 > Kitty requires `allow_remote_control socket-only` and `listen_on` in your `kitty.conf`.
-> Without remote control enabled, Kitty falls back to app activation (same as Warp/Ghostty).
+> Without remote control enabled, Kitty falls back to app activation (same as Warp).
+>
+> Ghostty requires version 1.3.0+ for AppleScript support. Because Ghostty does not
+> yet expose a per-surface env var inside the shell, cctop matches by working
+> directory — ambiguous when multiple Ghostty splits share the same cwd.
 
 ### Terminal Multiplexers
 

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -11,9 +11,6 @@ enum FocusStrategy: Equatable {
     /// Focus a Kitty window via remote control socket, with bundle ID fallback.
     case kitty(socket: String, windowId: String)
     /// Focus a Ghostty terminal by matching its working directory, with a bundle ID fallback.
-    /// Best-effort: Ghostty does not yet expose a per-surface env var inside the shell
-    /// (see ghostty-org/ghostty#9084, #10603), so we cannot do an exact-id match like
-    /// iTerm2/Kitty. When `GHOSTTY_SURFACE_ID` ships, switch to id-based matching here.
     case ghostty(workingDirectory: String)
     /// Activate a running app by its localized name.
     case activateByName(String)
@@ -60,10 +57,6 @@ func resolveFocusStrategy(session: Session) -> FocusStrategy {
         return .kitty(socket: socket, windowId: windowId)
     }
 
-    // Ghostty → AppleScript match on working directory.
-    // Ambiguous when multiple Ghostty splits share the same cwd (picks first); breaks
-    // if the user `cd`s elsewhere in the shell. The script falls back to plain activation
-    // internally when no terminal matches.
     if hostApp == .ghostty {
         return .ghostty(workingDirectory: session.projectPath)
     }
@@ -170,8 +163,14 @@ func extractITermGUID(from sessionId: String?) -> String? {
     return String(id[id.index(after: colonIndex)...])
 }
 
+private func runAppleScript(_ source: String) -> Bool {
+    var error: NSDictionary?
+    NSAppleScript(source: source)?.executeAndReturnError(&error)
+    return error == nil
+}
+
 private func executeITerm2Script(guid: String) -> Bool {
-    let script = """
+    runAppleScript("""
     tell application "iTerm2"
         activate
         repeat with w in windows
@@ -192,18 +191,22 @@ private func executeITerm2Script(guid: String) -> Bool {
             end tell
         end repeat
     end tell
-    """
-    var error: NSDictionary?
-    NSAppleScript(source: script)?.executeAndReturnError(&error)
-    return error == nil
+    """)
 }
 
 // MARK: - Ghostty AppleScript
 // Ghostty 1.3.0+ exposes an AppleScript API (windows → tabs → terminals).
 // Each `terminal` (= one split/pane) has `id`, `name`, `working directory`.
-// No env var carries the terminal id into the shell yet, so we match on cwd.
-// FUTURE: when ghostty-org/ghostty#10603 ships GHOSTTY_SURFACE_ID, capture it
-// in HookHandler.captureTerminalInfo() and switch this script to `whose id is …`
+// No env var carries the terminal id into the shell yet, so we match on cwd —
+// best-effort: ambiguous when multiple Ghostty splits share the same cwd
+// (picks first), and breaks if the user `cd`s elsewhere after session start.
+// The script's leading `activate` covers the no-match case (plain app focus),
+// so a separate fallback isn't needed unless the script itself errors.
+// Tracked upstream:
+//   - ghostty-org/ghostty#9084  (TERM_SESSION_ID request)
+//   - ghostty-org/ghostty#10603 (GHOSTTY_SURFACE_ID env var + URL scheme)
+// FUTURE: when GHOSTTY_SURFACE_ID ships, capture it in
+// HookHandler.captureTerminalInfo() and switch this script to `whose id is …`
 // for an exact, unambiguous match (analogous to iTerm2's GUID strategy).
 
 /// Escape a string for safe interpolation inside an AppleScript double-quoted literal.
@@ -214,7 +217,7 @@ func escapeAppleScriptString(_ value: String) -> String {
 
 private func executeGhosttyFocusScript(workingDirectory: String) -> Bool {
     let escaped = escapeAppleScriptString(workingDirectory)
-    let script = """
+    return runAppleScript("""
     tell application "Ghostty"
         activate
         set matches to (every terminal whose working directory is "\(escaped)")
@@ -223,10 +226,7 @@ private func executeGhosttyFocusScript(workingDirectory: String) -> Bool {
             return
         end if
     end tell
-    """
-    var error: NSDictionary?
-    NSAppleScript(source: script)?.executeAndReturnError(&error)
-    return error == nil
+    """)
 }
 
 // MARK: - Kitty Remote Control

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -207,8 +207,8 @@ private func executeITerm2Script(guid: String) -> Bool {
 // for an exact, unambiguous match (analogous to iTerm2's GUID strategy).
 
 /// Escape a string for safe interpolation inside an AppleScript double-quoted literal.
-func escapeAppleScriptString(_ s: String) -> String {
-    s.replacingOccurrences(of: "\\", with: "\\\\")
+func escapeAppleScriptString(_ value: String) -> String {
+    value.replacingOccurrences(of: "\\", with: "\\\\")
         .replacingOccurrences(of: "\"", with: "\\\"")
 }
 

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -10,6 +10,11 @@ enum FocusStrategy: Equatable {
     case iTerm2(guid: String)
     /// Focus a Kitty window via remote control socket, with bundle ID fallback.
     case kitty(socket: String, windowId: String)
+    /// Focus a Ghostty terminal by matching its working directory, with a bundle ID fallback.
+    /// Best-effort: Ghostty does not yet expose a per-surface env var inside the shell
+    /// (see ghostty-org/ghostty#9084, #10603), so we cannot do an exact-id match like
+    /// iTerm2/Kitty. When `GHOSTTY_SURFACE_ID` ships, switch to id-based matching here.
+    case ghostty(workingDirectory: String)
     /// Activate a running app by its localized name.
     case activateByName(String)
     /// Activate a running app by its bundle identifier.
@@ -53,6 +58,14 @@ func resolveFocusStrategy(session: Session) -> FocusStrategy {
        let socket = terminal.socket,
        let windowId = terminal.sessionId {
         return .kitty(socket: socket, windowId: windowId)
+    }
+
+    // Ghostty → AppleScript match on working directory.
+    // Ambiguous when multiple Ghostty splits share the same cwd (picks first); breaks
+    // if the user `cd`s elsewhere in the shell. The script falls back to plain activation
+    // internally when no terminal matches.
+    if hostApp == .ghostty {
+        return .ghostty(workingDirectory: session.projectPath)
     }
 
     // Try activation by name, then bundle ID, then Finder
@@ -131,6 +144,13 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
             }
         }
 
+    case .ghostty(let workingDirectory):
+        if !executeGhosttyFocusScript(workingDirectory: workingDirectory) {
+            if let bundleID = HostApp.ghostty.bundleID {
+                activateAppByBundleID(bundleID)
+            }
+        }
+
     case .activateByName(let name):
         activateAppByName(name)
 
@@ -171,6 +191,37 @@ private func executeITerm2Script(guid: String) -> Bool {
                 end repeat
             end tell
         end repeat
+    end tell
+    """
+    var error: NSDictionary?
+    NSAppleScript(source: script)?.executeAndReturnError(&error)
+    return error == nil
+}
+
+// MARK: - Ghostty AppleScript
+// Ghostty 1.3.0+ exposes an AppleScript API (windows → tabs → terminals).
+// Each `terminal` (= one split/pane) has `id`, `name`, `working directory`.
+// No env var carries the terminal id into the shell yet, so we match on cwd.
+// FUTURE: when ghostty-org/ghostty#10603 ships GHOSTTY_SURFACE_ID, capture it
+// in HookHandler.captureTerminalInfo() and switch this script to `whose id is …`
+// for an exact, unambiguous match (analogous to iTerm2's GUID strategy).
+
+/// Escape a string for safe interpolation inside an AppleScript double-quoted literal.
+func escapeAppleScriptString(_ s: String) -> String {
+    s.replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "\"", with: "\\\"")
+}
+
+private func executeGhosttyFocusScript(workingDirectory: String) -> Bool {
+    let escaped = escapeAppleScriptString(workingDirectory)
+    let script = """
+    tell application "Ghostty"
+        activate
+        set matches to (every terminal whose working directory is "\(escaped)")
+        if (count of matches) > 0 then
+            focus (item 1 of matches)
+            return
+        end if
     end tell
     """
     var error: NSDictionary?

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -144,10 +144,44 @@ final class FocusStrategyTests: XCTestCase {
         XCTAssertEqual(strategy, .activateByName("warp"))
     }
 
-    func testGhosttyUsesActivateByName() {
+    func testGhosttyUsesAppleScriptWithWorkingDirectory() {
         let session = makeSession(program: "Ghostty")
         let strategy = resolveFocusStrategy(session: session)
-        XCTAssertEqual(strategy, .activateByName("ghostty"))
+        XCTAssertEqual(strategy, .ghostty(workingDirectory: projectPath))
+    }
+
+    func testGhosttyDetectedByBundleIdWhenProgramDiffers() {
+        // User runs a multiplexer (e.g. tmux) inside Ghostty — TERM_PROGRAM may not
+        // say "ghostty", but __CFBundleIdentifier still does.
+        let session = makeSession(program: "tmux", bundleId: "com.mitchellh.ghostty")
+        let strategy = resolveFocusStrategy(session: session)
+        XCTAssertEqual(strategy, .ghostty(workingDirectory: projectPath))
+    }
+
+    // MARK: - AppleScript path escaping
+
+    func testGhosttyEscapesQuotesInPath() {
+        XCTAssertEqual(
+            escapeAppleScriptString(#"/Users/test/has"quote"#),
+            #"/Users/test/has\"quote"#
+        )
+    }
+
+    func testGhosttyEscapesBackslashesInPath() {
+        XCTAssertEqual(
+            escapeAppleScriptString(#"/Users/test/back\slash"#),
+            #"/Users/test/back\\slash"#
+        )
+    }
+
+    func testGhosttyEscapesBackslashesBeforeQuotes() {
+        // Backslashes must be escaped first so that an existing `\` doesn't pair up
+        // with the escape character we add for `"`, producing `\\"` (legal) rather
+        // than `\\\"` (also legal but produced by wrong order would yield `\"\"`).
+        XCTAssertEqual(
+            escapeAppleScriptString(#"a\b"c"#),
+            #"a\\b\"c"#
+        )
     }
 
     func testAppleTerminalUsesActivateByName() {

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -175,9 +175,8 @@ final class FocusStrategyTests: XCTestCase {
     }
 
     func testGhosttyEscapesBackslashesBeforeQuotes() {
-        // Backslashes must be escaped first so that an existing `\` doesn't pair up
-        // with the escape character we add for `"`, producing `\\"` (legal) rather
-        // than `\\\"` (also legal but produced by wrong order would yield `\"\"`).
+        // Backslashes must be escaped first; otherwise the second pass would
+        // re-escape the backslashes we just inserted to escape quotes.
         XCTAssertEqual(
             escapeAppleScriptString(#"a\b"c"#),
             #"a\\b\"c"#

--- a/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
+++ b/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
@@ -109,7 +109,8 @@ final class MultiplexerFocusTests: XCTestCase {
     // MARK: - Multiplexer focus is independent of emulator focus
 
     func testEmulatorStrategyUnaffectedByMultiplexer() {
-        // zellij inside Ghostty — emulator strategy should still be activateByName
+        // zellij inside Ghostty — emulator strategy and multiplexer focus are
+        // resolved independently from the same session.
         let session = Session.mock(
             terminal: TerminalInfo(
                 program: "Ghostty",
@@ -117,7 +118,7 @@ final class MultiplexerFocusTests: XCTestCase {
             )
         )
         let emulatorStrategy = resolveFocusStrategy(session: session)
-        XCTAssertEqual(emulatorStrategy, .activateByName("ghostty"))
+        XCTAssertEqual(emulatorStrategy, .ghostty(workingDirectory: "/Users/test/projects/cctop"))
 
         let muxStrategy = resolveMultiplexerFocus(session: session)
         XCTAssertEqual(muxStrategy, .zellij(sessionName: "dev", paneId: "terminal_1", binaryPath: "/usr/bin/zellij"))

--- a/raycast/src/actions.ts
+++ b/raycast/src/actions.ts
@@ -21,6 +21,33 @@ function isValidGUID(s: string): boolean {
   return /^[0-9a-fA-F-]+$/.test(s);
 }
 
+/** Escape a string for safe interpolation inside an AppleScript double-quoted literal. */
+function escapeAppleScriptString(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Build the AppleScript to focus a Ghostty terminal whose working directory matches.
+ * Mirrors executeGhosttyFocusScript() in FocusTerminal.swift.
+ *
+ * Best-effort: Ghostty does not yet expose a per-surface env var inside the shell
+ * (see ghostty-org/ghostty#9084, #10603), so we cannot do an exact-id match like
+ * iTerm2/Kitty. When GHOSTTY_SURFACE_ID ships, switch to id-based matching.
+ */
+function buildGhosttyScript(workingDirectory: string): string {
+  const escaped = escapeAppleScriptString(workingDirectory);
+  return `
+    tell application "Ghostty"
+      activate
+      set matches to (every terminal whose working directory is "${escaped}")
+      if (count of matches) > 0 then
+        focus (item 1 of matches)
+        return
+      end if
+    end tell
+  `;
+}
+
 /**
  * Build the AppleScript to focus a specific iTerm2 session by GUID.
  * Matches the AppleScript in FocusTerminal.swift:focusITerm2Session().
@@ -97,7 +124,13 @@ export async function jumpToSession(session: CctopSession): Promise<void> {
     } else if (program.includes("warp")) {
       execFileSync("open", ["-a", "Warp"]);
     } else if (program.includes("ghostty")) {
-      execFileSync("open", ["-a", "Ghostty"]);
+      // Ghostty 1.3.0+ exposes AppleScript; match the terminal by working directory
+      // and fall back to plain activation if no terminal matches or the script errors.
+      try {
+        execFileSync("osascript", ["-e", buildGhosttyScript(session.project_path)]);
+      } catch {
+        execFileSync("open", ["-a", "Ghostty"]);
+      }
     } else if (session.terminal?.program) {
       // Generic terminal: try activating the app by name first (matches Swift's activateAppByName)
       try {

--- a/raycast/src/actions.ts
+++ b/raycast/src/actions.ts
@@ -102,7 +102,14 @@ export function getTerminalLabel(session: CctopSession): string {
 export async function jumpToSession(session: CctopSession): Promise<void> {
   try {
     const program = session.terminal?.program?.toLowerCase() ?? "";
+    const bundleId = session.terminal?.bundle_id ?? "";
     const target = session.workspace_file ?? session.project_path;
+
+    // Bundle ID is more reliable than TERM_PROGRAM: when a multiplexer (tmux,
+    // zellij) runs inside Ghostty, TERM_PROGRAM becomes the multiplexer name
+    // while __CFBundleIdentifier still identifies the host emulator. Mirrors
+    // HostApp.from(bundleIdentifier:) in the Swift menubar app.
+    const isGhostty = program.includes("ghostty") || bundleId === "com.mitchellh.ghostty";
 
     if (
       program.includes("code") ||
@@ -123,7 +130,7 @@ export async function jumpToSession(session: CctopSession): Promise<void> {
       }
     } else if (program.includes("warp")) {
       execFileSync("open", ["-a", "Warp"]);
-    } else if (program.includes("ghostty")) {
+    } else if (isGhostty) {
       // Ghostty 1.3.0+ exposes AppleScript; match the terminal by working directory
       // and fall back to plain activation if no terminal matches or the script errors.
       try {

--- a/raycast/src/types.ts
+++ b/raycast/src/types.ts
@@ -16,6 +16,7 @@ export interface TerminalInfo {
   program: string;
   session_id?: string | null;
   tty?: string | null;
+  bundle_id?: string | null;
 }
 
 export interface SubagentInfo {

--- a/site/index.html
+++ b/site/index.html
@@ -543,6 +543,7 @@
         <div class="chips">
           <span class="chip">iTerm2</span>
           <span class="chip">Kitty<sup>*</sup></span>
+          <span class="chip">Ghostty<sup>&dagger;</sup></span>
           <span class="chip">Zellij</span>
           <span class="chip">tmux</span>
         </div>
@@ -567,11 +568,12 @@
         <div class="chips">
           <span class="chip">Warp</span>
           <span class="chip">Terminal</span>
-          <span class="chip">Ghostty</span>
         </div>
       </div>
       <p class="tier-footnote" style="font-size:.85rem;color:var(--c-muted);margin-top:8px">
         *&thinsp;Kitty targets the exact window when <a href="https://sw.kovidgoyal.net/kitty/remote-control/" target="_blank" rel="noopener noreferrer"><code>remote control</code></a> is enabled in kitty.conf. Without it, falls back to app activation.
+        <br>
+        &dagger;&thinsp;Ghostty 1.3.0+ targets a terminal by working directory via AppleScript. Ambiguous if multiple Ghostty splits share the same cwd; falls back to app activation otherwise.
       </p>
     </div>
 


### PR DESCRIPTION
## Summary

- Ghostty 1.3.0+ exposes an AppleScript API. cctop now finds the terminal whose `working directory` matches the session project path and `focus`es it, falling back to plain app activation when no match is found.
- Mirrors iTerm2/Kitty pattern: a new `FocusStrategy.ghostty(workingDirectory:)` case, an `executeGhosttyFocusScript` helper, parallel logic in the Raycast extension, and updated docs.

## Why best-effort (and the future improvement)

Ghostty does not yet expose a per-surface env var inside the shell, so cctop can't capture a stable terminal ID at hook time the way it does for iTerm2 (`ITERM_SESSION_ID`) and Kitty (`KITTY_WINDOW_ID`). Matching by working directory is ambiguous when multiple Ghostty splits share the same `cwd`, and breaks if the user `cd`s the shell elsewhere after starting the session.

Tracked upstream:
- [ghostty-org/ghostty#9084](https://github.com/ghostty-org/ghostty/discussions/9084) — TERM_SESSION_ID request (open)
- [ghostty-org/ghostty#10603](https://github.com/ghostty-org/ghostty/discussions/10603) — `GHOSTTY_SURFACE_ID` env var + `ghostty://present-surface/0x...` URL scheme (WIP, Feb–Apr 2026)

When `GHOSTTY_SURFACE_ID` ships, switch `HookHandler.captureTerminalInfo()` to capture it and replace the `whose working directory is …` filter with `whose id is …`. Internal `FUTURE:` comments in `FocusTerminal.swift` and `raycast/src/actions.ts` mark the spots.

## Files changed

- `menubar/CctopMenubar/Services/FocusTerminal.swift` — new `.ghostty(workingDirectory:)` strategy + AppleScript executor + path-escaping helper
- `menubar/CctopMenubarTests/FocusStrategyTests.swift` — replaced stale `testGhosttyUsesActivateByName`; new tests for resolution, bundle-ID detection (e.g. tmux inside Ghostty), and AppleScript path escaping
- `raycast/src/actions.ts` — mirrors the Swift change so the Raycast extension targets the same terminal
- `README.md` + `site/index.html` — Ghostty moved to the "Targets the exact pane" tier with a footnote about the working-directory caveat and the 1.3.0+ requirement

## Test plan

- [x] CI builds (`make build` on macOS runner)
- [x] CI runs Swift tests (`FocusStrategyTests`)
- [x] CI lints (`swiftlint --strict`)
- [ ] Raycast `npx ray lint` (if part of CI)
- [ ] Manual: run a Claude Code session inside a Ghostty split and click its card — Ghostty should come forward with that split focused
- [ ] Manual: open two splits in the same project; verify cctop focuses one of them (ambiguous-but-acceptable case)
- [ ] Manual: with no Ghostty terminal matching the project path, verify fallback to plain app activation

https://claude.ai/code/session_01HnZSsBuob7N7iAS6maMyTP

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnZSsBuob7N7iAS6maMyTP)_