### PR TITLE
Support Claude Desktop and Codex Desktop sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ When you click a session card (or jump via Navigate mode), cctop focuses the hos
 | Kitty | Targets the specific window via remote control |
 | Ghostty | Targets a terminal whose working directory matches the project (best-effort) |
 | Terminal | Targets the specific tab by tty |
-| Warp | Activates the app (no per-tab targeting) |
+| Codex Desktop | Targets the specific thread |
+| Claude Desktop, Warp | Activates the app (no per-tab targeting) |
 | Other | Falls back to opening the project folder in Finder |
 
 > [!NOTE]

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -12,6 +12,10 @@ enum HostApp {
     case terminal
     case ghostty
     case kitty
+    /// Claude Desktop runs sessions inside the app itself — no terminal, no editor.
+    case claudeDesktop
+    /// Codex Desktop runs sessions inside the app itself — no terminal, no editor.
+    case codexDesktop
     case unknown
 
     /// Match a bundle identifier to a HostApp. Preferred over program name matching
@@ -50,11 +54,14 @@ enum HostApp {
         case .terminal: return "com.apple.Terminal"
         case .ghostty: return "com.mitchellh.ghostty"
         case .kitty: return "net.kovidgoyal.kitty"
+        case .claudeDesktop: return "com.anthropic.claudefordesktop"
+        case .codexDesktop: return "com.openai.codex"
         case .unknown: return nil
         }
     }
 
     /// Lowercased name for matching against `NSRunningApplication.localizedName`.
+    /// Nil for desktop AI apps — bundle ID is exact and avoids substring collisions.
     var activationName: String? {
         switch self {
         case .vscode: return "code"
@@ -66,7 +73,7 @@ enum HostApp {
         case .terminal: return "terminal"
         case .ghostty: return "ghostty"
         case .kitty: return "kitty"
-        case .unknown: return nil
+        case .claudeDesktop, .codexDesktop, .unknown: return nil
         }
     }
 
@@ -76,6 +83,8 @@ enum HostApp {
             return "chevron.left.forwardslash.chevron.right"
         case .iterm2, .warp, .terminal, .ghostty, .kitty, .unknown:
             return "terminal"
+        case .claudeDesktop, .codexDesktop:
+            return "sparkles"
         }
     }
 
