### PR TITLE
fix(focus): target Apple Terminal tab by tty via AppleScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ When you click a session card (or jump via Navigate mode), cctop focuses the hos
 | iTerm2 | Targets the specific window, tab, and pane |
 | Kitty | Targets the specific window via remote control |
 | Ghostty | Targets a terminal whose working directory matches the project (best-effort) |
-| Warp, Terminal | Activates the app (no per-tab targeting) |
+| Terminal | Targets the specific tab by tty |
+| Warp | Activates the app (no per-tab targeting) |
 | Other | Falls back to opening the project folder in Finder |
 
 > [!NOTE]
-> iTerm2 and Ghostty require macOS Automation permission. You'll be prompted to grant it on first use.
+> iTerm2, Ghostty, and Apple Terminal require macOS Automation permission. You'll be prompted to grant it on first use.
 >
 > Kitty requires `allow_remote_control socket-only` and `listen_on` in your `kitty.conf`.
 > Without remote control enabled, Kitty falls back to app activation (same as Warp).
@@ -77,6 +78,10 @@ When you click a session card (or jump via Navigate mode), cctop focuses the hos
 > Ghostty requires version 1.3.0+ for AppleScript support. Because Ghostty does not
 > yet expose a per-surface env var inside the shell, cctop matches by working
 > directory — ambiguous when multiple Ghostty splits share the same cwd.
+>
+> Apple Terminal targeting works when the shell runs directly in a tab. Inside a
+> multiplexer (tmux, screen) the captured tty is the multiplexer pane's pty, not
+> the Terminal tab's, so cctop raises Terminal without selecting a specific tab.
 
 ### Terminal Multiplexers
 

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -12,6 +12,8 @@ enum FocusStrategy: Equatable {
     case kitty(socket: String, windowId: String, binaryPath: String)
     /// Focus a Ghostty terminal by matching its working directory, with a bundle ID fallback.
     case ghostty(workingDirectory: String)
+    /// Focus an Apple Terminal tab by its tty (e.g. /dev/ttys003), with a bundle ID fallback.
+    case appleTerminal(tty: String)
     /// Activate a running app by its localized name.
     case activateByName(String)
     /// Activate a running app by its bundle identifier.
@@ -60,6 +62,15 @@ func resolveFocusStrategy(session: Session) -> FocusStrategy {
 
     if hostApp == .ghostty {
         return .ghostty(workingDirectory: session.projectPath)
+    }
+
+    // Apple Terminal → AppleScript to focus the specific tab by tty.
+    // NSRunningApplication.activate() can't target a single tab, and on macOS
+    // Sonoma+ cooperative activation often fails to even raise the app.
+    if hostApp == .terminal,
+       let tty = terminal.tty,
+       tty.range(of: #"^/dev/ttys\d+$"#, options: .regularExpression) != nil {
+        return .appleTerminal(tty: tty)
     }
 
     // Try activation by name, then bundle ID, then Finder
@@ -128,25 +139,18 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
         }
 
     case .iTerm2(let guid):
-        if !executeITerm2Script(guid: guid) {
-            if let bundleID = HostApp.iterm2.bundleID {
-                activateAppByBundleID(bundleID)
-            }
-        }
+        runScriptOrActivate(.iterm2) { executeITerm2Script(guid: guid) }
 
     case .kitty(let socket, let windowId, let binaryPath):
-        if !executeKittyFocusWindow(binaryPath: binaryPath, socket: socket, windowId: windowId) {
-            if let bundleID = HostApp.kitty.bundleID {
-                activateAppByBundleID(bundleID)
-            }
+        runScriptOrActivate(.kitty) {
+            executeKittyFocusWindow(binaryPath: binaryPath, socket: socket, windowId: windowId)
         }
 
     case .ghostty(let workingDirectory):
-        if !executeGhosttyFocusScript(workingDirectory: workingDirectory) {
-            if let bundleID = HostApp.ghostty.bundleID {
-                activateAppByBundleID(bundleID)
-            }
-        }
+        runScriptOrActivate(.ghostty) { executeGhosttyFocusScript(workingDirectory: workingDirectory) }
+
+    case .appleTerminal(let tty):
+        runScriptOrActivate(.terminal) { executeAppleTerminalScript(tty: tty) }
 
     case .activateByName(let name):
         activateAppByName(name)
@@ -156,6 +160,13 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
 
     case .openInFinder(let path):
         NSWorkspace.shared.open(URL(fileURLWithPath: path))
+    }
+}
+
+/// Run a focus script for `host`; if it fails, fall back to activating the host by bundle ID.
+private func runScriptOrActivate(_ host: HostApp, script: () -> Bool) {
+    if !script(), let bundleID = host.bundleID {
+        activateAppByBundleID(bundleID)
     }
 }
 
