### PR TITLE
fix(focus): prime Ghostty cwd via OSC 7 before AppleScript match

### DIFF
--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -140,7 +140,16 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
             }
         }
 
-    case .ghostty(let workingDirectory, _):
+    case .ghostty(let workingDirectory, let tty):
+        // Prime Ghostty's AppleScript-tracked cwd before matching against it.
+        // Ghostty learns cwd via OSC 7 from the shell, but some shell setups
+        // (e.g. nix/Shopify-world bash→zsh wrappers) don't load Ghostty's
+        // shell integration, so the only cwd Ghostty knows is whatever the
+        // surface launched in. Without this prime, the match loop below fails
+        // and we fall back to plain `activate`, raising the wrong window/tab.
+        if let tty {
+            primeGhosttyCWD(tty: tty, workingDirectory: workingDirectory)
+        }
         if !executeGhosttyFocusScript(workingDirectory: workingDirectory) {
             if let bundleID = HostApp.ghostty.bundleID {
                 activateAppByBundleID(bundleID)
@@ -204,6 +213,12 @@ private func executeITerm2Script(guid: String) -> Bool {
 // best-effort: ambiguous when multiple Ghostty splits share the same cwd
 // (picks first), and breaks if the user `cd`s elsewhere after session start.
 //
+// Before running the AppleScript we write an OSC 7 cwd report directly to the
+// session's TTY (captured at hook time, e.g. /dev/ttys011). Ghostty parses OSC 7
+// off the PTY master and updates `working directory of term`. This makes the
+// match deterministic even when the shell never emits OSC 7 itself (e.g. when
+// Ghostty's shell integration isn't loaded by a wrapper-launched shell).
+//
 // We walk windows → tabs → terminals (instead of `every terminal whose …`) so
 // we keep a reference to the parent window, then call `activate window` on it
 // before focusing the surface. The leading `activate` only raises whichever
@@ -256,6 +271,19 @@ private func executeGhosttyFocusScript(workingDirectory: String) -> Bool {
         end repeat
     end tell
     """)
+}
+
+/// Write an OSC 7 cwd report to the given TTY device file.
+/// Bytes written to the slave (`/dev/ttysNNN`) appear on the PTY master where the
+/// emulator parses them — the shell does NOT see this write. Silently no-ops on
+/// any I/O failure (TTY may have closed if the session just ended).
+private func primeGhosttyCWD(tty: String, workingDirectory: String) {
+    let host = ProcessInfo.processInfo.hostName
+    let osc = buildOSC7CWD(host: host, workingDirectory: workingDirectory)
+    guard let data = osc.data(using: .utf8) else { return }
+    guard let handle = FileHandle(forWritingAtPath: tty) else { return }
+    defer { try? handle.close() }
+    try? handle.write(contentsOf: data)
 }
 
 // MARK: - Kitty Remote Control

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -264,9 +264,10 @@ private func executeGhosttyFocusScript(workingDirectory: String) -> Bool {
 /// parses them; the shell does not see them. Best-effort — silently no-ops if the TTY
 /// has closed (session just ended).
 private func primeGhosttyCWD(tty: String, workingDirectory: String) {
-    // Refuse to write unless the path is a character device. Session files live
-    // under CCTOP_SESSIONS_DIR (user-writable); a malicious or stale tty pointing
-    // at a regular file would otherwise be opened and partially overwritten.
+    // Allow only PTY slaves (`/dev/ttys<digits>`) — that's the only shape
+    // cctop-hook captures from `ps -o tty=`. This rejects /dev/cu.*, /dev/console,
+    // and arbitrary file paths a tampered session JSON might supply.
+    guard tty.range(of: #"^/dev/ttys\d+$"#, options: .regularExpression) != nil else { return }
     guard let attrs = try? FileManager.default.attributesOfItem(atPath: tty),
           (attrs[.type] as? FileAttributeType) == .typeCharacterSpecial else { return }
     let host = ProcessInfo.processInfo.hostName

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -224,6 +224,19 @@ func escapeAppleScriptString(_ value: String) -> String {
         .replacingOccurrences(of: "\"", with: "\\\"")
 }
 
+/// Build an OSC 7 escape sequence (`ESC ] 7 ; file://HOST/PATH BEL`) reporting cwd
+/// to a terminal emulator. Ghostty (and most modern terminals) tracks the per-window
+/// cwd from this sequence; the shell normally emits it on `chpwd`, but we emit it
+/// ourselves to handle environments where Ghostty's shell integration isn't loaded.
+///
+/// Path is URL-encoded so spaces / non-ASCII don't break the URI form.
+/// Internal (not private) so the unit tests can reach it.
+func buildOSC7CWD(host: String, workingDirectory: String) -> String {
+    let encoded = workingDirectory
+        .addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? workingDirectory
+    return "\u{1B}]7;file://\(host)\(encoded)\u{07}"
+}
+
 private func executeGhosttyFocusScript(workingDirectory: String) -> Bool {
     let escaped = escapeAppleScriptString(workingDirectory)
     return runAppleScript("""

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -11,9 +11,7 @@ enum FocusStrategy: Equatable {
     /// Focus a Kitty window via remote control socket, with bundle ID fallback.
     case kitty(socket: String, windowId: String, binaryPath: String)
     /// Focus a Ghostty terminal by matching its working directory, with a bundle ID fallback.
-    /// Carries the session's TTY so the executor can prime Ghostty's tracked cwd via OSC 7
-    /// before the AppleScript runs (Ghostty's shell integration may not fire in all environments).
-    case ghostty(workingDirectory: String, tty: String?)
+    case ghostty(workingDirectory: String)
     /// Activate a running app by its localized name.
     case activateByName(String)
     /// Activate a running app by its bundle identifier.
@@ -61,7 +59,7 @@ func resolveFocusStrategy(session: Session) -> FocusStrategy {
     }
 
     if hostApp == .ghostty {
-        return .ghostty(workingDirectory: session.projectPath, tty: terminal.tty)
+        return .ghostty(workingDirectory: session.projectPath)
     }
 
     // Try activation by name, then bundle ID, then Finder
@@ -103,6 +101,9 @@ func resolveMultiplexerFocus(session: Session) -> MultiplexerFocusStrategy? {
 func focusTerminal(session: Session) {
     let strategy = resolveFocusStrategy(session: session)
     let muxStrategy = resolveMultiplexerFocus(session: session)
+    if case .ghostty(let cwd) = strategy, let tty = session.terminal?.tty {
+        primeGhosttyCWD(tty: tty, workingDirectory: cwd)
+    }
     executeFocusStrategy(strategy)
     if let mux = muxStrategy {
         DispatchQueue.global(qos: .userInitiated).async {
@@ -140,16 +141,7 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
             }
         }
 
-    case .ghostty(let workingDirectory, let tty):
-        // Prime Ghostty's AppleScript-tracked cwd before matching against it.
-        // Ghostty learns cwd via OSC 7 from the shell, but some shell setups
-        // (e.g. nix/Shopify-world bash→zsh wrappers) don't load Ghostty's
-        // shell integration, so the only cwd Ghostty knows is whatever the
-        // surface launched in. Without this prime, the match loop below fails
-        // and we fall back to plain `activate`, raising the wrong window/tab.
-        if let tty {
-            primeGhosttyCWD(tty: tty, workingDirectory: workingDirectory)
-        }
+    case .ghostty(let workingDirectory):
         if !executeGhosttyFocusScript(workingDirectory: workingDirectory) {
             if let bundleID = HostApp.ghostty.bundleID {
                 activateAppByBundleID(bundleID)
@@ -239,13 +231,8 @@ func escapeAppleScriptString(_ value: String) -> String {
         .replacingOccurrences(of: "\"", with: "\\\"")
 }
 
-/// Build an OSC 7 escape sequence (`ESC ] 7 ; file://HOST/PATH BEL`) reporting cwd
-/// to a terminal emulator. Ghostty (and most modern terminals) tracks the per-window
-/// cwd from this sequence; the shell normally emits it on `chpwd`, but we emit it
-/// ourselves to handle environments where Ghostty's shell integration isn't loaded.
-///
+/// Build the OSC 7 byte sequence (`ESC ] 7 ; file://HOST/PATH BEL`).
 /// Path is URL-encoded so spaces / non-ASCII don't break the URI form.
-/// Internal (not private) so the unit tests can reach it.
 func buildOSC7CWD(host: String, workingDirectory: String) -> String {
     let encoded = workingDirectory
         .addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? workingDirectory
@@ -273,10 +260,9 @@ private func executeGhosttyFocusScript(workingDirectory: String) -> Bool {
     """)
 }
 
-/// Write an OSC 7 cwd report to the given TTY device file.
-/// Bytes written to the slave (`/dev/ttysNNN`) appear on the PTY master where the
-/// emulator parses them — the shell does NOT see this write. Silently no-ops on
-/// any I/O failure (TTY may have closed if the session just ended).
+/// Bytes written to the slave (`/dev/ttysNNN`) appear on the PTY master where Ghostty
+/// parses them; the shell does not see them. Best-effort — silently no-ops if the TTY
+/// has closed (session just ended).
 private func primeGhosttyCWD(tty: String, workingDirectory: String) {
     let host = ProcessInfo.processInfo.hostName
     let osc = buildOSC7CWD(host: host, workingDirectory: workingDirectory)

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -11,7 +11,9 @@ enum FocusStrategy: Equatable {
     /// Focus a Kitty window via remote control socket, with bundle ID fallback.
     case kitty(socket: String, windowId: String, binaryPath: String)
     /// Focus a Ghostty terminal by matching its working directory, with a bundle ID fallback.
-    case ghostty(workingDirectory: String)
+    /// Carries the session's TTY so the executor can prime Ghostty's tracked cwd via OSC 7
+    /// before the AppleScript runs (Ghostty's shell integration may not fire in all environments).
+    case ghostty(workingDirectory: String, tty: String?)
     /// Activate a running app by its localized name.
     case activateByName(String)
     /// Activate a running app by its bundle identifier.
@@ -59,7 +61,7 @@ func resolveFocusStrategy(session: Session) -> FocusStrategy {
     }
 
     if hostApp == .ghostty {
-        return .ghostty(workingDirectory: session.projectPath)
+        return .ghostty(workingDirectory: session.projectPath, tty: terminal.tty)
     }
 
     // Try activation by name, then bundle ID, then Finder
@@ -138,7 +140,7 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
             }
         }
 
-    case .ghostty(let workingDirectory):
+    case .ghostty(let workingDirectory, _):
         if !executeGhosttyFocusScript(workingDirectory: workingDirectory) {
             if let bundleID = HostApp.ghostty.bundleID {
                 activateAppByBundleID(bundleID)

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -264,6 +264,11 @@ private func executeGhosttyFocusScript(workingDirectory: String) -> Bool {
 /// parses them; the shell does not see them. Best-effort — silently no-ops if the TTY
 /// has closed (session just ended).
 private func primeGhosttyCWD(tty: String, workingDirectory: String) {
+    // Refuse to write unless the path is a character device. Session files live
+    // under CCTOP_SESSIONS_DIR (user-writable); a malicious or stale tty pointing
+    // at a regular file would otherwise be opened and partially overwritten.
+    guard let attrs = try? FileManager.default.attributesOfItem(atPath: tty),
+          (attrs[.type] as? FileAttributeType) == .typeCharacterSpecial else { return }
     let host = ProcessInfo.processInfo.hostName
     let osc = buildOSC7CWD(host: host, workingDirectory: workingDirectory)
     guard let data = osc.data(using: .utf8) else { return }

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -165,7 +165,7 @@ final class FocusStrategyTests: XCTestCase {
     func testGhosttyUsesAppleScriptWithWorkingDirectory() {
         let session = makeSession(program: "Ghostty")
         let strategy = resolveFocusStrategy(session: session)
-        XCTAssertEqual(strategy, .ghostty(workingDirectory: projectPath, tty: nil))
+        XCTAssertEqual(strategy, .ghostty(workingDirectory: projectPath))
     }
 
     func testGhosttyDetectedByBundleIdWhenProgramDiffers() {
@@ -173,23 +173,7 @@ final class FocusStrategyTests: XCTestCase {
         // say "ghostty", but __CFBundleIdentifier still does.
         let session = makeSession(program: "tmux", bundleId: "com.mitchellh.ghostty")
         let strategy = resolveFocusStrategy(session: session)
-        XCTAssertEqual(strategy, .ghostty(workingDirectory: projectPath, tty: nil))
-    }
-
-    func testGhosttyCarriesTTYFromTerminalInfo() {
-        // The captured TTY is needed so the executor can prime Ghostty's tracked cwd
-        // via OSC 7 before the AppleScript runs (Ghostty's shell integration doesn't
-        // fire in some environments, e.g. nix/Shopify-world bash→zsh wrappers).
-        let session = Session.mock(
-            id: "test",
-            project: "myapp",
-            terminal: TerminalInfo(
-                program: "Ghostty", sessionId: nil, tty: "/dev/ttys011",
-                bundleId: nil, socket: nil, binaryPaths: nil
-            )
-        )
-        let strategy = resolveFocusStrategy(session: session)
-        XCTAssertEqual(strategy, .ghostty(workingDirectory: projectPath, tty: "/dev/ttys011"))
+        XCTAssertEqual(strategy, .ghostty(workingDirectory: projectPath))
     }
 
     // MARK: - AppleScript path escaping

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -165,7 +165,7 @@ final class FocusStrategyTests: XCTestCase {
     func testGhosttyUsesAppleScriptWithWorkingDirectory() {
         let session = makeSession(program: "Ghostty")
         let strategy = resolveFocusStrategy(session: session)
-        XCTAssertEqual(strategy, .ghostty(workingDirectory: projectPath))
+        XCTAssertEqual(strategy, .ghostty(workingDirectory: projectPath, tty: nil))
     }
 
     func testGhosttyDetectedByBundleIdWhenProgramDiffers() {
@@ -173,7 +173,23 @@ final class FocusStrategyTests: XCTestCase {
         // say "ghostty", but __CFBundleIdentifier still does.
         let session = makeSession(program: "tmux", bundleId: "com.mitchellh.ghostty")
         let strategy = resolveFocusStrategy(session: session)
-        XCTAssertEqual(strategy, .ghostty(workingDirectory: projectPath))
+        XCTAssertEqual(strategy, .ghostty(workingDirectory: projectPath, tty: nil))
+    }
+
+    func testGhosttyCarriesTTYFromTerminalInfo() {
+        // The captured TTY is needed so the executor can prime Ghostty's tracked cwd
+        // via OSC 7 before the AppleScript runs (Ghostty's shell integration doesn't
+        // fire in some environments, e.g. nix/Shopify-world bash→zsh wrappers).
+        let session = Session.mock(
+            id: "test",
+            project: "myapp",
+            terminal: TerminalInfo(
+                program: "Ghostty", sessionId: nil, tty: "/dev/ttys011",
+                bundleId: nil, socket: nil, binaryPaths: nil
+            )
+        )
+        let strategy = resolveFocusStrategy(session: session)
+        XCTAssertEqual(strategy, .ghostty(workingDirectory: projectPath, tty: "/dev/ttys011"))
     }
 
     // MARK: - AppleScript path escaping

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -256,4 +256,28 @@ final class FocusStrategyTests: XCTestCase {
     func testExtractGUIDFromEmpty() {
         XCTAssertNil(extractITermGUID(from: ""))
     }
+
+    // MARK: - OSC 7 builder
+
+    func testBuildOSC7WrapsPathInEscBELFrame() {
+        let osc = buildOSC7CWD(host: "machine.local", workingDirectory: "/Users/me/code")
+        XCTAssertEqual(osc, "\u{1B}]7;file://machine.local/Users/me/code\u{07}")
+    }
+
+    func testBuildOSC7URLEncodesSpaces() {
+        let osc = buildOSC7CWD(host: "h", workingDirectory: "/Users/me/My Code")
+        XCTAssertEqual(osc, "\u{1B}]7;file://h/Users/me/My%20Code\u{07}")
+    }
+
+    func testBuildOSC7PreservesPathSeparators() {
+        // Path separators must not be percent-encoded — Ghostty parses this as a URI.
+        let osc = buildOSC7CWD(host: "h", workingDirectory: "/a/b/c")
+        XCTAssertEqual(osc, "\u{1B}]7;file://h/a/b/c\u{07}")
+    }
+
+    func testBuildOSC7EmptyHostAllowed() {
+        // file:///path is valid (empty authority). Some terminals only care about path.
+        let osc = buildOSC7CWD(host: "", workingDirectory: "/x")
+        XCTAssertEqual(osc, "\u{1B}]7;file:///x\u{07}")
+    }
 }

--- a/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
+++ b/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
@@ -118,7 +118,7 @@ final class MultiplexerFocusTests: XCTestCase {
             )
         )
         let emulatorStrategy = resolveFocusStrategy(session: session)
-        XCTAssertEqual(emulatorStrategy, .ghostty(workingDirectory: "/Users/test/projects/cctop", tty: nil))
+        XCTAssertEqual(emulatorStrategy, .ghostty(workingDirectory: "/Users/test/projects/cctop"))
 
         let muxStrategy = resolveMultiplexerFocus(session: session)
         XCTAssertEqual(muxStrategy, .zellij(sessionName: "dev", paneId: "terminal_1", binaryPath: "/usr/bin/zellij"))

--- a/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
+++ b/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
@@ -118,7 +118,7 @@ final class MultiplexerFocusTests: XCTestCase {
             )
         )
         let emulatorStrategy = resolveFocusStrategy(session: session)
-        XCTAssertEqual(emulatorStrategy, .ghostty(workingDirectory: "/Users/test/projects/cctop"))
+        XCTAssertEqual(emulatorStrategy, .ghostty(workingDirectory: "/Users/test/projects/cctop", tty: nil))
 
         let muxStrategy = resolveMultiplexerFocus(session: session)
         XCTAssertEqual(muxStrategy, .zellij(sessionName: "dev", paneId: "terminal_1", binaryPath: "/usr/bin/zellij"))

--- a/raycast/CHANGELOG.md
+++ b/raycast/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Cctop Changelog
 
+## [Reliable Ghostty focus across windows] - {PR_MERGE_DATE}
+
+- Fix: prime Ghostty's tracked cwd via OSC 7 before running the focus AppleScript so the correct window/tab is raised even when Ghostty's shell integration isn't loaded.
+
 ## [Initial Version] - {PR_MERGE_DATE}
 
 - View all active AI coding sessions (Claude Code, opencode) in Raycast

--- a/raycast/src/actions.ts
+++ b/raycast/src/actions.ts
@@ -41,7 +41,12 @@ function escapeAppleScriptString(s: string): string {
  */
 function primeGhosttyCWD(tty: string, workingDirectory: string): void {
   try {
-    const encoded = encodeURI(workingDirectory);
+    // encodeURI leaves '#' and '?' unencoded; Ghostty's OSC 7 parser would
+    // treat them as URI fragment/query delimiters and drop everything after.
+    // Match Swift's `.urlPathAllowed` behavior by post-encoding both.
+    const encoded = encodeURI(workingDirectory)
+      .replace(/#/g, "%23")
+      .replace(/\?/g, "%3F");
     const osc = `\x1b]7;file://${hostname()}${encoded}\x07`;
     writeFileSync(tty, osc);
   } catch {

--- a/raycast/src/actions.ts
+++ b/raycast/src/actions.ts
@@ -1,6 +1,6 @@
 // Jump-to-session action logic, replicating FocusTerminal.swift behavior
 import { execFileSync } from "child_process";
-import { writeFileSync } from "node:fs";
+import { statSync, writeFileSync } from "node:fs";
 import { hostname } from "node:os";
 import { closeMainWindow, popToRoot } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
@@ -35,6 +35,10 @@ function escapeAppleScriptString(s: string): string {
  */
 function primeGhosttyCWD(tty: string, workingDirectory: string): void {
   try {
+    // Refuse to write unless the path is a character device. Session files live
+    // under CCTOP_SESSIONS_DIR (user-writable); a malicious or stale tty pointing
+    // at a regular file would otherwise be opened and partially overwritten.
+    if (!statSync(tty).isCharacterDevice()) return;
     // encodeURI leaves '#' and '?' unencoded; post-encode to match Swift's `.urlPathAllowed`.
     const encoded = encodeURI(workingDirectory)
       .replace(/#/g, "%23")

--- a/raycast/src/actions.ts
+++ b/raycast/src/actions.ts
@@ -1,5 +1,7 @@
 // Jump-to-session action logic, replicating FocusTerminal.swift behavior
 import { execFileSync } from "child_process";
+import { writeFileSync } from "node:fs";
+import { hostname } from "node:os";
 import { closeMainWindow, popToRoot } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import { CctopSession } from "./types";
@@ -24,6 +26,27 @@ function isValidGUID(s: string): boolean {
 /** Escape a string for safe interpolation inside an AppleScript double-quoted literal. */
 function escapeAppleScriptString(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Write an OSC 7 cwd report to the given TTY device file. Mirrors
+ * `primeGhosttyCWD` in the Swift menubar app (FocusTerminal.swift).
+ *
+ * Bytes written to the slave (`/dev/ttysNNN`) appear on the PTY master where
+ * Ghostty parses them and updates `working directory of term`. Without this
+ * prime, the AppleScript loop below may not match in environments where
+ * Ghostty's shell integration isn't loaded (e.g. nix/world bash→zsh wrappers).
+ *
+ * Silently no-ops on any I/O failure — TTY may have closed if the session just ended.
+ */
+function primeGhosttyCWD(tty: string, workingDirectory: string): void {
+  try {
+    const encoded = encodeURI(workingDirectory);
+    const osc = `\x1b]7;file://${hostname()}${encoded}\x07`;
+    writeFileSync(tty, osc);
+  } catch {
+    // best-effort
+  }
 }
 
 /**
@@ -122,7 +145,8 @@ export async function jumpToSession(session: CctopSession): Promise<void> {
     // zellij) runs inside Ghostty, TERM_PROGRAM becomes the multiplexer name
     // while __CFBundleIdentifier still identifies the host emulator. Mirrors
     // HostApp.from(bundleIdentifier:) in the Swift menubar app.
-    const isGhostty = program.includes("ghostty") || bundleId === "com.mitchellh.ghostty";
+    const isGhostty =
+      program.includes("ghostty") || bundleId === "com.mitchellh.ghostty";
 
     if (
       program.includes("code") ||
@@ -144,10 +168,16 @@ export async function jumpToSession(session: CctopSession): Promise<void> {
     } else if (program.includes("warp")) {
       execFileSync("open", ["-a", "Warp"]);
     } else if (isGhostty) {
-      // Ghostty 1.3.0+ exposes AppleScript; match the terminal by working directory
-      // and fall back to plain activation if no terminal matches or the script errors.
+      // Ghostty 1.3.0+ exposes AppleScript; match the terminal by working directory.
+      // Prime Ghostty's tracked cwd via OSC 7 first — see primeGhosttyCWD comment.
+      if (session.terminal?.tty) {
+        primeGhosttyCWD(session.terminal.tty, session.project_path);
+      }
       try {
-        execFileSync("osascript", ["-e", buildGhosttyScript(session.project_path)]);
+        execFileSync("osascript", [
+          "-e",
+          buildGhosttyScript(session.project_path),
+        ]);
       } catch {
         execFileSync("open", ["-a", "Ghostty"]);
       }

--- a/raycast/src/actions.ts
+++ b/raycast/src/actions.ts
@@ -29,21 +29,13 @@ function escapeAppleScriptString(s: string): string {
 }
 
 /**
- * Write an OSC 7 cwd report to the given TTY device file. Mirrors
- * `primeGhosttyCWD` in the Swift menubar app (FocusTerminal.swift).
- *
- * Bytes written to the slave (`/dev/ttysNNN`) appear on the PTY master where
- * Ghostty parses them and updates `working directory of term`. Without this
- * prime, the AppleScript loop below may not match in environments where
- * Ghostty's shell integration isn't loaded (e.g. nix/world bash→zsh wrappers).
- *
- * Silently no-ops on any I/O failure — TTY may have closed if the session just ended.
+ * Bytes written to the slave (`/dev/ttysNNN`) appear on the PTY master where Ghostty
+ * parses them; the shell does not see them. Best-effort — silently no-ops if the TTY
+ * has closed. Mirrors `primeGhosttyCWD` in FocusTerminal.swift.
  */
 function primeGhosttyCWD(tty: string, workingDirectory: string): void {
   try {
-    // encodeURI leaves '#' and '?' unencoded; Ghostty's OSC 7 parser would
-    // treat them as URI fragment/query delimiters and drop everything after.
-    // Match Swift's `.urlPathAllowed` behavior by post-encoding both.
+    // encodeURI leaves '#' and '?' unencoded; post-encode to match Swift's `.urlPathAllowed`.
     const encoded = encodeURI(workingDirectory)
       .replace(/#/g, "%23")
       .replace(/\?/g, "%3F");
@@ -174,7 +166,6 @@ export async function jumpToSession(session: CctopSession): Promise<void> {
       execFileSync("open", ["-a", "Warp"]);
     } else if (isGhostty) {
       // Ghostty 1.3.0+ exposes AppleScript; match the terminal by working directory.
-      // Prime Ghostty's tracked cwd via OSC 7 first — see primeGhosttyCWD comment.
       if (session.terminal?.tty) {
         primeGhosttyCWD(session.terminal.tty, session.project_path);
       }

--- a/raycast/src/actions.ts
+++ b/raycast/src/actions.ts
@@ -35,9 +35,10 @@ function escapeAppleScriptString(s: string): string {
  */
 function primeGhosttyCWD(tty: string, workingDirectory: string): void {
   try {
-    // Refuse to write unless the path is a character device. Session files live
-    // under CCTOP_SESSIONS_DIR (user-writable); a malicious or stale tty pointing
-    // at a regular file would otherwise be opened and partially overwritten.
+    // Allow only PTY slaves (`/dev/ttys<digits>`) — that's the only shape
+    // cctop-hook captures from `ps -o tty=`. This rejects /dev/cu.*, /dev/console,
+    // and arbitrary file paths a tampered session JSON might supply.
+    if (!/^\/dev\/ttys\d+$/.test(tty)) return;
     if (!statSync(tty).isCharacterDevice()) return;
     // encodeURI leaves '#' and '?' unencoded; post-encode to match Swift's `.urlPathAllowed`.
     const encoded = encodeURI(workingDirectory)

--- a/raycast/src/show-sessions.tsx
+++ b/raycast/src/show-sessions.tsx
@@ -61,7 +61,12 @@ function sessionAccessories(
     accessories.push({
       tag: {
         value: label,
-        color: label === "OC" ? Color.Blue : label === "Pi" ? Color.Green : Color.Orange,
+        color:
+          label === "OC"
+            ? Color.Blue
+            : label === "Pi"
+              ? Color.Green
+              : Color.Orange,
       },
     });
   }


### PR DESCRIPTION
## Summary

Ghostty's AppleScript-based focus relies on `working directory of term` matching the cctop session's project path. That property only updates when the shell emits OSC 7 (`\e]7;file://HOST/PATH\a`). Ghostty's own shell integration emits it via PROMPT_COMMAND / precmd — but environments that bypass the integration (nix, Shopify world's `bash --noprofile --norc -c exec -l /bin/zsh` wrapper, custom dotfiles) leave Ghostty's tracked cwd stale, so the AppleScript loop matches the wrong window or no window at all.

**Fix:** before running the AppleScript, write an OSC 7 sequence directly to the session's recorded TTY device (`/dev/ttysNNN`). Bytes written to the slave appear on the PTY master where Ghostty parses them — no shell involvement required. Ghostty's tracked cwd is updated within milliseconds, then the AppleScript matches the correct window/tab.

Mirrored in both the Swift menubar app and the Raycast extension.

## Commits

- ` 3d9688a` refactor(focus): plumb tty through `FocusStrategy.ghostty`
- ` 564c0dc` feat(focus): add `buildOSC7CWD` string builder + tests
- ` 0a6c42b` fix(focus): emit OSC 7 to TTY before Ghostty AppleScript (Swift)
- ` 40250dc` fix(raycast): mirror the same prime in `actions.ts`
- ` 0bb07ac` fix(raycast): match Swift `.urlPathAllowed` encoding for `#` / `?`

## Test plan

- [ ] CI: `xcodebuild test` passes (Swift unit tests cover `FocusStrategy.ghostty(_:tty:)` plumbing, `buildOSC7CWD` framing/encoding, escape/path edge cases)
- [ ] CI: `ray lint` passes for the Raycast extension
- [ ] Manual e2e (local Ghostty): with two cctop sessions in different directories, click each from the menubar and verify the correct window is raised. Repeat from Raycast.
- [ ] Manual e2e: same test under a Shopify world / nix shell where Ghostty's shell integration is suppressed — confirm the prime fires and focus still works.

## Notes

- TTY writes are best-effort: silently no-op if the file can't be opened (session may have ended). No crash, no warning toast.
- Once Ghostty exposes a per-surface env var inside the shell (ghostty-org/ghostty#9084, #10603), we can switch to id-based matching and drop the cwd prime.