### PR TITLE
fix: Desktop session name handling (Claude + Codex)

### DIFF
--- a/fixtures/UserPromptSubmit-opencode.json
+++ b/fixtures/UserPromptSubmit-opencode.json
@@ -1,0 +1,7 @@
+{
+  "session_id": "opencode-12345",
+  "cwd": "/tmp/test-project",
+  "hook_event_name": "UserPromptSubmit",
+  "harness_name": "opencode",
+  "prompt": "Help me debug this"
+}

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -101,9 +101,18 @@ enum HookHandler {
             // sessionName with nil on every UserPromptSubmit whose transcript
             // didn't yet contain a `custom-title` entry, regressing any name set
             // by an earlier event.
-            if let name = SessionNameLookup.lookupSessionName(
-                transcriptPath: input.transcriptPath, sessionId: input.sessionId
-            ) {
+            //
+            // Codex sessions use a different local source: `~/.codex/session_index.jsonl`
+            // — Codex Desktop writes the user-visible thread name there, keyed by session_id.
+            let lookedUp: String?
+            if session.source == "codex" {
+                lookedUp = SessionNameLookup.lookupCodexThreadName(sessionId: input.sessionId)
+            } else {
+                lookedUp = SessionNameLookup.lookupSessionName(
+                    transcriptPath: input.transcriptPath, sessionId: input.sessionId
+                )
+            }
+            if let name = lookedUp {
                 session.sessionName = name
             }
         }

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -182,9 +182,17 @@ enum HookHandler {
            abs(storedStart - currentStart) > 1.0 {
             return fresh
         }
-        // Same process but CC assigned a new session_id (e.g. resume) — carry over state
+        // Same PID, different session_id — the OS process is now hosting a new
+        // conversation. Common for Codex Desktop, which keeps one long-lived
+        // process and spawns a new session_id per "new chat". Drop all
+        // conversation-specific state (project, name, prompt, tools, etc.) and
+        // only carry over PID liveness metadata so the process-alive check
+        // keeps working.
         guard existing.sessionId == fresh.sessionId else {
-            return existing.withSessionId(fresh.sessionId, branch: fresh.branch, terminal: fresh.terminal)
+            var carried = fresh
+            carried.pid = existing.pid
+            carried.pidStartTime = existing.pidStartTime
+            return carried
         }
         return existing
     }

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -97,9 +97,15 @@ enum HookHandler {
         if let name = input.sessionName {
             session.sessionName = name
         } else if event == .sessionStart || event == .userPromptSubmit {
-            session.sessionName = SessionNameLookup.lookupSessionName(
+            // Only overwrite when the lookup succeeds. Previously this clobbered
+            // sessionName with nil on every UserPromptSubmit whose transcript
+            // didn't yet contain a `custom-title` entry, regressing any name set
+            // by an earlier event.
+            if let name = SessionNameLookup.lookupSessionName(
                 transcriptPath: input.transcriptPath, sessionId: input.sessionId
-            )
+            ) {
+                session.sessionName = name
+            }
         }
         return (oldStatus, newStatus)
     }

--- a/menubar/CctopMenubar/Hook/SessionNameLookup.swift
+++ b/menubar/CctopMenubar/Hook/SessionNameLookup.swift
@@ -39,6 +39,32 @@ enum SessionNameLookup {
         return nil
     }
 
+    /// Look up a Codex Desktop thread name from `~/.codex/session_index.jsonl`.
+    /// That file is JSONL with `{"id":"<uuid>","thread_name":"<title>","updated_at":"..."}`
+    /// per line, written by Codex Desktop itself. This is the canonical local source
+    /// for Codex Desktop conversation titles — unlike Claude Desktop, which keeps
+    /// titles server-side.
+    static func lookupCodexThreadName(
+        sessionId: String,
+        indexPath: String = NSString(string: "~/.codex/session_index.jsonl").expandingTildeInPath
+    ) -> String? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: indexPath)),
+              let content = String(data: data, encoding: .utf8)
+        else { return nil }
+
+        // Scan in reverse so the most recent entry for a session_id wins.
+        for line in content.components(separatedBy: "\n").reversed() {
+            guard line.contains(sessionId) else { continue }
+            guard let lineData = line.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  json["id"] as? String == sessionId,
+                  let name = json["thread_name"] as? String, !name.isEmpty
+            else { continue }
+            return name
+        }
+        return nil
+    }
+
     private static func lookupNameFromIndex(indexPath: String, sessionId: String) -> String? {
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: indexPath)),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -249,11 +249,37 @@ final class HookHandlerTests: XCTestCase {
         try handleFixture("SessionStart-opencode")  // sets sessionName = "Fix login bug"
         XCTAssertEqual(try loadSession().sessionName, "Fix login bug")
 
-        // UserPromptSubmit fixture has no session_name and no transcript path,
-        // so the lookup will return nil. sessionName should be preserved.
-        try handleFixture("UserPromptSubmit")
+        // Same session_id, UserPromptSubmit with no `session_name` field and no
+        // transcript_path. Lookup will return nil. sessionName should be preserved.
+        try handleFixture("UserPromptSubmit-opencode")
         XCTAssertEqual(try loadSession().sessionName, "Fix login bug",
-                       "sessionName should be preserved when lookup returns nil")
+                       "sessionName should be preserved when lookup returns nil within the same session")
+    }
+
+    /// Regression: same OS process, new session_id (Codex Desktop's "new chat"
+    /// flow) used to carry over all conversation state — name, project, prompt,
+    /// tool detail — from the previous conversation, surfacing the old chat's
+    /// title under the new one. The fix drops conversation-specific state and
+    /// keeps only PID liveness metadata.
+    func testSessionIdChange_inSamePID_resetsConversationState() throws {
+        try handleFixture("SessionStart-opencode")
+        let first = try loadSession()
+        XCTAssertEqual(first.sessionId, "opencode-12345")
+        XCTAssertEqual(first.sessionName, "Fix login bug")
+        XCTAssertEqual(first.projectName, "test-project")
+
+        // Same PID (test runner), different session_id. Simulates Codex Desktop
+        // spawning a new conversation inside the same OS process.
+        try handleFixture("SessionStart")
+        let second = try loadSession()
+        XCTAssertEqual(second.sessionId, "test-session-001",
+                       "session_id should update to the new conversation's id")
+        XCTAssertNil(second.sessionName,
+                     "sessionName should be reset — not carried over from the previous conversation")
+        XCTAssertEqual(second.pid, first.pid,
+                       "PID liveness metadata should carry over")
+        XCTAssertEqual(second.pidStartTime, first.pidStartTime,
+                       "pidStartTime should carry over for the process-alive check")
     }
 
     // MARK: - Full lifecycle sequence

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -239,6 +239,23 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertEqual(session.sessionName, "Refactor auth module")
     }
 