@@ -193,6 +204,31 @@ private func executeITerm2Script(guid: String) -> Bool {
                     end tell
                 end repeat
             end tell
+        end repeat
+    end tell
+    """)
+}
+
+// MARK: - Apple Terminal AppleScript
+// Each Terminal tab exposes its `tty` (e.g. /dev/ttys003) over AppleScript. For
+// a shell running directly in a tab the match is unambiguous. Under a multiplexer
+// (tmux, screen) the captured tty is the multiplexer pane's pty and won't appear
+// in Terminal's tab list — the loop no-ops, but the leading `activate` still
+// raises the app (the previous .activateByName behavior, more reliable on Sonoma+).
+
+private func executeAppleTerminalScript(tty: String) -> Bool {
+    runAppleScript("""
+    tell application "Terminal"
+        activate
+        repeat with w in windows
+            repeat with t in tabs of w
+                if tty of t is "\(tty)" then
+                    set miniaturized of w to false
+                    set selected of t to true
+                    set frontmost of w to true
+                    return
+                end if
+            end repeat
         end repeat
     end tell
     """)

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -8,6 +8,7 @@ final class FocusStrategyTests: XCTestCase {
     private func makeSession(
         program: String,
         sessionId: String? = nil,
+        tty: String? = nil,
         bundleId: String? = nil,
         socket: String? = nil,
         binaryPaths: [String: String]? = nil
@@ -16,7 +17,7 @@ final class FocusStrategyTests: XCTestCase {
             id: "test",
             project: "myapp",
             terminal: TerminalInfo(
-                program: program, sessionId: sessionId, tty: nil,
+                program: program, sessionId: sessionId, tty: tty,
                 bundleId: bundleId, socket: socket,
                 binaryPaths: binaryPaths
             )
@@ -201,8 +202,31 @@ final class FocusStrategyTests: XCTestCase {
         )
     }
 
-    func testAppleTerminalUsesActivateByName() {
+    // MARK: - Apple Terminal uses AppleScript with tty
+
+    func testAppleTerminalWithTTYUsesScript() {
+        let session = makeSession(program: "Apple_Terminal", tty: "/dev/ttys003")
+        let strategy = resolveFocusStrategy(session: session)
+        XCTAssertEqual(strategy, .appleTerminal(tty: "/dev/ttys003"))
+    }
+
+    func testAppleTerminalDetectedByBundleIdWhenProgramDiffers() {
+        // User runs a multiplexer (e.g. tmux) inside Terminal — TERM_PROGRAM may not
+        // say "Apple_Terminal", but __CFBundleIdentifier still does.
+        let session = makeSession(program: "tmux", tty: "/dev/ttys007", bundleId: "com.apple.Terminal")
+        let strategy = resolveFocusStrategy(session: session)
+        XCTAssertEqual(strategy, .appleTerminal(tty: "/dev/ttys007"))
+    }
+
+    func testAppleTerminalWithoutTTYFallsBackToActivate() {
         let session = makeSession(program: "Terminal")
+        let strategy = resolveFocusStrategy(session: session)
+        XCTAssertEqual(strategy, .activateByName("terminal"))
+    }
+
+    func testAppleTerminalWithInvalidTTYFallsBackToActivate() {
+        // Anything not matching /dev/ttys\d+ is rejected to keep AppleScript interpolation safe.
+        let session = makeSession(program: "Terminal", tty: "/dev/cu.usb\"oops")
         let strategy = resolveFocusStrategy(session: session)
         XCTAssertEqual(strategy, .activateByName("terminal"))
     }

--- a/site/index.html
+++ b/site/index.html
@@ -544,6 +544,7 @@
           <span class="chip">iTerm2</span>
           <span class="chip">Kitty<sup>*</sup></span>
           <span class="chip">Ghostty<sup>&dagger;</sup></span>
+          <span class="chip">Terminal<sup>&Dagger;</sup></span>
           <span class="chip">Zellij</span>
           <span class="chip">tmux</span>
         </div>
@@ -567,13 +568,14 @@
         </div>
         <div class="chips">
           <span class="chip">Warp</span>
-          <span class="chip">Terminal</span>
         </div>
       </div>
       <p class="tier-footnote" style="font-size:.85rem;color:var(--c-muted);margin-top:8px">
         *&thinsp;Kitty targets the exact window when <a href="https://sw.kovidgoyal.net/kitty/remote-control/" target="_blank" rel="noopener noreferrer"><code>remote control</code></a> is enabled in kitty.conf. Without it, falls back to app activation.
         <br>
         &dagger;&thinsp;Ghostty 1.3.0+ targets a terminal by working directory via AppleScript. Ambiguous if multiple Ghostty splits share the same cwd; falls back to app activation otherwise.
+        <br>
+        &Dagger;&thinsp;Apple Terminal targets the tab by tty via AppleScript. Falls back to app activation inside a multiplexer (tmux, screen), where the captured tty is the multiplexer pane's pty rather than the Terminal tab's.
       </p>
     </div>
 


### PR DESCRIPTION
Apple Terminal sessions were routed through `.activateByName("terminal")`,
which calls `NSRunningApplication.activate()`. On macOS Sonoma+ this is
unreliable (cooperative activation), and even when it succeeds it can only
raise the app — it cannot focus the specific tab the session is running in.

Add `.appleTerminal(tty:)` strategy that matches the tab via AppleScript's
`tty` property (already captured in `TerminalInfo.tty`), mirroring the
iTerm2 GUID and Ghostty cwd strategies. Falls back to bundle-ID activation
if the AppleScript fails, and to the previous activate-by-name path when
no valid tty was captured. The tty is regex-guarded to /dev/ttys\\d+ before
interpolation.