### PR TITLE
fix: capture Claude Desktop session titles

### DIFF
--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -3,6 +3,10 @@ import Foundation
 private let maxToolDetailLen = 120
 
 enum HookHandler {
+    // Claude Desktop's app bundle id. Mirrors HostApp.claudeDesktop.bundleID, which
+    // isn't compiled into the cctop-hook target — keep the two values in sync.
+    private static let claudeDesktopBundleID = "com.anthropic.claudefordesktop"
+
     // MIGRATION(v0.6.0): Remove after all users have migrated to PID-keyed sessions.
     private static let noPIDMaxAge: TimeInterval = 300
 
@@ -96,17 +100,21 @@ enum HookHandler {
         if let harness = input.resolvedHarnessName { session.source = harness }
         if let name = input.sessionName {
             session.sessionName = name
-        } else if event == .sessionStart || event == .userPromptSubmit {
-            // Only overwrite when the lookup succeeds. Previously this clobbered
-            // sessionName with nil on every UserPromptSubmit whose transcript
-            // didn't yet contain a `custom-title` entry, regressing any name set
-            // by an earlier event.
+        } else if event == .sessionStart || event == .userPromptSubmit || event == .stop {
+            // Only overwrite when the lookup succeeds (preserve-on-fail). Re-running on
+            // .stop lets a just-started session pick up its title as soon as the first
+            // turn completes, instead of waiting for the next prompt.
             //
-            // Codex sessions use a different local source: `~/.codex/session_index.jsonl`
-            // — Codex Desktop writes the user-visible thread name there, keyed by session_id.
+            // Each harness exposes the title from a different local source:
+            //   - codex:          ~/.codex/session_index.jsonl (keyed by session_id)
+            //   - Claude Desktop: claude-code-sessions/**/local_*.json (keyed by cliSessionId);
+            //                     Desktop never writes a `custom-title` to the CC transcript
+            //   - terminal CC:    the transcript JSONL `custom-title` entry
             let lookedUp: String?
             if session.source == "codex" {
                 lookedUp = SessionNameLookup.lookupCodexThreadName(sessionId: input.sessionId)
+            } else if session.terminal?.bundleId == claudeDesktopBundleID {
+                lookedUp = SessionNameLookup.lookupClaudeDesktopTitle(cliSessionId: input.sessionId)
             } else {
                 lookedUp = SessionNameLookup.lookupSessionName(
                     transcriptPath: input.transcriptPath, sessionId: input.sessionId

--- a/menubar/CctopMenubar/Hook/SessionNameLookup.swift
+++ b/menubar/CctopMenubar/Hook/SessionNameLookup.swift
@@ -70,7 +70,7 @@ enum SessionNameLookup {
     /// Claude Desktop writes one JSON file per session with the user-visible `title`,
     /// keyed by `cliSessionId` (the Claude Code session_id). Unlike terminal Claude Code
     /// it never writes a `custom-title` entry to the transcript JSONL, so the transcript
-    /// lookup always fails for these sessions. Latest entry (by `lastActivityAt`) wins.
+    /// lookup always fails for these sessions. One file per session, so the first match wins.
     static func lookupClaudeDesktopTitle(
         cliSessionId: String,
         baseDir: String = Config.claudeCodeSessionsDir()
@@ -80,24 +80,19 @@ enum SessionNameLookup {
             at: URL(fileURLWithPath: baseDir), includingPropertiesForKeys: nil
         ) else { return nil }
 
-        var bestTitle: String?
-        var bestActivity = -Double.greatestFiniteMagnitude
         for case let url as URL in enumerator where url.pathExtension == "json" {
             guard let data = try? Data(contentsOf: url),
-                  // Cheap pre-filter before the full JSON parse.
+                  // Substring pre-filter skips the JSON parse for files that can't
+                  // match — these files are large (system prompt, MCP config, etc.).
                   let content = String(data: data, encoding: .utf8),
                   content.contains(cliSessionId),
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   json["cliSessionId"] as? String == cliSessionId,
                   let title = json["title"] as? String, !title.isEmpty
             else { continue }
-            let activity = (json["lastActivityAt"] as? Double) ?? 0
-            if activity > bestActivity {
-                bestActivity = activity
-                bestTitle = title
-            }
+            return title
         }
-        return bestTitle
+        return nil
     }
 
     private static func lookupNameFromIndex(indexPath: String, sessionId: String) -> String? {

--- a/menubar/CctopMenubar/Hook/SessionNameLookup.swift
+++ b/menubar/CctopMenubar/Hook/SessionNameLookup.swift
@@ -65,6 +65,41 @@ enum SessionNameLookup {
         return nil
     }
 
+    /// Look up a Claude Desktop conversation title from
+    /// `~/Library/Application Support/Claude/claude-code-sessions/<acct>/<org>/local_*.json`.
+    /// Claude Desktop writes one JSON file per session with the user-visible `title`,
+    /// keyed by `cliSessionId` (the Claude Code session_id). Unlike terminal Claude Code
+    /// it never writes a `custom-title` entry to the transcript JSONL, so the transcript
+    /// lookup always fails for these sessions. Latest entry (by `lastActivityAt`) wins.
+    static func lookupClaudeDesktopTitle(
+        cliSessionId: String,
+        baseDir: String = Config.claudeCodeSessionsDir()
+    ) -> String? {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: URL(fileURLWithPath: baseDir), includingPropertiesForKeys: nil
+        ) else { return nil }
+
+        var bestTitle: String?
+        var bestActivity = -Double.greatestFiniteMagnitude
+        for case let url as URL in enumerator where url.pathExtension == "json" {
+            guard let data = try? Data(contentsOf: url),
+                  // Cheap pre-filter before the full JSON parse.
+                  let content = String(data: data, encoding: .utf8),
+                  content.contains(cliSessionId),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  json["cliSessionId"] as? String == cliSessionId,
+                  let title = json["title"] as? String, !title.isEmpty
+            else { continue }
+            let activity = (json["lastActivityAt"] as? Double) ?? 0
+            if activity > bestActivity {
+                bestActivity = activity
+                bestTitle = title
+            }
+        }
+        return bestTitle
+    }
+
     private static func lookupNameFromIndex(indexPath: String, sessionId: String) -> String? {
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: indexPath)),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/menubar/CctopMenubar/Models/Config.swift
+++ b/menubar/CctopMenubar/Models/Config.swift
@@ -27,6 +27,18 @@ enum Config {
         return dir
     }
 
+    /// Directory where Claude Desktop stores per-session metadata (incl. the
+    /// user-visible `title`), keyed by `cliSessionId`. Read-only — never created.
+    static func claudeCodeSessionsDir() -> String {
+        if let override = ProcessInfo.processInfo.environment["CCTOP_CLAUDE_CODE_SESSIONS_DIR"],
+           !override.isEmpty {
+            return override
+        }
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return (home as NSString)
+            .appendingPathComponent("Library/Application Support/Claude/claude-code-sessions")
+    }
+
     private static func ensureDirectoryExists(_ path: String) {
         let fm = FileManager.default
         if !fm.fileExists(atPath: path) {

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -304,4 +304,51 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertTrue(sessionFileExists())
         XCTAssertNotNil(try loadSession().endedAt)
     }
+
+    // MARK: - Claude Desktop session naming (claude-code-sessions lookup)
+
+    func testClaudeDesktop_namesSessionFromClaudeCodeSessions() throws {
+        let ccsDir = NSTemporaryDirectory() + "cctop-ccs-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: ccsDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: ccsDir) }
+
+        let content = """
+        {"cliSessionId":"test-session-001","title":"Investigate RBS RDoc plugin","lastActivityAt":1779281104333}
+        """
+        try content.write(toFile: ccsDir + "/local_x.json", atomically: true, encoding: .utf8)
+
+        setenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR", ccsDir, 1)
+        setenv("__CFBundleIdentifier", "com.anthropic.claudefordesktop", 1)
+        defer { unsetenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR"); unsetenv("__CFBundleIdentifier") }
+
+        try handleFixture("SessionStart")  // session_id test-session-001, no session_name
+        XCTAssertEqual(try loadSession().sessionName, "Investigate RBS RDoc plugin")
+    }
+
+    /// A just-started Desktop session has no title yet at SessionStart; Claude Desktop
+    /// auto-titles after the first turn. The lookup must re-run on Stop so the name
+    /// appears without waiting for the next prompt.
+    func testClaudeDesktop_refreshesNameOnStop() throws {
+        let ccsDir = NSTemporaryDirectory() + "cctop-ccs-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: ccsDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: ccsDir) }
+
+        setenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR", ccsDir, 1)
+        setenv("__CFBundleIdentifier", "com.anthropic.claudefordesktop", 1)
+        defer { unsetenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR"); unsetenv("__CFBundleIdentifier") }
+
+        // No title file yet → name stays nil at SessionStart.
+        try handleFixture("SessionStart")
+        XCTAssertNil(try loadSession().sessionName)
+
+        // Claude Desktop writes the auto title after the first turn.
+        let content = """
+        {"cliSessionId":"test-session-001","title":"Auto title","lastActivityAt":1}
+        """
+        try content.write(toFile: ccsDir + "/local_x.json", atomically: true, encoding: .utf8)
+
+        // Stop re-runs the lookup and picks it up.
+        try handleFixture("Stop")
+        XCTAssertEqual(try loadSession().sessionName, "Auto title")
+    }
 }

--- a/menubar/CctopMenubarTests/SessionNameLookupTests.swift
+++ b/menubar/CctopMenubarTests/SessionNameLookupTests.swift
@@ -265,4 +265,84 @@ final class SessionNameLookupTests: XCTestCase {
         )
         XCTAssertEqual(result, "correct match")
     }
+
+    // MARK: - Claude Desktop claude-code-sessions lookup
+
+    func testClaudeDesktop_findsTitleByCliSessionId() {
+        let content = """
+        {"cliSessionId":"a879e259-4cc5-4c27-b490-61ac8a18e86c","title":"Investigate RBS RDoc plugin","lastActivityAt":1779281104333}
+        """
+        try! content.write(toFile: tmpDir + "/local_x.json", atomically: true, encoding: .utf8)
+
+        let result = SessionNameLookup.lookupClaudeDesktopTitle(
+            cliSessionId: "a879e259-4cc5-4c27-b490-61ac8a18e86c", baseDir: tmpDir
+        )
+        XCTAssertEqual(result, "Investigate RBS RDoc plugin")
+    }
+
+    func testClaudeDesktop_findsTitleInNestedSubdirs() {
+        // Real layout nests files two levels deep: <acct>/<org>/local_*.json
+        let nested = tmpDir + "/acct-123/org-456"
+        try! FileManager.default.createDirectory(atPath: nested, withIntermediateDirectories: true)
+        let content = """
+        {"cliSessionId":"s1","title":"nested title","lastActivityAt":1}
+        """
+        try! content.write(toFile: nested + "/local_x.json", atomically: true, encoding: .utf8)
+
+        let result = SessionNameLookup.lookupClaudeDesktopTitle(cliSessionId: "s1", baseDir: tmpDir)
+        XCTAssertEqual(result, "nested title")
+    }
+
+    func testClaudeDesktop_latestByLastActivityWins() {
+        let older = """
+        {"cliSessionId":"s1","title":"older title","lastActivityAt":1000}
+        """
+        let newer = """
+        {"cliSessionId":"s1","title":"newer title","lastActivityAt":2000}
+        """
+        try! older.write(toFile: tmpDir + "/local_a.json", atomically: true, encoding: .utf8)
+        try! newer.write(toFile: tmpDir + "/local_b.json", atomically: true, encoding: .utf8)
+
+        let result = SessionNameLookup.lookupClaudeDesktopTitle(cliSessionId: "s1", baseDir: tmpDir)
+        XCTAssertEqual(result, "newer title")
+    }
+
+    func testClaudeDesktop_missingBaseDirReturnsNil() {
+        let result = SessionNameLookup.lookupClaudeDesktopTitle(
+            cliSessionId: "s1", baseDir: tmpDir + "/does-not-exist"
+        )
+        XCTAssertNil(result)
+    }
+
+    func testClaudeDesktop_noMatchingCliSessionIdReturnsNil() {
+        let content = """
+        {"cliSessionId":"other","title":"other title","lastActivityAt":1}
+        """
+        try! content.write(toFile: tmpDir + "/local_x.json", atomically: true, encoding: .utf8)
+
+        let result = SessionNameLookup.lookupClaudeDesktopTitle(cliSessionId: "s1", baseDir: tmpDir)
+        XCTAssertNil(result)
+    }
+
+    func testClaudeDesktop_emptyTitleIsIgnored() {
+        let content = """
+        {"cliSessionId":"s1","title":"","lastActivityAt":1}
+        """
+        try! content.write(toFile: tmpDir + "/local_x.json", atomically: true, encoding: .utf8)
+
+        let result = SessionNameLookup.lookupClaudeDesktopTitle(cliSessionId: "s1", baseDir: tmpDir)
+        XCTAssertNil(result)
+    }
+
+    func testClaudeDesktop_ignoresUnrelatedJsonFiles() {
+        // Files without cliSessionId (e.g. spaces.json) must not throw off the match.
+        try! "{\"spaces\":[]}".write(toFile: tmpDir + "/spaces.json", atomically: true, encoding: .utf8)
+        let content = """
+        {"cliSessionId":"s1","title":"real title","lastActivityAt":1}
+        """
+        try! content.write(toFile: tmpDir + "/local_x.json", atomically: true, encoding: .utf8)
+
+        let result = SessionNameLookup.lookupClaudeDesktopTitle(cliSessionId: "s1", baseDir: tmpDir)
+        XCTAssertEqual(result, "real title")
+    }
 }

--- a/menubar/CctopMenubarTests/SessionNameLookupTests.swift
+++ b/menubar/CctopMenubarTests/SessionNameLookupTests.swift
@@ -293,18 +293,18 @@ final class SessionNameLookupTests: XCTestCase {
         XCTAssertEqual(result, "nested title")
     }
 
-    func testClaudeDesktop_latestByLastActivityWins() {
-        let older = """
-        {"cliSessionId":"s1","title":"older title","lastActivityAt":1000}
+    func testClaudeDesktop_picksFileMatchingCliSessionId() {
+        let other = """
+        {"cliSessionId":"other","title":"other title","lastActivityAt":1}
         """
-        let newer = """
-        {"cliSessionId":"s1","title":"newer title","lastActivityAt":2000}
+        let mine = """
+        {"cliSessionId":"s1","title":"my title","lastActivityAt":1}
         """
-        try! older.write(toFile: tmpDir + "/local_a.json", atomically: true, encoding: .utf8)
-        try! newer.write(toFile: tmpDir + "/local_b.json", atomically: true, encoding: .utf8)
+        try! other.write(toFile: tmpDir + "/local_a.json", atomically: true, encoding: .utf8)
+        try! mine.write(toFile: tmpDir + "/local_b.json", atomically: true, encoding: .utf8)
 
         let result = SessionNameLookup.lookupClaudeDesktopTitle(cliSessionId: "s1", baseDir: tmpDir)
-        XCTAssertEqual(result, "newer title")
+        XCTAssertEqual(result, "my title")
     }
 
     func testClaudeDesktop_missingBaseDirReturnsNil() {


### PR DESCRIPTION
## Summary

Claude Desktop project sessions showed the worktree **folder name** instead of the conversation **title** in cctop. cctop sources a session's name from the Claude Code transcript's `custom-title` entry, but Claude Desktop never writes one there (it keeps the title in its own store), so `sessionName` stayed `nil` and the card fell back to `projectName`.

- Add `SessionNameLookup.lookupClaudeDesktopTitle`, which reads the title from Claude Desktop's own per-session JSON under `~/Library/Application Support/Claude/claude-code-sessions/`, keyed by `cliSessionId` (the Claude Code `session_id`). This mirrors the Codex `~/.codex/session_index.jsonl` lookup added in [#116](https://github.com/st0012/cctop/pull/116).
- The hook branches to this source only for Claude Desktop sessions (`terminal.bundleId == com.anthropic.claudefordesktop`); terminal Claude Code keeps the transcript lookup and Codex keeps its index. The `HostApp.claudeDesktop` bundle id is duplicated as a literal because `HostApp.swift` is not compiled into the `cctop-hook` target.
- The name lookup also re-runs on the `Stop` event, so a just-started Desktop session picks up its auto-generated title once the first turn completes instead of waiting for the next prompt. `custom-title` preserve-on-fail from [#116](https://github.com/st0012/cctop/pull/116) is unchanged.
- The lookup returns on the first `cliSessionId` match (one file per session) rather than scanning the whole directory, since these per-session files are large.

Builds on Claude Desktop support from [#108](https://github.com/st0012/cctop/pull/108) and the session-name handling from [#116](https://github.com/st0012/cctop/pull/116).

## Notes

- The `claude-code-sessions/` location and `cliSessionId`/`title` keys are observed local behavior of Claude Desktop, not a documented API — same basis as the Codex index lookup in [#116](https://github.com/st0012/cctop/pull/116).
- Eventual consistency: Claude Desktop auto-titles a session a few seconds into the first turn, so a brand-new session shows its name on the first `Stop` (or next prompt), not instantly at launch.