### PR TITLE
Show each Codex Desktop conversation as its own card

### DIFF
--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		SN0000050000000000000001 /* SessionNameLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = SN0000020000000000000001 /* SessionNameLookup.swift */; };
 		SP0000010000000000000001 /* SparkleUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = SP0000020000000000000001 /* SparkleUpdater.swift */; };
 		T10000010000000000000001 /* SessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T10000020000000000000001 /* SessionTests.swift */; };
+		SFF000010000000000000001 /* SessionFileFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SFF000020000000000000001 /* SessionFileFormatTests.swift */; };
 		AGT000010000000000000001 /* AgentBadgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AGT000020000000000000001 /* AgentBadgeTests.swift */; };
 		QSC000010000000000000001 /* QaShowcaseCoverageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = QSC000020000000000000001 /* QaShowcaseCoverageTests.swift */; };
 		T10000030000000000000001 /* SessionStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T10000040000000000000001 /* SessionStatusTests.swift */; };
@@ -177,6 +178,7 @@
 		SN0000040000000000000001 /* SessionNameLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNameLookupTests.swift; sourceTree = "<group>"; };
 		SP0000020000000000000001 /* SparkleUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdater.swift; sourceTree = "<group>"; };
 		T10000020000000000000001 /* SessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTests.swift; sourceTree = "<group>"; };
+		SFF000020000000000000001 /* SessionFileFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionFileFormatTests.swift; sourceTree = "<group>"; };
 		AGT000020000000000000001 /* AgentBadgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBadgeTests.swift; sourceTree = "<group>"; };
 		QSC000020000000000000001 /* QaShowcaseCoverageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QaShowcaseCoverageTests.swift; sourceTree = "<group>"; };
 		T10000040000000000000001 /* SessionStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStatusTests.swift; sourceTree = "<group>"; };
@@ -355,6 +357,7 @@
 			isa = PBXGroup;
 			children = (
 				T10000020000000000000001 /* SessionTests.swift */,
+				SFF000020000000000000001 /* SessionFileFormatTests.swift */,
 				AGT000020000000000000001 /* AgentBadgeTests.swift */,
 				QSC000020000000000000001 /* QaShowcaseCoverageTests.swift */,
 				T10000040000000000000001 /* SessionStatusTests.swift */,