@@ -83,13 +92,27 @@ enum HostApp {
     var usesWorkspaceFile: Bool {
         switch self {
         case .vscode, .cursor, .windsurf, .zed: return true
-        case .iterm2, .warp, .terminal, .ghostty, .kitty, .unknown: return false
+        case .iterm2, .warp, .terminal, .ghostty, .kitty,
+             .claudeDesktop, .codexDesktop, .unknown: return false
+        }
+    }
+
+    /// Apps that host AI coding sessions inside themselves (no project folder to reopen).
+    /// Used to: skip path-based focus, skip Recent Projects archival.
+    var isDesktopApp: Bool {
+        switch self {
+        case .claudeDesktop, .codexDesktop: return true
+        default: return false
         }
     }
 
     /// Reverse lookup: bundle ID → HostApp.
     static let allByBundleID: [String: HostApp] = {
-        let all: [HostApp] = [.vscode, .cursor, .windsurf, .zed, .iterm2, .warp, .terminal, .ghostty, .kitty]
+        let all: [HostApp] = [
+            .vscode, .cursor, .windsurf, .zed,
+            .iterm2, .warp, .terminal, .ghostty, .kitty,
+            .claudeDesktop, .codexDesktop
+        ]
         return Dictionary(uniqueKeysWithValues: all.compactMap { app in
             app.bundleID.map { ($0, app) }
         })
@@ -104,5 +127,43 @@ enum HostApp {
         case .zed: return "zed"
         default: return nil
         }
+    }
+}
+
+extension Session {
+    /// True when the session is hosted by an AI desktop app (Claude Desktop, Codex Desktop)
+    /// rather than a terminal/editor. These sessions have no project folder worth reopening,
+    /// so they're excluded from Recent Projects.
+    var isHostedByDesktopApp: Bool {
+        guard let bundleId = terminal?.bundleId else { return false }
+        return HostApp.from(bundleIdentifier: bundleId)?.isDesktopApp == true
+    }
+}
+
+extension HostApp {
+    /// Deep-link URL that focuses a specific session inside this app, if supported.
+    /// Returns nil when the app has no session-jump scheme, or `sessionId` isn't a
+    /// canonical UUID — the URL handler rejects non-UUID values, so we mirror its
+    /// validation client-side and fall back to plain app activation upstream.
+    /// - Codex Desktop: `codex://threads/<uuid>` — navigates to a local conversation.
+    /// - Claude Desktop: no deep link. `claude://resume?session=<uuid>` exists but
+    ///   forks the conversation rather than focusing the existing one, which would
+    ///   silently pollute the user's history. We just activate the app instead.
+    func sessionDeepLink(sessionId: String) -> URL? {
+        guard Self.isUUID(sessionId) else { return nil }
+        switch self {
+        case .codexDesktop:
+            return URL(string: "codex://threads/\(sessionId)")
+        default:
+            return nil
+        }
+    }
+
+    /// The host-app URL handler validates with this exact pattern (8-4-4-4-12 hex).
+    static func isUUID(_ value: String) -> Bool {
+        value.range(
+            of: #"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"#,
+            options: [.regularExpression, .caseInsensitive]
+        ) != nil
     }
 }

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -18,6 +18,8 @@ enum FocusStrategy: Equatable {
     case activateByName(String)
     /// Activate a running app by its bundle identifier.
     case activateByBundleID(String)
+    /// Open an app-specific deep link URL (e.g. claude://resume?session=...).
+    case openURL(URL)
     /// Open a path in Finder.
     case openInFinder(String)
 }
