### PR TITLE
Fix settings overlay height flicker during session updates

### DIFF
--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -11,6 +11,7 @@ enum PopupTab {
 }
 
 private let overlayAnimationDuration: TimeInterval = 0.2
+private let popupContentHeight: CGFloat = 290
 
 struct PopupView: View {
     let sessions: [Session]
@@ -55,6 +56,7 @@ struct PopupView: View {
                     case .recent: recentContent
                     }
                 }
+                .frame(maxWidth: .infinity)
                 .opacity(overlayController.hideContent ? 0 : 1)
                 .animation(.none, value: overlayController.hideContent)
                 if let overlay = overlayController.active {
@@ -71,6 +73,7 @@ struct PopupView: View {
                     }
                 }
             }
+            .frame(minHeight: overlayController.active != nil ? popupContentHeight : 0)
             .clipped()
             .animation(.easeInOut(duration: overlayAnimationDuration), value: overlayController.active)
             Divider()
@@ -161,7 +164,7 @@ struct PopupView: View {
                         }
                         .padding(.vertical, 4)
                     }
-                    .frame(maxHeight: 290)
+                    .frame(maxHeight: popupContentHeight)
                     .onChange(of: selectedIndex) { newIndex in
                         guard selectedTab == .active,
                               let idx = newIndex, idx < sortedSessions.count else { return }
@@ -203,7 +206,7 @@ struct PopupView: View {
                     }
                     .padding(.vertical, 4)
                 }
-                .frame(maxHeight: 290)
+                .frame(maxHeight: popupContentHeight)
                 .onChange(of: selectedIndex) { newIndex in
                     guard selectedTab == .recent,
                           let idx = newIndex, idx < recentProjects.count else { return }


### PR DESCRIPTION
### Motivation

Prevent the settings/about overlay from flickering when the underlying session list resizes while the overlay is open. The overlay uses `.frame(maxHeight: .infinity)` to cover the underlying content, so the ZStack's `max-of-children` size — and therefore the overlay's rendered height — was tracking session changes in real time.

### Description

Lock the popup container's `minHeight` to `popupContentHeight` (290) only while an overlay is active. The lock is computed directly from `overlayController.active` in the body, so the un-lock and the overlay's `.transition(...)` removal share a single SwiftUI animation transaction — the parent's layout change animates in lockstep with the overlay's roll-up rather than as a separate step ([SwiftUI Lab — Advanced Transitions](https://swiftui-lab.com/advanced-transitions/)).

The lock value is the same as the inner `ScrollView.maxHeight` cap, so when the overlay is active the ZStack's max-of-children resolves to a stable value regardless of how the session list grows or shrinks underneath — no measurement is required. The three `290` literals (overlay min-height + active/recent ScrollView `maxHeight`) are unified under the new `popupContentHeight` constant to make that contract explicit.

When no overlay is active, `minHeight` is `0` so the popup retains its natural compact size for the empty / few-sessions states.

### Testing

- Manual verification: opened/closed Settings and About overlays from the popup; close is one continuous motion. Verified flicker is gone by triggering session updates while Settings is open.
- `make build` and `make lint` (SwiftLint strict) pass.
- No automated UI/animation tests added — animations aren't covered by the existing snapshot tests.