@@ -580,6 +583,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				T10000010000000000000001 /* SessionTests.swift in Sources */,
+				SFF000010000000000000001 /* SessionFileFormatTests.swift in Sources */,
 				AGT000010000000000000001 /* AgentBadgeTests.swift in Sources */,
 				QSC000010000000000000001 /* QaShowcaseCoverageTests.swift in Sources */,
 				T10000030000000000000001 /* SessionStatusTests.swift in Sources */,

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -433,7 +433,7 @@ func withSessionLock(sessionPath: String, body: () throws -> Void) throws {
 /// file. The `codex-` prefix keeps the name non-UUID so the menubar's legacy-file
 /// cleanup (which deletes bare pre-PID UUID files) leaves it alone.
 func sessionFileName(input: HookInput, pid: UInt32, safeSessionId: String) -> String {
-    if input.resolvedHarnessName == "codex" {
+    if input.resolvedHarnessName == Session.codexSource {
         return "codex-\(safeSessionId).json"
     }
     return "\(pid).json"

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -23,7 +23,7 @@ enum HookHandler {
         let safeId = Session.sanitizeSessionId(raw: input.sessionId)
         let pid = getParentPID()
         let label = HookLogger.sessionLabel(cwd: input.cwd, sessionId: safeId)
-        let sessionPath = (sessionsDir as NSString).appendingPathComponent("\(pid).json")
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent(sessionFileName(input: input, pid: pid, safeSessionId: safeId))
 
         let branch = getCurrentBranch(cwd: input.cwd)
         let terminal = captureTerminalInfo()
@@ -194,12 +194,10 @@ enum HookHandler {
            abs(storedStart - currentStart) > 1.0 {
             return fresh
         }
-        // Same PID, different session_id — the OS process is now hosting a new
-        // conversation. Common for Codex Desktop, which keeps one long-lived
-        // process and spawns a new session_id per "new chat". Drop all
-        // conversation-specific state (project, name, prompt, tools, etc.) and
-        // only carry over PID liveness metadata so the process-alive check
-        // keeps working.
+        // Same PID, different session_id — a PID-keyed source (opencode/pi) reused the
+        // process for a new conversation. Drop conversation-specific state (project, name,
+        // prompt, tools, etc.) and carry over only PID liveness metadata. (Codex no longer
+        // reaches this: it is keyed by session_id, so each conversation has its own file.)
         guard existing.sessionId == fresh.sessionId else {
             var carried = fresh
             carried.pid = existing.pid
@@ -340,7 +338,7 @@ enum HookHandler {
     private static func handleSessionEnd(hookName: String, input: HookInput) {
         let pid = getParentPID()
         let safeId = Session.sanitizeSessionId(raw: input.sessionId)
-        let path = (Config.sessionsDir() as NSString).appendingPathComponent("\(pid).json")
+        let path = (Config.sessionsDir() as NSString).appendingPathComponent(sessionFileName(input: input, pid: pid, safeSessionId: safeId))
         let label = HookLogger.sessionLabel(cwd: input.cwd, sessionId: safeId)
         // Stamp endedAt instead of deleting — the menubar app archives to history on next poll.
         try? withSessionLock(sessionPath: path) {
@@ -425,6 +423,20 @@ func withSessionLock(sessionPath: String, body: () throws -> Void) throws {
     }
     defer { flock(fd, LOCK_UN) }
     try body()
+}
+
+// MARK: - Session File Naming
+
+/// Session files are keyed by PID, except Codex. Codex Desktop fires every
+/// conversation's hooks from one shared host process, so PID keying would collapse
+/// them into a single slot — key Codex by session_id so each conversation is its own
+/// file. The `codex-` prefix keeps the name non-UUID so the menubar's legacy-file
+/// cleanup (which deletes bare pre-PID UUID files) leaves it alone.
+func sessionFileName(input: HookInput, pid: UInt32, safeSessionId: String) -> String {
+    if input.resolvedHarnessName == "codex" {
+        return "codex-\(safeSessionId).json"
+    }
+    return "\(pid).json"
 }
 
 // MARK: - Git Branch

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -168,11 +168,16 @@ struct Session: Codable, Identifiable, Equatable {
     var endedAt: Date?
     var activeSubagents: [SubagentInfo]?
 
-    // Codex Desktop multiplexes many conversations onto a single host process, so the PID
-    // is not unique per conversation — identify Codex sessions by their session_id (which
-    // matches their codex-<id> file key). Every other source runs one session per PID.
+    /// Harness id Codex reports (CLI and Desktop both pass `--harness codex`).
+    static let codexSource = "codex"
+
+    var isCodex: Bool { source == Self.codexSource }
+
+    // Codex multiplexes many conversations onto one host process, so the PID is not unique
+    // per conversation — identify Codex sessions by session_id (matching their codex-<id>
+    // file key). Every other source runs one session per PID.
     var id: String {
-        if source == "codex" { return sessionId }
+        if isCodex { return sessionId }
         return pid.map { String($0) } ?? sessionId
     }
 

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -168,7 +168,13 @@ struct Session: Codable, Identifiable, Equatable {
     var endedAt: Date?
     var activeSubagents: [SubagentInfo]?
 
-    var id: String { pid.map { String($0) } ?? sessionId }
+    // Codex Desktop multiplexes many conversations onto a single host process, so the PID
+    // is not unique per conversation — identify Codex sessions by their session_id (which
+    // matches their codex-<id> file key). Every other source runs one session per PID.
+    var id: String {
+        if source == "codex" { return sessionId }
+        return pid.map { String($0) } ?? sessionId
+    }
 
     var displayName: String {
         sessionName ?? projectName

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -154,26 +154,7 @@ class SessionManager: ObservableObject {
     private func adjustDisplayStatus(_ session: Session) -> Session {
         var result = adjustPermissionStatus(session)
         result = Self.adjustIdleTimeout(result)
-        result = Self.adjustCodexStaleWorking(result)
         return result
-    }
-
-    // Codex has no SessionEnd and its Stop hook isn't always delivered, so a finished
-    // conversation can be stranded on `working`. Treat this much silence as turn-done.
-    private static let codexWorkingStaleSeconds: TimeInterval = 300 // 5 minutes
-
-    /// Codex has no SessionEnd and may not deliver Stop, so a finished conversation can sit
-    /// on `working` until its host process exits. After `codexWorkingStaleSeconds` of no
-    /// events, show it as `idle` (display-only and reversible — the next event flips it back
-    /// to working). The on-disk file is NOT modified.
-    nonisolated static func adjustCodexStaleWorking(_ session: Session) -> Session {
-        guard session.isCodex, session.status == .working,
-              -session.lastActivity.timeIntervalSinceNow > Self.codexWorkingStaleSeconds else {
-            return session
-        }
-        var adjusted = session
-        adjusted.status = .idle
-        return adjusted
     }
 
     private static let idleTimeoutSeconds: TimeInterval = 3600 // 60 minutes

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -139,7 +139,25 @@ class SessionManager: ObservableObject {
     private func adjustDisplayStatus(_ session: Session) -> Session {
         var result = adjustPermissionStatus(session)
         result = Self.adjustIdleTimeout(result)
+        result = Self.adjustCodexStaleWorking(result)
         return result
+    }
+
+    // Codex emits no Stop/SessionEnd; treat this much silence as "turn finished".
+    // Display-only and reversible — the next event flips the card back to working.
+    private static let codexWorkingStaleSeconds: TimeInterval = 300 // 5 minutes
+
+    /// Codex never fires Stop, so a finished conversation would otherwise sit on
+    /// `working` until its host process exits. After `codexWorkingStaleSeconds` of no
+    /// events, show it as `idle`. The on-disk file is NOT modified.
+    nonisolated static func adjustCodexStaleWorking(_ session: Session) -> Session {
+        guard session.source == "codex", session.status == .working,
+              -session.lastActivity.timeIntervalSinceNow > Self.codexWorkingStaleSeconds else {
+            return session
+        }
+        var adjusted = session
+        adjusted.status = .idle
+        return adjusted
     }
 
     private static let idleTimeoutSeconds: TimeInterval = 3600 // 60 minutes

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -39,7 +39,9 @@ class SessionManager: ObservableObject {
             return
         }
 
-        let oldStatuses = Dictionary(uniqueKeysWithValues: sessions.map { ($0.id, $0.status) })
+        // Tolerate duplicate ids defensively — `sessions` is deduped below, but a transient
+        // double-file must never trap here (uniqueKeysWithValues crashes on a dup key).
+        let oldStatuses = Dictionary(sessions.map { ($0.id, $0.status) }, uniquingKeysWith: { first, _ in first })
 
         let jsonFiles = files.filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasSuffix(".tmp") }
         let allDecoded = jsonFiles
@@ -62,9 +64,7 @@ class SessionManager: ObservableObject {
             if entry.1.endedAt != nil || !entry.1.isAlive { dead.append(entry) } else { alive.append(entry) }
         }
         logger.info("loadSessions: \(jsonFiles.count) files, \(allDecoded.count) decoded, \(alive.count) alive, \(dead.count) dead")
-        let newSessions = alive.map(\.1).map { session in
-            adjustDisplayStatus(session)
-        }.sorted { $0.id < $1.id }
+        let newSessions = Self.dedupedByID(alive.map(\.1).map { adjustDisplayStatus($0) })
 
         // Side effects: run before the equality guard so they always execute.
         if UserDefaults.standard.bool(forKey: "notificationsEnabled") {
@@ -133,6 +133,21 @@ class SessionManager: ObservableObject {
                 try? FileManager.default.removeItem(at: url)
             }
         }
+    }
+
+    /// Distinct sessions can transiently share an `id`: Codex multiplexes conversations
+    /// onto one host PID, and a migration window can briefly leave two files for the same
+    /// conversation. Collapse by `id` (keeping the most recently active) so the published
+    /// list — and everything keyed by id (SwiftUI identity, the status map) — stays unique.
+    nonisolated static func dedupedByID(_ sessions: [Session]) -> [Session] {
+        var byID: [String: Session] = [:]
+        for session in sessions {
+            if let existing = byID[session.id], existing.lastActivity >= session.lastActivity {
+                continue
+            }
+            byID[session.id] = session
+        }
+        return byID.values.sorted { $0.id < $1.id }
     }
 
     /// Apply display-side status adjustments. The session file on disk is NOT modified.

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -115,13 +115,20 @@ class SessionManager: ObservableObject {
         )
     }
 
+    /// A pre-PID session file was keyed by a bare session UUID. Today's files are either
+    /// numeric (PID) or `codex-<uuid>` (one Codex conversation per file); neither is a bare
+    /// UUID, so only genuinely old files match and get cleaned up.
+    nonisolated static func isLegacyUUIDFilename(_ stem: String) -> Bool {
+        HostApp.isUUID(stem)
+    }
+
     // MIGRATION(v0.6.0): Remove after all users have migrated to PID-keyed sessions.
     /// Remove old-format UUID-keyed session files (pre-PID migration).
     /// PID-keyed filenames are purely numeric; UUID filenames contain letters/hyphens.
     private func cleanupOldFormatFiles(_ jsonFiles: [URL]) {
         for url in jsonFiles {
             let stem = url.deletingPathExtension().lastPathComponent
-            if stem.rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) != nil {
+            if Self.isLegacyUUIDFilename(stem) {
                 logger.info("removing old-format session file: \(stem, privacy: .public)")
                 try? FileManager.default.removeItem(at: url)
             }

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -158,15 +158,16 @@ class SessionManager: ObservableObject {
         return result
     }
 
-    // Codex emits no Stop/SessionEnd; treat this much silence as "turn finished".
-    // Display-only and reversible — the next event flips the card back to working.
+    // Codex has no SessionEnd and its Stop hook isn't always delivered, so a finished
+    // conversation can be stranded on `working`. Treat this much silence as turn-done.
     private static let codexWorkingStaleSeconds: TimeInterval = 300 // 5 minutes
 
-    /// Codex never fires Stop, so a finished conversation would otherwise sit on
-    /// `working` until its host process exits. After `codexWorkingStaleSeconds` of no
-    /// events, show it as `idle`. The on-disk file is NOT modified.
+    /// Codex has no SessionEnd and may not deliver Stop, so a finished conversation can sit
+    /// on `working` until its host process exits. After `codexWorkingStaleSeconds` of no
+    /// events, show it as `idle` (display-only and reversible — the next event flips it back
+    /// to working). The on-disk file is NOT modified.
     nonisolated static func adjustCodexStaleWorking(_ session: Session) -> Session {
-        guard session.source == "codex", session.status == .working,
+        guard session.isCodex, session.status == .working,
               -session.lastActivity.timeIntervalSinceNow > Self.codexWorkingStaleSeconds else {
             return session
         }

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -392,4 +392,29 @@ final class HookHandlerTests: XCTestCase {
         try handle(toolJSON, "PreToolUse")
         XCTAssertEqual(try loadSession().sessionName, "Investigate session name capture")
     }
+
+    /// Codex Desktop fires every conversation's hooks from one shared host process, so
+    /// PID keying collapses them into a single file. Keyed by session_id, two concurrent
+    /// Codex conversations (same host PID — here the test runner's PID) get two files.
+    func testCodex_keepsSeparateFilePerSessionId() throws {
+        func handle(_ json: String, _ hook: String) throws {
+            let input = try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
+            try HookHandler.handleHook(hookName: hook, input: input)
+        }
+        let convoA = """
+        {"session_id":"019e0000-aaaa-7000-8000-000000000001","cwd":"/tmp/p","hook_event_name":"SessionStart","harness_name":"codex"}
+        """
+        let convoB = """
+        {"session_id":"019e0000-bbbb-7000-8000-000000000002","cwd":"/tmp/p","hook_event_name":"SessionStart","harness_name":"codex"}
+        """
+        try handle(convoA, "SessionStart")
+        try handle(convoB, "SessionStart")
+
+        let files = try FileManager.default.contentsOfDirectory(atPath: sessionsDir)
+            .filter { $0.hasSuffix(".json") }.sorted()
+        XCTAssertEqual(files, [
+            "codex-019e0000-aaaa-7000-8000-000000000001.json",
+            "codex-019e0000-bbbb-7000-8000-000000000002.json"
+        ])
+    }
 }

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -11,25 +11,6 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertFalse(SessionManager.isLegacyUUIDFilename("codex-019e4b0c-9473-7a33-a4b9-749fd2c83a9e"))
     }
 
-    func testCodexStaleWorkingDemotedToIdleForDisplay() {
-        var s = Session(sessionId: "codex-1", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
-        s.source = "codex"
-        s.status = .working
-
-        // Silent for 10 minutes → display as idle.
-        s.lastActivity = Date(timeIntervalSinceNow: -600)
-        XCTAssertEqual(SessionManager.adjustCodexStaleWorking(s).status, .idle)
-
-        // Active within the window → stays working.
-        s.lastActivity = Date()
-        XCTAssertEqual(SessionManager.adjustCodexStaleWorking(s).status, .working)
-
-        // Non-codex sources are never demoted by this rule.
-        s.source = "cc"
-        s.lastActivity = Date(timeIntervalSinceNow: -600)
-        XCTAssertEqual(SessionManager.adjustCodexStaleWorking(s).status, .working)
-    }
-
     // MARK: - Shared-PID identity
 
     /// Codex multiplexes every conversation onto one host PID, so identifying a session

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -29,4 +29,49 @@ final class SessionFileFormatTests: XCTestCase {
         s.lastActivity = Date(timeIntervalSinceNow: -600)
         XCTAssertEqual(SessionManager.adjustCodexStaleWorking(s).status, .working)
     }
+
+    // MARK: - Shared-PID identity
+
+    /// Codex multiplexes every conversation onto one host PID, so identifying a session
+    /// by PID collapses them. Two Codex conversations sharing a host PID must get
+    /// distinct ids (by session_id); non-codex sources keep PID-based identity.
+    func testCodexSessionsWithSharedPIDHaveDistinctIDs() {
+        var a = Session(sessionId: "conv-a", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        a.source = "codex"; a.pid = 31349
+        var b = Session(sessionId: "conv-b", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        b.source = "codex"; b.pid = 31349
+
+        XCTAssertEqual(a.id, "conv-a")
+        XCTAssertEqual(b.id, "conv-b")
+        XCTAssertNotEqual(a.id, b.id)
+
+        // Non-codex still identified by PID.
+        var cc = Session(sessionId: "conv-c", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        cc.source = "cc"; cc.pid = 31349
+        XCTAssertEqual(cc.id, "31349")
+    }
+
+    /// A transient migration window can leave two files for the same conversation (the old
+    /// PID-keyed file plus the new codex-<id> file), so the loaded list can contain two
+    /// sessions with the same id. dedupedByID must collapse them (keeping the freshest)
+    /// so nothing keyed by id — SwiftUI identity, the status map — ever sees a duplicate.
+    func testDedupedByIDCollapsesDuplicateIDsKeepingFreshest() {
+        var old = Session(sessionId: "conv-a", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        old.source = "codex"; old.pid = 31349
+        old.sessionName = "stale"
+        old.lastActivity = Date(timeIntervalSinceNow: -120)
+
+        var fresh = Session(sessionId: "conv-a", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        fresh.source = "codex"; fresh.pid = 31349
+        fresh.sessionName = "current"
+        fresh.lastActivity = Date()
+
+        var other = Session(sessionId: "conv-b", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        other.source = "codex"; other.pid = 31349
+
+        let result = SessionManager.dedupedByID([old, fresh, other])
+        // Two distinct ids survive; the duplicate id keeps the most recently active entry.
+        XCTAssertEqual(result.map(\.id).sorted(), ["conv-a", "conv-b"])
+        XCTAssertEqual(result.first { $0.id == "conv-a" }?.sessionName, "current")
+    }
 }

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -10,4 +10,23 @@ final class SessionFileFormatTests: XCTestCase {
         // Codex per-conversation files → keep.
         XCTAssertFalse(SessionManager.isLegacyUUIDFilename("codex-019e4b0c-9473-7a33-a4b9-749fd2c83a9e"))
     }
+
+    func testCodexStaleWorkingDemotedToIdleForDisplay() {
+        var s = Session(sessionId: "codex-1", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        s.source = "codex"
+        s.status = .working
+
+        // Silent for 10 minutes → display as idle.
+        s.lastActivity = Date(timeIntervalSinceNow: -600)
+        XCTAssertEqual(SessionManager.adjustCodexStaleWorking(s).status, .idle)
+
+        // Active within the window → stays working.
+        s.lastActivity = Date()
+        XCTAssertEqual(SessionManager.adjustCodexStaleWorking(s).status, .working)
+
+        // Non-codex sources are never demoted by this rule.
+        s.source = "cc"
+        s.lastActivity = Date(timeIntervalSinceNow: -600)
+        XCTAssertEqual(SessionManager.adjustCodexStaleWorking(s).status, .working)
+    }
 }

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import CctopMenubar
+
+final class SessionFileFormatTests: XCTestCase {
+    func testLegacyUUIDFilenameClassification() {
+        // Pre-PID files were keyed by a bare session UUID → should be removed.
+        XCTAssertTrue(SessionManager.isLegacyUUIDFilename("019e4b0c-9473-7a33-a4b9-749fd2c83a9e"))
+        // PID-keyed files are numeric → keep.
+        XCTAssertFalse(SessionManager.isLegacyUUIDFilename("31349"))
+        // Codex per-conversation files → keep.
+        XCTAssertFalse(SessionManager.isLegacyUUIDFilename("codex-019e4b0c-9473-7a33-a4b9-749fd2c83a9e"))
+    }
+}


### PR DESCRIPTION
## Summary

- **Per-conversation cards.** Codex Desktop fires every conversation's lifecycle hooks from a single shared host process, so PID-keyed session files (`{pid}.json`) collapsed all conversations into one slot. Key Codex sessions by `session_id` (`codex-<id>.json`) so each conversation gets its own file and card; liveness still rides on the host PID stored inside each file.
- **Don't sweep the new files.** The menubar's pre-v0.6.0 cleanup deleted any session file with a non-numeric stem, which would delete `codex-<id>.json` on sight. Tighten it to match only bare UUID filenames (`HostApp.isUUID`).
- **Fix a launch crash the keying change exposed.** `Session.id` was the PID string, unique only because one session owned a PID. With conversations now sharing the host PID, ids collided and `Dictionary(uniqueKeysWithValues:)` in `loadSessions` trapped (`Fatal error: Duplicate values for key`). Identify Codex sessions by `session_id`, dedup the loaded list by id (keeping the most recently active) to absorb the transient old-file/new-file migration window, and make the status map tolerant of duplicate keys.

## Notes

- Rebased on top of #122/#123/#124. Applies to both Codex Desktop and Codex CLI (both run through `--harness codex`); the CLI case stays one-card-per-session, since each CLI session has its own process PID and `session_id`.
- One-time migration note: an in-flight conversation can briefly own both the old `{pid}.json` and the new `codex-<id>.json`; the dedup handles it, and the stale numeric file clears when Codex Desktop quits.