### PR TITLE
fix: fill Codex Desktop session names mid-turn

### DIFF
--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -100,10 +100,13 @@ enum HookHandler {
         if let harness = input.resolvedHarnessName { session.source = harness }
         if let name = input.sessionName {
             session.sessionName = name
-        } else if event == .sessionStart || event == .userPromptSubmit || event == .stop {
-            // Only overwrite when the lookup succeeds (preserve-on-fail). Re-running on
-            // .stop lets a just-started session pick up its title as soon as the first
-            // turn completes, instead of waiting for the next prompt.
+        } else if event == .sessionStart || event == .userPromptSubmit || event == .stop
+                    || (session.source == "codex" && session.sessionName == nil) {
+            // Only overwrite when the lookup succeeds (preserve-on-fail). Re-run on prompt
+            // boundaries (and .stop, for Claude Code) to catch renames. Codex additionally
+            // re-runs on ANY event while the name is still missing: it never fires .stop and
+            // titles its thread mid-turn, and its index is a single small file — so this
+            // fills the name within seconds, without a per-tool-call directory scan.
             //
             // Each harness exposes the title from a different local source:
             //   - codex:          ~/.codex/session_index.jsonl (keyed by session_id)

--- a/menubar/CctopMenubar/Hook/SessionNameLookup.swift
+++ b/menubar/CctopMenubar/Hook/SessionNameLookup.swift
@@ -46,7 +46,7 @@ enum SessionNameLookup {
     /// titles server-side.
     static func lookupCodexThreadName(
         sessionId: String,
-        indexPath: String = NSString(string: "~/.codex/session_index.jsonl").expandingTildeInPath
+        indexPath: String = Config.codexSessionIndexPath()
     ) -> String? {
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: indexPath)),
               let content = String(data: data, encoding: .utf8)

--- a/menubar/CctopMenubar/Models/Config.swift
+++ b/menubar/CctopMenubar/Models/Config.swift
@@ -39,6 +39,16 @@ enum Config {
             .appendingPathComponent("Library/Application Support/Claude/claude-code-sessions")
     }
 
+    /// Codex's session index (JSONL), which maps `id` (session_id) to the
+    /// user-visible `thread_name`. Read-only — never created.
+    static func codexSessionIndexPath() -> String {
+        if let override = ProcessInfo.processInfo.environment["CCTOP_CODEX_SESSION_INDEX"],
+           !override.isEmpty {
+            return override
+        }
+        return NSString(string: "~/.codex/session_index.jsonl").expandingTildeInPath
+    }
+
     private static func ensureDirectoryExists(_ path: String) {
         let fm = FileManager.default
         if !fm.fileExists(atPath: path) {

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -351,4 +351,38 @@ final class HookHandlerTests: XCTestCase {
         try handleFixture("Stop")
         XCTAssertEqual(try loadSession().sessionName, "Auto title")
     }
+
+    /// Codex never fires Stop and titles its thread mid-turn, so the name lookup must
+    /// re-run on non-prompt events (e.g. PreToolUse) while sessionName is still nil —
+    /// otherwise the name wouldn't appear until the user's next prompt.
+    func testCodex_fillsNameOnToolEventWhileNil() throws {
+        let idx = NSTemporaryDirectory() + "cctop-codex-\(UUID().uuidString).jsonl"
+        defer { try? FileManager.default.removeItem(atPath: idx) }
+        setenv("CCTOP_CODEX_SESSION_INDEX", idx, 1)
+        defer { unsetenv("CCTOP_CODEX_SESSION_INDEX") }
+
+        func handle(_ json: String, _ hook: String) throws {
+            let input = try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
+            try HookHandler.handleHook(hookName: hook, input: input)
+        }
+
+        // SessionStart before Codex has titled the thread → name stays nil.
+        let startJSON = """
+        {"session_id":"codex-1","cwd":"/tmp/p","hook_event_name":"SessionStart","harness_name":"codex"}
+        """
+        try handle(startJSON, "SessionStart")
+        XCTAssertNil(try loadSession().sessionName)
+
+        // Codex writes the thread name to its index mid-turn.
+        try """
+        {"id":"codex-1","thread_name":"Investigate session name capture"}
+        """.write(toFile: idx, atomically: true, encoding: .utf8)
+
+        // A tool event (not a prompt boundary) picks it up because the name is still nil.
+        let toolJSON = """
+        {"session_id":"codex-1","cwd":"/tmp/p","hook_event_name":"PreToolUse","harness_name":"codex","tool_name":"Bash"}
+        """
+        try handle(toolJSON, "PreToolUse")
+        XCTAssertEqual(try loadSession().sessionName, "Investigate session name capture")
+    }
 }


### PR DESCRIPTION
## Summary

Codex Desktop sessions could show the project folder name instead of the conversation title in the menubar. The Codex thread-name lookup ([#116](https://github.com/st0012/cctop/pull/116)) only re-ran on prompt boundaries (`SessionStart`/`UserPromptSubmit`), and the `Stop` refresh from [#121](https://github.com/st0012/cctop/pull/121) doesn't apply because Codex never fires `Stop`. Since Codex titles its thread mid-turn (after cctop's last lookup), the name stayed blank until the user's next prompt.

- Re-run the name lookup on **any** event while `sessionName` is still `nil` for Codex sessions, so the title fills within seconds — on the next `PreToolUse`/`PostToolUse` — once Codex writes it to `~/.codex/session_index.jsonl`.
- Scoped to Codex because its index is a single small file. Claude Desktop's heavier `claude-code-sessions/` directory scan stays on prompt boundaries (it already fires `Stop`, so [#121](https://github.com/st0012/cctop/pull/121) covers it). Prompt-boundary refresh is unchanged, so renames are still caught.
- Routed the Codex index path through `Config.codexSessionIndexPath()` with a `CCTOP_CODEX_SESSION_INDEX` override for testability, mirroring `CCTOP_CLAUDE_CODE_SESSIONS_DIR` from [#121](https://github.com/st0012/cctop/pull/121).

Builds on the Codex thread-name lookup in [#116](https://github.com/st0012/cctop/pull/116) and the Claude Desktop title work in [#121](https://github.com/st0012/cctop/pull/121).