### PR TITLE
Share Desktop host app bundle constants

### DIFF
--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -2,11 +2,12 @@ import Foundation
 
 private let maxToolDetailLen = 120
 
-enum HookHandler {
-    // Claude Desktop's app bundle id. Mirrors HostApp.claudeDesktop.bundleID, which
-    // isn't compiled into the cctop-hook target — keep the two values in sync.
-    private static let claudeDesktopBundleID = "com.anthropic.claudefordesktop"
+enum HostAppBundleID {
+    static let claudeDesktop = "com.anthropic.claudefordesktop"
+    static let codexDesktop = "com.openai.codex"
+}
 
+enum HookHandler {
     // MIGRATION(v0.6.0): Remove after all users have migrated to PID-keyed sessions.
     private static let noPIDMaxAge: TimeInterval = 300
 
@@ -113,7 +114,7 @@ enum HookHandler {
             let lookedUp: String?
             if session.source == "codex" {
                 lookedUp = SessionNameLookup.lookupCodexThreadName(sessionId: input.sessionId)
-            } else if session.terminal?.bundleId == claudeDesktopBundleID {
+            } else if session.terminal?.bundleId == HostAppBundleID.claudeDesktop {
                 lookedUp = SessionNameLookup.lookupClaudeDesktopTitle(cliSessionId: input.sessionId)
             } else {
                 lookedUp = SessionNameLookup.lookupSessionName(

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -54,8 +54,8 @@ enum HostApp {
         case .terminal: return "com.apple.Terminal"
         case .ghostty: return "com.mitchellh.ghostty"
         case .kitty: return "net.kovidgoyal.kitty"
-        case .claudeDesktop: return "com.anthropic.claudefordesktop"
-        case .codexDesktop: return "com.openai.codex"
+        case .claudeDesktop: return HostAppBundleID.claudeDesktop
+        case .codexDesktop: return HostAppBundleID.codexDesktop
         case .unknown: return nil
         }
     }

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -54,6 +54,13 @@ final class HookHandlerTests: XCTestCase {
         return entries.contains { $0.hasSuffix(".json") }
     }
 
+    // MARK: - Shared host app bundle IDs
+
+    func testDesktopBundleIDsAreSharedWithHostApp() {
+        XCTAssertEqual(HostApp.claudeDesktop.bundleID, HostAppBundleID.claudeDesktop)
+        XCTAssertEqual(HostApp.codexDesktop.bundleID, HostAppBundleID.codexDesktop)
+    }
+
     // MARK: - SessionStart creates idle session
 
     func testSessionStartCreatesIdleSession() throws {
@@ -318,7 +325,7 @@ final class HookHandlerTests: XCTestCase {
         try content.write(toFile: ccsDir + "/local_x.json", atomically: true, encoding: .utf8)
 
         setenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR", ccsDir, 1)
-        setenv("__CFBundleIdentifier", "com.anthropic.claudefordesktop", 1)
+        setenv("__CFBundleIdentifier", HostAppBundleID.claudeDesktop, 1)
         defer { unsetenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR"); unsetenv("__CFBundleIdentifier") }
 
         try handleFixture("SessionStart")  // session_id test-session-001, no session_name
@@ -334,7 +341,7 @@ final class HookHandlerTests: XCTestCase {
         defer { try? FileManager.default.removeItem(atPath: ccsDir) }
 
         setenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR", ccsDir, 1)
-        setenv("__CFBundleIdentifier", "com.anthropic.claudefordesktop", 1)
+        setenv("__CFBundleIdentifier", HostAppBundleID.claudeDesktop, 1)
         defer { unsetenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR"); unsetenv("__CFBundleIdentifier") }
 
         // No title file yet → name stays nil at SessionStart.


### PR DESCRIPTION
## Summary

- Added `HostAppBundleID` in `HookHandler.swift`; `HookHandler.swift` is already in both the app and `cctop-hook` source build phases, so the constants are hook-safe. Sources: [constants](https://github.com/st0012/cctop/blob/41461aa5921baf9acab3a0ce04a8d28585d28a75/menubar/CctopMenubar/Hook/HookHandler.swift#L5-L8), [app sources](https://github.com/st0012/cctop/blob/41461aa5921baf9acab3a0ce04a8d28585d28a75/menubar/CctopMenubar.xcodeproj/project.pbxproj#L536-L549), [hook sources](https://github.com/st0012/cctop/blob/41461aa5921baf9acab3a0ce04a8d28585d28a75/menubar/CctopMenubar.xcodeproj/project.pbxproj#L562-L571).
- Updated `HostApp.bundleID` so Claude Desktop and Codex Desktop return the shared constants instead of separate app-side string literals. Source: [HostApp.bundleID](https://github.com/st0012/cctop/blob/41461aa5921baf9acab3a0ce04a8d28585d28a75/menubar/CctopMenubar/Models/HostApp.swift#L46-L59).
- Updated Claude Desktop title lookup to compare against the shared Claude Desktop bundle ID constant, while leaving the Codex title lookup branch keyed by `source == "codex"`. Source: [HookHandler lookup branch](https://github.com/st0012/cctop/blob/41461aa5921baf9acab3a0ce04a8d28585d28a75/menubar/CctopMenubar/Hook/HookHandler.swift#L114-L123).
- Kept Desktop focus behavior covered by existing tests: Claude Desktop activates by bundle ID, Codex Desktop deep-links for UUID session IDs, and Codex Desktop falls back to bundle activation for non-UUID session IDs. Source: [FocusStrategyTests desktop app cases](https://github.com/st0012/cctop/blob/41461aa5921baf9acab3a0ce04a8d28585d28a75/menubar/CctopMenubarTests/FocusStrategyTests.swift#L237-L269).
- Added a HookHandler test that ties the shared Desktop constants back to `HostApp.bundleID`, and updated Claude Desktop title tests to set `__CFBundleIdentifier` from the shared constant. Source: [HookHandlerTests shared constants and Claude setup](https://github.com/st0012/cctop/blob/41461aa5921baf9acab3a0ce04a8d28585d28a75/menubar/CctopMenubarTests/HookHandlerTests.swift#L57-L62).

## Verification

```
git diff --check
xcodebuild build -project menubar/CctopMenubar.xcodeproj -scheme cctop-hook -configuration Debug -derivedDataPath menubar/build CODE_SIGN_IDENTITY="-"
xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -configuration Debug -derivedDataPath menubar/build CODE_SIGN_IDENTITY="-" -only-testing:CctopMenubarTests/HookHandlerTests -only-testing:CctopMenubarTests/FocusStrategyTests
```