+    // MARK: - Session name preservation across events
+
+    /// Regression: previously, UserPromptSubmit re-looked up the session name from
+    /// the transcript and overwrote `sessionName` with nil when no `custom-title`
+    /// entry was present. Subsequent prompts kept clobbering it. The fix: only
+    /// overwrite sessionName when the lookup actually returns a value.
+    func testUserPromptSubmit_doesNotClobberSessionName_whenLookupFails() throws {
+        try handleFixture("SessionStart-opencode")  // sets sessionName = "Fix login bug"
+        XCTAssertEqual(try loadSession().sessionName, "Fix login bug")
+
+        // UserPromptSubmit fixture has no session_name and no transcript path,
+        // so the lookup will return nil. sessionName should be preserved.
+        try handleFixture("UserPromptSubmit")
+        XCTAssertEqual(try loadSession().sessionName, "Fix login bug",
+                       "sessionName should be preserved when lookup returns nil")
+    }
+
     // MARK: - Full lifecycle sequence
 
     func testFullLifecycle() throws {

--- a/menubar/CctopMenubarTests/SessionNameLookupTests.swift
+++ b/menubar/CctopMenubarTests/SessionNameLookupTests.swift
@@ -183,4 +183,86 @@ final class SessionNameLookupTests: XCTestCase {
         )
         XCTAssertEqual(result, "from transcript")
     }
