### PR TITLE
Hide Codex Desktop maintenance sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ ls ~/.cctop/sessions/
 cat ~/.cctop/sessions/*.json | python3 -m json.tool
 ```
 
+The session-file fields are documented in [`docs/session-files.md`](docs/session-files.md).
+
 ## FAQ
 
 **Does cctop slow down my coding tool?**
@@ -163,7 +165,7 @@ No. Once the plugin is installed, all sessions are automatically tracked. No per
 By default, the project directory name (e.g. `/path/to/my-app` shows as "my-app"). In Claude Code, you can rename a session with `/rename` and cctop picks that up.
 
 **No sessions are showing up — what do I check?**
-First, make sure you restarted sessions after installing the plugin. Then check if session files exist: `ls ~/.cctop/sessions/`. If the directory is empty, the plugin isn't writing data — verify it's installed correctly (see Step 2). If files exist but the menubar shows nothing, try restarting the cctop app.
+First, make sure you restarted sessions after installing the plugin. Then check if session files exist: `ls ~/.cctop/sessions/`. If the directory is empty, the plugin isn't writing data — verify it's installed correctly (see Step 2). If files exist but the menubar shows nothing, check whether those JSON files have `"hidden": true`, then try restarting the cctop app.
 
 **What happens if a coding tool crashes?**
 cctop detects dead sessions automatically. It checks whether each session's process is still running and removes stale entries. No manual cleanup needed.

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -14,6 +14,6 @@ Default: `false` when omitted.
 
 When `hidden` is `true`, cctop reads the session file but does not show that session in the active list, does not archive it into Recent Projects, and does not remove it during dead-session cleanup.
 
-Use `hidden` for real session records that should remain on disk for liveness, debugging, or ownership tracking, but should not appear as user-facing work. Current examples include Codex Desktop memory-maintenance sessions. Future cases can use the same attribute for background or delegated review sessions, such as Codex sessions summoned by Claude for review.
+Use `hidden` for real session records that should remain on disk for liveness, debugging, or ownership tracking, but should not appear as user-facing work. Current examples include Codex Desktop memory-maintenance sessions and Codex Desktop title-generation helper sessions. Future cases can use the same attribute for background or delegated review sessions, such as Codex sessions summoned by Claude for review.
 
 Do not use file deletion as the hiding signal. Delete a session file only when the session is genuinely obsolete and no longer useful as state.

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -1,0 +1,19 @@
+# Session Files
+
+cctop stores live session state as JSON files in `~/.cctop/sessions/`. The menubar app treats these files as the local source of truth for what to render, while the hook binary updates them as tools emit lifecycle events.
+
+Session files are intentionally local and inspectable. Missing optional fields must be treated as their default values so older files continue to load.
+
+## Visibility
+
+### `hidden`
+
+Type: `boolean`
+
+Default: `false` when omitted.
+
+When `hidden` is `true`, cctop reads the session file but does not show that session in the active list, does not archive it into Recent Projects, and does not remove it during dead-session cleanup.
+
+Use `hidden` for real session records that should remain on disk for liveness, debugging, or ownership tracking, but should not appear as user-facing work. Current examples include Codex Desktop memory-maintenance sessions. Future cases can use the same attribute for background or delegated review sessions, such as Codex sessions summoned by Claude for review.
+
+Do not use file deletion as the hiding signal. Delete a session file only when the session is genuinely obsolete and no longer useful as state.

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -44,6 +44,7 @@ enum HookHandler {
 
             let (oldStatus, newStatus) = applyTransition(&session, event: event, input: input, branch: branch, terminal: terminal)
             applySideEffects(event: event, session: &session, input: input, sessionsDir: sessionsDir, safeId: safeId)
+            if session.shouldAutoHide { session.hidden = true }
 
             let suffix = newStatus == nil ? " (preserved)" : ""
             HookLogger.appendHookLog(
@@ -59,6 +60,7 @@ enum HookHandler {
             cleanupSessionsForProject(sessionsDir: sessionsDir, projectPath: input.cwd, currentPid: pid)
         }
     }
+
     private static func clearToolState(_ session: inout Session) {
         session.lastTool = nil
         session.lastToolDetail = nil

--- a/menubar/CctopMenubar/Models/Config.swift
+++ b/menubar/CctopMenubar/Models/Config.swift
@@ -39,6 +39,16 @@ enum Config {
             .appendingPathComponent("Library/Application Support/Claude/claude-code-sessions")
     }
 
+    /// Codex's local memory folder. Read-only — never created.
+    static func codexMemoriesDir() -> String {
+        if let override = ProcessInfo.processInfo.environment["CCTOP_CODEX_MEMORIES_DIR"],
+           !override.isEmpty {
+            return override
+        }
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return (home as NSString).appendingPathComponent(".codex/memories")
+    }
+
     /// Codex's session index (JSONL), which maps `id` (session_id) to the
     /// user-visible `thread_name`. Read-only — never created.
     static func codexSessionIndexPath() -> String {
@@ -47,6 +57,10 @@ enum Config {
             return override
         }
         return NSString(string: "~/.codex/session_index.jsonl").expandingTildeInPath
+    }
+
+    static func standardizedPath(_ path: String) -> String {
+        NSString(string: NSString(string: path).expandingTildeInPath).standardizingPath
     }
 
     private static func ensureDirectoryExists(_ path: String) {

--- a/menubar/CctopMenubar/Models/Config.swift
+++ b/menubar/CctopMenubar/Models/Config.swift
@@ -73,3 +73,31 @@ enum Config {
         }
     }
 }
+
+extension Session {
+    private static let codexDesktopBundleID = "com.openai.codex"
+    private static let codexTitleGenerationPromptPrefix =
+        "You are a helpful assistant. You will be presented with a user prompt, and your job is to provide a short title"
+
+    /// True for Codex Desktop's local memory-consolidation runs. These are maintenance
+    /// artifacts, not user workspace sessions, so cctop marks their live files hidden.
+    var isCodexMemoryMaintenanceSession: Bool {
+        source == Session.codexSource
+            && terminal?.bundleId == Self.codexDesktopBundleID
+            && Config.standardizedPath(projectPath) == Config.standardizedPath(Config.codexMemoriesDir())
+    }
+
+    /// True for Codex Desktop's internal title-generation helper runs. They briefly create
+    /// hook-visible conversations in the current project, but are not user workspace sessions.
+    var isCodexDesktopTitleGenerationSession: Bool {
+        source == Session.codexSource
+            && terminal?.bundleId == Self.codexDesktopBundleID
+            && (sessionName?.isEmpty ?? true)
+            && (lastPrompt?.hasPrefix(Self.codexTitleGenerationPromptPrefix) == true)
+            && (lastPrompt?.contains("Generate a concise UI title") == true)
+    }
+
+    var shouldAutoHide: Bool {
+        isCodexMemoryMaintenanceSession || isCodexDesktopTitleGenerationSession
+    }
+}

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -138,6 +138,14 @@ extension Session {
         guard let bundleId = terminal?.bundleId else { return false }
         return HostApp.from(bundleIdentifier: bundleId)?.isDesktopApp == true
     }
+
+    /// True for Codex Desktop's local memory-consolidation runs. These are maintenance
+    /// artifacts, not user workspace sessions, so cctop hides and removes their live files.
+    var isCodexMemoryMaintenanceSession: Bool {
+        source == Session.codexSource
+            && HostApp.from(bundleIdentifier: terminal?.bundleId) == .codexDesktop
+            && Config.standardizedPath(projectPath) == Config.standardizedPath(Config.codexMemoriesDir())
+    }
 }
 
 extension HostApp {

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -131,37 +131,12 @@ enum HostApp {
 }
 
 extension Session {
-    private static let codexTitleGenerationPromptPrefix =
-        "You are a helpful assistant. You will be presented with a user prompt, and your job is to provide a short title"
-
     /// True when the session is hosted by an AI desktop app (Claude Desktop, Codex Desktop)
     /// rather than a terminal/editor. These sessions have no project folder worth reopening,
     /// so they're excluded from Recent Projects.
     var isHostedByDesktopApp: Bool {
         guard let bundleId = terminal?.bundleId else { return false }
         return HostApp.from(bundleIdentifier: bundleId)?.isDesktopApp == true
-    }
-
-    /// True for Codex Desktop's local memory-consolidation runs. These are maintenance
-    /// artifacts, not user workspace sessions, so cctop marks their live files hidden.
-    var isCodexMemoryMaintenanceSession: Bool {
-        source == Session.codexSource
-            && HostApp.from(bundleIdentifier: terminal?.bundleId) == .codexDesktop
-            && Config.standardizedPath(projectPath) == Config.standardizedPath(Config.codexMemoriesDir())
-    }
-
-    /// True for Codex Desktop's internal title-generation helper runs. They briefly create
-    /// hook-visible conversations in the current project, but are not user workspace sessions.
-    var isCodexDesktopTitleGenerationSession: Bool {
-        source == Session.codexSource
-            && HostApp.from(bundleIdentifier: terminal?.bundleId) == .codexDesktop
-            && (sessionName?.isEmpty ?? true)
-            && (lastPrompt?.hasPrefix(Self.codexTitleGenerationPromptPrefix) == true)
-            && (lastPrompt?.contains("Generate a concise UI title") == true)
-    }
-
-    var shouldAutoHide: Bool {
-        isCodexMemoryMaintenanceSession || isCodexDesktopTitleGenerationSession
     }
 }
 

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -131,6 +131,9 @@ enum HostApp {
 }
 
 extension Session {
+    private static let codexTitleGenerationPromptPrefix =
+        "You are a helpful assistant. You will be presented with a user prompt, and your job is to provide a short title"
+
     /// True when the session is hosted by an AI desktop app (Claude Desktop, Codex Desktop)
     /// rather than a terminal/editor. These sessions have no project folder worth reopening,
     /// so they're excluded from Recent Projects.
@@ -140,11 +143,25 @@ extension Session {
     }
 
     /// True for Codex Desktop's local memory-consolidation runs. These are maintenance
-    /// artifacts, not user workspace sessions, so cctop hides and removes their live files.
+    /// artifacts, not user workspace sessions, so cctop marks their live files hidden.
     var isCodexMemoryMaintenanceSession: Bool {
         source == Session.codexSource
             && HostApp.from(bundleIdentifier: terminal?.bundleId) == .codexDesktop
             && Config.standardizedPath(projectPath) == Config.standardizedPath(Config.codexMemoriesDir())
+    }
+
+    /// True for Codex Desktop's internal title-generation helper runs. They briefly create
+    /// hook-visible conversations in the current project, but are not user workspace sessions.
+    var isCodexDesktopTitleGenerationSession: Bool {
+        source == Session.codexSource
+            && HostApp.from(bundleIdentifier: terminal?.bundleId) == .codexDesktop
+            && (sessionName?.isEmpty ?? true)
+            && (lastPrompt?.hasPrefix(Self.codexTitleGenerationPromptPrefix) == true)
+            && (lastPrompt?.contains("Generate a concise UI title") == true)
+    }
+
+    var shouldAutoHide: Bool {
+        isCodexMemoryMaintenanceSession || isCodexDesktopTitleGenerationSession
     }
 }
 

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -167,6 +167,7 @@ struct Session: Codable, Identifiable, Equatable {
     var source: String?
     var endedAt: Date?
     var activeSubagents: [SubagentInfo]?
+    var hidden: Bool
 
     /// Harness id Codex reports (CLI and Desktop both pass `--harness codex`).
     static let codexSource = "codex"
@@ -207,9 +208,34 @@ struct Session: Codable, Identifiable, Equatable {
         case source
         case endedAt = "ended_at"
         case activeSubagents = "active_subagents"
+        case hidden
     }
 
     // MARK: - Constructors
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessionId = try container.decode(String.self, forKey: .sessionId)
+        projectPath = try container.decode(String.self, forKey: .projectPath)
+        projectName = try container.decode(String.self, forKey: .projectName)
+        branch = try container.decode(String.self, forKey: .branch)
+        status = try container.decode(SessionStatus.self, forKey: .status)
+        lastPrompt = try container.decodeIfPresent(String.self, forKey: .lastPrompt)
+        lastActivity = try container.decode(Date.self, forKey: .lastActivity)
+        startedAt = try container.decode(Date.self, forKey: .startedAt)
+        terminal = try container.decodeIfPresent(TerminalInfo.self, forKey: .terminal)
+        pid = try container.decodeIfPresent(UInt32.self, forKey: .pid)
+        pidStartTime = try container.decodeIfPresent(TimeInterval.self, forKey: .pidStartTime)
+        lastTool = try container.decodeIfPresent(String.self, forKey: .lastTool)
+        lastToolDetail = try container.decodeIfPresent(String.self, forKey: .lastToolDetail)
+        notificationMessage = try container.decodeIfPresent(String.self, forKey: .notificationMessage)
+        sessionName = try container.decodeIfPresent(String.self, forKey: .sessionName)
+        workspaceFile = try container.decodeIfPresent(String.self, forKey: .workspaceFile)
+        source = try container.decodeIfPresent(String.self, forKey: .source)
+        endedAt = try container.decodeIfPresent(Date.self, forKey: .endedAt)
+        activeSubagents = try container.decodeIfPresent([SubagentInfo].self, forKey: .activeSubagents)
+        hidden = try container.decodeIfPresent(Bool.self, forKey: .hidden) ?? false
+    }
 
     /// Full memberwise init (used by mocks and tests).
     init(
@@ -231,7 +257,8 @@ struct Session: Codable, Identifiable, Equatable {
         workspaceFile: String? = nil,
         source: String? = nil,
         endedAt: Date? = nil,
-        activeSubagents: [SubagentInfo]? = nil
+        activeSubagents: [SubagentInfo]? = nil,
+        hidden: Bool = false
     ) {
         self.sessionId = sessionId
         self.projectPath = projectPath
@@ -252,6 +279,7 @@ struct Session: Codable, Identifiable, Equatable {
         self.source = source
         self.endedAt = endedAt
         self.activeSubagents = activeSubagents
+        self.hidden = hidden
     }
 
     /// Convenience init for creating new sessions (used by cctop-hook).
@@ -275,6 +303,7 @@ struct Session: Codable, Identifiable, Equatable {
         self.source = nil
         self.endedAt = nil
         self.activeSubagents = nil
+        self.hidden = false
     }
 
     // MARK: - File I/O
@@ -338,7 +367,8 @@ struct Session: Codable, Identifiable, Equatable {
             workspaceFile: workspaceFile,
             source: source,
             endedAt: endedAt,
-            activeSubagents: activeSubagents
+            activeSubagents: activeSubagents,
+            hidden: hidden
         )
     }
 

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -6,7 +6,7 @@ import os.log
 
 private let logger = Logger(subsystem: "com.st0012.CctopMenubar", category: "SessionManager")
 private typealias SessionFile = (url: URL, session: Session)
-private typealias SessionBuckets = (hidden: [SessionFile], memoryMaintenance: [SessionFile], alive: [SessionFile], dead: [SessionFile])
+private typealias SessionBuckets = (hidden: [SessionFile], autoHidden: [SessionFile], alive: [SessionFile], dead: [SessionFile])
 
 @MainActor
 class SessionManager: ObservableObject {
@@ -71,7 +71,7 @@ class SessionManager: ObservableObject {
             sessions = newSessions
         }
 
-        hideCodexMemoryMaintenanceSessions(partition.memoryMaintenance)
+        hideAutoHiddenSessions(partition.autoHidden)
         archiveAndRemoveDeadSessions(partition.dead)
         cleanupOldFormatFiles(jsonFiles)
     }
@@ -94,15 +94,15 @@ class SessionManager: ObservableObject {
 
     private func partitionSessions(_ entries: [SessionFile]) -> SessionBuckets {
         var hidden: [SessionFile] = []
-        var memoryMaintenance: [SessionFile] = []
+        var autoHidden: [SessionFile] = []
         var alive: [SessionFile] = []
         var dead: [SessionFile] = []
 
         for entry in entries {
             if entry.session.hidden {
                 hidden.append(entry)
-            } else if entry.session.isCodexMemoryMaintenanceSession {
-                memoryMaintenance.append(entry)
+            } else if entry.session.shouldAutoHide {
+                autoHidden.append(entry)
             } else if entry.session.endedAt != nil || !entry.session.isAlive {
                 dead.append(entry)
             } else {
@@ -110,18 +110,24 @@ class SessionManager: ObservableObject {
             }
         }
 
-        return (hidden, memoryMaintenance, alive, dead)
+        return (hidden, autoHidden, alive, dead)
     }
 
-    private func hideCodexMemoryMaintenanceSessions(_ sessions: [(URL, Session)]) {
+    private func hideAutoHiddenSessions(_ sessions: [(URL, Session)]) {
         for (url, session) in sessions {
             logger.info(
-                "hiding Codex memory maintenance session \(session.sessionId, privacy: .public)"
+                "hiding \(self.autoHideReason(for: session), privacy: .public) session \(session.sessionId, privacy: .public)"
             )
             var hiddenSession = session
             hiddenSession.hidden = true
             try? hiddenSession.writeToFile(path: url.path)
         }
+    }
+
+    private func autoHideReason(for session: Session) -> String {
+        if session.isCodexMemoryMaintenanceSession { return "Codex memory maintenance" }
+        if session.isCodexDesktopTitleGenerationSession { return "Codex title generation" }
+        return "maintenance"
     }
 
     private func archiveAndRemoveDeadSessions(_ dead: [(URL, Session)]) {

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -5,6 +5,8 @@ import UserNotifications
 import os.log
 
 private let logger = Logger(subsystem: "com.st0012.CctopMenubar", category: "SessionManager")
+private typealias SessionFile = (url: URL, session: Session)
+private typealias SessionBuckets = (hidden: [SessionFile], memoryMaintenance: [SessionFile], alive: [SessionFile], dead: [SessionFile])
 
 @MainActor
 class SessionManager: ObservableObject {
@@ -44,27 +46,13 @@ class SessionManager: ObservableObject {
         let oldStatuses = Dictionary(sessions.map { ($0.id, $0.status) }, uniquingKeysWith: { first, _ in first })
 
         let jsonFiles = files.filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasSuffix(".tmp") }
-        let allDecoded = jsonFiles
-            .compactMap { url -> (URL, Session)? in
-                guard let data = try? Data(contentsOf: url) else {
-                    logger.warning("loadSessions: could not read \(url.lastPathComponent, privacy: .public)")
-                    return nil
-                }
-                do {
-                    let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: data)
-                    return (url, session)
-                } catch {
-                    logger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public): \(error, privacy: .public)")
-                    return nil
-                }
-            }
-        var alive: [(URL, Session)] = []
-        var dead: [(URL, Session)] = []
-        for entry in allDecoded {
-            if entry.1.endedAt != nil || !entry.1.isAlive { dead.append(entry) } else { alive.append(entry) }
-        }
-        logger.info("loadSessions: \(jsonFiles.count) files, \(allDecoded.count) decoded, \(alive.count) alive, \(dead.count) dead")
-        let newSessions = Self.dedupedByID(alive.map(\.1).map { adjustDisplayStatus($0) })
+        let allDecoded = decodedSessions(from: jsonFiles)
+        let partition = partitionSessions(allDecoded)
+        logger.info("loadSessions: \(jsonFiles.count) files, \(allDecoded.count) decoded")
+        logger.info(
+            "loadSessions: \(partition.alive.count) alive, \(partition.dead.count) dead, \(partition.hidden.count) hidden"
+        )
+        let newSessions = Self.dedupedByID(partition.alive.map(\.1).map { adjustDisplayStatus($0) })
 
         // Side effects: run before the equality guard so they always execute.
         if UserDefaults.standard.bool(forKey: "notificationsEnabled") {
@@ -83,8 +71,57 @@ class SessionManager: ObservableObject {
             sessions = newSessions
         }
 
-        archiveAndRemoveDeadSessions(dead)
+        hideCodexMemoryMaintenanceSessions(partition.memoryMaintenance)
+        archiveAndRemoveDeadSessions(partition.dead)
         cleanupOldFormatFiles(jsonFiles)
+    }
+
+    private func decodedSessions(from jsonFiles: [URL]) -> [SessionFile] {
+        jsonFiles.compactMap { url in
+            guard let data = try? Data(contentsOf: url) else {
+                logger.warning("loadSessions: could not read \(url.lastPathComponent, privacy: .public)")
+                return nil
+            }
+            do {
+                let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: data)
+                return (url, session)
+            } catch {
+                logger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public): \(error, privacy: .public)")
+                return nil
+            }
+        }
+    }
+
+    private func partitionSessions(_ entries: [SessionFile]) -> SessionBuckets {
+        var hidden: [SessionFile] = []
+        var memoryMaintenance: [SessionFile] = []
+        var alive: [SessionFile] = []
+        var dead: [SessionFile] = []
+
+        for entry in entries {
+            if entry.session.hidden {
+                hidden.append(entry)
+            } else if entry.session.isCodexMemoryMaintenanceSession {
+                memoryMaintenance.append(entry)
+            } else if entry.session.endedAt != nil || !entry.session.isAlive {
+                dead.append(entry)
+            } else {
+                alive.append(entry)
+            }
+        }
+
+        return (hidden, memoryMaintenance, alive, dead)
+    }
+
+    private func hideCodexMemoryMaintenanceSessions(_ sessions: [(URL, Session)]) {
+        for (url, session) in sessions {
+            logger.info(
+                "hiding Codex memory maintenance session \(session.sessionId, privacy: .public)"
+            )
+            var hiddenSession = session
+            hiddenSession.hidden = true
+            try? hiddenSession.writeToFile(path: url.path)
+        }
     }
 
     private func archiveAndRemoveDeadSessions(_ dead: [(URL, Session)]) {
@@ -96,16 +133,14 @@ class SessionManager: ObservableObject {
             // live file directly so it doesn't linger as a "dead" entry forever.
             if session.isHostedByDesktopApp {
                 logger.info("dropping dead desktop-app session \(sid, privacy: .public) pid=\(pid, privacy: .public)")
-                try? FileManager.default.removeItem(at: url)
-                try? FileManager.default.removeItem(at: url.appendingPathExtension("lock"))
+                removeSessionFile(at: url)
                 continue
             }
 
             logger.info("archiving dead session \(sid, privacy: .public) pid=\(pid, privacy: .public)")
             let archived = historyManager.archiveSession(session)
             if archived {
-                try? FileManager.default.removeItem(at: url)
-                try? FileManager.default.removeItem(at: url.appendingPathExtension("lock"))
+                removeSessionFile(at: url)
             } else {
                 logger.warning("skipping removal of \(sid, privacy: .public) — archive failed")
             }
@@ -113,6 +148,11 @@ class SessionManager: ObservableObject {
         historyManager.rebuildRecentProjects(
             excludingActive: Set(sessions.map(\.projectPath))
         )
+    }
+
+    private func removeSessionFile(at url: URL) {
+        try? FileManager.default.removeItem(at: url)
+        try? FileManager.default.removeItem(at: url.appendingPathExtension("lock"))
     }
 
     /// A pre-PID session file was keyed by a bare session UUID. Today's files are either

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -118,9 +118,16 @@ class SessionManager: ObservableObject {
             logger.info(
                 "hiding \(self.autoHideReason(for: session), privacy: .public) session \(session.sessionId, privacy: .public)"
             )
-            var hiddenSession = session
-            hiddenSession.hidden = true
-            try? hiddenSession.writeToFile(path: url.path)
+            do {
+                try withSessionLock(sessionPath: url.path) {
+                    guard let hiddenSession = try Self.autoHiddenSessionSnapshot(path: url.path) else { return }
+                    try hiddenSession.writeToFile(path: url.path)
+                }
+            } catch {
+                logger.warning(
+                    "skipping auto-hide update for \(session.sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+            }
         }
     }
 
@@ -365,5 +372,15 @@ class SessionManager: ObservableObject {
     deinit {
         source?.cancel()
         livenessTimer?.invalidate()
+    }
+}
+
+extension SessionManager {
+    nonisolated static func autoHiddenSessionSnapshot(path: String) throws -> Session? {
+        guard FileManager.default.fileExists(atPath: path) else { return nil }
+        var latest = try Session.fromFile(path: path)
+        guard !latest.hidden, latest.shouldAutoHide else { return nil }
+        latest.hidden = true
+        return latest
     }
 }

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -393,6 +393,37 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertEqual(try loadSession().sessionName, "Investigate session name capture")
     }
 
+    func testCodexDesktopTitleGenerationPromptWritesHiddenSession() throws {
+        setenv("__CFBundleIdentifier", HostAppBundleID.codexDesktop, 1)
+        defer { unsetenv("__CFBundleIdentifier") }
+
+        func handle(_ json: String, _ hook: String) throws {
+            let input = try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
+            try HookHandler.handleHook(hookName: hook, input: input)
+        }
+
+        let startJSON = """
+        {"session_id":"title-helper","cwd":"/tmp/cctop","hook_event_name":"SessionStart","harness_name":"codex"}
+        """
+        try handle(startJSON, "SessionStart")
+        XCTAssertFalse(try loadSession().hidden)
+
+        let titlePrompt = """
+        You are a helpful assistant. You will be presented with a user prompt, and your job is to provide a short title for a task that will be created from that prompt.
+        The tasks typically have to do with coding-related tasks, for example requests for bug fixes or questions about a codebase. The title you generate will be shown in the UI to represent the prompt.
+        Generate a concise UI title (up to 36 characters) for this task.
+        Fill the structured title field with plain text.
+
+        User prompt:
+        You are the navigator for a cctop implementation task.
+        """
+        let promptJSON = """
+        {"session_id":"title-helper","cwd":"/tmp/cctop","hook_event_name":"UserPromptSubmit","harness_name":"codex","prompt":\(try jsonString(titlePrompt))}
+        """
+        try handle(promptJSON, "UserPromptSubmit")
+        XCTAssertTrue(try loadSession().hidden)
+    }
+
     /// Codex Desktop fires every conversation's hooks from one shared host process, so
     /// PID keying collapses them into a single file. Keyed by session_id, two concurrent
     /// Codex conversations (same host PID — here the test runner's PID) get two files.
@@ -416,5 +447,10 @@ final class HookHandlerTests: XCTestCase {
             "codex-019e0000-aaaa-7000-8000-000000000001.json",
             "codex-019e0000-bbbb-7000-8000-000000000002.json"
         ])
+    }
+
+    private func jsonString(_ value: String) throws -> String {
+        let data = try JSONEncoder().encode(value)
+        return String(decoding: data, as: UTF8.self)
     }
 }

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -235,6 +235,56 @@ final class SessionFileFormatTests: XCTestCase {
         manager = nil
     }
 
+    func testAutoHiddenSessionSnapshotPreservesLatestFileFields() throws {
+        let root = NSTemporaryDirectory() + "cctop-auto-hide-merge-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let memoriesDir = (root as NSString).appendingPathComponent("carol/.codex/memories")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+
+        setenv("CCTOP_CODEX_MEMORIES_DIR", memoriesDir, 1)
+        defer {
+            unsetenv("CCTOP_CODEX_MEMORIES_DIR")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        var latest = codexDesktopSession(sessionId: "memory-session", projectPath: memoriesDir)
+        latest.status = .working
+        latest.lastTool = "Read"
+        latest.lastToolDetail = "Sources.swift"
+        latest.lastPrompt = "Summarize project state"
+        latest.activeSubagents = [
+            SubagentInfo(agentId: "agent-1", agentType: "reviewer", startedAt: Date(timeIntervalSince1970: 100))
+        ]
+
+        let memoryPath = (sessionsDir as NSString).appendingPathComponent("codex-memory-session.json")
+        try latest.writeToFile(path: memoryPath)
+
+        let hidden = try XCTUnwrap(SessionManager.autoHiddenSessionSnapshot(path: memoryPath))
+
+        XCTAssertTrue(hidden.hidden)
+        XCTAssertEqual(hidden.status, .working)
+        XCTAssertEqual(hidden.lastTool, "Read")
+        XCTAssertEqual(hidden.lastToolDetail, "Sources.swift")
+        XCTAssertEqual(hidden.lastPrompt, "Summarize project state")
+        XCTAssertEqual(hidden.activeSubagents, latest.activeSubagents)
+    }
+
+    func testAutoHiddenSessionSnapshotSkipsFilesThatNoLongerNeedHiding() throws {
+        let root = NSTemporaryDirectory() + "cctop-auto-hide-skip-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let normalSession = codexDesktopSession(
+            sessionId: "normal-codex",
+            projectPath: (root as NSString).appendingPathComponent("projects/cctop")
+        )
+        let path = (sessionsDir as NSString).appendingPathComponent("codex-normal.json")
+        try normalSession.writeToFile(path: path)
+
+        XCTAssertNil(try SessionManager.autoHiddenSessionSnapshot(path: path))
+    }
+
     @MainActor
     func testSessionManagerSkipsAlreadyHiddenSessionsWithoutArchivingOrRemovingThem() throws {
         let root = NSTemporaryDirectory() + "cctop-hidden-\(UUID().uuidString)"

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -2,6 +2,19 @@ import XCTest
 @testable import CctopMenubar
 
 final class SessionFileFormatTests: XCTestCase {
+    private func codexDesktopSession(sessionId: String, projectPath: String) -> Session {
+        var session = Session(
+            sessionId: sessionId,
+            projectPath: projectPath,
+            branch: "main",
+            terminal: TerminalInfo(bundleId: "com.openai.codex")
+        )
+        session.source = Session.codexSource
+        session.pid = UInt32(ProcessInfo.processInfo.processIdentifier)
+        session.status = .waitingInput
+        return session
+    }
+
     func testLegacyUUIDFilenameClassification() {
         // Pre-PID files were keyed by a bare session UUID → should be removed.
         XCTAssertTrue(SessionManager.isLegacyUUIDFilename("019e4b0c-9473-7a33-a4b9-749fd2c83a9e"))
@@ -54,5 +67,128 @@ final class SessionFileFormatTests: XCTestCase {
         // Two distinct ids survive; the duplicate id keeps the most recently active entry.
         XCTAssertEqual(result.map(\.id).sorted(), ["conv-a", "conv-b"])
         XCTAssertEqual(result.first { $0.id == "conv-a" }?.sessionName, "current")
+    }
+
+    // MARK: - Codex memory maintenance sessions
+
+    func testCodexMemoryMaintenanceSessionUsesConfiguredDirectory() {
+        let root = NSTemporaryDirectory() + "cctop-memory-\(UUID().uuidString)"
+        let memoriesDir = (root as NSString).appendingPathComponent("alice/.codex/memories")
+        setenv("CCTOP_CODEX_MEMORIES_DIR", memoriesDir + "/", 1)
+        defer {
+            unsetenv("CCTOP_CODEX_MEMORIES_DIR")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        let normalizedEquivalent = (root as NSString)
+            .appendingPathComponent("alice/.codex/../.codex/memories")
+        let session = codexDesktopSession(sessionId: "codex-memory", projectPath: normalizedEquivalent)
+
+        XCTAssertEqual(Config.codexMemoriesDir(), memoriesDir + "/")
+        XCTAssertTrue(session.isCodexMemoryMaintenanceSession)
+    }
+
+    func testCodexMemoryMaintenanceClassificationIsNarrow() {
+        let root = NSTemporaryDirectory() + "cctop-memory-\(UUID().uuidString)"
+        let memoriesDir = (root as NSString).appendingPathComponent("bob/.codex/memories")
+        setenv("CCTOP_CODEX_MEMORIES_DIR", memoriesDir, 1)
+        defer {
+            unsetenv("CCTOP_CODEX_MEMORIES_DIR")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        let normalProject = codexDesktopSession(
+            sessionId: "normal-codex",
+            projectPath: (root as NSString).appendingPathComponent("bob/projects/cctop")
+        )
+        XCTAssertFalse(normalProject.isCodexMemoryMaintenanceSession)
+
+        var nonDesktopMemory = Session(
+            sessionId: "codex-cli-memory",
+            projectPath: memoriesDir,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        nonDesktopMemory.source = Session.codexSource
+        XCTAssertFalse(nonDesktopMemory.isCodexMemoryMaintenanceSession)
+
+        var nonCodexMemory = codexDesktopSession(sessionId: "other-memory", projectPath: memoriesDir)
+        nonCodexMemory.source = "cc"
+        XCTAssertFalse(nonCodexMemory.isCodexMemoryMaintenanceSession)
+
+        XCTAssertEqual(normalProject.projectName, "cctop")
+    }
+
+    @MainActor
+    func testSessionManagerHidesCodexMemoryMaintenanceSessionsWithoutRemovingFiles() throws {
+        let root = NSTemporaryDirectory() + "cctop-memory-cleanup-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        let memoriesDir = (root as NSString).appendingPathComponent("carol/.codex/memories")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+
+        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
+        setenv("CCTOP_CODEX_MEMORIES_DIR", memoriesDir, 1)
+        defer {
+            unsetenv("CCTOP_SESSIONS_DIR")
+            unsetenv("CCTOP_CODEX_MEMORIES_DIR")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        let memorySession = codexDesktopSession(sessionId: "memory-session", projectPath: memoriesDir)
+        let memoryPath = (sessionsDir as NSString).appendingPathComponent("codex-memory-session.json")
+        try memorySession.writeToFile(path: memoryPath)
+        FileManager.default.createFile(atPath: memoryPath + ".lock", contents: nil)
+
+        var manager: SessionManager? = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
+        )
+        manager?.loadSessions()
+
+        XCTAssertEqual(manager?.sessions, [])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: memoryPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: memoryPath + ".lock"))
+        XCTAssertTrue(try Session.fromFile(path: memoryPath).hidden)
+        XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
+
+        manager = nil
+    }
+
+    @MainActor
+    func testSessionManagerSkipsAlreadyHiddenSessionsWithoutArchivingOrRemovingThem() throws {
+        let root = NSTemporaryDirectory() + "cctop-hidden-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+
+        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
+        defer {
+            unsetenv("CCTOP_SESSIONS_DIR")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        var hidden = Session(
+            sessionId: "hidden-review",
+            projectPath: (root as NSString).appendingPathComponent("reviews/cctop"),
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        hidden.hidden = true
+        hidden.pid = 999_999
+        let hiddenPath = (sessionsDir as NSString).appendingPathComponent("999999.json")
+        try hidden.writeToFile(path: hiddenPath)
+
+        var manager: SessionManager? = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
+        )
+        manager?.loadSessions()
+
+        XCTAssertEqual(manager?.sessions, [])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: hiddenPath))
+        XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
+
+        manager = nil
     }
 }

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -15,6 +15,18 @@ final class SessionFileFormatTests: XCTestCase {
         return session
     }
 
+    private func codexTitleGenerationPrompt(for userPrompt: String = "Why do I have several memories sessions?") -> String {
+        """
+        You are a helpful assistant. You will be presented with a user prompt, and your job is to provide a short title for a task that will be created from that prompt.
+        The tasks typically have to do with coding-related tasks, for example requests for bug fixes or questions about a codebase. The title you generate will be shown in the UI to represent the prompt.
+        Generate a concise UI title (up to 36 characters) for this task.
+        Fill the structured title field with plain text.
+
+        User prompt:
+        \(userPrompt)
+        """
+    }
+
     func testLegacyUUIDFilenameClassification() {
         // Pre-PID files were keyed by a bare session UUID → should be removed.
         XCTAssertTrue(SessionManager.isLegacyUUIDFilename("019e4b0c-9473-7a33-a4b9-749fd2c83a9e"))
@@ -119,6 +131,37 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertEqual(normalProject.projectName, "cctop")
     }
 
+    func testCodexDesktopTitleGenerationClassificationIsNarrow() {
+        let projectPath = "/Users/alice/projects/cctop"
+
+        var titleGeneration = codexDesktopSession(sessionId: "title-helper", projectPath: projectPath)
+        titleGeneration.lastPrompt = codexTitleGenerationPrompt()
+        XCTAssertTrue(titleGeneration.isCodexDesktopTitleGenerationSession)
+
+        var normalCodexDesktop = codexDesktopSession(sessionId: "normal-codex", projectPath: projectPath)
+        normalCodexDesktop.sessionName = "Explain Codex memory sessions"
+        normalCodexDesktop.lastPrompt = "They disappeared indeed. commit."
+        XCTAssertFalse(normalCodexDesktop.isCodexDesktopTitleGenerationSession)
+
+        var namedTitleGeneration = titleGeneration
+        namedTitleGeneration.sessionName = "Generated title"
+        XCTAssertFalse(namedTitleGeneration.isCodexDesktopTitleGenerationSession)
+
+        var nonDesktopTitleGeneration = Session(
+            sessionId: "terminal-title-helper",
+            projectPath: projectPath,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        nonDesktopTitleGeneration.source = Session.codexSource
+        nonDesktopTitleGeneration.lastPrompt = codexTitleGenerationPrompt()
+        XCTAssertFalse(nonDesktopTitleGeneration.isCodexDesktopTitleGenerationSession)
+
+        var nonCodexTitleGeneration = titleGeneration
+        nonCodexTitleGeneration.source = "cc"
+        XCTAssertFalse(nonCodexTitleGeneration.isCodexDesktopTitleGenerationSession)
+    }
+
     @MainActor
     func testSessionManagerHidesCodexMemoryMaintenanceSessionsWithoutRemovingFiles() throws {
         let root = NSTemporaryDirectory() + "cctop-memory-cleanup-\(UUID().uuidString)"
@@ -150,6 +193,43 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: memoryPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: memoryPath + ".lock"))
         XCTAssertTrue(try Session.fromFile(path: memoryPath).hidden)
+        XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
+
+        manager = nil
+    }
+
+    @MainActor
+    func testSessionManagerHidesCodexDesktopTitleGenerationSessionsWithoutRemovingFiles() throws {
+        let root = NSTemporaryDirectory() + "cctop-title-helper-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+
+        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
+        defer {
+            unsetenv("CCTOP_SESSIONS_DIR")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        var titleGeneration = codexDesktopSession(
+            sessionId: "title-helper",
+            projectPath: (root as NSString).appendingPathComponent("projects/cctop")
+        )
+        titleGeneration.lastPrompt = codexTitleGenerationPrompt(for: "Why do I have several memories sessions?")
+        let titleHelperPath = (sessionsDir as NSString).appendingPathComponent("codex-title-helper.json")
+        try titleGeneration.writeToFile(path: titleHelperPath)
+        FileManager.default.createFile(atPath: titleHelperPath + ".lock", contents: nil)
+
+        var manager: SessionManager? = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
+        )
+        manager?.loadSessions()
+
+        XCTAssertEqual(manager?.sessions, [])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: titleHelperPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: titleHelperPath + ".lock"))
+        XCTAssertTrue(try Session.fromFile(path: titleHelperPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
 
         manager = nil

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -27,6 +27,25 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.status, .working)
         XCTAssertEqual(session.lastTool, "Bash")
         XCTAssertEqual(session.pid, 12345)
+        XCTAssertFalse(session.hidden)
+    }
+
+    func testDecodesHiddenSessionJSON() throws {
+        let json = """
+        {
+            "session_id": "hidden-1",
+            "project_path": "/Users/test/projects/myapp",
+            "project_name": "myapp",
+            "branch": "main",
+            "status": "working",
+            "last_activity": "2026-02-08T12:00:00Z",
+            "started_at": "2026-02-08T11:00:00Z",
+            "terminal": {"program": "Code"},
+            "hidden": true
+        }
+        """
+        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        XCTAssertTrue(session.hidden)
     }
 
     func testDecodesDateWithFractionalSeconds() throws {


### PR DESCRIPTION
## Symptom

Codex Desktop can create hook-visible sessions that look like normal cctop work even though they are background maintenance/helper activity: memory-maintenance runs rooted in Codex's memories directory and internal title-generation helper prompts are both covered by the new classification tests. Sources: https://github.com/st0012/cctop/blob/codex/hide-codex-memory-sessions/menubar/CctopMenubarTests/SessionFileFormatTests.swift#L86-L100 and https://github.com/st0012/cctop/blob/codex/hide-codex-memory-sessions/menubar/CctopMenubarTests/SessionFileFormatTests.swift#L134-L162

## Cause

Before this branch, the session file format had no persisted visibility flag; decoded sessions were partitioned only into alive/dead, and every alive session was published to the active list. Sources: https://github.com/st0012/cctop/blob/a3a824b79d78f51a4b8cff44fabe5c58bc4a30f0/menubar/CctopMenubar/Services/SessionManager.swift#L61-L67 and https://github.com/st0012/cctop/blob/a3a824b79d78f51a4b8cff44fabe5c58bc4a30f0/menubar/CctopMenubar/Models/Session.swift#L150-L210

That made deletion or dead-session cleanup the only way to suppress a file-backed session, which is too coarse for real background records that should remain available for debugging or ownership tracking. Source: https://github.com/st0012/cctop/blob/codex/hide-codex-memory-sessions/docs/session-files.md#L15-L19

## Solution

- Add a `hidden` session-file attribute that defaults to `false` for older files. Sources: https://github.com/st0012/cctop/blob/codex/hide-codex-memory-sessions/menubar/CctopMenubar/Models/Session.swift#L168-L237 and https://github.com/st0012/cctop/blob/codex/hide-codex-memory-sessions/docs/session-files.md#L7-L19
- Resolve Codex's memories directory as the current user's `~/.codex/memories`, with `CCTOP_CODEX_MEMORIES_DIR` available for tests. Source: https://github.com/st0012/cctop/blob/codex/hide-codex-memory-sessions/menubar/CctopMenubar/Models/Config.swift#L42-L50
- Add narrow auto-hide classifiers for Codex Desktop memory-maintenance sessions and Codex Desktop title-generation helper sessions in model code shared by the app and `cctop-hook` targets. Source: https://github.com/st0012/cctop/blob/codex/hide-codex-memory-sessions/menubar/CctopMenubar/Models/Config.swift#L77-L103
- Have `SessionManager` skip hidden sessions, mark newly recognized helper sessions hidden on disk, and avoid archiving them into Recent Projects. Sources: https://github.com/st0012/cctop/blob/codex/hide-codex-memory-sessions/menubar/CctopMenubar/Services/SessionManager.swift#L95-L124 and https://github.com/st0012/cctop/blob/codex/hide-codex-memory-sessions/menubar/CctopMenubarTests/SessionFileFormatTests.swift#L165-L235
- Have the hook writer persist `hidden = true` as soon as a hook payload contains enough information to classify an auto-hidden helper session. Sources: https://github.com/st0012/cctop/blob/codex/hide-codex-memory-sessions/menubar/CctopMenubar/Hook/HookHandler.swift#L45-L54 and https://github.com/st0012/cctop/blob/codex/hide-codex-memory-sessions/menubar/CctopMenubarTests/HookHandlerTests.swift#L396-L425

## Not in scope

This does not fix the separate interrupted-turn case where Codex Desktop can leave a normal user thread in `working` after a steered/aborted turn. That needs different lifecycle handling because normal Codex Desktop threads share the long-lived app-server PID, and the current liveness check is process-based. Source: https://github.com/st0012/cctop/blob/codex/hide-codex-memory-sessions/menubar/CctopMenubar/Models/Session.swift#L479-L493

## Validation

- `xcodebuild build -project menubar/CctopMenubar.xcodeproj -scheme cctop-hook -configuration Debug -derivedDataPath menubar/build/ CODE_SIGN_IDENTITY="-"`
- `xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -configuration Debug -derivedDataPath menubar/build/ -only-testing:CctopMenubarTests/HookHandlerTests/testCodexDesktopTitleGenerationPromptWritesHiddenSession -only-testing:CctopMenubarTests/SessionFileFormatTests CODE_SIGN_IDENTITY="-"`
- `make lint`
- `make test`

Relevant test coverage: https://github.com/st0012/cctop/blob/codex/hide-codex-memory-sessions/menubar/CctopMenubarTests/SessionFileFormatTests.swift and https://github.com/st0012/cctop/blob/codex/hide-codex-memory-sessions/menubar/CctopMenubarTests/HookHandlerTests.swift#L396-L425
