### PR TITLE
Centralize source badge labels

### DIFF
--- a/menubar/CctopMenubar/Models/AgentBadge.swift
+++ b/menubar/CctopMenubar/Models/AgentBadge.swift
@@ -10,7 +10,7 @@ enum AgentBadge: Equatable {
     case opencode
     case pi
 
-    /// Short user-facing label rendered in the meta row.
+    /// The single user-facing source label API for badge rendering.
     var label: String {
         switch self {
         case .cc: return "CC"

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -174,15 +174,6 @@ struct Session: Codable, Identifiable, Equatable {
         sessionName ?? projectName
     }
 
-    var sourceLabel: String {
-        switch source {
-        case "opencode": return "OC"
-        case "pi": return "Pi"
-        case "codex": return "Codex"
-        default: return "CC"
-        }
-    }
-
     var subagentCount: Int {
         activeSubagents?.count ?? 0
     }

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -241,7 +241,7 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.projectName, "api-server")
         XCTAssertEqual(session.status, .working)
         XCTAssertEqual(session.source, "opencode")
-        XCTAssertEqual(session.sourceLabel, "OC")
+        XCTAssertEqual(session.agentBadge.label, "OC")
         XCTAssertEqual(session.pid, 54321)
         XCTAssertNil(session.pidStartTime)
     }
@@ -261,27 +261,27 @@ final class SessionTests: XCTestCase {
         """
         let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
         XCTAssertNil(session.source)
-        XCTAssertEqual(session.sourceLabel, "CC")
+        XCTAssertEqual(session.agentBadge.label, "CC")
     }
 
-    func testSourceLabelOpencode() {
+    func testAgentBadgeLabelOpencode() {
         let session = Session.mock(source: "opencode")
-        XCTAssertEqual(session.sourceLabel, "OC")
+        XCTAssertEqual(session.agentBadge.label, "OC")
     }
 
-    func testSourceLabelDefault() {
+    func testAgentBadgeLabelDefault() {
         let session = Session.mock()
-        XCTAssertEqual(session.sourceLabel, "CC")
+        XCTAssertEqual(session.agentBadge.label, "CC")
     }
 
-    func testSourceLabelPi() {
+    func testAgentBadgeLabelPi() {
         let session = Session.mock(source: "pi")
-        XCTAssertEqual(session.sourceLabel, "Pi")
+        XCTAssertEqual(session.agentBadge.label, "Pi")
     }
 
-    func testSourceLabelUnknownValue() {
+    func testAgentBadgeLabelUnknownValue() {
         let session = Session.mock(source: "aider")
-        XCTAssertEqual(session.sourceLabel, "CC")
+        XCTAssertEqual(session.agentBadge.label, "CC")
     }
 
     func testSourceCarriedInWithSessionId() {


### PR DESCRIPTION
## Summary
- Removed the separate `Session.sourceLabel` mapper so `Session` no longer exposes a second source-label API; the removal is shown in this commit diff, and `Session` now goes from `displayName` directly to `subagentCount` in the model surface. [source](https://github.com/st0012/cctop/commit/cb3709be3e58ed9bd3c971f730b117d0b01e29a9) [source](https://github.com/st0012/cctop/blob/cb3709be3e58ed9bd3c971f730b117d0b01e29a9/menubar/CctopMenubar/Models/Session.swift#L171-L178)
- Kept `AgentBadge.label` as the single user-facing source-label API and preserved the existing labels for CC, Claude Desktop, Codex, Codex Desktop, opencode, and pi. [source](https://github.com/st0012/cctop/blob/cb3709be3e58ed9bd3c971f730b117d0b01e29a9/menubar/CctopMenubar/Models/AgentBadge.swift#L13-L22)
- Left visible badge rendering routed through `SourceBadgeView`, which reads `badge.label` for both visible text and accessibility labels. [source](https://github.com/st0012/cctop/blob/cb3709be3e58ed9bd3c971f730b117d0b01e29a9/menubar/CctopMenubar/Views/SourceBadgeView.swift#L9-L33)
- Updated source-field session tests to assert labels through `session.agentBadge.label`, while the AgentBadge tests continue to cover source/host classification and the label matrix. [source](https://github.com/st0012/cctop/blob/cb3709be3e58ed9bd3c971f730b117d0b01e29a9/menubar/CctopMenubarTests/SessionTests.swift#L240-L284) [source](https://github.com/st0012/cctop/blob/cb3709be3e58ed9bd3c971f730b117d0b01e29a9/menubar/CctopMenubarTests/AgentBadgeTests.swift#L5-L109)

## Verification
- `git diff --check` passed; Git documents this mode as checking diff output for whitespace errors. [source](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---check)
- `xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -destination 'platform=macOS' -derivedDataPath /tmp/cctop-badges-derived-data -only-testing:CctopMenubarTests/AgentBadgeTests -only-testing:CctopMenubarTests/SessionTests` passed 42 tests; Apple documents `test` as an `xcodebuild` action. [source](https://developer.apple.com/library/archive/technotes/tn2339/_index.html)
- `xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -destination 'platform=macOS' -derivedDataPath /tmp/cctop-badges-derived-data -only-testing:CctopMenubarTests/QaShowcaseCoverageTests` passed 3 tests covering the QA showcase badge mix. [source](https://developer.apple.com/library/archive/technotes/tn2339/_index.html) [source](https://github.com/st0012/cctop/blob/cb3709be3e58ed9bd3c971f730b117d0b01e29a9/menubar/CctopMenubarTests/QaShowcaseCoverageTests.swift#L4-L14)