+
+    // MARK: - Codex session_index.jsonl lookup
+
+    func testCodex_findsThreadNameByExactSessionId() {
+        let indexPath = tmpDir + "/session_index.jsonl"
+        let content = """
+        {"id":"019e1ef6-0cde-77a2-a873-ddcb33240005","thread_name":"Help me create a zh-tw draft","updated_at":"2026-05-13T01:31:42.415727Z"}
+        {"id":"019e1eff-3374-74b0-8d3d-6fba94e7d75f","thread_name":"Investigate tanstack incident","updated_at":"2026-05-13T01:42:01.071611Z"}
+        {"id":"019e415d-b7a1-77d2-b019-1288a45e57f3","thread_name":"Review project architecture","updated_at":"2026-05-19T17:52:37.293141Z"}
+        """
+        try! content.write(toFile: indexPath, atomically: true, encoding: .utf8)
+
+        let result = SessionNameLookup.lookupCodexThreadName(
+            sessionId: "019e415d-b7a1-77d2-b019-1288a45e57f3",
+            indexPath: indexPath
+        )
+        XCTAssertEqual(result, "Review project architecture")
+    }
+
+    func testCodex_returnsLatestEntryWhenSessionIdAppearsTwice() {
+        let indexPath = tmpDir + "/session_index.jsonl"
+        let content = """
+        {"id":"s1","thread_name":"original","updated_at":"2026-05-19T17:00:00Z"}
+        {"id":"other","thread_name":"unrelated","updated_at":"2026-05-19T17:30:00Z"}
+        {"id":"s1","thread_name":"renamed","updated_at":"2026-05-19T18:00:00Z"}
+        """
+        try! content.write(toFile: indexPath, atomically: true, encoding: .utf8)
+
+        let result = SessionNameLookup.lookupCodexThreadName(
+            sessionId: "s1", indexPath: indexPath
+        )
+        XCTAssertEqual(result, "renamed")
+    }
+
+    func testCodex_missingFileReturnsNil() {
+        let result = SessionNameLookup.lookupCodexThreadName(
+            sessionId: "s1", indexPath: tmpDir + "/nonexistent.jsonl"
+        )
+        XCTAssertNil(result)
+    }
+
+    func testCodex_noMatchingSessionIdReturnsNil() {
+        let indexPath = tmpDir + "/session_index.jsonl"
+        let content = """
+        {"id":"other","thread_name":"unrelated","updated_at":"2026-05-19T17:00:00Z"}
+        """
+        try! content.write(toFile: indexPath, atomically: true, encoding: .utf8)
+
+        let result = SessionNameLookup.lookupCodexThreadName(
+            sessionId: "s1", indexPath: indexPath
+        )
+        XCTAssertNil(result)
+    }
+
+    func testCodex_emptyThreadNameIsIgnored() {
+        let indexPath = tmpDir + "/session_index.jsonl"
+        let content = """
+        {"id":"s1","thread_name":"","updated_at":"2026-05-19T17:00:00Z"}
+        """
+        try! content.write(toFile: indexPath, atomically: true, encoding: .utf8)
+
+        let result = SessionNameLookup.lookupCodexThreadName(
+            sessionId: "s1", indexPath: indexPath
+        )
+        XCTAssertNil(result)
+    }
+
+    func testCodex_skipsLinesContainingIdSubstringButDifferentId() {
+        // Guard against the contains() shortcut matching the wrong line —
+        // e.g. a session_id that's a prefix of another.
+        let indexPath = tmpDir + "/session_index.jsonl"
+        let content = """
+        {"id":"s1-prefix-of-something-else","thread_name":"wrong match","updated_at":"2026-05-19T17:00:00Z"}
+        {"id":"s1","thread_name":"correct match","updated_at":"2026-05-19T18:00:00Z"}
+        """
+        try! content.write(toFile: indexPath, atomically: true, encoding: .utf8)
+
+        let result = SessionNameLookup.lookupCodexThreadName(
+            sessionId: "s1", indexPath: indexPath
+        )
+        XCTAssertEqual(result, "correct match")
+    }
 }


### PR DESCRIPTION
## Summary

