### PR TITLE
Add cctop:// panel toggle and e2e session-test skill

### DIFF
--- a/.claude/skills/e2e-session-test/SKILL.md
+++ b/.claude/skills/e2e-session-test/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: e2e-session-test
+description: >-
+  Use when smoke-testing cctop end to end — verifying a real coding-agent session
+  is tracked and shows in the panel. Trigger on "smoke test sessions", "verify
+  session tracking", "test the hook pipeline", "check cctop picks up a
+  claude/codex/opencode/pi session", or "run the e2e test", even without the word
+  "skill". Creates a real CLI agent session in a terminal, confirms cctop tracks
+  it, opens the panel programmatically, and captures screenshot proof.
+---
+
+# cctop end-to-end session test
+
+Verify a real session flows all the way through:
+
+```
+agent in a terminal → cctop hooks → ~/.cctop/sessions/<pid>.json → panel card
+```
+
+A good smoke test after touching hooks, the session schema, or the panel.
+
+## Capabilities, not tools
+
+Harness-agnostic — it needs three generic capabilities. Use your environment's
+equivalent; don't assume a specific tool:
+
+- **run shell commands**
+- **capture a screenshot** of the screen (or fall back to the `screencapture` CLI)
+- **view an image** you captured
+
+## Create the session with a CLI agent in a terminal
+
+Drive a CLI agent (`claude` / `codex` / `opencode` / `pi`) in a terminal window —
+it's a real session and one shell command starts it. Don't try to puppet a
+*desktop* agent's GUI: if it's the app hosting you, screen capture hides its window
+and you can't confirm input landed (see `references/troubleshooting.md`). Requires a
+cctop build with the `cctop://` URL scheme (ships with this skill).
+
+## Steps (run from the repo root)
+
+```bash
+# 1. Baseline — note the PIDs
+.claude/skills/e2e-session-test/scripts/cctop-sessions.sh
+
+# 2. Create a session — opens a terminal running the agent, waits for it to register
+.claude/skills/e2e-session-test/scripts/launch-cli-session.sh claude ~/projects/cctop
+
+# 3. Verify — a new PID entry with the right source (cc/codex/opencode/pi) appears
+.claude/skills/e2e-session-test/scripts/cctop-sessions.sh
+
+# 4. Summon the panel
+open cctop://toggle
+```
+
+Then **capture a screenshot** and confirm the new session's card is in the panel
+(right status, source, project). Run `open cctop://toggle` again to close it — a
+clean closed/open pair if you want before/after proof. For a shareable record,
+write a small HTML log embedding the screenshots.
+
+Two details the launcher handles, because they otherwise make this fail silently: a
+**login shell** (so the agent's `PATH`, e.g. `~/.local/bin`, resolves) and a
+**trusted directory** (so the agent doesn't stall at a folder-trust prompt).
+`open cctop://toggle` is used instead of a menu-bar click or hotkey because those
+need extra OS permissions under automation.
+
+## PASS
+
+- New tracked session within ~5s, correct `source`.
+- `open cctop://toggle` opens **and** closes the panel.
+- A screenshot shows the card.
+
+On failure, grab the relevant `~/.cctop/logs/<session>.log` entry and see
+`references/troubleshooting.md`.

--- a/.claude/skills/e2e-session-test/references/troubleshooting.md
+++ b/.claude/skills/e2e-session-test/references/troubleshooting.md
@@ -1,0 +1,64 @@
+# Troubleshooting the e2e session test
+
+Read this when a step fails. It maps symptoms to causes and explains the design
+choices behind the happy path.
+
+## No new session appears after launching the agent (step 2/3)
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Terminal window opens, agent prints "command not found" | The terminal ran the agent with a minimal `PATH` (no `~/.local/bin`). | Run via a login shell — `zsh -lc <agent>`. The launcher does this. |
+| Agent starts but no `~/.cctop/sessions/<pid>.json` | Agent is stalled at a folder-trust prompt and hasn't fired its session hook. | Launch in a directory the user already trusts (a repo they work in), not `$HOME`. |
+| Window opens but agent never starts | The terminal's "run a command" flag differs from Ghostty's `-e`. | Adjust the launch line in `launch-cli-session.sh` for your terminal. |
+| Session file exists but status never changes | The hook ran once but later events aren't reaching cctop. | Inspect `~/.cctop/logs/<session>.log` — SHIM vs HOOK entries show where the chain broke. |
+
+Per-session logs live in `~/.cctop/logs/`. Each line is
+`{timestamp} {SHIM|HOOK} {event} {project}:{id} {detail}`. SHIM-but-no-HOOK means
+the hook binary didn't start; no log at all means the agent isn't firing hooks.
+
+## The panel won't open (step 4)
+
+`open cctop://toggle` is deliberately the only supported programmatic path. The
+alternatives were tried and rejected:
+
+- **Clicking the menu-bar icon via screen automation** is refused — when an agent
+  drives the screen, the OS reports the desktop shell as frontmost and blocks the
+  click on it.
+- **Sending the global toggle hotkey** works for a human but, posted
+  synthetically, needs the Accessibility permission granted to the posting process.
+- **Scripting a keystroke via the OS automation bridge** triggers a consent prompt
+  that blocks and times out.
+
+The `cctop://` URL scheme needs none of these permissions, so it's what the skill
+uses. If `open cctop://toggle` does nothing:
+
+- Confirm a cctop build that registers the scheme is running. Older builds predate
+  it. `osascript -e 'id of app "cctop"'` should resolve, and the build should be
+  the one from the PR that added `CFBundleURLTypes` for `cctop`.
+- If several cctop bundles exist on disk, `open` may route the URL to a stale one.
+  Target the running build explicitly:
+  `open -a /path/to/CctopMenubar.app cctop://toggle`.
+
+## Why not drive a desktop agent's GUI to create the session?
+
+If the coding agent is the same desktop app that hosts the agent running this test,
+two things break:
+
+1. **You can't see it.** Screen-capture tooling excludes the host app's own window
+   (so the agent never captures its own conversation), so screenshots show empty
+   desktop where that window is.
+2. **You can't verify input.** With the window invisible, a blindly-typed message
+   might land in the wrong place — including back into the test agent's own session.
+
+A CLI agent in a separate terminal window has neither problem: it's a real session,
+created with one shell command, fully visible, and verified by the session file
+rather than by sight. That's why the skill standardizes on it.
+
+## Cleaning up
+
+Close the terminal windows you spawned (each hosts a real agent session that will
+otherwise keep showing in the panel). Remove temp screenshots. A quick check:
+
+```bash
+.claude/skills/e2e-session-test/scripts/cctop-sessions.sh   # should be back to baseline-ish
+```

--- a/.claude/skills/e2e-session-test/scripts/cctop-sessions.sh
+++ b/.claude/skills/e2e-session-test/scripts/cctop-sessions.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# List the sessions cctop currently tracks, one compact JSON object per line.
+# Used for both the baseline snapshot and the post-launch verification.
+#
+# Usage: cctop-sessions.sh
+#
+# Output (one line per session):
+#   {"pid":58384,"source":"cc","project":"cctop","status":"idle"}
+# or "(no sessions)" when the directory is empty.
+
+set -euo pipefail
+
+dir="$HOME/.cctop/sessions"
+shopt -s nullglob
+
+found=0
+for f in "$dir"/*.json; do
+  found=1
+  if command -v jq >/dev/null 2>&1; then
+    jq -c '{pid, source, project: .project_name, status}' "$f" 2>/dev/null \
+      || echo "{\"file\":\"$(basename "$f")\",\"error\":\"unparseable\"}"
+  else
+    # No jq available — fall back to the filename (PID-keyed) as the identity.
+    basename "$f"
+  fi
+done
+
+[ "$found" -eq 0 ] && echo "(no sessions)"
+exit 0

--- a/.claude/skills/e2e-session-test/scripts/launch-cli-session.sh
+++ b/.claude/skills/e2e-session-test/scripts/launch-cli-session.sh
@@ -18,13 +18,16 @@
 # terminal, adjust the launch command for its "run this command" flag.
 
 set -euo pipefail
+# nullglob: an empty sessions dir must expand to nothing, not abort the script —
+# the "no existing sessions" case is a valid baseline this test must support.
+shopt -s nullglob
 
 agent="${1:-claude}"
 workdir="${2:-$PWD}"
 terminal="${3:-Ghostty}"
 sessions="$HOME/.cctop/sessions"
 
-snapshot() { ls "$sessions"/*.json 2>/dev/null | xargs -n1 basename 2>/dev/null | sort; }
+snapshot() { local f; for f in "$sessions"/*.json; do basename "$f"; done | sort; }
 
 before="$(snapshot)"
 

--- a/.claude/skills/e2e-session-test/scripts/launch-cli-session.sh
+++ b/.claude/skills/e2e-session-test/scripts/launch-cli-session.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Launch an interactive CLI coding-agent session in a terminal window so cctop
+# tracks it, then wait until a NEW session file appears and print it.
+#
+# Usage: launch-cli-session.sh <agent> [project-dir] [terminal-app]
+#   agent         claude | codex | opencode | pi   (must be on your login PATH)
+#   project-dir   a directory the agent already trusts (default: current dir)
+#   terminal-app  GUI terminal to host it (default: Ghostty)
+#
+# Why the odd invocation: two pitfalls otherwise make this fail silently.
+#   1. Login shell (zsh -lc): a bare exec uses a minimal PATH that often lacks
+#      ~/.local/bin, so the agent binary isn't found and nothing launches.
+#   2. Trusted dir: agents prompt for folder trust on first use of an unknown
+#      directory and won't emit a session hook until answered — so launch in a
+#      directory the user already works in.
+#
+# The launch line below uses macOS `open` + Ghostty's `-e`. If you use a different
+# terminal, adjust the launch command for its "run this command" flag.
+
+set -euo pipefail
+
+agent="${1:-claude}"
+workdir="${2:-$PWD}"
+terminal="${3:-Ghostty}"
+sessions="$HOME/.cctop/sessions"
+
+snapshot() { ls "$sessions"/*.json 2>/dev/null | xargs -n1 basename 2>/dev/null | sort; }
+
+before="$(snapshot)"
+
+open -na "$terminal" --args --working-directory="$workdir" -e zsh -lc "$agent"
+echo "launched '$agent' in $terminal (cwd: $workdir) — waiting for cctop to register..."
+
+for _ in $(seq 1 15); do
+  sleep 1
+  new="$(comm -13 <(printf '%s\n' "$before") <(snapshot) | grep -v '^$' || true)"
+  if [ -n "$new" ]; then
+    for f in $new; do
+      echo "tracked: $f"
+      if command -v jq >/dev/null 2>&1; then
+        jq -c '{pid, source, project: .project_name, status}' "$sessions/$f" 2>/dev/null || true
+      fi
+    done
+    exit 0
+  fi
+done
+
+echo "FAIL: no new session registered within 15s." >&2
+echo "Check ~/.cctop/logs/ and references/troubleshooting.md." >&2
+exit 1

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -1,5 +1,6 @@
 // swiftlint:disable file_length
 import AppKit
+import Carbon
 import Combine
 import KeyboardShortcuts
 import SwiftUI
@@ -73,6 +74,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
         applyAppearance()
         registerShortcuts()
+        registerURLHandler()
         observeSessionUpdates()
         observeThemeChanges()
     }
@@ -617,5 +619,34 @@ extension AppDelegate {
             }
             try fm.createSymbolicLink(at: symlinkPath, withDestinationURL: bundledHook)
         } catch {}
+    }
+}
+// MARK: - URL scheme handling (cctop://)
+extension AppDelegate {
+    /// Registers a handler for the `cctop://` URL scheme so the panel can be
+    /// toggled programmatically — e.g. `open cctop://toggle` from the shell or
+    /// any automation tool. This avoids needing a global hotkey or a menubar click.
+    @MainActor func registerURLHandler() {
+        NSAppleEventManager.shared().setEventHandler(
+            self,
+            andSelector: #selector(handleURLEvent(_:withReplyEvent:)),
+            forEventClass: AEEventClass(kInternetEventClass),
+            andEventID: AEEventID(kAEGetURL)
+        )
+    }
+
+    @objc private func handleURLEvent(
+        _ event: NSAppleEventDescriptor, withReplyEvent _: NSAppleEventDescriptor
+    ) {
+        guard let string = event.paramDescriptor(forKeyword: AEKeyword(keyDirectObject))?.stringValue,
+              let url = URL(string: string) else { return }
+        // Command lives in the host (cctop://toggle) or path (cctop:toggle).
+        let command = url.host ?? url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        switch command {
+        case "toggle":
+            DispatchQueue.main.async { [weak self] in self?.togglePanel() }
+        default:
+            break
+        }
     }
 }

--- a/menubar/CctopMenubar/Info.plist
+++ b/menubar/CctopMenubar/Info.plist
@@ -6,5 +6,16 @@
 	<string>https://raw.githubusercontent.com/st0012/cctop/master/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>7Ts0HFX10tBXROh8uS9x2Gvuy+K5g3WT48FFYSIR51g=</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.st0012.CctopMenubar</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>cctop</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- **`cctop://` URL scheme** — `open cctop://toggle` opens or closes the panel from a shell. Registered via `CFBundleURLTypes` in `Info.plist` and handled in `AppDelegate` through `NSAppleEventManager` → `togglePanel()`. Gives a permission-free way to control the panel for automation, where a menu-bar click or global hotkey is blocked or needs Accessibility/Automation grants.
- **`e2e-session-test` project skill** (`.claude/skills/`) — a tool-agnostic end-to-end smoke test for session tracking: launch a CLI agent in a terminal, confirm cctop writes the `~/.cctop/sessions/<pid>.json` entry, summon the panel via the new scheme, and capture screenshot proof. Bundles two helper scripts (a session lister, and an agent launcher that handles the login-shell `PATH` and folder-trust pitfalls) plus a troubleshooting reference.

Together these provide an automatic end-to-end path for verifying session tracking.

## Notes

- The skill names capabilities (run a shell command, capture a screenshot, view an image) rather than specific tools, so any agent harness can run it.
- The URL scheme takes effect after relaunching the app; running sessions are unaffected.