### PR TITLE
Surface Claude Code install in the app and fix orphaned-cache detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,15 @@ brew install --cask st0012/cctop/cctop
 
 ### Step 2: Connect your tools
 
-Follow the app's instructions to connect your tools. The app auto-detects installed tools and offers one-click plugin installation.
+The app auto-detects installed coding tools. For **opencode**, **pi**, and **Codex CLI**, click *Install Plugin* in Settings > Monitored Tools.
+
+For **Claude Code**, run this one-liner in your terminal (the app also exposes a *Copy Install Command* button under Settings > Monitored Tools):
+
+```bash
+claude plugin marketplace add st0012/cctop && claude plugin install cctop
+```
+
+Restart any running sessions to pick up the hooks.
 
 ## Themes
 

--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		PT0000010000000000000001 /* PanelToggleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PT0000020000000000000001 /* PanelToggleTests.swift */; };
 		PCT000010000000000000001 /* PanelCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PCT000020000000000000001 /* PanelCoordinatorTests.swift */; };
 		NSN000010000000000000001 /* NSScreen+Notch.swift in Sources */ = {isa = PBXBuildFile; fileRef = NSN000020000000000000001 /* NSScreen+Notch.swift */; };
+		NPB000010000000000000001 /* NSPasteboard+Copy.swift in Sources */ = {isa = PBXBuildFile; fileRef = NPB000020000000000000001 /* NSPasteboard+Copy.swift */; };
 		NSP000010000000000000001 /* NotchStatusPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = NSP000020000000000000001 /* NotchStatusPanel.swift */; };
 		NSV000010000000000000001 /* NotchStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = NSV000020000000000000001 /* NotchStatusView.swift */; };
 		NSC000010000000000000001 /* NotchStatusController.swift in Sources */ = {isa = PBXBuildFile; fileRef = NSC000020000000000000001 /* NotchStatusController.swift */; };
@@ -175,6 +176,7 @@
 		PT0000020000000000000001 /* PanelToggleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelToggleTests.swift; sourceTree = "<group>"; };
 		PCT000020000000000000001 /* PanelCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelCoordinatorTests.swift; sourceTree = "<group>"; };
 		NSN000020000000000000001 /* NSScreen+Notch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScreen+Notch.swift"; sourceTree = "<group>"; };
+		NPB000020000000000000001 /* NSPasteboard+Copy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPasteboard+Copy.swift"; sourceTree = "<group>"; };
 		NSP000020000000000000001 /* NotchStatusPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchStatusPanel.swift; sourceTree = "<group>"; };
 		NSV000020000000000000001 /* NotchStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchStatusView.swift; sourceTree = "<group>"; };
 		NSC000020000000000000001 /* NotchStatusController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchStatusController.swift; sourceTree = "<group>"; };
@@ -375,6 +377,7 @@
 			isa = PBXGroup;
 			children = (
 				NSN000020000000000000001 /* NSScreen+Notch.swift */,
+				NPB000020000000000000001 /* NSPasteboard+Copy.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -528,6 +531,7 @@
 				EK0000010000000000000001 /* HostApp.swift in Sources */,
 				RPM000010000000000000001 /* RecentProject+Mock.swift in Sources */,
 				NSN000010000000000000001 /* NSScreen+Notch.swift in Sources */,
+				NPB000010000000000000001 /* NSPasteboard+Copy.swift in Sources */,
 				NSP000010000000000000001 /* NotchStatusPanel.swift in Sources */,
 				NSV000010000000000000001 /* NotchStatusView.swift in Sources */,
 				NSC000010000000000000001 /* NotchStatusController.swift in Sources */,

--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		FX0000010000000000000001 /* HookInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FX0000020000000000000001 /* HookInputTests.swift */; };
 		CPT000010000000000000001 /* CodexPluginInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CPT000020000000000000001 /* CodexPluginInstallerTests.swift */; };
 		CPTOML010000000000000001 /* CodexPluginTomlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CPTOML020000000000000001 /* CodexPluginTomlTests.swift */; };
+		PMCCD0010000000000000001 /* PluginManagerCcDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PMCCD0020000000000000001 /* PluginManagerCcDetectionTests.swift */; };
 		FX0000030000000000000001 /* HookInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = P10000040000000000000001 /* HookInput.swift */; };
 		HH0000010000000000000001 /* HookHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = HH0000020000000000000001 /* HookHandlerTests.swift */; };
 		HH0000030000000000000001 /* HookHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = P10000060000000000000001 /* HookHandler.swift */; };