Three independent fixes to how cctop populates `Session.sessionName` for Desktop AI app sessions. Each addresses a visible regression where the menubar showed the wrong title (or the project folder name) instead of the actual conversation title.

## Bugs fixed

### 1. `sessionName` clobbered on `UserPromptSubmit` when transcript lookup returns nil — [`0f02a69`](https://github.com/st0012/cctop/commit/0f02a69)

`HookHandler.applyTransition` re-ran `SessionNameLookup.lookupSessionName` on every `UserPromptSubmit` and unconditionally wrote the result into `session.sessionName` — including when the result was `nil`. Any name set by a prior hook (or by Claude Desktop sending `session_name` directly in an earlier payload) got nuked on the next user prompt unless the transcript already contained a `{\"type\":\"custom-title\",\"customTitle\":...}` line.

Fix: only overwrite when the lookup actually returns a value.

### 2. Codex Desktop conversation titles never displayed — [`ea83861`](https://github.com/st0012/cctop/commit/ea83861)

Codex Desktop writes a per-conversation name to `~/.codex/session_index.jsonl` — JSONL with `{\"id\":\"<session_id>\",\"thread_name\":\"<title>\",\"updated_at\":\"...\"}` per line — but cctop only looked in Claude Code's transcript JSONL. We never consulted Codex's local index, so titles from Codex Desktop's own UI never made it into the card.

Fix: new `SessionNameLookup.lookupCodexThreadName(sessionId:)` that reads the JSONL and returns the latest matching `thread_name`. `HookHandler` dispatches by `session.source` — codex sessions use the new lookup; everything else keeps the transcript path.

This is the canonical local source for Codex Desktop titles. For contrast, [Anthropic's hooks reference](https://code.claude.com/docs/en/hooks) doesn't expose any session-title field on hook *input* (only as an *output* via `hookSpecificOutput.sessionTitle` on `UserPromptSubmit`), and Claude Desktop keeps titles server-side. Tracking issues for proposed native input support: [anthropics/claude-code#23998](https://github.com/anthropics/claude-code/issues/23998), [#35316](https://github.com/anthropics/claude-code/issues/35316), [#47176](https://github.com/anthropics/claude-code/issues/47176).

### 3. Stale conversation state carried across `session_id` changes — [`1c3b11f`](https://github.com/st0012/cctop/commit/1c3b11f)

Codex Desktop runs one long-lived OS process that hosts many sequential conversations, each with its own `session_id`. cctop session files are PID-keyed, so the same file was reused across logical conversations. The old `existing.withSessionId(...)` path carried over **all** state — `projectName`, `projectPath`, `sessionName`, `lastPrompt`, `lastTool`, etc. — surfacing the previous chat's identity under the new one.

Symptom observed live: a fresh Codex Desktop session displayed \"Investigate tanstack incident\" (the previous chat's name) under \"goal-there-s-a-tanstack-security\" (the previous chat's cwd), even though both had changed.

Fix: when `session_id` changes within the same PID, return the fresh session unchanged except for `pid` + `pidStartTime` (still needed for the process-alive liveness check). The misleading comment about \"CC resume\" is removed — `claude resume` spawns a new process with a different PID, so it doesn't traverse this code path anyway.

## Coverage

- `SessionNameLookupTests` — 6 new tests covering exact-id match, latest-entry-wins on duplicate ids, missing file, no match, empty `thread_name`, and substring-containment edge case
- `HookHandlerTests.testUserPromptSubmit_doesNotClobberSessionName_whenLookupFails` — new regression test
- `HookHandlerTests.testSessionIdChange_inSamePID_resetsConversationState` — new regression test covering the Codex Desktop new-chat flow
- New `fixtures/UserPromptSubmit-opencode.json` for the same-session-id preserve test

## Net behavior

| Scenario | Before | After |
|---|---|---|
| Claude Code CLI with `/rename` | Correct | Correct (unchanged) |
| Claude Desktop sending `session_name` in payload | Worked once, then nuked | Persists across events |
| Codex Desktop named conversation | Folder name shown | Correct title from `session_index.jsonl` |
| Codex Desktop new chat in same process | Old chat's title + project | New chat's project; title looked up freshly |