@@ -34,6 +36,12 @@ func resolveFocusStrategy(session: Session) -> FocusStrategy {
     let hostApp = HostApp.from(bundleIdentifier: terminal.bundleId)
         ?? HostApp.from(editorName: terminal.program)
     let target = session.workspaceFile ?? session.projectPath
+
+    // Falls through to bundle-ID activation below if the session ID isn't a
+    // valid UUID, so the user still gets the app focused.
+    if let url = hostApp.sessionDeepLink(sessionId: session.sessionId) {
+        return .openURL(url)
+    }
 
     // Editors with a known bundle ID → open the project with that app.
     // Uses NSWorkspace instead of CLI (e.g., `code <path>`) to avoid PATH issues
@@ -157,6 +165,9 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
 
     case .activateByBundleID(let bundleID):
         activateAppByBundleID(bundleID)
+
+    case .openURL(let url):
+        NSWorkspace.shared.open(url)
 
     case .openInFinder(let path):
         NSWorkspace.shared.open(URL(fileURLWithPath: path))

--- a/menubar/CctopMenubar/Services/HistoryManager.swift
+++ b/menubar/CctopMenubar/Services/HistoryManager.swift
@@ -23,8 +23,14 @@ class HistoryManager: ObservableObject {
 
     /// Archive a dead session to the history directory.
     /// Sets `endedAt`, writes to history, prunes old files, and returns success.
+    /// Desktop-app sessions (Claude Desktop, Codex Desktop) are not archived — they
+    /// have no project folder worth reopening from Recent Projects.
     @discardableResult
     func archiveSession(_ session: Session) -> Bool {
+        if session.isHostedByDesktopApp {
+            logger.info("skipping archive for desktop-app session \(session.sessionId, privacy: .public)")
+            return false
+        }
         var archived = session
         archived.endedAt = archived.endedAt ?? Date()
 
@@ -68,6 +74,8 @@ class HistoryManager: ObservableObject {
     ) -> [RecentProject] {
         var grouped: [String: (latest: Session, count: Int)] = [:]
         for session in sessions {
+            // Drop on read too — catches archive files that predate the write-time skip.
+            if session.isHostedByDesktopApp { continue }
             if let existing = grouped[session.projectPath] {
                 let newer = session.effectiveEndDate > existing.latest.effectiveEndDate
                 grouped[session.projectPath] = (

--- a/menubar/CctopMenubar/Services/HistoryManager.swift
+++ b/menubar/CctopMenubar/Services/HistoryManager.swift
@@ -74,7 +74,6 @@ class HistoryManager: ObservableObject {
     ) -> [RecentProject] {
         var grouped: [String: (latest: Session, count: Int)] = [:]
         for session in sessions {
-            // Drop on read too — catches archive files that predate the write-time skip.
             if session.isHostedByDesktopApp { continue }
             if let existing = grouped[session.projectPath] {
                 let newer = session.effectiveEndDate > existing.latest.effectiveEndDate

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -91,6 +91,16 @@ class SessionManager: ObservableObject {
         for (url, session) in dead {
             let sid = session.sessionId
             let pid = session.pid.map(String.init) ?? "nil"
+
+            // Desktop-app sessions are deliberately skipped from archiving — drop the
+            // live file directly so it doesn't linger as a "dead" entry forever.
+            if session.isHostedByDesktopApp {
+                logger.info("dropping dead desktop-app session \(sid, privacy: .public) pid=\(pid, privacy: .public)")
+                try? FileManager.default.removeItem(at: url)
+                try? FileManager.default.removeItem(at: url.appendingPathExtension("lock"))
+                continue
+            }
+
             logger.info("archiving dead session \(sid, privacy: .public) pid=\(pid, privacy: .public)")
             let archived = historyManager.archiveSession(session)
             if archived {

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -238,12 +238,13 @@ final class FocusStrategyTests: XCTestCase {
         // Claude Desktop has a claude://resume?session=... URL but it FORKS the
         // conversation instead of focusing it — destructive, so we deliberately
         // fall through to plain bundle-ID activation. See HostApp.sessionDeepLink.
+        let bundleID = HostApp.claudeDesktop.bundleID!
         let session = makeSession(
-            program: "", bundleId: "com.anthropic.claudefordesktop",
+            program: "", bundleId: bundleID,
             sessionUuid: "002fb6fa-eae0-4631-94bd-84071dbd21d8"
         )
         let strategy = resolveFocusStrategy(session: session)
-        XCTAssertEqual(strategy, .activateByBundleID("com.anthropic.claudefordesktop"))
+        XCTAssertEqual(strategy, .activateByBundleID(bundleID))
     }
 
     func testCodexDesktopUsesDeepLinkWhenSessionIdIsUUID() {
@@ -251,7 +252,7 @@ final class FocusStrategyTests: XCTestCase {
         // and rejects anything that's not a canonical UUID — we mirror that check.
         let uuid = "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
         let session = makeSession(
-            program: "", bundleId: "com.openai.codex", sessionUuid: uuid
+            program: "", bundleId: HostApp.codexDesktop.bundleID!, sessionUuid: uuid
         )
         let strategy = resolveFocusStrategy(session: session)
         XCTAssertEqual(strategy, .openURL(URL(string: "codex://threads/\(uuid)")!))
@@ -260,11 +261,12 @@ final class FocusStrategyTests: XCTestCase {
     func testCodexDesktopFallsBackToActivateWhenSessionIdNotUUID() {
         // Legacy or test sessions may not have UUID IDs — we should still focus
         // the app rather than build a URL the handler will reject.
+        let bundleID = HostApp.codexDesktop.bundleID!
         let session = makeSession(
-            program: "", bundleId: "com.openai.codex", sessionUuid: "not-a-uuid"
+            program: "", bundleId: bundleID, sessionUuid: "not-a-uuid"
         )
         let strategy = resolveFocusStrategy(session: session)
-        XCTAssertEqual(strategy, .activateByBundleID("com.openai.codex"))
+        XCTAssertEqual(strategy, .activateByBundleID(bundleID))
     }
 
     // MARK: - No terminal info falls back to Finder

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -11,10 +11,11 @@ final class FocusStrategyTests: XCTestCase {
         tty: String? = nil,
         bundleId: String? = nil,
         socket: String? = nil,
-        binaryPaths: [String: String]? = nil
+        binaryPaths: [String: String]? = nil,
+        sessionUuid: String = "test"
     ) -> Session {
         Session.mock(
-            id: "test",
+            id: sessionUuid,
             project: "myapp",
             terminal: TerminalInfo(
                 program: program, sessionId: sessionId, tty: tty,
@@ -229,6 +230,41 @@ final class FocusStrategyTests: XCTestCase {
         let session = makeSession(program: "Terminal", tty: "/dev/cu.usb\"oops")
         let strategy = resolveFocusStrategy(session: session)
         XCTAssertEqual(strategy, .activateByName("terminal"))
+    }
+
+    // MARK: - Desktop AI apps
+
+    func testClaudeDesktopUsesActivateByBundleID() {
+        // Claude Desktop has a claude://resume?session=... URL but it FORKS the
+        // conversation instead of focusing it — destructive, so we deliberately
+        // fall through to plain bundle-ID activation. See HostApp.sessionDeepLink.
+        let session = makeSession(
+            program: "", bundleId: "com.anthropic.claudefordesktop",
+            sessionUuid: "002fb6fa-eae0-4631-94bd-84071dbd21d8"
+        )
+        let strategy = resolveFocusStrategy(session: session)
+        XCTAssertEqual(strategy, .activateByBundleID("com.anthropic.claudefordesktop"))
+    }
+
+    func testCodexDesktopUsesDeepLinkWhenSessionIdIsUUID() {
+        // Codex's URL handler routes codex://threads/<uuid> to the conversation
+        // and rejects anything that's not a canonical UUID — we mirror that check.
+        let uuid = "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
+        let session = makeSession(
+            program: "", bundleId: "com.openai.codex", sessionUuid: uuid
+        )
+        let strategy = resolveFocusStrategy(session: session)
+        XCTAssertEqual(strategy, .openURL(URL(string: "codex://threads/\(uuid)")!))
+    }
+
+    func testCodexDesktopFallsBackToActivateWhenSessionIdNotUUID() {
+        // Legacy or test sessions may not have UUID IDs — we should still focus
+        // the app rather than build a URL the handler will reject.
+        let session = makeSession(
+            program: "", bundleId: "com.openai.codex", sessionUuid: "not-a-uuid"
+        )
+        let strategy = resolveFocusStrategy(session: session)
+        XCTAssertEqual(strategy, .activateByBundleID("com.openai.codex"))
     }
 
     // MARK: - No terminal info falls back to Finder

--- a/menubar/CctopMenubarTests/HistoryManagerTests.swift
+++ b/menubar/CctopMenubarTests/HistoryManagerTests.swift
@@ -27,7 +27,8 @@ final class HistoryManagerTests: XCTestCase {
     private func mockSession(
         project: String,
         endedAt: Date? = nil,
-        lastActivity: Date = Date()
+        lastActivity: Date = Date(),
+        terminal: TerminalInfo? = TerminalInfo(program: "Code")
     ) -> Session {
         Session(
             sessionId: UUID().uuidString,
@@ -38,7 +39,7 @@ final class HistoryManagerTests: XCTestCase {
             lastPrompt: nil,
             lastActivity: lastActivity,
             startedAt: lastActivity,
-            terminal: TerminalInfo(program: "Code"),
+            terminal: terminal,
             pid: nil,
             lastTool: nil,
             lastToolDetail: nil,
@@ -195,6 +196,40 @@ final class HistoryManagerTests: XCTestCase {
         // lastSessionAt should use endedAt (60s ago), not lastActivity (2h ago)
         let elapsed = Int(-result[0].lastSessionAt.timeIntervalSinceNow)
         XCTAssertTrue(elapsed < 120, "Should use endedAt, not lastActivity")
+    }
+
+    func testBuildRecentProjectsExcludesDesktopAppSessions() {
+        let desktopApps = [
+            (bundleId: "com.anthropic.claudefordesktop", project: "claude-thing"),
+            (bundleId: "com.openai.codex", project: "codex-thing"),
+        ]
+        for app in desktopApps {
+            let terminal = TerminalInfo(
+                program: "", sessionId: nil, tty: nil, bundleId: app.bundleId
+            )
+            let sessions = [
+                mockSession(project: app.project, endedAt: Date(), terminal: terminal),
+                mockSession(project: "vscode-thing", endedAt: Date()),
+            ]
+            let result = HistoryManager.buildRecentProjects(from: sessions)
+            XCTAssertEqual(result.map(\.projectName), ["vscode-thing"], "for \(app.bundleId)")
+        }
+    }
+
+    func testArchiveSessionSkipsDesktopAppSessions() {
+        let claudeTerminal = TerminalInfo(
+            program: "", sessionId: nil, tty: nil,
+            bundleId: "com.anthropic.claudefordesktop"
+        )
+        let session = mockSession(project: "claude-thing", terminal: claudeTerminal)
+        let archived = sut.archiveSession(session)
+        XCTAssertFalse(archived, "Desktop-app sessions must not be archived")
+
+        // No history file should have been written.
+        let files = try? FileManager.default.contentsOfDirectory(
+            at: historyDir, includingPropertiesForKeys: nil
+        )
+        XCTAssertEqual(files?.count, 0)
     }
 
     func testBuildRecentProjectsPopulatesLastEditor() {

--- a/raycast/src/actions.ts
+++ b/raycast/src/actions.ts
@@ -23,6 +23,14 @@ function isValidGUID(s: string): boolean {
   return /^[0-9a-fA-F-]+$/.test(s);
 }
 
+/** Canonical 8-4-4-4-12 UUID — matches the validation Codex's URL handler runs. */
+function isUUID(s: string | null | undefined): boolean {
+  if (!s) return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    s,
+  );
+}
+
 /** Escape a string for safe interpolation inside an AppleScript double-quoted literal. */
 function escapeAppleScriptString(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
@@ -116,11 +124,18 @@ function buildITermScript(guid: string): string {
   `;
 }
 
+/** Bundle IDs of AI desktop apps that host sessions inside themselves. */
+const CLAUDE_DESKTOP_BUNDLE_ID = "com.anthropic.claudefordesktop";
+const CODEX_DESKTOP_BUNDLE_ID = "com.openai.codex";
+
 /**
  * Return a human-readable label for the terminal program.
  * Used for contextual action labels like "Open in VS Code".
  */
 export function getTerminalLabel(session: CctopSession): string {
+  const bundleId = session.terminal?.bundle_id ?? "";
+  if (bundleId === CLAUDE_DESKTOP_BUNDLE_ID) return "Claude";
+  if (bundleId === CODEX_DESKTOP_BUNDLE_ID) return "Codex";
   const program = session.terminal?.program?.toLowerCase() ?? "";
   if (program.includes("cursor")) return "Cursor";
   if (program.includes("windsurf")) return "Windsurf";
@@ -150,7 +165,18 @@ export async function jumpToSession(session: CctopSession): Promise<void> {
     const isGhostty =
       program.includes("ghostty") || bundleId === "com.mitchellh.ghostty";
 
+    // Codex Desktop: deep-link to the specific thread (codex://threads/<uuid>).
+    // Claude Desktop: claude://resume forks the conversation, so we just activate.
     if (
+      bundleId === CODEX_DESKTOP_BUNDLE_ID ||
+      bundleId === CLAUDE_DESKTOP_BUNDLE_ID
+    ) {
+      if (bundleId === CODEX_DESKTOP_BUNDLE_ID && isUUID(session.session_id)) {
+        execFileSync("open", [`codex://threads/${session.session_id}`]);
+      } else {
+        execFileSync("open", ["-b", bundleId]);
+      }
+    } else if (
       program.includes("code") ||
       program.includes("cursor") ||
       program.includes("windsurf")

--- a/site/index.html
+++ b/site/index.html
@@ -537,14 +537,15 @@
       </div>
       <div class="tier-row reveal">
         <div class="tier-label">
-          <strong>Targets the exact pane</strong>
-          <span class="sg-note">right window, tab, and pane</span>
+          <strong>Targets the exact session</strong>
+          <span class="sg-note">right window, tab, and pane — or the specific thread in a desktop app</span>
         </div>
         <div class="chips">
           <span class="chip">iTerm2</span>
           <span class="chip">Kitty<sup>*</sup></span>
           <span class="chip">Ghostty<sup>&dagger;</sup></span>
           <span class="chip">Terminal<sup>&Dagger;</sup></span>
+          <span class="chip">Codex Desktop</span>
           <span class="chip">Zellij</span>
           <span class="chip">tmux</span>
         </div>
@@ -567,6 +568,7 @@
           <span class="sg-note">raises the app; find the tab manually</span>
         </div>
         <div class="chips">
+          <span class="chip">Claude Desktop</span>
           <span class="chip">Warp</span>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Detect sessions hosted by Claude Desktop (`com.anthropic.claudefordesktop`) and Codex Desktop (`com.openai.codex`) via `terminal.bundle_id` and route them differently from terminal/editor sessions.
- Codex Desktop: jump to the specific thread via `codex://threads/<uuid>` deep link (with UUID validation mirroring the [URL handler's regex](https://code.claude.com/docs/en/deep-links)).
- Claude Desktop: just activate the app. `claude://resume?session=<uuid>` exists but [forks the conversation](https://github.com/anthropics/claude-code/issues/50345) instead of focusing it — verified empirically that opening the URL for a live session creates a duplicate thread.
- Exclude these sessions from the Recent Projects panel since they have no project folder worth reopening.

## Why

Before this change, clicking a Claude Desktop or Codex Desktop session in cctop fell through to `.openInFinder(project_path)` — neither app sets `terminal.program`, and the bundle IDs weren't mapped to a `HostApp` case. The session also got archived on death and cluttered Recent Projects with entries that couldn't be reopened.

## Implementation notes

- `HostApp` gets two new cases (`.claudeDesktop`, `.codexDesktop`) with `cliCommand = nil` and `activationName = nil` so the existing `resolveFocusStrategy` cascade naturally falls to `.activateByBundleID` (exact match, no substring collisions).
- New `FocusStrategy.openURL(URL)` case for the Codex deep link.
- `Session.isHostedByDesktopApp` predicate lives in an extension in `HostApp.swift` (not `Session.swift`) because the hook target compiles `Session.swift` but not `HostApp.swift`.
- `archiveSession` returns `false` for desktop-app sessions and `SessionManager` removes the live session file directly instead of waiting on `archiveSession`. `buildRecentProjects` also filters at read time, so any archive files written before this change get cleaned up automatically.
- Same routing logic mirrored in the Raycast extension (`raycast/src/actions.ts`).

## Sources / verification

- [Anthropic issue #50345](https://github.com/anthropics/claude-code/issues/50345) (closed) — explicitly confirms no supported way to focus an existing Claude Desktop session by UUID. The deep-link path component `resume` calls `Kr.importCliSession(o)` in the asar bundle; "import" is literal.
- [Claude Code deep-links docs](https://code.claude.com/docs/en/deep-links) — `claude-cli://open` exists but always creates a new session.
- Codex's URL routing was verified by reading `Codex.app/Contents/Resources/app.asar`: `case 'threads': ... wA(t) ? {kind:'localConversation', conversationId: ...} : null`, where `wA` is `/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(e)`.

## Test plan

- [x] `make build && make lint && make test` (413 menubar tests pass)
- [x] `npx ray lint` (Raycast)
- [x] Manually verified live: clicking a Codex Desktop session jumps to the right thread; clicking a Claude Desktop session activates the app
- [x] Site (`site/index.html`) and README "Supported Editors & Terminals" sections updated in sync