@@ -133,6 +134,7 @@
 		FX0000020000000000000001 /* HookInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInputTests.swift; sourceTree = "<group>"; };
 		CPT000020000000000000001 /* CodexPluginInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexPluginInstallerTests.swift; sourceTree = "<group>"; };
 		CPTOML020000000000000001 /* CodexPluginTomlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexPluginTomlTests.swift; sourceTree = "<group>"; };
+		PMCCD0020000000000000001 /* PluginManagerCcDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginManagerCcDetectionTests.swift; sourceTree = "<group>"; };
 		HH0000020000000000000001 /* HookHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookHandlerTests.swift; sourceTree = "<group>"; };
 		HT0000020000000000000001 /* HookEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookEventTests.swift; sourceTree = "<group>"; };
 		J10000020000000000000001 /* SettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSection.swift; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 				FX0000020000000000000001 /* HookInputTests.swift */,
 				CPT000020000000000000001 /* CodexPluginInstallerTests.swift */,
 				CPTOML020000000000000001 /* CodexPluginTomlTests.swift */,
+				PMCCD0020000000000000001 /* PluginManagerCcDetectionTests.swift */,
 				HH0000020000000000000001 /* HookHandlerTests.swift */,
 				SN0000040000000000000001 /* SessionNameLookupTests.swift */,
 				FK0000020000000000000001 /* ForkSessionTests.swift */,
@@ -563,6 +566,7 @@
 				FX0000010000000000000001 /* HookInputTests.swift in Sources */,
 				CPT000010000000000000001 /* CodexPluginInstallerTests.swift in Sources */,
 				CPTOML010000000000000001 /* CodexPluginTomlTests.swift in Sources */,
+				PMCCD0010000000000000001 /* PluginManagerCcDetectionTests.swift in Sources */,
 				HH0000010000000000000001 /* HookHandlerTests.swift in Sources */,
 				SN0000030000000000000001 /* SessionNameLookupTests.swift in Sources */,
 				FK0000010000000000000001 /* ForkSessionTests.swift in Sources */,

--- a/menubar/CctopMenubar/Extensions/NSPasteboard+Copy.swift
+++ b/menubar/CctopMenubar/Extensions/NSPasteboard+Copy.swift
@@ -1,0 +1,9 @@
+import AppKit
+
+extension NSPasteboard {
+    /// Replaces the general pasteboard's contents with `string`.
+    static func copyToClipboard(_ string: String) {
+        general.clearContents()
+        general.setString(string, forType: .string)
+    }
+}

