### PR TITLE
Validate hook contract drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,9 @@ make test
 # Lint with swiftlint --strict
 make lint
 
+# Validate the hook input contract against fixtures, Swift parsing, and plugins
+make contract
+
 # Build + lint + test (default)
 make all
 
@@ -205,6 +208,10 @@ scripts/bundle-macos.sh
 ```
 
 **IMPORTANT:** Always use `scripts/bump-version.sh <version>` to bump versions. Never edit version numbers manually — the script updates all files including `CURRENT_PROJECT_VERSION` in the Xcode project.
+
+### Hook Contract Validation
+
+Use `make contract` as the single validation entry point for hook contract work. It runs the fixture schema checks and hook/plugin drift checks together. Treat `scripts/validate-fixtures.sh`, `scripts/validate-hooks-coverage.sh`, and `scripts/validate-hook-contract.py` as implementation details or narrower debugging tools, not as separate commands agents need to remember for normal verification.
 
 ### Linting
 

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ PROJECT = menubar/CctopMenubar.xcodeproj
 DERIVED = menubar/build
 SIGN = CODE_SIGN_IDENTITY="-"
 
-.PHONY: all build test lint clean install run restart
+.PHONY: all build test lint contract clean install run restart
 
-all: lint build test
+all: lint contract build test
 
 build:
 	xcodebuild build -project $(PROJECT) -scheme CctopMenubar -configuration Debug -derivedDataPath $(DERIVED) $(SIGN)
@@ -20,6 +20,10 @@ test:
 
 lint:
 	swiftlint lint --strict
+
+contract:
+	scripts/validate-fixtures.sh
+	scripts/validate-hooks-coverage.sh
 
 clean:
 	xcodebuild clean -project $(PROJECT) -scheme CctopMenubar -derivedDataPath $(DERIVED)

--- a/hook-input.schema.json
+++ b/hook-input.schema.json
@@ -42,7 +42,60 @@
     "agent_id":         { "type": "string" },
     "agent_type":       { "type": "string" },
     "source":           { "type": "string", "description": "Tool that created this session (e.g. \"opencode\")" },
+    "harness_name":     {
+      "type": "string",
+      "enum": ["cc", "codex", "opencode", "pi"],
+      "description": "Tool harness that produced this payload. Legacy plugins may still send this value in source."
+    },
     "session_name":     { "type": "string", "description": "Display name for the session" }
   },
-  "additionalProperties": true
+  "additionalProperties": true,
+  "x-cctop": {
+    "harnesses": ["cc", "codex", "opencode", "pi"],
+    "events_by_harness": {
+      "cc": [
+        "SessionStart",
+        "SessionEnd",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "Stop",
+        "PreCompact",
+        "Notification",
+        "PermissionRequest",
+        "SubagentStart",
+        "SubagentStop"
+      ],
+      "codex": [
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "Stop"
+      ],
+      "opencode": [
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "Stop",
+        "PreCompact",
+        "PermissionRequest",
+        "PostCompact",
+        "SessionError"
+      ],
+      "pi": [
+        "SessionStart",
+        "SessionEnd",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "Stop",
+        "PreCompact",
+        "PostCompact"
+      ]
+    }
+  }
 }

--- a/menubar/CctopMenubarTests/HookInputTests.swift
+++ b/menubar/CctopMenubarTests/HookInputTests.swift
@@ -4,14 +4,17 @@ import XCTest
 final class HookInputTests: XCTestCase {
 
     private func loadFixture(_ name: String) throws -> Data {
+        try Data(contentsOf: fixturesDirectory().appendingPathComponent("\(name).json"))
+    }
+
+    private func fixturesDirectory() -> URL {
         let projectDir = ProcessInfo.processInfo.environment["PROJECT_DIR"]
             ?? URL(fileURLWithPath: #filePath)
                 .deletingLastPathComponent()  // CctopMenubarTests/
                 .deletingLastPathComponent()  // menubar/
                 .deletingLastPathComponent()  // repo root
                 .path
-        let path = (projectDir as NSString).appendingPathComponent("fixtures/\(name).json")
-        return try Data(contentsOf: URL(fileURLWithPath: path))
+        return URL(fileURLWithPath: projectDir).appendingPathComponent("fixtures")
     }
 
     // MARK: - SessionStart
@@ -167,32 +170,21 @@ final class HookInputTests: XCTestCase {
         XCTAssertEqual(input.sessionId, "test")
     }
 
-    // MARK: - Schema coverage
+    // MARK: - Fixture coverage
 
-    func testAllFixturesHaveValidEventNames() throws {
-        let validEvents: Set<String> = [
-            "SessionStart", "SessionEnd", "UserPromptSubmit", "Stop",
-            "PreToolUse", "PostToolUse", "PostToolUseFailure",
-            "PermissionRequest", "Notification",
-            "SubagentStart", "SubagentStop", "PreCompact",
-            "PostCompact", "SessionError"
-        ]
+    func testAllFixturesDecode() throws {
+        let fixtureURLs = try FileManager.default.contentsOfDirectory(
+            at: fixturesDirectory(),
+            includingPropertiesForKeys: nil
+        )
+        .filter { $0.pathExtension == "json" }
 
-        let fixtureNames = [
-            "SessionStart", "SessionEnd", "UserPromptSubmit", "Stop",
-            "PreToolUse", "PostToolUse", "PostToolUseFailure",
-            "PermissionRequest", "Notification-idle", "Notification-permission",
-            "SubagentStart", "SubagentStop", "PreCompact",
-            "PostCompact", "SessionError",
-            "SessionStart-opencode",
-            "codex-SessionStart"
-        ]
+        XCTAssertFalse(fixtureURLs.isEmpty)
 
-        for name in fixtureNames {
-            let input = try JSONDecoder().decode(HookInput.self, from: loadFixture(name))
-            XCTAssertTrue(
-                validEvents.contains(input.hookEventName),
-                "Fixture \(name) has unexpected event: \(input.hookEventName)"
+        for url in fixtureURLs {
+            XCTAssertNoThrow(
+                try JSONDecoder().decode(HookInput.self, from: Data(contentsOf: url)),
+                "Fixture \(url.lastPathComponent) should decode"
             )
         }
     }

--- a/scripts/validate-fixtures.sh
+++ b/scripts/validate-fixtures.sh
@@ -1,19 +1,27 @@
 #!/bin/sh
 # Validate fixture JSON files against the hook input schema.
-# Requires: pip3 install check-jsonschema (or npx ajv-cli)
+# Uses check-jsonschema/ajv for JSON Schema validation, plus the repo's drift validator.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 SCHEMA="$ROOT_DIR/hook-input.schema.json"
 FIXTURES_DIR="$ROOT_DIR/fixtures"
+CONTRACT_VALIDATOR="$SCRIPT_DIR/validate-hook-contract.py"
 
 if command -v check-jsonschema >/dev/null 2>&1; then
     check-jsonschema --schemafile "$SCHEMA" "$FIXTURES_DIR"/*.json
-elif command -v npx >/dev/null 2>&1; then
-    npx --yes ajv-cli validate -s "$SCHEMA" -d "$FIXTURES_DIR/*.json"
+elif command -v npx >/dev/null 2>&1 && npx --no-install ajv-cli help >/dev/null 2>&1; then
+    npx --no-install ajv-cli validate --strict=false -s "$SCHEMA" -d "$FIXTURES_DIR/*.json"
 else
-    echo "ERROR: install check-jsonschema or npm for schema validation" >&2
+    echo "ERROR: install check-jsonschema or a local ajv-cli for schema validation" >&2
+    exit 1
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+    python3 "$CONTRACT_VALIDATOR" fixtures
+else
+    echo "ERROR: install python3 for fixture contract validation" >&2
     exit 1
 fi
 

--- a/scripts/validate-hook-contract.py
+++ b/scripts/validate-hook-contract.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Validate cctop hook contract drift across schema, fixtures, Swift, and plugins.
+
+The JSON Schema remains the source of truth. This script intentionally stays
+narrow: it checks that consumers agree with schema-owned event and harness
+metadata, while validate-fixtures.sh handles full fixture schema validation.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "hook-input.schema.json"
+FIXTURES = ROOT / "fixtures"
+HOOK_EVENT_SWIFT = ROOT / "menubar/CctopMenubar/Models/HookEvent.swift"
+HOOK_INPUT_SWIFT = ROOT / "menubar/CctopMenubar/Hook/HookInput.swift"
+CODEX_INSTALLER_SWIFT = ROOT / "menubar/CctopMenubar/Services/CodexPluginInstaller.swift"
+CC_HOOKS_JSON = ROOT / "plugins/cctop/hooks/hooks.json"
+CODEX_HOOKS_JSON = ROOT / "plugins/codex/hooks.json"
+CC_SHIM = ROOT / "plugins/cctop/hooks/run-hook.sh"
+CODEX_SHIM = ROOT / "plugins/codex/cctop-shim.sh"
+OPENCODE_PLUGIN = ROOT / "plugins/opencode/plugin.js"
+PI_PLUGIN = ROOT / "plugins/pi/cctop.ts"
+
+
+def load_json(path: Path) -> object:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def expect(condition: bool, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def compare_sets(label: str, expected: set[str], actual: set[str], errors: list[str]) -> None:
+    if expected == actual:
+        return
+
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    parts = []
+    if missing:
+        parts.append(f"missing={missing}")
+    if extra:
+        parts.append(f"extra={extra}")
+    errors.append(f"{label} drifted: {', '.join(parts)}")
+
+
+def quoted_strings(text: str) -> set[str]:
+    return set(re.findall(r'"([^"]+)"', text))
+
+
+def schema_contract(errors: list[str]) -> tuple[set[str], set[str], dict[str, set[str]]]:
+    schema = load_json(SCHEMA)
+    if not isinstance(schema, dict):
+        errors.append("hook-input.schema.json must be a JSON object")
+        return set(), set(), {}
+
+    properties = schema.get("properties", {})
+    if not isinstance(properties, dict):
+        errors.append("schema properties must be an object")
+        return set(), set(), {}
+
+    event_schema = properties.get("hook_event_name", {})
+    events = set(event_schema.get("enum", [])) if isinstance(event_schema, dict) else set()
+    expect(bool(events), "schema hook_event_name must define an enum", errors)
+
+    harness_schema = properties.get("harness_name")
+    expect(isinstance(harness_schema, dict), "schema must define harness_name", errors)
+    harnesses = (
+        set(harness_schema.get("enum", []))
+        if isinstance(harness_schema, dict) and isinstance(harness_schema.get("enum"), list)
+        else set()
+    )
+    expect(bool(harnesses), "schema harness_name must define an enum", errors)
+
+    source_schema = properties.get("source", {})
+    expect(isinstance(source_schema, dict), "schema must preserve legacy source", errors)
+    if isinstance(source_schema, dict):
+        expect(
+            "source" not in schema.get("required", []),
+            "legacy source must remain optional",
+            errors,
+        )
+
+    metadata = schema.get("x-cctop")
+    expect(isinstance(metadata, dict), "schema must define x-cctop contract metadata", errors)
+    if not isinstance(metadata, dict):
+        return events, harnesses, {}
+
+    metadata_harnesses = set(metadata.get("harnesses", []))
+    compare_sets("x-cctop harnesses", harnesses, metadata_harnesses, errors)
+
+    raw_harness_events = metadata.get("events_by_harness", {})
+    expect(isinstance(raw_harness_events, dict), "x-cctop events_by_harness must be an object", errors)
+    harness_events: dict[str, set[str]] = {}
+    if isinstance(raw_harness_events, dict):
+        for harness, event_list in raw_harness_events.items():
+            harness_events[harness] = set(event_list) if isinstance(event_list, list) else set()
+        compare_sets("events_by_harness keys", harnesses, set(harness_events), errors)
+        for harness, event_names in sorted(harness_events.items()):
+            expect(bool(event_names), f"{harness} events_by_harness must not be empty", errors)
+            expect(
+                event_names <= events,
+                f"{harness} events_by_harness contains events outside schema: {sorted(event_names - events)}",
+                errors,
+            )
+
+    return events, harnesses, harness_events
+
+
+def fixture_contract(
+    schema_events: set[str],
+    harnesses: set[str],
+    harness_events: dict[str, set[str]],
+    errors: list[str],
+) -> None:
+    seen_events: set[str] = set()
+    for path in sorted(FIXTURES.glob("*.json")):
+        payload = load_json(path)
+        if not isinstance(payload, dict):
+            errors.append(f"{path.relative_to(ROOT)} must be a JSON object")
+            continue
+
+        for field in ("session_id", "cwd", "hook_event_name"):
+            expect(field in payload, f"{path.relative_to(ROOT)} missing required {field}", errors)
+
+        event = payload.get("hook_event_name")
+        expect(isinstance(event, str), f"{path.relative_to(ROOT)} hook_event_name must be a string", errors)
+        if isinstance(event, str):
+            seen_events.add(event)
+            expect(
+                event in schema_events,
+                f"{path.relative_to(ROOT)} event {event!r} not in schema enum",
+                errors,
+            )
+
+        harness = payload.get("harness_name")
+        if harness is not None:
+            expect(
+                harness in harnesses,
+                f"{path.relative_to(ROOT)} harness_name {harness!r} not in schema enum",
+                errors,
+            )
+            if isinstance(harness, str) and isinstance(event, str) and harness in harness_events:
+                expect(
+                    event in harness_events[harness],
+                    f"{path.relative_to(ROOT)} event {event!r} not in {harness} event subset",
+                    errors,
+                )
+
+    compare_sets("fixture event coverage", schema_events, seen_events, errors)
+
+
+def swift_events(schema_events: set[str], errors: list[str]) -> None:
+    text = read_text(HOOK_EVENT_SWIFT)
+    mapped = set(re.findall(r'"([^"]+)":\s*\.', text))
+    if 'hookName == "Notification"' in text:
+        mapped.add("Notification")
+    compare_sets("Swift HookEvent events", schema_events, mapped, errors)
+
+
+def swift_harnesses(harnesses: set[str], errors: list[str]) -> None:
+    text = read_text(HOOK_INPUT_SWIFT)
+    match = re.search(r"knownHarnesses:\s*Set<String>\s*=\s*\[([^\]]*)\]", text)
+    expect(match is not None, "HookInput.swift must define knownHarnesses", errors)
+    if match:
+        compare_sets("HookInput knownHarnesses", harnesses, quoted_strings(match.group(1)), errors)
+
+
+def hook_commands(value: object) -> list[str]:
+    if isinstance(value, dict):
+        commands = []
+        command = value.get("command")
+        if isinstance(command, str):
+            commands.append(command)
+        for nested in value.values():
+            commands.extend(hook_commands(nested))
+        return commands
+    if isinstance(value, list):
+        commands = []
+        for item in value:
+            commands.extend(hook_commands(item))
+        return commands
+    return []
+
+
+def hooks_json_events(path: Path, errors: list[str]) -> set[str]:
+    payload = load_json(path)
+    if not isinstance(payload, dict) or not isinstance(payload.get("hooks"), dict):
+        return set()
+    hooks = payload["hooks"]
+    for event, entries in hooks.items():
+        invoked = set()
+        for command in hook_commands(entries):
+            match = re.search(r"(?:run-hook\.sh|\{SHIM\})\s+([A-Za-z]+)", command)
+            if match:
+                invoked.add(match.group(1))
+        compare_sets(f"{path.relative_to(ROOT)} commands for {event}", {event}, invoked, errors)
+    return set(hooks)
+
+
+def call_hook_events(path: Path) -> set[str]:
+    return set(re.findall(r"callHook\([^,\n]+,\s*\"([A-Za-z]+)\"", read_text(path)))
+
+
+def cli_harness_args(path: Path) -> set[str]:
+    return set(re.findall(r"--harness\s+([A-Za-z0-9_-]+)", read_text(path)))
+
+
+def payload_harness_names(path: Path) -> set[str]:
+    return set(re.findall(r'harness_name:\s*"([^"]+)"', read_text(path)))
+
+
+def plugin_contract(harnesses: set[str], harness_events: dict[str, set[str]], errors: list[str]) -> None:
+    plugin_ids = set()
+    plugin_ids |= cli_harness_args(CC_SHIM)
+    plugin_ids |= cli_harness_args(CODEX_SHIM)
+    plugin_ids |= payload_harness_names(OPENCODE_PLUGIN)
+    plugin_ids |= payload_harness_names(PI_PLUGIN)
+    compare_sets("plugin harness IDs", harnesses, plugin_ids, errors)
+
+    actual_events = {
+        "cc": hooks_json_events(CC_HOOKS_JSON, errors),
+        "codex": hooks_json_events(CODEX_HOOKS_JSON, errors),
+        "opencode": call_hook_events(OPENCODE_PLUGIN),
+        "pi": call_hook_events(PI_PLUGIN),
+    }
+    for harness, events in sorted(actual_events.items()):
+        compare_sets(f"{harness} hook events", harness_events.get(harness, set()), events, errors)
+
+    installer = read_text(CODEX_INSTALLER_SWIFT)
+    match = re.search(r"registeredEvents:\s*\[String\]\s*=\s*\[([^\]]*)\]", installer)
+    expect(match is not None, "CodexPluginInstaller.swift must define registeredEvents", errors)
+    if match:
+        compare_sets(
+            "Codex installer events",
+            harness_events.get("codex", set()),
+            quoted_strings(match.group(1)),
+            errors,
+        )
+
+
+def main() -> int:
+    mode = sys.argv[1] if len(sys.argv) > 1 else "all"
+    if mode not in {"all", "fixtures", "hooks"}:
+        print("usage: validate-hook-contract.py [all|fixtures|hooks]", file=sys.stderr)
+        return 2
+
+    errors: list[str] = []
+    schema_events, harnesses, harness_events = schema_contract(errors)
+    if mode in {"all", "fixtures"}:
+        fixture_contract(schema_events, harnesses, harness_events, errors)
+    if mode in {"all", "hooks"}:
+        swift_events(schema_events, errors)
+        swift_harnesses(harnesses, errors)
+        plugin_contract(harnesses, harness_events, errors)
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print("Hook contract matches schema, fixtures, Swift, and plugins.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-hooks-coverage.sh
+++ b/scripts/validate-hooks-coverage.sh
@@ -1,26 +1,13 @@
 #!/bin/sh
-# Verify that hooks.json registers handlers for all spec events.
+# Verify hook contract coverage across schema, Swift, fixtures, and plugins.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(dirname "$SCRIPT_DIR")"
-HOOKS_JSON="$ROOT_DIR/plugins/cctop/hooks/hooks.json"
+CONTRACT_VALIDATOR="$SCRIPT_DIR/validate-hook-contract.py"
 
-# Events that Claude Code fires (subset of the full spec).
-# PostCompact and SessionError are opencode-only — CC doesn't fire them.
-CC_EVENTS="SessionStart SessionEnd UserPromptSubmit Stop PreToolUse PostToolUse PostToolUseFailure PermissionRequest Notification SubagentStart SubagentStop PreCompact"
-
-missing=0
-for event in $CC_EVENTS; do
-    if ! grep -q "\"$event\"" "$HOOKS_JSON"; then
-        echo "MISSING: $event not found in $HOOKS_JSON"
-        missing=$((missing + 1))
-    fi
-done
-
-if [ "$missing" -gt 0 ]; then
-    echo "ERROR: $missing events missing from hooks.json"
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: install python3 for hook contract validation" >&2
     exit 1
 fi
 
-echo "All spec events covered in hooks.json."
+python3 "$CONTRACT_VALIDATOR" hooks


### PR DESCRIPTION
## What changed

- `hook-input.schema.json` now declares `harness_name` with the supported harness IDs and keeps legacy `source` optional, while `x-cctop` records the harness/event matrix used by the local validator. Sources: [`hook-input.schema.json`](https://github.com/st0012/cctop/blob/a7b093f87b4de38dc26925b96854803d78918c53/hook-input.schema.json), [`HookInput.swift`](https://github.com/st0012/cctop/blob/a7b093f87b4de38dc26925b96854803d78918c53/menubar/CctopMenubar/Hook/HookInput.swift)
- `scripts/validate-hook-contract.py` validates drift between schema events, fixture event usage, Swift `HookEvent` parsing, Swift `HookInput.knownHarnesses`, plugin harness IDs, hook JSON registrations, hook command event arguments, and opencode/pi callback event names. Sources: [`validate-hook-contract.py`](https://github.com/st0012/cctop/blob/a7b093f87b4de38dc26925b96854803d78918c53/scripts/validate-hook-contract.py), [`HookEvent.swift`](https://github.com/st0012/cctop/blob/a7b093f87b4de38dc26925b96854803d78918c53/menubar/CctopMenubar/Models/HookEvent.swift), [`CodexPluginInstaller.swift`](https://github.com/st0012/cctop/blob/a7b093f87b4de38dc26925b96854803d78918c53/menubar/CctopMenubar/Services/CodexPluginInstaller.swift), [`plugins/cctop/hooks/run-hook.sh`](https://github.com/st0012/cctop/blob/a7b093f87b4de38dc26925b96854803d78918c53/plugins/cctop/hooks/run-hook.sh), [`plugins/codex/cctop-shim.sh`](https://github.com/st0012/cctop/blob/a7b093f87b4de38dc26925b96854803d78918c53/plugins/codex/cctop-shim.sh), [`plugins/opencode/plugin.js`](https://github.com/st0012/cctop/blob/a7b093f87b4de38dc26925b96854803d78918c53/plugins/opencode/plugin.js), [`plugins/pi/cctop.ts`](https://github.com/st0012/cctop/blob/a7b093f87b4de38dc26925b96854803d78918c53/plugins/pi/cctop.ts)
- `validate-fixtures.sh`, `validate-hooks-coverage.sh`, and `make contract` run the shared contract validator from the existing validation entry points; fixture schema validation uses installed `check-jsonschema` or a local `ajv-cli` package if present. Sources: [`validate-fixtures.sh`](https://github.com/st0012/cctop/blob/a7b093f87b4de38dc26925b96854803d78918c53/scripts/validate-fixtures.sh), [`validate-hooks-coverage.sh`](https://github.com/st0012/cctop/blob/a7b093f87b4de38dc26925b96854803d78918c53/scripts/validate-hooks-coverage.sh), [`Makefile`](https://github.com/st0012/cctop/blob/a7b093f87b4de38dc26925b96854803d78918c53/Makefile)
- `CLAUDE.md` now presents `make contract` as the single agent-facing validation entry point and treats the individual validation scripts as implementation details or narrower debugging tools. Source: [`CLAUDE.md`](https://github.com/st0012/cctop/blob/a7b093f87b4de38dc26925b96854803d78918c53/CLAUDE.md)
- `HookInputTests` now decodes every fixture discovered under `fixtures/*.json`, which keeps the Swift fixture smoke test aligned with the fixture directory instead of a hard-coded list. Source: [`HookInputTests.swift`](https://github.com/st0012/cctop/blob/a7b093f87b4de38dc26925b96854803d78918c53/menubar/CctopMenubarTests/HookInputTests.swift)

## Local verification

Commands run locally:

```sh
git diff --check
PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/validate-hook-contract.py
python3 scripts/validate-hook-contract.py
scripts/validate-fixtures.sh
scripts/validate-hooks-coverage.sh
make contract
swiftlint lint --strict menubar/CctopMenubarTests/HookInputTests.swift
xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -configuration Debug -derivedDataPath menubar/build CODE_SIGN_IDENTITY="-" -only-testing:CctopMenubarTests/HookInputTests
```

After the `CLAUDE.md` update, `git diff --check` and `make contract` were run again locally.
