### PR TITLE
fix(focus): raise the right Ghostty window when multiple are open

### DIFF
--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -201,8 +201,14 @@ private func executeITerm2Script(guid: String) -> Bool {
 // No env var carries the terminal id into the shell yet, so we match on cwd —
 // best-effort: ambiguous when multiple Ghostty splits share the same cwd
 // (picks first), and breaks if the user `cd`s elsewhere after session start.
-// The script's leading `activate` covers the no-match case (plain app focus),
-// so a separate fallback isn't needed unless the script itself errors.
+//
+// We walk windows → tabs → terminals (instead of `every terminal whose …`) so
+// we keep a reference to the parent window, then call `activate window` on it
+// before focusing the surface. The leading `activate` only raises whichever
+// Ghostty window was most recently active, so without the explicit
+// `activate window w` the wrong window can stay on top when the user clicks
+// a session whose window is sitting behind another Ghostty window.
+//
 // Tracked upstream:
 //   - ghostty-org/ghostty#9084  (TERM_SESSION_ID request)
 //   - ghostty-org/ghostty#10603 (GHOSTTY_SURFACE_ID env var + URL scheme)
@@ -221,11 +227,18 @@ private func executeGhosttyFocusScript(workingDirectory: String) -> Bool {
     return runAppleScript("""
     tell application "Ghostty"
         activate
-        set matches to (every terminal whose working directory is "\(escaped)")
-        if (count of matches) > 0 then
-            focus (item 1 of matches)
-            return
-        end if
+        repeat with w in windows
+            repeat with t in tabs of w
+                repeat with term in terminals of t
+                    if working directory of term is "\(escaped)" then
+                        activate window w
+                        select tab t
+                        focus term
+                        return
+                    end if
+                end repeat
+            end repeat
+        end repeat
     end tell
     """)
 }

--- a/raycast/src/actions.ts
+++ b/raycast/src/actions.ts
@@ -30,6 +30,12 @@ function escapeAppleScriptString(s: string): string {
  * Build the AppleScript to focus a Ghostty terminal whose working directory matches.
  * Mirrors executeGhosttyFocusScript() in FocusTerminal.swift.
  *
+ * We walk windows → tabs → terminals so we keep a reference to the parent window
+ * and call `activate window w` on it before focusing the surface. Without the
+ * explicit window activation, the leading `activate` only raises whichever
+ * Ghostty window was most recently active — so a click on a session whose
+ * window is behind another Ghostty window leaves the wrong window on top.
+ *
  * Best-effort: Ghostty does not yet expose a per-surface env var inside the shell
  * (see ghostty-org/ghostty#9084, #10603), so we cannot do an exact-id match like
  * iTerm2/Kitty. When GHOSTTY_SURFACE_ID ships, switch to id-based matching.
@@ -39,11 +45,18 @@ function buildGhosttyScript(workingDirectory: string): string {
   return `
     tell application "Ghostty"
       activate
-      set matches to (every terminal whose working directory is "${escaped}")
-      if (count of matches) > 0 then
-        focus (item 1 of matches)
-        return
-      end if
+      repeat with w in windows
+        repeat with t in tabs of w
+          repeat with term in terminals of t
+            if working directory of term is "${escaped}" then
+              activate window w
+              select tab t
+              focus term
+              return
+            end if
+          end repeat
+        end repeat
+      end repeat
     end tell
   `;
 }


### PR DESCRIPTION
The previous Ghostty AppleScript queried `every terminal whose working
directory is X` and called `focus` on the first match. With two Ghostty
windows open in different projects (foo and bar), clicking the bar
session would leave the foo window on top: the leading `activate` raises
whichever Ghostty window was most recently active, and `focus` on a
terminal does not reliably bring its parent window forward in z-order.

Walk windows -> tabs -> terminals instead, so we hold the parent window
reference, then call `activate window w` (Ghostty's documented
"Bring a window to the front" command) before focusing the surface.
This mirrors the iTerm2 path's `set index of w to 1` pattern, which the
user already reports works correctly with multiple windows.

Apply the same fix to the Raycast extension's `buildGhosttyScript`.