--- a/menubar/CctopMenubar/Services/PluginManager.swift
+++ b/menubar/CctopMenubar/Services/PluginManager.swift
@@ -16,6 +16,9 @@ class PluginManager: ObservableObject {
     @Published var codexConfigExists: Bool = false
     @Published var codexFlagAlreadyEnabled: Bool = false
 
+    static let ccInstallCommand =
+        "claude plugin marketplace add st0012/cctop && claude plugin install cctop"
+
     private static let home = FileManager.default.homeDirectoryForCurrentUser
     private static let ocPluginPath = home.appendingPathComponent(
         ".config/opencode/plugins/cctop.js"

--- a/menubar/CctopMenubar/Services/PluginManager.swift
+++ b/menubar/CctopMenubar/Services/PluginManager.swift
@@ -29,6 +29,8 @@ class PluginManager: ObservableObject {
     private static let ccPluginCacheDir = home.appendingPathComponent(
         ".claude/plugins/cache/cctop/cctop"
     )
+    static let ccOrphanedMarker = ".orphaned_at"
+    static let ccPluginManifestPath = ".claude-plugin/plugin.json"
 
     init() {
         refresh()
@@ -61,20 +63,17 @@ class PluginManager: ObservableObject {
         }
     }
 
-    /// Returns true if `baseDir` contains at least one version subdirectory that has a plugin
-    /// manifest and is not marked orphaned by Claude Code. The cache layout is
-    /// `<marketplace>/<plugin>/<version>/`, where each version dir may contain a `.orphaned_at`
-    /// marker after uninstall. Treating the marketplace cache dir alone as the install signal
-    /// causes false positives when only orphaned versions remain.
-    static func hasActiveClaudeCodePluginVersion(in baseDir: URL) -> Bool {
+    /// Cache layout is `<marketplace>/<plugin>/<version>/`. Claude Code writes a `.orphaned_at`
+    /// marker inside a version directory after uninstall instead of deleting the directory.
+    nonisolated static func hasActiveClaudeCodePluginVersion(in baseDir: URL) -> Bool {
         let fm = FileManager.default
         guard let versions = try? fm.contentsOfDirectory(atPath: baseDir.path) else {
             return false
         }
         return versions.contains { version in
             let versionDir = baseDir.appendingPathComponent(version)
-            let orphaned = versionDir.appendingPathComponent(".orphaned_at")
-            let manifest = versionDir.appendingPathComponent(".claude-plugin/plugin.json")
+            let orphaned = versionDir.appendingPathComponent(ccOrphanedMarker)
+            let manifest = versionDir.appendingPathComponent(ccPluginManifestPath)
             return !fm.fileExists(atPath: orphaned.path)
                 && fm.fileExists(atPath: manifest.path)
         }

--- a/menubar/CctopMenubar/Services/PluginManager.swift
+++ b/menubar/CctopMenubar/Services/PluginManager.swift
@@ -26,6 +26,9 @@ class PluginManager: ObservableObject {
     private static let piPluginPath = home.appendingPathComponent(
         ".pi/agent/extensions/cctop.ts"
     )
+    private static let ccPluginCacheDir = home.appendingPathComponent(
+        ".claude/plugins/cache/cctop/cctop"
+    )
 
     init() {
         refresh()
@@ -35,10 +38,7 @@ class PluginManager: ObservableObject {
         let fm = FileManager.default
         let home = Self.home
 
-        let ccDir = home.appendingPathComponent(".claude/plugins/cache/cctop")
-        var isDir: ObjCBool = false
-        ccInstalled = fm.fileExists(atPath: ccDir.path, isDirectory: &isDir)
-            && isDir.boolValue
+        ccInstalled = Self.hasActiveClaudeCodePluginVersion(in: Self.ccPluginCacheDir)
 
         let ocConfigDir = home.appendingPathComponent(".config/opencode")
         ocConfigExists = fm.fileExists(atPath: ocConfigDir.path)
@@ -58,6 +58,25 @@ class PluginManager: ObservableObject {
             codexFlagAlreadyEnabled = CodexPluginInstaller.isFeatureFlagEnabled(text)
         } else {
             codexFlagAlreadyEnabled = false
+        }
+    }
+
+    /// Returns true if `baseDir` contains at least one version subdirectory that has a plugin
+    /// manifest and is not marked orphaned by Claude Code. The cache layout is
+    /// `<marketplace>/<plugin>/<version>/`, where each version dir may contain a `.orphaned_at`
+    /// marker after uninstall. Treating the marketplace cache dir alone as the install signal
+    /// causes false positives when only orphaned versions remain.
+    static func hasActiveClaudeCodePluginVersion(in baseDir: URL) -> Bool {
+        let fm = FileManager.default
+        guard let versions = try? fm.contentsOfDirectory(atPath: baseDir.path) else {
+            return false
+        }
+        return versions.contains { version in
+            let versionDir = baseDir.appendingPathComponent(version)
+            let orphaned = versionDir.appendingPathComponent(".orphaned_at")
+            let manifest = versionDir.appendingPathComponent(".claude-plugin/plugin.json")
+            return !fm.fileExists(atPath: orphaned.path)
+                && fm.fileExists(atPath: manifest.path)
         }
     }
 

--- a/menubar/CctopMenubar/Views/EmptyStateView.swift
+++ b/menubar/CctopMenubar/Views/EmptyStateView.swift
@@ -188,8 +188,7 @@ struct EmptyStateView: View {
             Spacer(minLength: 0)
 
             Button {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(command, forType: .string)
+                NSPasteboard.copyToClipboard(command)
                 copied = true
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                     copied = false

--- a/menubar/CctopMenubar/Views/EmptyStateView.swift
+++ b/menubar/CctopMenubar/Views/EmptyStateView.swift
@@ -2,12 +2,9 @@ import SwiftUI
 
 struct EmptyStateView: View {
     @ObservedObject var pluginManager: PluginManager
-    @State private var copiedIndex: Int?
+    @State private var copied = false
     @State private var justInstalledOC = false
     @State private var justInstalledPi = false
-
-    private static let ccMarketplace = "claude plugin marketplace add st0012/cctop"
-    private static let ccInstall = "claude plugin install cctop"
 
     private var anyInstalled: Bool {
         pluginManager.ccInstalled || pluginManager.ocInstalled
@@ -150,8 +147,7 @@ struct EmptyStateView: View {
         VStack(spacing: 12) {
             VStack(spacing: 6) {
                 sectionHeader("Claude Code")
-                commandRow(Self.ccMarketplace, index: 1)
-                commandRow(Self.ccInstall, index: 2)
+                commandRow(PluginManager.ccInstallCommand)
             }
 
             if pluginManager.ocConfigExists {
@@ -181,7 +177,7 @@ struct EmptyStateView: View {
         }
     }
 
-    private func commandRow(_ command: String, index: Int) -> some View {
+    private func commandRow(_ command: String) -> some View {
         HStack(spacing: 6) {
             Text(command)
                 .font(.system(size: 10, design: .monospaced))
@@ -194,14 +190,14 @@ struct EmptyStateView: View {
             Button {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(command, forType: .string)
-                copiedIndex = index
+                copied = true
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                    if copiedIndex == index { copiedIndex = nil }
+                    copied = false
                 }
             } label: {
-                Image(systemName: copiedIndex == index ? "checkmark" : "doc.on.doc")
+                Image(systemName: copied ? "checkmark" : "doc.on.doc")
                     .font(.system(size: 10))
-                    .foregroundStyle(copiedIndex == index ? .green : Color.textSecondary)
+                    .foregroundStyle(copied ? .green : Color.textSecondary)
                     .frame(width: 20, height: 20)
             }
             .buttonStyle(.plain)

--- a/menubar/CctopMenubar/Views/EmptyStateView.swift
+++ b/menubar/CctopMenubar/Views/EmptyStateView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct EmptyStateView: View {
     @ObservedObject var pluginManager: PluginManager
-    @State private var copied = false
     @State private var justInstalledOC = false
     @State private var justInstalledPi = false
 
@@ -147,7 +146,10 @@ struct EmptyStateView: View {
         VStack(spacing: 12) {
             VStack(spacing: 6) {
                 sectionHeader("Claude Code")
-                commandRow(PluginManager.ccInstallCommand)
+                HStack {
+                    Spacer()
+                    ClaudeCodeInstallButton()
+                }
             }
 
             if pluginManager.ocConfigExists {
@@ -175,36 +177,6 @@ struct EmptyStateView: View {
                 .foregroundStyle(Color.textSecondary)
             Spacer()
         }
-    }
-
-    private func commandRow(_ command: String) -> some View {
-        HStack(spacing: 6) {
-            Text(command)
-                .font(.system(size: 10, design: .monospaced))
-                .foregroundStyle(Color.textSecondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-
-            Spacer(minLength: 0)
-
-            Button {
-                NSPasteboard.copyToClipboard(command)
-                copied = true
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                    copied = false
-                }
-            } label: {
-                Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                    .font(.system(size: 10))
-                    .foregroundStyle(copied ? .green : Color.textSecondary)
-                    .frame(width: 20, height: 20)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 5)
-        .background(Color.textPrimary.opacity(0.04))
-        .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 
     private func stepRow(text: String) -> some View {

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -340,7 +340,6 @@ private struct PluginRowView: View {
 
 private struct ClaudeCodePluginRowView: View {
     @ObservedObject var pluginManager: PluginManager
-    @State private var justCopied = false
 
     var body: some View {
         HStack(spacing: 8) {
@@ -350,13 +349,25 @@ private struct ClaudeCodePluginRowView: View {
             Spacer()
             if pluginManager.ccInstalled {
                 ConnectedBadge()
-            } else if justCopied {
-                copiedPill
             } else {
-                copyButton
+                ClaudeCodeInstallButton()
             }
         }
         .padding(.vertical, 7)
+    }
+}
+
+/// Amber "Copy Install Command" button that flips to a green confirmation pill for 2s on click.
+/// Shared by the Settings row and the empty-state install prompt.
+struct ClaudeCodeInstallButton: View {
+    @State private var justCopied = false
+
+    var body: some View {
+        if justCopied {
+            copiedPill
+        } else {
+            copyButton
+        }
     }
 
     private var copyButton: some View {

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -256,7 +256,7 @@ private struct MonitoredToolsView: View {
     @Binding var installFailed: Bool
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            toolStatusRow(name: "Claude Code", installed: pluginManager.ccInstalled)
+            ClaudeCodePluginRowView(pluginManager: pluginManager)
             if pluginManager.ocConfigExists {
                 PluginRowView(name: "opencode", installed: pluginManager.ocInstalled,
                     needsUpdate: pluginManager.ocNeedsUpdate, installFailed: $installFailed,

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -392,15 +392,15 @@ private struct ClaudeCodePluginRowView: View {
         HStack(spacing: 4) {
             Image(systemName: "checkmark")
                 .font(.system(size: 9, weight: .bold))
-                .foregroundStyle(.green)
+                .foregroundStyle(Color.statusGreen)
             Text("Copied \u{2014} paste in terminal")
                 .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(.green)
+                .foregroundStyle(Color.statusGreen)
         }
         .padding(.horizontal, 8).padding(.vertical, 3)
         .overlay(
             RoundedRectangle(cornerRadius: 4)
-                .stroke(Color.green, lineWidth: 1)
+                .stroke(Color.statusGreen, lineWidth: 1)
         )
         .transition(.opacity)
     }

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -274,14 +274,6 @@ private struct MonitoredToolsView: View {
         }
         .padding(.horizontal, 14).padding(.bottom, 8)
     }
-    private func toolStatusRow(name: String, installed: Bool) -> some View {
-        HStack(spacing: 8) {
-            Text(name).font(.system(size: 11, weight: .medium)).foregroundStyle(Color.textPrimary)
-            Spacer()
-            if installed { ConnectedBadge()
-            } else { Text("Not installed").font(.system(size: 10)).foregroundStyle(Color.textMuted) }
-        }.padding(.vertical, 7)
-    }
 }
 
 private struct PluginRowView: View {
@@ -369,10 +361,7 @@ private struct ClaudeCodePluginRowView: View {
 
     private var copyButton: some View {
         Button {
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(
-                PluginManager.ccInstallCommand, forType: .string
-            )
+            NSPasteboard.copyToClipboard(PluginManager.ccInstallCommand)
             justCopied = true
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                 justCopied = false

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -346,6 +346,66 @@ private struct PluginRowView: View {
     }
 }
 
+private struct ClaudeCodePluginRowView: View {
+    @ObservedObject var pluginManager: PluginManager
+    @State private var justCopied = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text("Claude Code")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(Color.textPrimary)
+            Spacer()
+            if pluginManager.ccInstalled {
+                ConnectedBadge()
+            } else if justCopied {
+                copiedPill
+            } else {
+                copyButton
+            }
+        }
+        .padding(.vertical, 7)
+    }
+
+    private var copyButton: some View {
+        Button {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(
+                PluginManager.ccInstallCommand, forType: .string
+            )
+            justCopied = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                justCopied = false
+            }
+        } label: {
+            Text("Copy Install Command")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Color.segmentActiveText)
+                .padding(.horizontal, 8).padding(.vertical, 3)
+                .background(Color.amber)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var copiedPill: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "checkmark")
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(.green)
+            Text("Copied \u{2014} paste in terminal")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.green)
+        }
+        .padding(.horizontal, 8).padding(.vertical, 3)
+        .overlay(
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(Color.green, lineWidth: 1)
+        )
+        .transition(.opacity)
+    }
+}
+
 private struct CodexPluginRowView: View {
     @ObservedObject var pluginManager: PluginManager
     @Binding var installFailed: Bool
@@ -386,6 +446,21 @@ private struct ConnectedBadge: View {
     } }
 }
 // MARK: - Previews
+@MainActor private func previewCCRow(installed: Bool) -> PluginManager {
+    let pm = PluginManager()
+    pm.ccInstalled = installed
+    return pm
+}
+
+#Preview("CC row - Not installed") {
+    ClaudeCodePluginRowView(pluginManager: previewCCRow(installed: false))
+        .frame(width: 320).padding()
+}
+#Preview("CC row - Connected") {
+    ClaudeCodePluginRowView(pluginManager: previewCCRow(installed: true))
+        .frame(width: 320).padding()
+}
+
 @MainActor private class MockUpdater: UpdaterBase { override var canCheckForUpdates: Bool { true } }
 @MainActor private func previewPM() -> PluginManager {
     let pm = PluginManager(); pm.ccInstalled = true; pm.ocInstalled = true

--- a/menubar/CctopMenubarTests/PluginManagerCcDetectionTests.swift
+++ b/menubar/CctopMenubarTests/PluginManagerCcDetectionTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import CctopMenubar
 
-@MainActor
 final class PluginManagerCcDetectionTests: XCTestCase {
 
     func testReturnsFalseWhenCacheDirMissing() {
@@ -9,7 +8,7 @@ final class PluginManagerCcDetectionTests: XCTestCase {
         XCTAssertFalse(PluginManager.hasActiveClaudeCodePluginVersion(in: dir))
     }
 
-    func testReturnsFalseWhenCacheDirEmpty() throws {
+    func testReturnsFalseWhenCacheDirEmpty() {
         let dir = makeTempDir()
         XCTAssertFalse(PluginManager.hasActiveClaudeCodePluginVersion(in: dir))
     }
@@ -59,18 +58,15 @@ final class PluginManagerCcDetectionTests: XCTestCase {
             at: versionDir, withIntermediateDirectories: true
         )
         if manifest {
-            let claudePluginDir = versionDir.appendingPathComponent(".claude-plugin")
+            let manifestURL = versionDir.appendingPathComponent(PluginManager.ccPluginManifestPath)
             try FileManager.default.createDirectory(
-                at: claudePluginDir, withIntermediateDirectories: true
+                at: manifestURL.deletingLastPathComponent(), withIntermediateDirectories: true
             )
-            try "{}".write(
-                to: claudePluginDir.appendingPathComponent("plugin.json"),
-                atomically: true, encoding: .utf8
-            )
+            try "{}".write(to: manifestURL, atomically: true, encoding: .utf8)
         }
         if orphaned {
             try "2026-05-15T00:00:00Z".write(
-                to: versionDir.appendingPathComponent(".orphaned_at"),
+                to: versionDir.appendingPathComponent(PluginManager.ccOrphanedMarker),
                 atomically: true, encoding: .utf8
             )
         }

--- a/menubar/CctopMenubarTests/PluginManagerCcDetectionTests.swift
+++ b/menubar/CctopMenubarTests/PluginManagerCcDetectionTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import CctopMenubar
+
+@MainActor
+final class PluginManagerCcDetectionTests: XCTestCase {
+
+    func testReturnsFalseWhenCacheDirMissing() {
+        let dir = makeTempDir().appendingPathComponent("missing")
+        XCTAssertFalse(PluginManager.hasActiveClaudeCodePluginVersion(in: dir))
+    }
+
+    func testReturnsFalseWhenCacheDirEmpty() throws {
+        let dir = makeTempDir()
+        XCTAssertFalse(PluginManager.hasActiveClaudeCodePluginVersion(in: dir))
+    }
+
+    func testReturnsFalseWhenOnlyOrphanedVersion() throws {
+        let dir = makeTempDir()
+        try makeVersion(in: dir, name: "0.11.0", orphaned: true, manifest: true)
+        XCTAssertFalse(PluginManager.hasActiveClaudeCodePluginVersion(in: dir))
+    }
+
+    func testReturnsFalseWhenVersionMissingManifest() throws {
+        let dir = makeTempDir()
+        try makeVersion(in: dir, name: "0.11.0", orphaned: false, manifest: false)
+        XCTAssertFalse(PluginManager.hasActiveClaudeCodePluginVersion(in: dir))
+    }
+
+    func testReturnsTrueForActiveVersion() throws {
+        let dir = makeTempDir()
+        try makeVersion(in: dir, name: "0.15.3", orphaned: false, manifest: true)
+        XCTAssertTrue(PluginManager.hasActiveClaudeCodePluginVersion(in: dir))
+    }
+
+    func testReturnsTrueWhenMixedOrphanedAndActive() throws {
+        let dir = makeTempDir()
+        try makeVersion(in: dir, name: "0.11.0", orphaned: true, manifest: true)
+        try makeVersion(in: dir, name: "0.15.3", orphaned: false, manifest: true)
+        XCTAssertTrue(PluginManager.hasActiveClaudeCodePluginVersion(in: dir))
+    }
+
+    // MARK: - Helpers
+
+    private func makeTempDir() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-cc-detect-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+
+    private func makeVersion(
+        in baseDir: URL, name: String, orphaned: Bool, manifest: Bool
+    ) throws {
+        let versionDir = baseDir.appendingPathComponent(name)
+        try FileManager.default.createDirectory(
+            at: versionDir, withIntermediateDirectories: true
+        )
+        if manifest {
+            let claudePluginDir = versionDir.appendingPathComponent(".claude-plugin")
+            try FileManager.default.createDirectory(
+                at: claudePluginDir, withIntermediateDirectories: true
+            )
+            try "{}".write(
+                to: claudePluginDir.appendingPathComponent("plugin.json"),
+                atomically: true, encoding: .utf8
+            )
+        }
+        if orphaned {
+            try "2026-05-15T00:00:00Z".write(
+                to: versionDir.appendingPathComponent(".orphaned_at"),
+                atomically: true, encoding: .utf8
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes [#109](https://github.com/st0012/cctop/issues/109).

## Why

The reporter couldn't figure out how to install the Claude Code plugin. Three gaps compounded:

1. The [README documented uninstall but not install](https://github.com/st0012/cctop/blob/868f151d6845bd397e3f269cbc7f6e3e1cb88b7e/README.md#L168) — the install path was implicit ("Follow the app's instructions").
2. The Settings panel had no install affordance for Claude Code, while [opencode/pi/Codex CLI rows showed an *Install Plugin* button](https://github.com/st0012/cctop/blob/868f151d6845bd397e3f269cbc7f6e3e1cb88b7e/menubar/CctopMenubar/Views/SettingsSection.swift#L257-L274) — Claude Code rendered as just "Not installed" with no action.
3. The empty state showed [two separate copy rows](https://github.com/st0012/cctop/blob/868f151d6845bd397e3f269cbc7f6e3e1cb88b7e/menubar/CctopMenubar/Views/EmptyStateView.swift#L150-L155) for `claude plugin marketplace add` and `claude plugin install`. Copying only the obvious "install" line skipped the marketplace step.

While investigating, I also found that `PluginManager.ccInstalled` reported `true` whenever `~/.claude/plugins/cache/cctop` existed as a directory — Claude Code leaves that directory in place after uninstall and just adds an [`.orphaned_at` marker inside the version subdirectory](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces#how-claude-code-discovers-plugins), so cctop was reporting "Connected" for users who had uninstalled.

## What changed

**App surface**
- [`ClaudeCodePluginRowView`](https://github.com/st0012/cctop/pull/110/files#diff-be6c12af9a31bba2538430a7e35eb6e5f7f47c4e88dec5d089db4f7e3acb5d24) renders an amber "Copy Install Command" button when CC isn't installed, flips to a `Color.statusGreen` "Copied — paste in terminal" pill for 2 seconds on click, and shows the existing `ConnectedBadge` when installed. Lives in `MonitoredToolsView` next to the other plugin rows.
- The empty state now shows one command row instead of two, copying the chained one-liner `claude plugin marketplace add st0012/cctop && claude plugin install cctop`. `&&` ensures the second command only runs if the first succeeds, so users can't skip the marketplace step. The command is a single static constant (`PluginManager.ccInstallCommand`) shared by both views.

**Detection fix**
- `PluginManager.hasActiveClaudeCodePluginVersion(in:)` walks `~/.claude/plugins/cache/cctop/cctop/<version>/` and treats a version as active only if it has `.claude-plugin/plugin.json` *and* lacks `.orphaned_at`. The cache layout (`<marketplace>/<plugin>/<version>/`) follows [Claude Code's documented plugin storage structure](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces).
- Covered by 6 new unit tests in `PluginManagerCcDetectionTests.swift` (missing dir, empty dir, orphaned-only, manifest-only, happy path, mixed orphaned + active).

**Docs**
- README §Installation Step 2 now includes the one-liner explicitly and points at the *Copy Install Command* button in the app.

**Cleanup (post-review simplify pass)**
- Extracted `NSPasteboard.copyToClipboard(_:)` used by both views.
- Deleted dead `MonitoredToolsView.toolStatusRow` helper (replaced by `ClaudeCodePluginRowView`).
- Hoisted `.orphaned_at` and `.claude-plugin/plugin.json` to named constants shared between code and tests.

## Why not auto-run the install command?

cctop deliberately doesn't shell out to `claude` directly. The project guideline is to never modify a user's tool configuration without explicit consent ([CLAUDE.md](https://github.com/st0012/cctop/blob/master/CLAUDE.md#must-follow-development-principles)), and we don't know where `claude` lives in the user's `PATH`. Copy-to-clipboard puts the user in control while still removing the marketplace/install ordering pitfall.