### PR TITLE
Preserve dormant desktop sessions across app restarts

### DIFF
--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -92,9 +92,11 @@ CLI sessions do not need `disconnected_at` because disconnected CLI sessions bec
 
 ## Dedup and Cleanup
 
-Session files are deduplicated by a lifecycle key before publishing. Codex sessions use `session_id` as a stable conversation key across both old PID-keyed files and newer `codex-<session_id>` files. Known desktop sessions also use `session_id`; other terminal or ambiguous sessions keep PID identity.
+Session files are deduplicated by a stable identity key before publishing. `SessionIdentityPolicy` owns that grouping rule. Codex sessions use `session_id` across both old PID-keyed files and newer `codex-<session_id>` files. Known desktop sessions also use `session_id`; other terminal or ambiguous sessions keep PID identity.
 
 Finished terminal or ambiguous sessions that survive dedup are archived to Recent Projects and then removed. Finished non-desktop duplicates that lose dedup are migration debris, so cctop removes their stale `.json` files without archiving them as separate recent sessions.
+
+`SessionLifecyclePolicy` owns the derived state question: whether the record is connected, and whether a disconnected record should be active, dormant, or finished for its host class. The lifecycle remains display-time state only; it is not persisted to the session file.
 
 ## Desktop Host Coverage
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -1,0 +1,83 @@
+# Session Lifecycle
+
+This flow documents how cctop turns a session file into a connection state and then into a UI/cleanup lifecycle.
+
+The key split is intentional:
+
+- File presence means cctop has a record to evaluate. It is not itself proof that the session is live.
+- `ended_at` is an explicit disconnect signal written by hook events.
+- `disconnected_at` is the retention clock for known desktop sessions that have become dormant.
+- CLI and ambiguous sessions do not use dormant retention. Once disconnected, they become finished.
+
+```mermaid
+flowchart TD
+    A["Session file exists"] --> B["Evaluate persisted fields"]
+    B --> C{"ended_at present?"}
+
+    C -->|yes| D["Connection state: disconnected"]
+    C -->|no| E["Run host-specific liveness check"]
+
+    E --> F{"Host class"}
+    F -->|"Known desktop"| G["Desktop liveness evidence"]
+    F -->|"Terminal / CLI"| H["Real process liveness"]
+    F -->|"Ambiguous"| I["Conservative process liveness"]
+
+    G --> G1{"Codex Desktop?"}
+    G1 -->|yes| G2["Recent hook activity within active window"]
+    G1 -->|no| G3["Process liveness"]
+
+    H --> J{"Live?"}
+    I --> J
+    G2 --> J
+    G3 --> J
+
+    J -->|yes| K["Connection state: connected"]
+    J -->|no| D
+
+    K --> L["Lifecycle: active"]
+
+    D --> M{"Host policy"}
+    M -->|"Known desktop"| N{"disconnected_at present?"}
+    M -->|"Terminal / CLI"| O["Lifecycle: finished"]
+    M -->|"Ambiguous"| O
+
+    N -->|no| P["Stamp disconnected_at now"]
+    P --> Q["Lifecycle: dormant"]
+    N -->|yes| R{"Retention expired?"}
+    R -->|no| Q
+    R -->|yes| S["Lifecycle: finished"]
+
+    Q --> T["Show dormant session"]
+    Q --> U["No notifications; neutral display status"]
+    S --> V["Desktop GC removes stale .json later"]
+    O --> W["Archive and remove .json promptly"]
+
+    V --> X["Never remove .lock files"]
+    W --> X
+```
+
+## Field Meanings
+
+### `ended_at`
+
+`ended_at` is set when a hook observes `SessionEnd`. It is read before any PID or recency check. If it is present, every host class is considered disconnected.
+
+New activity clears `ended_at` so a resumed session can become connected again.
+
+### `disconnected_at`
+
+`disconnected_at` is only meaningful for known desktop sessions. It starts the dormant retention window.
+
+It can be set in two ways:
+
+- A desktop `SessionEnd` stamps it at the same time as `ended_at`.
+- The menubar app stamps it when it first observes a known desktop session as dormant and the field is missing.
+
+CLI sessions do not need `disconnected_at` because disconnected CLI sessions become finished immediately.
+
+## Why This Shape
+
+The connection state is shared across host classes, but host policy differs:
+
+- Desktop disconnection may be temporary because the desktop app can close or update while conversations still exist inside the app.
+- CLI disconnection means the process is gone or the hook explicitly ended the session, so the old archive/remove behavior remains correct.

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -48,13 +48,27 @@ flowchart TD
     R -->|no| Q
     R -->|yes| S["Lifecycle: finished"]
 
-    Q --> T["Show dormant session"]
-    Q --> U["No notifications; neutral display status"]
-    S --> V["Desktop GC removes stale .json later"]
-    O --> W["Archive and remove .json promptly"]
+    L --> Y["Deduplicate by stable lifecycle key"]
+    Q --> Y
+    S --> Y
+    O --> Y
+
+    Y --> Z{"Survives dedup?"}
+    Z -->|yes| AA{"Lifecycle after dedup"}
+    Z -->|no| AB{"Finished non-desktop duplicate?"}
+
+    AA -->|"active"| AC["Show active session"]
+    AA -->|"dormant"| T["Show dormant session"]
+    AA -->|"finished desktop"| V["Desktop GC removes stale .json later"]
+    AA -->|"finished terminal / ambiguous"| W["Archive and remove .json promptly"]
+
+    T --> U["No notifications; neutral display status"]
+    AB -->|yes| AD["Remove stale duplicate .json without archiving"]
+    AB -->|no| AE["Ignore duplicate; winner owns display/cleanup"]
 
     V --> X["Never remove .lock files"]
     W --> X
+    AD --> X
 ```
 
 ## Field Meanings
@@ -75,6 +89,12 @@ It can be set in two ways:
 - The menubar app stamps it when it first observes a known desktop session as dormant and the field is missing.
 
 CLI sessions do not need `disconnected_at` because disconnected CLI sessions become finished immediately.
+
+## Dedup and Cleanup
+
+Session files are deduplicated by a lifecycle key before publishing. Codex sessions use `session_id` as a stable conversation key across both old PID-keyed files and newer `codex-<session_id>` files. Known desktop sessions also use `session_id`; other terminal or ambiguous sessions keep PID identity.
+
+Finished terminal or ambiguous sessions that survive dedup are archived to Recent Projects and then removed. Finished non-desktop duplicates that lose dedup are migration debris, so cctop removes their stale `.json` files without archiving them as separate recent sessions.
 
 ## Desktop Host Coverage
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -1,12 +1,13 @@
 # Session Lifecycle
 
 This flow documents how cctop turns a session file into a connection state and then into a UI/cleanup lifecycle.
+The desktop path applies to both Claude Desktop and Codex Desktop.
 
 The key split is intentional:
 
 - File presence means cctop has a record to evaluate. It is not itself proof that the session is live.
 - `ended_at` is an explicit disconnect signal written by hook events.
-- `disconnected_at` is the retention clock for known desktop sessions that have become dormant.
+- `disconnected_at` is the retention clock for known desktop sessions, including Claude Desktop and Codex Desktop, that have become dormant.
 - CLI and ambiguous sessions do not use dormant retention. Once disconnected, they become finished.
 
 ```mermaid
@@ -18,13 +19,13 @@ flowchart TD
     C -->|no| E["Run host-specific liveness check"]
 
     E --> F{"Host class"}
-    F -->|"Known desktop"| G["Desktop liveness evidence"]
+    F -->|"Known desktop app"| G["Desktop liveness evidence"]
     F -->|"Terminal / CLI"| H["Real process liveness"]
     F -->|"Ambiguous"| I["Conservative process liveness"]
 
     G --> G1{"Codex Desktop?"}
     G1 -->|yes| G2["Recent hook activity within active window"]
-    G1 -->|no| G3["Process liveness"]
+    G1 -->|"Claude Desktop / other desktop app"| G3["Process liveness"]
 
     H --> J{"Live?"}
     I --> J
@@ -37,7 +38,7 @@ flowchart TD
     K --> L["Lifecycle: active"]
 
     D --> M{"Host policy"}
-    M -->|"Known desktop"| N{"disconnected_at present?"}
+    M -->|"Known desktop app"| N{"disconnected_at present?"}
     M -->|"Terminal / CLI"| O["Lifecycle: finished"]
     M -->|"Ambiguous"| O
 
@@ -66,7 +67,7 @@ New activity clears `ended_at` so a resumed session can become connected again.
 
 ### `disconnected_at`
 
-`disconnected_at` is only meaningful for known desktop sessions. It starts the dormant retention window.
+`disconnected_at` is only meaningful for known desktop sessions, currently Claude Desktop and Codex Desktop. It starts the dormant retention window.
 
 It can be set in two ways:
 
@@ -75,9 +76,25 @@ It can be set in two ways:
 
 CLI sessions do not need `disconnected_at` because disconnected CLI sessions become finished immediately.
 
+## Desktop Host Coverage
+
+Claude Desktop and Codex Desktop both enter the desktop lifecycle path only through trusted bundle IDs:
+
+- Claude Desktop: `com.anthropic.claudefordesktop`
+- Codex Desktop: `com.openai.codex`
+
+Once either host is disconnected, the behavior is the same: cctop keeps the session as dormant while `disconnected_at` is inside the retention window, then the slow GC removes the stale `.json` file.
+
+The active liveness evidence is not identical:
+
+- Claude Desktop uses the normal process liveness check unless `ended_at` is present.
+- Codex Desktop uses recent hook activity instead of PID liveness, because Codex Desktop can report multiple conversations from a shared host process.
+
+Both hosts still use the same disconnected-state policy after the shared connection step.
+
 ## Why This Shape
 
 The connection state is shared across host classes, but host policy differs:
 
-- Desktop disconnection may be temporary because the desktop app can close or update while conversations still exist inside the app.
+- Desktop disconnection may be temporary because Claude Desktop or Codex Desktop can close or update while conversations still exist inside the app.
 - CLI disconnection means the process is gone or the hook explicitly ended the session, so the old archive/remove behavior remains correct.

--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -102,6 +102,8 @@
 		FST000010000000000000001 /* FocusStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FST000020000000000000001 /* FocusStrategyTests.swift */; };
 		MFT000010000000000000001 /* MultiplexerFocusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MFT000020000000000000001 /* MultiplexerFocusTests.swift */; };
 		TMT000010000000000000001 /* ThemeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TMT000020000000000000001 /* ThemeManagerTests.swift */; };
+		SLP000010000000000000001 /* SessionLifecyclePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = SLP000020000000000000001 /* SessionLifecyclePolicy.swift */; };
+		SIP000010000000000000001 /* SessionIdentityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = SIP000020000000000000001 /* SessionIdentityPolicy.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -121,6 +123,8 @@
 		B10000020000000000000001 /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		B10000040000000000000001 /* SessionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStatus.swift; sourceTree = "<group>"; };
 		C10000020000000000000001 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
+		SLP000020000000000000001 /* SessionLifecyclePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLifecyclePolicy.swift; sourceTree = "<group>"; };
+		SIP000020000000000000001 /* SessionIdentityPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIdentityPolicy.swift; sourceTree = "<group>"; };
 		D1000000A000000000000001 /* QuitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitButton.swift; sourceTree = "<group>"; };
 		D10000020000000000000001 /* StatusChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusChip.swift; sourceTree = "<group>"; };
 		D10000040000000000000001 /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
@@ -244,6 +248,8 @@
 			isa = PBXGroup;
 			children = (
 				C10000020000000000000001 /* SessionManager.swift */,
+				SLP000020000000000000001 /* SessionLifecyclePolicy.swift */,
+				SIP000020000000000000001 /* SessionIdentityPolicy.swift */,
 				HM0000020000000000000001 /* HistoryManager.swift */,
 				E10000020000000000000001 /* FocusTerminal.swift */,
 				SP0000020000000000000001 /* SparkleUpdater.swift */,
@@ -511,6 +517,8 @@
 				B10000010000000000000001 /* Session.swift in Sources */,
 				B10000030000000000000001 /* SessionStatus.swift in Sources */,
 				C10000010000000000000001 /* SessionManager.swift in Sources */,
+				SLP000010000000000000001 /* SessionLifecyclePolicy.swift in Sources */,
+				SIP000010000000000000001 /* SessionIdentityPolicy.swift in Sources */,
 				D10000010000000000000001 /* StatusChip.swift in Sources */,
 				D10000030000000000000001 /* HeaderView.swift in Sources */,
 				D10000050000000000000001 /* SessionCardView.swift in Sources */,

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -359,6 +359,12 @@ enum HookHandler {
         forEachSession(in: sessionsDir) { path, session in
             guard session.projectPath == projectPath, session.pid != currentPid else { return }
 
+            // Desktop-app conversations survive host-app restarts as dormant cards in the menubar
+            // app and are reaped only by its lock-held GC. The hook must NOT delete them here, or
+            // resuming one conversation would reap its dormant same-project siblings.
+            let bundleId = session.terminal?.bundleId
+            guard bundleId != HostAppBundleID.claudeDesktop, bundleId != HostAppBundleID.codexDesktop else { return }
+
             let isStale: Bool
             if let pid = session.pid {
                 if !isPIDAlive(pid) {
@@ -393,7 +399,9 @@ enum HookHandler {
 
     private static func removeSession(at path: String, sessionId: String) {
         try? FileManager.default.removeItem(atPath: path)
-        try? FileManager.default.removeItem(atPath: path + ".lock")
+        // Never remove the .lock here: a concurrent hook may hold it, and unlinking a held lock
+        // splits the flock inode (a recreated path gets a different lock), defeating the mutex.
+        // Orphan .lock files are 0-byte and harmless; the app's GC also leaves them in place.
         HookLogger.cleanupSessionLog(sessionId: sessionId)
     }
 

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 
 private let maxToolDetailLen = 120
@@ -96,6 +97,8 @@ enum HookHandler {
         // Skip lastActivity for notificationPermission — PermissionRequest already set it,
         // and the menubar app needs the original timestamp for child-process-start-time comparison.
         if event != .notificationPermission { session.lastActivity = Date() }
+        session.endedAt = nil
+        session.disconnectedAt = nil
         session.branch = branch; session.terminal = terminal
         // MIGRATION(harness_name): The session JSON file still uses the `source` key.
         // Renaming the JSON key would require a reader-side migration in SessionManager.
@@ -335,6 +338,9 @@ enum HookHandler {
         return "/dev/" + String(cString: name)
     }
 
+}
+
+extension HookHandler {
     // MARK: - Cleanup
 
     private static func handleSessionEnd(hookName: String, input: HookInput) {
@@ -345,7 +351,11 @@ enum HookHandler {
         // Stamp endedAt instead of deleting — the menubar app archives to history on next poll.
         try? withSessionLock(sessionPath: path) {
             if var session = try? Session.fromFile(path: path) {
-                session.endedAt = Date()
+                let endedAt = Date()
+                session.endedAt = endedAt
+                if session.hostClass == .desktop {
+                    session.disconnectedAt = session.disconnectedAt ?? endedAt
+                }
                 try? session.writeToFile(path: path)
                 HookLogger.appendHookLog(sessionId: safeId, event: hookName, label: label, transition: "-> ended")
             } else {
@@ -399,9 +409,7 @@ enum HookHandler {
 
     private static func removeSession(at path: String, sessionId: String) {
         try? FileManager.default.removeItem(atPath: path)
-        // Never remove the .lock here: a concurrent hook may hold it, and unlinking a held lock
-        // splits the flock inode (a recreated path gets a different lock), defeating the mutex.
-        // Orphan .lock files are 0-byte and harmless; the app's GC also leaves them in place.
+        // Never remove the .lock here: unlinking a held lock splits the flock inode.
         HookLogger.cleanupSessionLog(sessionId: sessionId)
     }
 
@@ -437,11 +445,8 @@ func withSessionLock(sessionPath: String, body: () throws -> Void) throws {
 
 // MARK: - Session File Naming
 
-/// Session files are keyed by PID, except Codex. Codex Desktop fires every
-/// conversation's hooks from one shared host process, so PID keying would collapse
-/// them into a single slot — key Codex by session_id so each conversation is its own
-/// file. The `codex-` prefix keeps the name non-UUID so the menubar's legacy-file
-/// cleanup (which deletes bare pre-PID UUID files) leaves it alone.
+/// Session files are keyed by PID, except Codex where one host process can emit hooks
+/// for multiple conversations. The `codex-` prefix avoids legacy UUID-file cleanup.
 func sessionFileName(input: HookInput, pid: UInt32, safeSessionId: String) -> String {
     if input.resolvedHarnessName == Session.codexSource {
         return "codex-\(safeSessionId).json"
@@ -475,7 +480,6 @@ func getCurrentBranch(cwd: String) -> String {
 }
 
 // MARK: - Tool Detail Extraction
-
 func extractToolDetail(toolName: String, toolInput: [String: String]?) -> String? {
     guard let toolInput else { return nil }
 

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -97,8 +97,10 @@ enum HookHandler {
         // Skip lastActivity for notificationPermission — PermissionRequest already set it,
         // and the menubar app needs the original timestamp for child-process-start-time comparison.
         if event != .notificationPermission { session.lastActivity = Date() }
-        session.endedAt = nil
-        session.disconnectedAt = nil
+        if Transition.clearsInactiveMarkers(event: event) {
+            session.endedAt = nil
+            session.disconnectedAt = nil
+        }
         session.branch = branch; session.terminal = terminal
         // MIGRATION(harness_name): The session JSON file still uses the `source` key.
         // Renaming the JSON key would require a reader-side migration in SessionManager.

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -353,7 +353,7 @@ extension HookHandler {
             if var session = try? Session.fromFile(path: path) {
                 let endedAt = Date()
                 session.endedAt = endedAt
-                if session.hostClass == .desktop {
+                if isDesktopBundleId(session.terminal?.bundleId) {
                     session.disconnectedAt = session.disconnectedAt ?? endedAt
                 }
                 try? session.writeToFile(path: path)
@@ -372,8 +372,7 @@ extension HookHandler {
             // Desktop-app conversations survive host-app restarts as dormant cards in the menubar
             // app and are reaped only by its lock-held GC. The hook must NOT delete them here, or
             // resuming one conversation would reap its dormant same-project siblings.
-            let bundleId = session.terminal?.bundleId
-            guard bundleId != HostAppBundleID.claudeDesktop, bundleId != HostAppBundleID.codexDesktop else { return }
+            guard !isDesktopBundleId(session.terminal?.bundleId) else { return }
 
             let isStale: Bool
             if let pid = session.pid {
@@ -395,6 +394,10 @@ extension HookHandler {
                 removeSession(at: path, sessionId: session.sessionId)
             }
         }
+    }
+
+    private static func isDesktopBundleId(_ bundleId: String?) -> Bool {
+        bundleId == HostAppBundleID.claudeDesktop || bundleId == HostAppBundleID.codexDesktop
     }
 
     private static func forEachSession(in dir: String, body: (String, Session) -> Void) {

--- a/menubar/CctopMenubar/Models/HookEvent.swift
+++ b/menubar/CctopMenubar/Models/HookEvent.swift
@@ -59,4 +59,16 @@ enum Transition {
         case .notificationPermission, .notificationOther, .sessionEnd, .unknown: return nil
         }
     }
+
+    /// True when a hook is strong evidence that a previously ended/dormant session resumed.
+    static func clearsInactiveMarkers(event: HookEvent) -> Bool {
+        switch event {
+        case .sessionStart, .userPromptSubmit, .preToolUse, .postToolUse, .postToolUseFailure,
+             .stop, .notificationIdle, .permissionRequest, .subagentStart, .subagentStop,
+             .preCompact, .postCompact, .sessionError:
+            return true
+        case .notificationPermission, .notificationOther, .sessionEnd, .unknown:
+            return false
+        }
+    }
 }

--- a/menubar/CctopMenubar/Models/HookEvent.swift
+++ b/menubar/CctopMenubar/Models/HookEvent.swift
@@ -64,10 +64,10 @@ enum Transition {
     static func clearsInactiveMarkers(event: HookEvent) -> Bool {
         switch event {
         case .sessionStart, .userPromptSubmit, .preToolUse, .postToolUse, .postToolUseFailure,
-             .stop, .notificationIdle, .permissionRequest, .subagentStart, .subagentStop,
-             .preCompact, .postCompact, .sessionError:
+             .stop, .notificationIdle, .permissionRequest, .preCompact, .postCompact, .sessionError:
             return true
-        case .notificationPermission, .notificationOther, .sessionEnd, .unknown:
+        case .notificationPermission, .notificationOther, .subagentStart, .subagentStop,
+             .sessionEnd, .unknown:
             return false
         }
     }

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -140,6 +140,34 @@ extension Session {
     }
 }
 
+/// File-local classification of a session's host, used by the Phase-1 lifecycle GC to decide
+/// whether a dead-PID session may be destructively deleted. Deliberately strict: `source`
+/// never classifies (terminal Claude Code and Codex CLI share `source` strings with their
+/// desktop counterparts), and env-only signals are not trusted — only a recognized
+/// `bundle_id` is. Anything we can't confidently place is `ambiguous` and must be kept.
+enum SessionHostClass: Equatable {
+    case desktop    // confident: a desktop AI app (Claude Desktop, Codex Desktop)
+    case terminal   // confident: a known terminal or editor
+    case ambiguous  // unknown — keep; never destructively delete on the fast path
+}
+
+extension Session {
+    /// Phase-1 host classification from file-local signals only.
+    /// Precedence: a recognized bundle id (`__CFBundleIdentifier`, the same trusted signal
+    /// `isHostedByDesktopApp` uses) classifies desktop vs terminal. Failing that, a terminal
+    /// multiplexer (tmux/zellij) is hard terminal evidence — desktop is already returned
+    /// above, so a leaked `TMUX` env can't misclassify a desktop session here. Everything
+    /// else (no/unknown bundle id, only env-copyable `tty` or program name) → ambiguous,
+    /// which is kept and never destructively deleted on the fast path.
+    var hostClass: SessionHostClass {
+        if let app = HostApp.from(bundleIdentifier: terminal?.bundleId) {
+            return app.isDesktopApp ? .desktop : .terminal
+        }
+        if terminal?.multiplexer != nil { return .terminal }
+        return .ambiguous
+    }
+}
+
 extension HostApp {
     /// Deep-link URL that focuses a specific session inside this app, if supported.
     /// Returns nil when the app has no session-jump scheme, or `sessionId` isn't a

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -140,15 +140,14 @@ extension Session {
     }
 }
 
-/// File-local classification of a session's host, used by the Phase-1 lifecycle GC to decide
-/// whether a dead-PID session may be destructively deleted. Deliberately strict: `source`
-/// never classifies (terminal Claude Code and Codex CLI share `source` strings with their
-/// desktop counterparts), and env-only signals are not trusted — only a recognized
-/// `bundle_id` is. Anything we can't confidently place is `ambiguous` and must be kept.
+/// File-local classification of a session's host, used by lifecycle cleanup to decide which
+/// files can be retained after their process disappears. Deliberately strict: `source` never
+/// classifies (terminal Claude Code and Codex CLI share `source` strings with their desktop
+/// counterparts), and env-only signals are not trusted — only a recognized `bundle_id` is.
 enum SessionHostClass: Equatable {
     case desktop    // confident: a desktop AI app (Claude Desktop, Codex Desktop)
     case terminal   // confident: a known terminal or editor
-    case ambiguous  // unknown — keep; never destructively delete on the fast path
+    case ambiguous  // unknown — preserve existing terminal-style cleanup semantics
 }
 
 extension Session {
@@ -157,8 +156,7 @@ extension Session {
     /// `isHostedByDesktopApp` uses) classifies desktop vs terminal. Failing that, a terminal
     /// multiplexer (tmux/zellij) is hard terminal evidence — desktop is already returned
     /// above, so a leaked `TMUX` env can't misclassify a desktop session here. Everything
-    /// else (no/unknown bundle id, only env-copyable `tty` or program name) → ambiguous,
-    /// which is kept and never destructively deleted on the fast path.
+    /// else (no/unknown bundle id, only env-copyable `tty` or program name) → ambiguous.
     var hostClass: SessionHostClass {
         if let app = HostApp.from(bundleIdentifier: terminal?.bundleId) {
             return app.isDesktopApp ? .desktop : .terminal

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -158,11 +158,7 @@ extension Session {
     /// above, so a leaked `TMUX` env can't misclassify a desktop session here. Everything
     /// else (no/unknown bundle id, only env-copyable `tty` or program name) → ambiguous.
     var hostClass: SessionHostClass {
-        if let app = HostApp.from(bundleIdentifier: terminal?.bundleId) {
-            return app.isDesktopApp ? .desktop : .terminal
-        }
-        if terminal?.multiplexer != nil { return .terminal }
-        return .ambiguous
+        SessionIdentityPolicy.hostClass(for: self)
     }
 }
 

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 
 // MARK: - Shared date formatting
@@ -177,6 +178,7 @@ struct Session: Codable, Identifiable, Equatable {
     var workspaceFile: String?
     var source: String?
     var endedAt: Date?
+    var disconnectedAt: Date?
     var activeSubagents: [SubagentInfo]?
     var hidden: Bool
 
@@ -199,13 +201,6 @@ struct Session: Codable, Identifiable, Equatable {
         if isCodex { return sessionId }
         return pid.map { String($0) } ?? sessionId
     }
-
-    /// Stable per-conversation key for dedup and notification grouping. Unlike `id` (PID-based
-    /// for non-Codex), this never changes when a desktop conversation's subprocess is respawned
-    /// with a new PID across a host-app restart, so the old dead-PID file and the new live-PID
-    /// file collapse to one card. Class-independent on purpose: a file's `hostClass` can flicker
-    /// between loads (bundle id present/absent), but its `session_id` does not.
-    var conversationKey: String { sessionId }
 
     var displayName: String {
         sessionName ?? projectName
@@ -232,6 +227,7 @@ struct Session: Codable, Identifiable, Equatable {
         case workspaceFile = "workspace_file"
         case source
         case endedAt = "ended_at"
+        case disconnectedAt = "disconnected_at"
         case activeSubagents = "active_subagents"
         case hidden
     }
@@ -258,6 +254,7 @@ struct Session: Codable, Identifiable, Equatable {
         workspaceFile = try container.decodeIfPresent(String.self, forKey: .workspaceFile)
         source = try container.decodeIfPresent(String.self, forKey: .source)
         endedAt = try container.decodeIfPresent(Date.self, forKey: .endedAt)
+        disconnectedAt = try container.decodeIfPresent(Date.self, forKey: .disconnectedAt)
         activeSubagents = try container.decodeIfPresent([SubagentInfo].self, forKey: .activeSubagents)
         hidden = try container.decodeIfPresent(Bool.self, forKey: .hidden) ?? false
     }
@@ -282,6 +279,7 @@ struct Session: Codable, Identifiable, Equatable {
         workspaceFile: String? = nil,
         source: String? = nil,
         endedAt: Date? = nil,
+        disconnectedAt: Date? = nil,
         activeSubagents: [SubagentInfo]? = nil,
         hidden: Bool = false
     ) {
@@ -303,6 +301,7 @@ struct Session: Codable, Identifiable, Equatable {
         self.workspaceFile = workspaceFile
         self.source = source
         self.endedAt = endedAt
+        self.disconnectedAt = disconnectedAt
         self.activeSubagents = activeSubagents
         self.hidden = hidden
     }
@@ -327,6 +326,7 @@ struct Session: Codable, Identifiable, Equatable {
         self.workspaceFile = nil
         self.source = nil
         self.endedAt = nil
+        self.disconnectedAt = nil
         self.activeSubagents = nil
         self.hidden = false
     }
@@ -392,6 +392,7 @@ struct Session: Codable, Identifiable, Equatable {
             workspaceFile: workspaceFile,
             source: source,
             endedAt: endedAt,
+            disconnectedAt: disconnectedAt,
             activeSubagents: activeSubagents,
             hidden: hidden
         )
@@ -435,9 +436,9 @@ struct Session: Codable, Identifiable, Equatable {
         URL(fileURLWithPath: path).lastPathComponent
     }
 
-    /// The best available end-of-session timestamp: `endedAt` if archived, otherwise `lastActivity`.
+    /// The best available inactive timestamp for ordering retained files.
     var effectiveEndDate: Date {
-        endedAt ?? lastActivity
+        disconnectedAt ?? endedAt ?? lastActivity
     }
 
     var relativeTime: String {

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -424,8 +424,10 @@ struct Session: Codable, Identifiable, Equatable {
     }
 
     static func sorted(_ sessions: [Session]) -> [Session] {
+        // Live (active) sessions first, then dormant; within each tier by status, then recency.
         sessions.sorted {
-            ($0.status.sortOrder, $1.lastActivity) < ($1.status.sortOrder, $0.lastActivity)
+            ($0.lifecycle.rawValue, $0.status.sortOrder, $1.lastActivity)
+                < ($1.lifecycle.rawValue, $1.status.sortOrder, $0.lastActivity)
         }
     }
 

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -182,6 +182,13 @@ struct Session: Codable, Identifiable, Equatable {
         return pid.map { String($0) } ?? sessionId
     }
 
+    /// Stable per-conversation key for dedup and notification grouping. Unlike `id` (PID-based
+    /// for non-Codex), this never changes when a desktop conversation's subprocess is respawned
+    /// with a new PID across a host-app restart, so the old dead-PID file and the new live-PID
+    /// file collapse to one card. Class-independent on purpose: a file's `hostClass` can flicker
+    /// between loads (bundle id present/absent), but its `session_id` does not.
+    var conversationKey: String { sessionId }
+
     var displayName: String {
         sessionName ?? projectName
     }

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -147,6 +147,17 @@ struct SubagentInfo: Codable, Equatable {
     }
 }
 
+/// Display-only lifecycle of a session, derived on each load and never persisted (a new
+/// persisted `SessionStatus` would decode to `.working` on older app builds). Orthogonal to
+/// `SessionStatus`: a dormant card keeps its last-known status for context but is excluded
+/// from attention counts and notifications. The raw value is the dedup preference rank
+/// (lower = preferred): active beats dormant beats finished.
+enum SessionLifecycle: Int, Equatable {
+    case active = 0    // backing process alive, or (Codex Desktop) recent hook activity
+    case dormant = 1   // process gone, but the conversation is recent and may resume
+    case finished = 2  // ended or aged out → eligible for GC
+}
+
 struct Session: Codable, Identifiable, Equatable {
     let sessionId: String
     let projectPath: String
@@ -168,6 +179,13 @@ struct Session: Codable, Identifiable, Equatable {
     var endedAt: Date?
     var activeSubagents: [SubagentInfo]?
     var hidden: Bool
+
+    /// Display-only lifecycle, derived on each load. Deliberately NOT in `CodingKeys`, so the
+    /// synthesized `Codable` skips it and decode defaults it to `.active` (never persisted —
+    /// a persisted lifecycle would decode to `.working` on older builds via SessionStatus).
+    /// It IS a stored property, so it joins synthesized `Equatable` — a dormant flip changes
+    /// equality and re-renders.
+    var lifecycle: SessionLifecycle = .active
 
     /// Harness id Codex reports (CLI and Desktop both pass `--harness codex`).
     static let codexSource = "codex"

--- a/menubar/CctopMenubar/Models/StatusCounts.swift
+++ b/menubar/CctopMenubar/Models/StatusCounts.swift
@@ -18,7 +18,9 @@ struct StatusCounts: Equatable {
     /// Create counts by aggregating session statuses.
     init(sessions: [Session]) {
         var perm = 0, attn = 0, work = 0, idleCount = 0
-        for session in sessions {
+        // Only live (active) sessions drive the menubar badge. Dormant cards are reachable
+        // history, not live work, so they never inflate counts or trigger the attention pill.
+        for session in sessions where session.lifecycle == .active {
             switch session.status {
             case .idle: idleCount += 1
             case .working, .compacting: work += 1

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+enum SessionIdentityPolicy {
+    /// File-local host classification. Deliberately strict: `source` never classifies desktop
+    /// vs CLI because both integrations share source strings with their desktop counterparts.
+    static func hostClass(for session: Session) -> SessionHostClass {
+        if let app = HostApp.from(bundleIdentifier: session.terminal?.bundleId) {
+            return app.isDesktopApp ? .desktop : .terminal
+        }
+        if session.terminal?.multiplexer != nil { return .terminal }
+        return .ambiguous
+    }
+
+    /// UI identity. Codex multiplexes many conversations onto one host process, so its PID is
+    /// not unique per conversation; every other source keeps the existing PID identity.
+    static func displayID(for session: Session) -> String {
+        if session.isCodex { return session.sessionId }
+        return session.pid.map { String($0) } ?? session.sessionId
+    }
+
+    /// Durable file identity. Codex uses session_id to avoid shared-PID collisions and to avoid
+    /// legacy UUID-file cleanup; other sources remain PID-keyed.
+    static func fileName(harnessName: String?, pid: UInt32, safeSessionId: String) -> String {
+        if harnessName == Session.codexSource {
+            return "codex-\(safeSessionId).json"
+        }
+        return "\(pid).json"
+    }
+
+    /// Stable grouping key shared by dedup and notification transition guards.
+    static func stableKey(for session: Session) -> String {
+        if session.isCodex {
+            return "codex:\(session.sessionId)"
+        }
+        if hostClass(for: session) == .desktop {
+            return "desktop:\(session.sessionId)"
+        }
+        return "active:\(displayID(for: session))"
+    }
+
+    /// Collapse duplicate display ids during migration, keeping the most recently active copy.
+    static func dedupedByDisplayID(_ sessions: [Session]) -> [Session] {
+        var byID: [String: Session] = [:]
+        for session in sessions {
+            let id = displayID(for: session)
+            if let existing = byID[id], existing.lastActivity >= session.lastActivity {
+                continue
+            }
+            byID[id] = session
+        }
+        return byID.values.sorted { displayID(for: $0) < displayID(for: $1) }
+    }
+
+    /// Collapse multiple files for one conversation only for hosts with stable conversation identity.
+    static func dedupedCandidatesByStableKey(_ candidates: [DedupCandidate]) -> [DedupCandidate] {
+        var byKey: [String: DedupCandidate] = [:]
+        for candidate in candidates {
+            let key = stableKey(for: candidate.session)
+            if let existing = byKey[key], SessionLifecyclePolicy.prefers(existing, over: candidate) { continue }
+            byKey[key] = candidate
+        }
+        return byKey.values.sorted { stableKey(for: $0.session) < stableKey(for: $1.session) }
+    }
+}

--- a/menubar/CctopMenubar/Services/SessionLifecyclePolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionLifecyclePolicy.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Ordering inputs for lifecycle deduplication, kept separate from `Session`'s stored fields
+/// so the total order is unit-testable without disk or process probing. `mtime` is
+/// `.distantPast` when unknown so the comparison stays total.
+struct DedupCandidate {
+    let session: Session
+    let lifecycleRank: Int   // 0 = active, 1 = dormant, 2 = finished (lower = preferred)
+    let mtime: Date
+    let path: String         // absolute file path; final, total tiebreak
+}
+
+/// Tunable windows for lifecycle derivation.
+struct LifecycleWindows {
+    let active: TimeInterval     // Codex Desktop "recent activity counts as active" threshold
+    let retention: TimeInterval  // dormant desktop -> finished age-out from disconnected_at
+}
+
+enum SessionConnectionState: Equatable {
+    case connected
+    case disconnected
+}
+
+enum SessionLifecyclePolicy {
+    /// Pure connection derivation. Every host class goes through this same first step:
+    /// decide whether the session record still represents a connected session.
+    static func connectionState(
+        for session: Session, hostClass: SessionHostClass, processAlive: Bool,
+        now: Date, windows: LifecycleWindows
+    ) -> SessionConnectionState {
+        if session.endedAt != nil { return .disconnected }
+        let useRecency = session.isCodex && hostClass == .desktop
+        let connected = useRecency ? (now.timeIntervalSince(session.lastActivity) < windows.active) : processAlive
+        return connected ? .connected : .disconnected
+    }
+
+    /// Pure lifecycle derivation. Connection is detected uniformly first; host policy then
+    /// decides what disconnected means for desktop versus non-desktop sessions.
+    static func lifecycle(
+        for session: Session, hostClass: SessionHostClass, processAlive: Bool,
+        now: Date, windows: LifecycleWindows
+    ) -> SessionLifecycle {
+        let connection = connectionState(
+            for: session, hostClass: hostClass, processAlive: processAlive, now: now, windows: windows
+        )
+        if connection == .connected { return .active }
+        guard hostClass == .desktop else { return .finished }
+        guard let disconnectedAt = session.disconnectedAt else { return .dormant }
+        return now.timeIntervalSince(disconnectedAt) <= windows.retention ? .dormant : .finished
+    }
+
+    static func prefers(_ lhs: DedupCandidate, over rhs: DedupCandidate) -> Bool {
+        if lhs.lifecycleRank != rhs.lifecycleRank { return lhs.lifecycleRank < rhs.lifecycleRank }
+        if lhs.session.lastActivity != rhs.session.lastActivity {
+            return lhs.session.lastActivity > rhs.session.lastActivity
+        }
+        if lhs.session.effectiveEndDate != rhs.session.effectiveEndDate {
+            return lhs.session.effectiveEndDate > rhs.session.effectiveEndDate
+        }
+        if lhs.mtime != rhs.mtime { return lhs.mtime > rhs.mtime }
+        return lhs.path < rhs.path
+    }
+}

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -18,6 +18,12 @@ struct DedupCandidate {
     let path: String         // absolute file path; final, total tiebreak
 }
 
+/// Tunable windows for lifecycle derivation.
+struct LifecycleWindows {
+    let active: TimeInterval     // Codex Desktop "recent activity counts as active" threshold
+    let retention: TimeInterval  // dormant → finished age-out
+}
+
 @MainActor
 class SessionManager: ObservableObject {
     @Published var sessions: [Session] = []
@@ -227,6 +233,26 @@ class SessionManager: ObservableObject {
         return byKey.values
             .sorted { $0.session.conversationKey < $1.session.conversationKey }
             .map(\.session)
+    }
+
+    /// Pure lifecycle derivation. `processAlive` is the caller's raw PID-liveness result; it is
+    /// IGNORED for non-terminal Codex (Codex Desktop multiplexes conversations onto one shared
+    /// host PID, so it can't indicate a single conversation's liveness) — there "active" means
+    /// recent hook activity within `activeWindow`. A dead terminal session is `finished` (no
+    /// dormant — it's genuinely over); desktop/ambiguous stay `dormant` while within
+    /// `retentionWindow`, then `finished`.
+    nonisolated static func lifecycle(
+        for session: Session, hostClass: SessionHostClass, processAlive: Bool,
+        now: Date, windows: LifecycleWindows
+    ) -> SessionLifecycle {
+        // Non-terminal Codex shares one host PID across conversations, so processAlive can't
+        // speak to a single conversation — use recent activity. Codex CLI (terminal) keeps the
+        // real per-process PID so a long-running silent CLI is never treated as finished.
+        let useRecency = session.isCodex && hostClass != .terminal
+        let alive = useRecency ? (now.timeIntervalSince(session.lastActivity) < windows.active) : processAlive
+        if alive { return .active }
+        if hostClass == .terminal { return .finished }
+        return now.timeIntervalSince(session.lastActivity) <= windows.retention ? .dormant : .finished
     }
 
     /// Strict total order: true when `lhs` should be kept over `rhs`. Never uses PID as a clock.

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 import AppKit
 import Darwin.libproc
 import Foundation
@@ -7,27 +6,6 @@ import os.log
 
 private let logger = Logger(subsystem: "com.st0012.CctopMenubar", category: "SessionManager")
 private typealias SessionFile = (url: URL, session: Session)
-
-/// Ordering inputs for desktop dedup, kept separate from `Session`'s stored fields so the
-/// total order is unit-testable without disk or process probing. `mtime` is `.distantPast`
-/// when unknown so the comparison stays total.
-struct DedupCandidate {
-    let session: Session
-    let lifecycleRank: Int   // 0 = active, 1 = dormant, 2 = finished (lower = preferred)
-    let mtime: Date
-    let path: String         // absolute file path; final, total tiebreak
-}
-
-/// Tunable windows for lifecycle derivation.
-struct LifecycleWindows {
-    let active: TimeInterval     // Codex Desktop "recent activity counts as active" threshold
-    let retention: TimeInterval  // dormant desktop → finished age-out from disconnected_at
-}
-
-enum SessionConnectionState: Equatable {
-    case connected
-    case disconnected
-}
 
 @MainActor
 // swiftlint:disable:next type_body_length
@@ -74,7 +52,8 @@ class SessionManager: ObservableObject {
         // Notification transition guards use the same identity policy as dedup: Codex and
         // desktop conversations are stable by session_id; other sessions keep PID identity.
         let oldStatuses = Dictionary(
-            sessions.map { (Self.dedupKey(for: $0), $0.status) }, uniquingKeysWith: { first, _ in first }
+            sessions.map { (SessionIdentityPolicy.stableKey(for: $0), $0.status) },
+            uniquingKeysWith: { first, _ in first }
         )
 
         let jsonFiles = files.filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasSuffix(".tmp") }
@@ -91,7 +70,7 @@ class SessionManager: ObservableObject {
         )
 
         // Publish active + dormant; finished are hidden (swept below / by GC).
-        let winners = Self.dedupedCandidatesByLifecycleKey(candidates)
+        let winners = SessionIdentityPolicy.dedupedCandidatesByStableKey(candidates)
         let newSessions = winners
             .filter { $0.session.lifecycle != .finished }
             .map { adjustDisplayStatus($0.session) }
@@ -100,7 +79,7 @@ class SessionManager: ObservableObject {
         if UserDefaults.standard.bool(forKey: "notificationsEnabled") {
             for session in newSessions where session.lifecycle == .active {
                 guard session.status.needsAttention,
-                      let oldStatus = oldStatuses[Self.dedupKey(for: session)],
+                      let oldStatus = oldStatuses[SessionIdentityPolicy.stableKey(for: session)],
                       !oldStatus.needsAttention else { continue }
                 sendNotification(for: session)
             }
@@ -205,8 +184,8 @@ class SessionManager: ObservableObject {
                       session.disconnectedAt == nil else {
                     return
                 }
-                let lifecycle = Self.lifecycle(
-                    for: session, hostClass: .desktop, processAlive: session.isAlive,
+                let lifecycle = SessionLifecyclePolicy.lifecycle(
+                    for: session, hostClass: SessionHostClass.desktop, processAlive: session.isAlive,
                     now: now, windows: Self.lifecycleWindows
                 )
                 guard lifecycle == .dormant else { return }
@@ -237,7 +216,7 @@ class SessionManager: ObservableObject {
                 guard !session.hidden, !session.shouldAutoHide else { return }
                 let hostClass = session.hostClass
                 guard hostClass == .desktop else { return }   // non-desktop handled on the fast path
-                let life = Self.lifecycle(
+                let life = SessionLifecyclePolicy.lifecycle(
                     for: session, hostClass: hostClass, processAlive: session.isAlive,
                     now: now, windows: Self.lifecycleWindows
                 )
@@ -439,82 +418,6 @@ extension SessionManager {
         HostApp.isUUID(stem)
     }
 
-    /// Collapse duplicate ids during migration, keeping the most recently active copy.
-    nonisolated static func dedupedByID(_ sessions: [Session]) -> [Session] {
-        var byID: [String: Session] = [:]
-        for session in sessions {
-            if let existing = byID[session.id], existing.lastActivity >= session.lastActivity {
-                continue
-            }
-            byID[session.id] = session
-        }
-        return byID.values.sorted { $0.id < $1.id }
-    }
-
-    /// Collapse multiple files for one conversation only for hosts with stable conversation identity.
-    nonisolated static func dedupedCandidatesByLifecycleKey(_ candidates: [DedupCandidate]) -> [DedupCandidate] {
-        var byKey: [String: DedupCandidate] = [:]
-        for candidate in candidates {
-            let key = dedupKey(for: candidate.session)
-            if let existing = byKey[key], prefersFirst(existing, over: candidate) { continue }
-            byKey[key] = candidate
-        }
-        return byKey.values.sorted { dedupKey(for: $0.session) < dedupKey(for: $1.session) }
-    }
-
-    nonisolated static func dedupedByLifecycleKey(_ candidates: [DedupCandidate]) -> [Session] {
-        dedupedCandidatesByLifecycleKey(candidates).map(\.session)
-    }
-
-    /// Pure connection derivation. Every host class goes through this same first step:
-    /// decide whether the session record still represents a connected session.
-    nonisolated static func connectionState(
-        for session: Session, hostClass: SessionHostClass, processAlive: Bool,
-        now: Date, windows: LifecycleWindows
-    ) -> SessionConnectionState {
-        if session.endedAt != nil { return .disconnected }
-        let useRecency = session.isCodex && hostClass == .desktop
-        let connected = useRecency ? (now.timeIntervalSince(session.lastActivity) < windows.active) : processAlive
-        return connected ? .connected : .disconnected
-    }
-
-    /// Pure lifecycle derivation. Connection is detected uniformly first; host policy then decides
-    /// what disconnected means for desktop versus non-desktop sessions.
-    nonisolated static func lifecycle(
-        for session: Session, hostClass: SessionHostClass, processAlive: Bool,
-        now: Date, windows: LifecycleWindows
-    ) -> SessionLifecycle {
-        let connection = connectionState(
-            for: session, hostClass: hostClass, processAlive: processAlive, now: now, windows: windows
-        )
-        if connection == .connected { return .active }
-        guard hostClass == .desktop else { return .finished }
-        guard let disconnectedAt = session.disconnectedAt else { return .dormant }
-        return now.timeIntervalSince(disconnectedAt) <= windows.retention ? .dormant : .finished
-    }
-
-    private nonisolated static func dedupKey(for session: Session) -> String {
-        if session.isCodex {
-            return "codex:\(session.sessionId)"
-        }
-        if session.hostClass == .desktop {
-            return "desktop:\(session.sessionId)"
-        }
-        return "active:\(session.id)"
-    }
-
-    private nonisolated static func prefersFirst(_ lhs: DedupCandidate, over rhs: DedupCandidate) -> Bool {
-        if lhs.lifecycleRank != rhs.lifecycleRank { return lhs.lifecycleRank < rhs.lifecycleRank }
-        if lhs.session.lastActivity != rhs.session.lastActivity {
-            return lhs.session.lastActivity > rhs.session.lastActivity
-        }
-        if lhs.session.effectiveEndDate != rhs.session.effectiveEndDate {
-            return lhs.session.effectiveEndDate > rhs.session.effectiveEndDate
-        }
-        if lhs.mtime != rhs.mtime { return lhs.mtime > rhs.mtime }
-        return lhs.path < rhs.path
-    }
-
     /// Decode each session file, derive its lifecycle, and capture mtime — the inputs the dedup
     /// comparator needs. Pure (no published state), kept off the main class body.
     nonisolated static func buildCandidates(_ jsonFiles: [URL], now: Date) -> [DedupCandidate] {
@@ -528,7 +431,7 @@ extension SessionManager {
                 logger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public)")
                 continue
             }
-            session.lifecycle = lifecycle(
+            session.lifecycle = SessionLifecyclePolicy.lifecycle(
                 for: session, hostClass: session.hostClass, processAlive: session.isAlive,
                 now: now, windows: lifecycleWindows
             )

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import AppKit
 import Darwin.libproc
 import Foundation
@@ -29,6 +30,7 @@ enum SessionConnectionState: Equatable {
 }
 
 @MainActor
+// swiftlint:disable:next type_body_length
 class SessionManager: ObservableObject {
     @Published var sessions: [Session] = []
 
@@ -231,90 +233,6 @@ class SessionManager: ObservableObject {
         }
     }
 
-    /// A pre-PID session file was keyed by a bare session UUID. Today's files are either
-    /// numeric (PID) or `codex-<uuid>` (one Codex conversation per file); neither is a bare
-    /// UUID, so only genuinely old files match and get cleaned up.
-    nonisolated static func isLegacyUUIDFilename(_ stem: String) -> Bool {
-        HostApp.isUUID(stem)
-    }
-
-    /// Distinct sessions can transiently share an `id`: Codex multiplexes conversations
-    /// onto one host PID, and a migration window can briefly leave two files for the same
-    /// conversation. Collapse by `id` (keeping the most recently active) so the published
-    /// list — and everything keyed by id (SwiftUI identity, the status map) — stays unique.
-    nonisolated static func dedupedByID(_ sessions: [Session]) -> [Session] {
-        var byID: [String: Session] = [:]
-        for session in sessions {
-            if let existing = byID[session.id], existing.lastActivity >= session.lastActivity {
-                continue
-            }
-            byID[session.id] = session
-        }
-        return byID.values.sorted { $0.id < $1.id }
-    }
-
-    /// Collapse multiple files for one conversation only for confident desktop hosts.
-    nonisolated static func dedupedCandidatesByLifecycleKey(_ candidates: [DedupCandidate]) -> [DedupCandidate] {
-        var byKey: [String: DedupCandidate] = [:]
-        for candidate in candidates {
-            let key = dedupKey(for: candidate.session)
-            if let existing = byKey[key], prefersFirst(existing, over: candidate) { continue }
-            byKey[key] = candidate
-        }
-        return byKey.values.sorted { dedupKey(for: $0.session) < dedupKey(for: $1.session) }
-    }
-
-    nonisolated static func dedupedByLifecycleKey(_ candidates: [DedupCandidate]) -> [Session] {
-        dedupedCandidatesByLifecycleKey(candidates).map(\.session)
-    }
-
-    /// Pure connection derivation. Every host class goes through this same first step:
-    /// decide whether the session record still represents a connected session.
-    nonisolated static func connectionState(
-        for session: Session, hostClass: SessionHostClass, processAlive: Bool,
-        now: Date, windows: LifecycleWindows
-    ) -> SessionConnectionState {
-        if session.endedAt != nil { return .disconnected }
-        let useRecency = session.isCodex && hostClass == .desktop
-        let connected = useRecency ? (now.timeIntervalSince(session.lastActivity) < windows.active) : processAlive
-        return connected ? .connected : .disconnected
-    }
-
-    /// Pure lifecycle derivation. Connection is detected uniformly first; host policy then decides
-    /// what disconnected means for desktop versus non-desktop sessions.
-    nonisolated static func lifecycle(
-        for session: Session, hostClass: SessionHostClass, processAlive: Bool,
-        now: Date, windows: LifecycleWindows
-    ) -> SessionLifecycle {
-        let connection = connectionState(
-            for: session, hostClass: hostClass, processAlive: processAlive, now: now, windows: windows
-        )
-        if connection == .connected { return .active }
-        guard hostClass == .desktop else { return .finished }
-        guard let disconnectedAt = session.disconnectedAt else { return .dormant }
-        return now.timeIntervalSince(disconnectedAt) <= windows.retention ? .dormant : .finished
-    }
-
-    private nonisolated static func dedupKey(for session: Session) -> String {
-        if session.hostClass == .desktop {
-            return "desktop:\(session.sessionId)"
-        }
-        return "active:\(session.id)"
-    }
-
-    /// Strict total order: true when `lhs` should be kept over `rhs`. Never uses PID as a clock.
-    private nonisolated static func prefersFirst(_ lhs: DedupCandidate, over rhs: DedupCandidate) -> Bool {
-        if lhs.lifecycleRank != rhs.lifecycleRank { return lhs.lifecycleRank < rhs.lifecycleRank }
-        if lhs.session.lastActivity != rhs.session.lastActivity {
-            return lhs.session.lastActivity > rhs.session.lastActivity
-        }
-        if lhs.session.effectiveEndDate != rhs.session.effectiveEndDate {
-            return lhs.session.effectiveEndDate > rhs.session.effectiveEndDate
-        }
-        if lhs.mtime != rhs.mtime { return lhs.mtime > rhs.mtime }
-        return lhs.path < rhs.path
-    }
-
     /// Apply display-side status adjustments. The session file on disk is NOT modified.
     private func adjustDisplayStatus(_ session: Session) -> Session {
         // A dormant (backgrounded) session isn't actively in any state — render it neutral (idle)
@@ -497,6 +415,85 @@ class SessionManager: ObservableObject {
 }
 
 extension SessionManager {
+    /// A pre-PID session file was keyed by a bare session UUID. Today's files are either
+    /// numeric (PID) or `codex-<uuid>`, so only genuinely old files match.
+    nonisolated static func isLegacyUUIDFilename(_ stem: String) -> Bool {
+        HostApp.isUUID(stem)
+    }
+
+    /// Collapse duplicate ids during migration, keeping the most recently active copy.
+    nonisolated static func dedupedByID(_ sessions: [Session]) -> [Session] {
+        var byID: [String: Session] = [:]
+        for session in sessions {
+            if let existing = byID[session.id], existing.lastActivity >= session.lastActivity {
+                continue
+            }
+            byID[session.id] = session
+        }
+        return byID.values.sorted { $0.id < $1.id }
+    }
+
+    /// Collapse multiple files for one conversation only for confident desktop hosts.
+    nonisolated static func dedupedCandidatesByLifecycleKey(_ candidates: [DedupCandidate]) -> [DedupCandidate] {
+        var byKey: [String: DedupCandidate] = [:]
+        for candidate in candidates {
+            let key = dedupKey(for: candidate.session)
+            if let existing = byKey[key], prefersFirst(existing, over: candidate) { continue }
+            byKey[key] = candidate
+        }
+        return byKey.values.sorted { dedupKey(for: $0.session) < dedupKey(for: $1.session) }
+    }
+
+    nonisolated static func dedupedByLifecycleKey(_ candidates: [DedupCandidate]) -> [Session] {
+        dedupedCandidatesByLifecycleKey(candidates).map(\.session)
+    }
+
+    /// Pure connection derivation. Every host class goes through this same first step:
+    /// decide whether the session record still represents a connected session.
+    nonisolated static func connectionState(
+        for session: Session, hostClass: SessionHostClass, processAlive: Bool,
+        now: Date, windows: LifecycleWindows
+    ) -> SessionConnectionState {
+        if session.endedAt != nil { return .disconnected }
+        let useRecency = session.isCodex && hostClass == .desktop
+        let connected = useRecency ? (now.timeIntervalSince(session.lastActivity) < windows.active) : processAlive
+        return connected ? .connected : .disconnected
+    }
+
+    /// Pure lifecycle derivation. Connection is detected uniformly first; host policy then decides
+    /// what disconnected means for desktop versus non-desktop sessions.
+    nonisolated static func lifecycle(
+        for session: Session, hostClass: SessionHostClass, processAlive: Bool,
+        now: Date, windows: LifecycleWindows
+    ) -> SessionLifecycle {
+        let connection = connectionState(
+            for: session, hostClass: hostClass, processAlive: processAlive, now: now, windows: windows
+        )
+        if connection == .connected { return .active }
+        guard hostClass == .desktop else { return .finished }
+        guard let disconnectedAt = session.disconnectedAt else { return .dormant }
+        return now.timeIntervalSince(disconnectedAt) <= windows.retention ? .dormant : .finished
+    }
+
+    private nonisolated static func dedupKey(for session: Session) -> String {
+        if session.hostClass == .desktop {
+            return "desktop:\(session.sessionId)"
+        }
+        return "active:\(session.id)"
+    }
+
+    private nonisolated static func prefersFirst(_ lhs: DedupCandidate, over rhs: DedupCandidate) -> Bool {
+        if lhs.lifecycleRank != rhs.lifecycleRank { return lhs.lifecycleRank < rhs.lifecycleRank }
+        if lhs.session.lastActivity != rhs.session.lastActivity {
+            return lhs.session.lastActivity > rhs.session.lastActivity
+        }
+        if lhs.session.effectiveEndDate != rhs.session.effectiveEndDate {
+            return lhs.session.effectiveEndDate > rhs.session.effectiveEndDate
+        }
+        if lhs.mtime != rhs.mtime { return lhs.mtime > rhs.mtime }
+        return lhs.path < rhs.path
+    }
+
     /// Decode each session file, derive its lifecycle, and capture mtime — the inputs the dedup
     /// comparator needs. Pure (no published state), kept off the main class body.
     nonisolated static func buildCandidates(_ jsonFiles: [URL], now: Date) -> [DedupCandidate] {

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -71,8 +71,8 @@ class SessionManager: ObservableObject {
             return
         }
 
-        // Transition guard for notifications uses the same identity policy as dedup: desktop
-        // conversations are stable by session_id, terminal/unknown sessions keep PID identity.
+        // Notification transition guards use the same identity policy as dedup: Codex and
+        // desktop conversations are stable by session_id; other sessions keep PID identity.
         let oldStatuses = Dictionary(
             sessions.map { (Self.dedupKey(for: $0), $0.status) }, uniquingKeysWith: { first, _ in first }
         )
@@ -433,7 +433,7 @@ extension SessionManager {
         return byID.values.sorted { $0.id < $1.id }
     }
 
-    /// Collapse multiple files for one conversation only for confident desktop hosts.
+    /// Collapse multiple files for one conversation only for hosts with stable conversation identity.
     nonisolated static func dedupedCandidatesByLifecycleKey(_ candidates: [DedupCandidate]) -> [DedupCandidate] {
         var byKey: [String: DedupCandidate] = [:]
         for candidate in candidates {
@@ -476,6 +476,9 @@ extension SessionManager {
     }
 
     private nonisolated static func dedupKey(for session: Session) -> String {
+        if session.isCodex {
+            return "codex:\(session.sessionId)"
+        }
         if session.hostClass == .desktop {
             return "desktop:\(session.sessionId)"
         }

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -245,10 +245,12 @@ class SessionManager: ObservableObject {
         for session: Session, hostClass: SessionHostClass, processAlive: Bool,
         now: Date, windows: LifecycleWindows
     ) -> SessionLifecycle {
-        // Non-terminal Codex shares one host PID across conversations, so processAlive can't
-        // speak to a single conversation — use recent activity. Codex CLI (terminal) keeps the
-        // real per-process PID so a long-running silent CLI is never treated as finished.
-        let useRecency = session.isCodex && hostClass != .terminal
+        // Codex DESKTOP multiplexes conversations onto one shared host PID, so processAlive
+        // can't speak to a single conversation — use recent activity instead. This applies
+        // ONLY to confident Codex Desktop (hostClass == .desktop). Codex CLI (terminal) and
+        // ambiguous Codex both have a real per-process PID, so they keep processAlive — a
+        // live but quiet CLI session must never be discarded by the recency-only path.
+        let useRecency = session.isCodex && hostClass == .desktop
         let alive = useRecency ? (now.timeIntervalSince(session.lastActivity) < windows.active) : processAlive
         if alive { return .active }
         if hostClass == .terminal { return .finished }

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -8,6 +8,16 @@ private let logger = Logger(subsystem: "com.st0012.CctopMenubar", category: "Ses
 private typealias SessionFile = (url: URL, session: Session)
 private typealias SessionBuckets = (hidden: [SessionFile], autoHidden: [SessionFile], alive: [SessionFile], dead: [SessionFile])
 
+/// Ordering inputs for desktop dedup, kept separate from `Session`'s stored fields so the
+/// total order is unit-testable without disk or process probing. `mtime` is `.distantPast`
+/// when unknown so the comparison stays total.
+struct DedupCandidate {
+    let session: Session
+    let lifecycleRank: Int   // 0 = active, 1 = dormant, 2 = finished (lower = preferred)
+    let mtime: Date
+    let path: String         // absolute file path; final, total tiebreak
+}
+
 @MainActor
 class SessionManager: ObservableObject {
     @Published var sessions: [Session] = []
@@ -201,6 +211,35 @@ class SessionManager: ObservableObject {
             byID[session.id] = session
         }
         return byID.values.sorted { $0.id < $1.id }
+    }
+
+    /// Collapse multiple files for one conversation. Key: `sessionId` for desktop/ambiguous
+    /// hosts; PID-based `id` for confident-terminal (preserving today's terminal identity).
+    /// Within a key, pick by a TOTAL order: lifecycle rank asc, lastActivity desc,
+    /// effectiveEndDate desc, mtime desc, absolute path asc. Never PID as a clock.
+    nonisolated static func dedupedBySessionId(_ candidates: [DedupCandidate]) -> [Session] {
+        var byKey: [String: DedupCandidate] = [:]
+        for candidate in candidates {
+            let key = candidate.session.conversationKey
+            if let existing = byKey[key], prefersFirst(existing, over: candidate) { continue }
+            byKey[key] = candidate
+        }
+        return byKey.values
+            .sorted { $0.session.conversationKey < $1.session.conversationKey }
+            .map(\.session)
+    }
+
+    /// Strict total order: true when `lhs` should be kept over `rhs`. Never uses PID as a clock.
+    private nonisolated static func prefersFirst(_ lhs: DedupCandidate, over rhs: DedupCandidate) -> Bool {
+        if lhs.lifecycleRank != rhs.lifecycleRank { return lhs.lifecycleRank < rhs.lifecycleRank }
+        if lhs.session.lastActivity != rhs.session.lastActivity {
+            return lhs.session.lastActivity > rhs.session.lastActivity
+        }
+        if lhs.session.effectiveEndDate != rhs.session.effectiveEndDate {
+            return lhs.session.effectiveEndDate > rhs.session.effectiveEndDate
+        }
+        if lhs.mtime != rhs.mtime { return lhs.mtime > rhs.mtime }
+        return lhs.path < rhs.path
     }
 
     /// Apply display-side status adjustments. The session file on disk is NOT modified.

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -119,7 +119,7 @@ class SessionManager: ObservableObject {
         // Non-desktop finished sessions keep today's behavior: archive to Recent Projects and
         // remove now (no Recent-Projects lag). Desktop files are retained while dormant and reaped
         // only by the slow, lock-held GC. No dormant file is ever deleted on this fast path.
-        archiveAndRemoveFinishedNonDesktop(winners)
+        archiveAndRemoveFinishedNonDesktop(candidates, winners: winners)
         historyManager.rebuildRecentProjects(excludingActive: Set(sessions.map(\.projectPath)))
     }
 
@@ -163,17 +163,35 @@ class SessionManager: ObservableObject {
         return "maintenance"
     }
 
-    private func archiveAndRemoveFinishedNonDesktop(_ winners: [DedupCandidate]) {
-        for winner in winners where winner.session.lifecycle == .finished && winner.session.hostClass != .desktop {
-            let session = winner.session
-            // A dead non-desktop process holds no lock, so removing its .json needs no flock. Remove
-            // the .json ONLY — never the .lock (unlinking a lock a hook still holds splits the inode).
-            if historyManager.archiveSession(session) {
-                try? FileManager.default.removeItem(atPath: winner.path)
+    private func archiveAndRemoveFinishedNonDesktop(_ candidates: [DedupCandidate], winners: [DedupCandidate]) {
+        let winnerPaths = Set(winners.map(\.path))
+        for candidate in candidates where candidate.session.lifecycle == .finished
+                                    && candidate.session.hostClass != .desktop {
+            // A finished dedup winner is a real completed non-desktop session, so keep today's
+            // Recent Projects behavior. A finished duplicate loser is stale migration debris;
+            // remove it without archiving so it cannot later surface as a separate session.
+            if winnerPaths.contains(candidate.path) {
+                archiveAndRemove(candidate)
             } else {
-                logger.warning("skipping removal of \(session.sessionId, privacy: .public) — archive failed")
+                removeStaleDuplicate(candidate)
             }
         }
+    }
+
+    private func archiveAndRemove(_ candidate: DedupCandidate) {
+        let session = candidate.session
+        // A dead non-desktop process holds no lock, so removing its .json needs no flock. Remove
+        // the .json ONLY — never the .lock (unlinking a lock a hook still holds splits the inode).
+        if historyManager.archiveSession(session) {
+            try? FileManager.default.removeItem(atPath: candidate.path)
+        } else {
+            logger.warning("skipping removal of \(session.sessionId, privacy: .public) — archive failed")
+        }
+    }
+
+    private func removeStaleDuplicate(_ candidate: DedupCandidate) {
+        logger.info("removing stale duplicate session file \(candidate.path, privacy: .public)")
+        try? FileManager.default.removeItem(atPath: candidate.path)
     }
 
     private func stampDisconnectedDesktopSessions(_ candidates: [DedupCandidate], now: Date) {

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -6,7 +6,6 @@ import os.log
 
 private let logger = Logger(subsystem: "com.st0012.CctopMenubar", category: "SessionManager")
 private typealias SessionFile = (url: URL, session: Session)
-private typealias SessionBuckets = (hidden: [SessionFile], autoHidden: [SessionFile], alive: [SessionFile], dead: [SessionFile])
 
 /// Ordering inputs for desktop dedup, kept separate from `Session`'s stored fields so the
 /// total order is unit-testable without disk or process probing. `mtime` is `.distantPast`
@@ -21,7 +20,12 @@ struct DedupCandidate {
 /// Tunable windows for lifecycle derivation.
 struct LifecycleWindows {
     let active: TimeInterval     // Codex Desktop "recent activity counts as active" threshold
-    let retention: TimeInterval  // dormant → finished age-out
+    let retention: TimeInterval  // dormant desktop → finished age-out from disconnected_at
+}
+
+enum SessionConnectionState: Equatable {
+    case connected
+    case disconnected
 }
 
 @MainActor
@@ -34,47 +38,67 @@ class SessionManager: ObservableObject {
     private var source: DispatchSourceFileSystemObject?
     private var debounceTask: DispatchWorkItem?
     private var livenessTimer: Timer?
+    private var gcTimer: Timer?
+
+    /// Lifecycle windows: Codex Desktop counts as active within `active` of last activity;
+    /// a non-active desktop session stays dormant within `retention` after first observed disconnect.
+    nonisolated static let lifecycleWindows = LifecycleWindows(active: 600, retention: 1_209_600)
 
     init(historyManager: HistoryManager) {
         self.historyManager = historyManager
         self.sessionsDir = URL(fileURLWithPath: Config.sessionsDir())
         loadSessions()
         startWatching()
+        // Pass 1 (fast): read, derive lifecycle, dedup, publish.
         livenessTimer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.loadSessions()
-            }
+            Task { @MainActor in self?.loadSessions() }
+        }
+        // Pass 2 (slow): GC finished desktop files under the per-session lock.
+        gcTimer = Timer.scheduledTimer(withTimeInterval: 45, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.garbageCollectFinished() }
         }
     }
 
     func loadSessions() {
         guard let files = try? FileManager.default.contentsOfDirectory(
             at: sessionsDir,
-            includingPropertiesForKeys: nil
+            includingPropertiesForKeys: [.contentModificationDateKey]
         ) else {
             logger.warning("loadSessions: could not read directory")
             sessions = []
             return
         }
 
-        // Tolerate duplicate ids defensively — `sessions` is deduped below, but a transient
-        // double-file must never trap here (uniqueKeysWithValues crashes on a dup key).
-        let oldStatuses = Dictionary(sessions.map { ($0.id, $0.status) }, uniquingKeysWith: { first, _ in first })
+        // Transition guard for notifications uses the same identity policy as dedup: desktop
+        // conversations are stable by session_id, terminal/unknown sessions keep PID identity.
+        let oldStatuses = Dictionary(
+            sessions.map { (Self.dedupKey(for: $0), $0.status) }, uniquingKeysWith: { first, _ in first }
+        )
 
         let jsonFiles = files.filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasSuffix(".tmp") }
         let allDecoded = decodedSessions(from: jsonFiles)
-        let partition = partitionSessions(allDecoded)
+        let hidden = allDecoded.filter { $0.session.hidden }
+        let autoHidden = allDecoded.filter { !$0.session.hidden && $0.session.shouldAutoHide }
+        let visibleFiles = allDecoded
+            .filter { !$0.session.hidden && !$0.session.shouldAutoHide }
+            .map(\.url)
+        let candidates = Self.buildCandidates(visibleFiles, now: Date())
         logger.info("loadSessions: \(jsonFiles.count) files, \(allDecoded.count) decoded")
         logger.info(
-            "loadSessions: \(partition.alive.count) alive, \(partition.dead.count) dead, \(partition.hidden.count) hidden"
+            "loadSessions: \(candidates.count) visible candidates, \(hidden.count) hidden, \(autoHidden.count) auto-hidden"
         )
-        let newSessions = Self.dedupedByID(partition.alive.map(\.1).map { adjustDisplayStatus($0) })
 
-        // Side effects: run before the equality guard so they always execute.
+        // Publish active + dormant; finished are hidden (swept below / by GC).
+        let winners = Self.dedupedCandidatesByLifecycleKey(candidates)
+        let newSessions = winners
+            .filter { $0.session.lifecycle != .finished }
+            .map { adjustDisplayStatus($0.session) }
+
+        // Notifications: only a LIVE (active) session that NEWLY needs attention. Dormant never notifies.
         if UserDefaults.standard.bool(forKey: "notificationsEnabled") {
-            for session in newSessions {
+            for session in newSessions where session.lifecycle == .active {
                 guard session.status.needsAttention,
-                      let oldStatus = oldStatuses[session.id],
+                      let oldStatus = oldStatuses[Self.dedupKey(for: session)],
                       !oldStatus.needsAttention else { continue }
                 sendNotification(for: session)
             }
@@ -82,14 +106,19 @@ class SessionManager: ObservableObject {
         // Only publish when data actually changed to avoid unnecessary SwiftUI re-renders.
         if newSessions != sessions {
             if newSessions.count != sessions.count {
-                logger.info("loadSessions: session count changed \(self.sessions.count) -> \(newSessions.count)")
+                logger.info("loadSessions: session count \(self.sessions.count) -> \(newSessions.count)")
             }
             sessions = newSessions
         }
 
-        hideAutoHiddenSessions(partition.autoHidden)
-        archiveAndRemoveDeadSessions(partition.dead)
-        cleanupOldFormatFiles(jsonFiles)
+        hideAutoHiddenSessions(autoHidden)
+        stampDisconnectedDesktopSessions(candidates, now: Date())
+
+        // Non-desktop finished sessions keep today's behavior: archive to Recent Projects and
+        // remove now (no Recent-Projects lag). Desktop files are retained while dormant and reaped
+        // only by the slow, lock-held GC. No dormant file is ever deleted on this fast path.
+        archiveAndRemoveFinishedNonDesktop(winners)
+        historyManager.rebuildRecentProjects(excludingActive: Set(sessions.map(\.projectPath)))
     }
 
     private func decodedSessions(from jsonFiles: [URL]) -> [SessionFile] {
@@ -106,27 +135,6 @@ class SessionManager: ObservableObject {
                 return nil
             }
         }
-    }
-
-    private func partitionSessions(_ entries: [SessionFile]) -> SessionBuckets {
-        var hidden: [SessionFile] = []
-        var autoHidden: [SessionFile] = []
-        var alive: [SessionFile] = []
-        var dead: [SessionFile] = []
-
-        for entry in entries {
-            if entry.session.hidden {
-                hidden.append(entry)
-            } else if entry.session.shouldAutoHide {
-                autoHidden.append(entry)
-            } else if entry.session.endedAt != nil || !entry.session.isAlive {
-                dead.append(entry)
-            } else {
-                alive.append(entry)
-            }
-        }
-
-        return (hidden, autoHidden, alive, dead)
     }
 
     private func hideAutoHiddenSessions(_ sessions: [(URL, Session)]) {
@@ -153,35 +161,74 @@ class SessionManager: ObservableObject {
         return "maintenance"
     }
 
-    private func archiveAndRemoveDeadSessions(_ dead: [(URL, Session)]) {
-        for (url, session) in dead {
-            let sid = session.sessionId
-            let pid = session.pid.map(String.init) ?? "nil"
-
-            // Desktop-app sessions are deliberately skipped from archiving — drop the
-            // live file directly so it doesn't linger as a "dead" entry forever.
-            if session.isHostedByDesktopApp {
-                logger.info("dropping dead desktop-app session \(sid, privacy: .public) pid=\(pid, privacy: .public)")
-                removeSessionFile(at: url)
-                continue
-            }
-
-            logger.info("archiving dead session \(sid, privacy: .public) pid=\(pid, privacy: .public)")
-            let archived = historyManager.archiveSession(session)
-            if archived {
-                removeSessionFile(at: url)
+    private func archiveAndRemoveFinishedNonDesktop(_ winners: [DedupCandidate]) {
+        for winner in winners where winner.session.lifecycle == .finished && winner.session.hostClass != .desktop {
+            let session = winner.session
+            // A dead non-desktop process holds no lock, so removing its .json needs no flock. Remove
+            // the .json ONLY — never the .lock (unlinking a lock a hook still holds splits the inode).
+            if historyManager.archiveSession(session) {
+                try? FileManager.default.removeItem(atPath: winner.path)
             } else {
-                logger.warning("skipping removal of \(sid, privacy: .public) — archive failed")
+                logger.warning("skipping removal of \(session.sessionId, privacy: .public) — archive failed")
             }
         }
-        historyManager.rebuildRecentProjects(
-            excludingActive: Set(sessions.map(\.projectPath))
-        )
     }
 
-    private func removeSessionFile(at url: URL) {
-        try? FileManager.default.removeItem(at: url)
-        try? FileManager.default.removeItem(at: url.appendingPathExtension("lock"))
+    private func stampDisconnectedDesktopSessions(_ candidates: [DedupCandidate], now: Date) {
+        for candidate in candidates {
+            guard candidate.session.hostClass == .desktop,
+                  candidate.session.lifecycle == .dormant,
+                  candidate.session.disconnectedAt == nil else { continue }
+            try? withSessionLock(sessionPath: candidate.path) {
+                guard var session = try? Session.fromFile(path: candidate.path),
+                      session.hostClass == .desktop,
+                      session.disconnectedAt == nil else {
+                    return
+                }
+                let lifecycle = Self.lifecycle(
+                    for: session, hostClass: .desktop, processAlive: session.isAlive,
+                    now: now, windows: Self.lifecycleWindows
+                )
+                guard lifecycle == .dormant else { return }
+                session.disconnectedAt = now
+                try? session.writeToFile(path: candidate.path)
+            }
+        }
+    }
+
+    /// Pass 2: reap finished desktop files (non-desktop is handled on the fast path). Acquires
+    /// the per-session lock, re-validates under it, and unlinks the `.json` ONLY (never the `.lock`).
+    /// A decode failure is never treated as finished. Also sweeps pre-PID legacy files.
+    private func garbageCollectFinished() {
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(at: sessionsDir, includingPropertiesForKeys: nil) else { return }
+        let now = Date()
+        var removedAny = false
+        for url in files where url.pathExtension == "json" && !url.lastPathComponent.hasSuffix(".tmp") {
+            if Self.isLegacyUUIDFilename(url.deletingPathExtension().lastPathComponent) {
+                try? fm.removeItem(at: url)   // pre-PID legacy file; no live writer to race
+                continue
+            }
+            try? withSessionLock(sessionPath: url.path) {
+                guard let data = try? Data(contentsOf: url),
+                      let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data) else {
+                    return   // decode failure → never treat as finished
+                }
+                guard !session.hidden, !session.shouldAutoHide else { return }
+                let hostClass = session.hostClass
+                guard hostClass == .desktop else { return }   // non-desktop handled on the fast path
+                let life = Self.lifecycle(
+                    for: session, hostClass: hostClass, processAlive: session.isAlive,
+                    now: now, windows: Self.lifecycleWindows
+                )
+                guard life == .finished else { return }
+                try? fm.removeItem(at: url)   // .json ONLY — never the .lock
+                removedAny = true
+            }
+        }
+        if removedAny {
+            historyManager.rebuildRecentProjects(excludingActive: Set(sessions.map(\.projectPath)))
+        }
     }
 
     /// A pre-PID session file was keyed by a bare session UUID. Today's files are either
@@ -189,19 +236,6 @@ class SessionManager: ObservableObject {
     /// UUID, so only genuinely old files match and get cleaned up.
     nonisolated static func isLegacyUUIDFilename(_ stem: String) -> Bool {
         HostApp.isUUID(stem)
-    }
-
-    // MIGRATION(v0.6.0): Remove after all users have migrated to PID-keyed sessions.
-    /// Remove old-format UUID-keyed session files (pre-PID migration).
-    /// PID-keyed filenames are purely numeric; UUID filenames contain letters/hyphens.
-    private func cleanupOldFormatFiles(_ jsonFiles: [URL]) {
-        for url in jsonFiles {
-            let stem = url.deletingPathExtension().lastPathComponent
-            if Self.isLegacyUUIDFilename(stem) {
-                logger.info("removing old-format session file: \(stem, privacy: .public)")
-                try? FileManager.default.removeItem(at: url)
-            }
-        }
     }
 
     /// Distinct sessions can transiently share an `id`: Codex multiplexes conversations
@@ -219,42 +253,53 @@ class SessionManager: ObservableObject {
         return byID.values.sorted { $0.id < $1.id }
     }
 
-    /// Collapse multiple files for one conversation. Key: `sessionId` for desktop/ambiguous
-    /// hosts; PID-based `id` for confident-terminal (preserving today's terminal identity).
-    /// Within a key, pick by a TOTAL order: lifecycle rank asc, lastActivity desc,
-    /// effectiveEndDate desc, mtime desc, absolute path asc. Never PID as a clock.
-    nonisolated static func dedupedBySessionId(_ candidates: [DedupCandidate]) -> [Session] {
+    /// Collapse multiple files for one conversation only for confident desktop hosts.
+    nonisolated static func dedupedCandidatesByLifecycleKey(_ candidates: [DedupCandidate]) -> [DedupCandidate] {
         var byKey: [String: DedupCandidate] = [:]
         for candidate in candidates {
-            let key = candidate.session.conversationKey
+            let key = dedupKey(for: candidate.session)
             if let existing = byKey[key], prefersFirst(existing, over: candidate) { continue }
             byKey[key] = candidate
         }
-        return byKey.values
-            .sorted { $0.session.conversationKey < $1.session.conversationKey }
-            .map(\.session)
+        return byKey.values.sorted { dedupKey(for: $0.session) < dedupKey(for: $1.session) }
     }
 
-    /// Pure lifecycle derivation. `processAlive` is the caller's raw PID-liveness result; it is
-    /// IGNORED for non-terminal Codex (Codex Desktop multiplexes conversations onto one shared
-    /// host PID, so it can't indicate a single conversation's liveness) — there "active" means
-    /// recent hook activity within `activeWindow`. A dead terminal session is `finished` (no
-    /// dormant — it's genuinely over); desktop/ambiguous stay `dormant` while within
-    /// `retentionWindow`, then `finished`.
+    nonisolated static func dedupedByLifecycleKey(_ candidates: [DedupCandidate]) -> [Session] {
+        dedupedCandidatesByLifecycleKey(candidates).map(\.session)
+    }
+
+    /// Pure connection derivation. Every host class goes through this same first step:
+    /// decide whether the session record still represents a connected session.
+    nonisolated static func connectionState(
+        for session: Session, hostClass: SessionHostClass, processAlive: Bool,
+        now: Date, windows: LifecycleWindows
+    ) -> SessionConnectionState {
+        if session.endedAt != nil { return .disconnected }
+        let useRecency = session.isCodex && hostClass == .desktop
+        let connected = useRecency ? (now.timeIntervalSince(session.lastActivity) < windows.active) : processAlive
+        return connected ? .connected : .disconnected
+    }
+
+    /// Pure lifecycle derivation. Connection is detected uniformly first; host policy then decides
+    /// what disconnected means for desktop versus non-desktop sessions.
     nonisolated static func lifecycle(
         for session: Session, hostClass: SessionHostClass, processAlive: Bool,
         now: Date, windows: LifecycleWindows
     ) -> SessionLifecycle {
-        // Codex DESKTOP multiplexes conversations onto one shared host PID, so processAlive
-        // can't speak to a single conversation — use recent activity instead. This applies
-        // ONLY to confident Codex Desktop (hostClass == .desktop). Codex CLI (terminal) and
-        // ambiguous Codex both have a real per-process PID, so they keep processAlive — a
-        // live but quiet CLI session must never be discarded by the recency-only path.
-        let useRecency = session.isCodex && hostClass == .desktop
-        let alive = useRecency ? (now.timeIntervalSince(session.lastActivity) < windows.active) : processAlive
-        if alive { return .active }
-        if hostClass == .terminal { return .finished }
-        return now.timeIntervalSince(session.lastActivity) <= windows.retention ? .dormant : .finished
+        let connection = connectionState(
+            for: session, hostClass: hostClass, processAlive: processAlive, now: now, windows: windows
+        )
+        if connection == .connected { return .active }
+        guard hostClass == .desktop else { return .finished }
+        guard let disconnectedAt = session.disconnectedAt else { return .dormant }
+        return now.timeIntervalSince(disconnectedAt) <= windows.retention ? .dormant : .finished
+    }
+
+    private nonisolated static func dedupKey(for session: Session) -> String {
+        if session.hostClass == .desktop {
+            return "desktop:\(session.sessionId)"
+        }
+        return "active:\(session.id)"
     }
 
     /// Strict total order: true when `lhs` should be kept over `rhs`. Never uses PID as a clock.
@@ -272,6 +317,14 @@ class SessionManager: ObservableObject {
 
     /// Apply display-side status adjustments. The session file on disk is NOT modified.
     private func adjustDisplayStatus(_ session: Session) -> Session {
+        // A dormant (backgrounded) session isn't actively in any state — render it neutral (idle)
+        // so it never shows a false "waiting"/"permission" pill. It's already excluded from counts
+        // and notifications; this keeps the card itself honest.
+        if session.lifecycle == .dormant {
+            var result = session
+            result.status = .idle
+            return result
+        }
         var result = adjustPermissionStatus(session)
         result = Self.adjustIdleTimeout(result)
         return result
@@ -439,6 +492,34 @@ class SessionManager: ObservableObject {
     deinit {
         source?.cancel()
         livenessTimer?.invalidate()
+        gcTimer?.invalidate()
+    }
+}
+
+extension SessionManager {
+    /// Decode each session file, derive its lifecycle, and capture mtime — the inputs the dedup
+    /// comparator needs. Pure (no published state), kept off the main class body.
+    nonisolated static func buildCandidates(_ jsonFiles: [URL], now: Date) -> [DedupCandidate] {
+        var candidates: [DedupCandidate] = []
+        for url in jsonFiles {
+            guard let data = try? Data(contentsOf: url) else {
+                logger.warning("loadSessions: could not read \(url.lastPathComponent, privacy: .public)")
+                continue
+            }
+            guard var session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data) else {
+                logger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public)")
+                continue
+            }
+            session.lifecycle = lifecycle(
+                for: session, hostClass: session.hostClass, processAlive: session.isAlive,
+                now: now, windows: lifecycleWindows
+            )
+            let mtime = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate ?? .distantPast
+            candidates.append(DedupCandidate(session: session, lifecycleRank: session.lifecycle.rawValue,
+                                             mtime: mtime, path: url.path))
+        }
+        return candidates
     }
 }
 

--- a/menubar/CctopMenubar/Views/SessionCardView.swift
+++ b/menubar/CctopMenubar/Views/SessionCardView.swift
@@ -22,6 +22,8 @@ struct SessionCardView: View {
         .cardSelectionStyle(
             isSelected: isSelected, isHovered: isHovered, cornerRadius: 0
         )
+        // Dormant = backgrounded (no live process); mute it so live work reads first.
+        .opacity(session.lifecycle == .dormant ? 0.62 : 1.0)
         .contentShape(Rectangle())
         .onHover { isHovered = $0 }
         .animation(.easeOut(duration: 0.15), value: isHovered)
@@ -158,6 +160,7 @@ struct SessionCardView: View {
     }
 
     private var statusLabelText: String {
+        if session.lifecycle == .dormant { return "Dormant" }
         switch session.status {
         case .idle: return "Idle"
         case .working: return "Working"

--- a/menubar/CctopMenubarTests/ForkSessionTests.swift
+++ b/menubar/CctopMenubarTests/ForkSessionTests.swift
@@ -255,4 +255,33 @@ final class ForkSessionTests: XCTestCase {
             XCTAssertTrue(pidExists(hookPID))
         }
     }
+
+    // MARK: - Desktop sessions are protected from hook cleanup
+
+    // Resuming one desktop conversation must NOT reap its dormant same-project siblings; the
+    // menubar app's lock-held GC owns desktop removal. Dead terminal siblings are still reaped.
+    func testCleanupSkipsDesktopAppSessionsButReapsDeadTerminal() throws {
+        let project = "/tmp/cctop-gate-\(UUID().uuidString)"
+        // PIDs above macOS PID_MAX (99999) can never be live → deterministically "dead".
+        var desktop = Session(sessionId: "desk-1", projectPath: project, branch: "main",
+                              terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop))
+        desktop.pid = 999_999
+        let desktopPath = sessionsDir + "999999.json"
+        try desktop.writeToFile(path: desktopPath)
+
+        var term = Session(sessionId: "term-1", projectPath: project, branch: "main",
+                           terminal: TerminalInfo(bundleId: "com.googlecode.iterm2"))
+        term.pid = 999_998
+        let termPath = sessionsDir + "999998.json"
+        try term.writeToFile(path: termPath)
+
+        HookHandler.cleanupSessionsForProject(
+            sessionsDir: sessionsDir, projectPath: project, currentPid: UInt32(getpid())
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: desktopPath),
+                      "Desktop-app session must survive project cleanup (kept as a dormant card)")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: termPath),
+                       "Dead terminal session should still be reaped")
+    }
 }

--- a/menubar/CctopMenubarTests/ForkSessionTests.swift
+++ b/menubar/CctopMenubarTests/ForkSessionTests.swift
@@ -284,4 +284,23 @@ final class ForkSessionTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: termPath),
                        "Dead terminal session should still be reaped")
     }
+
+    func testCleanupLeavesLockFileWhenRemovingDeadTerminalSession() throws {
+        let project = "/tmp/cctop-lock-\(UUID().uuidString)"
+        let deadPID: UInt32 = 999_997
+        var term = Session(sessionId: "term-lock", projectPath: project, branch: "main",
+                           terminal: TerminalInfo(bundleId: "com.googlecode.iterm2"))
+        term.pid = deadPID
+        let termPath = sessionsDir + "\(deadPID).json"
+        let lockPath = termPath + ".lock"
+        try term.writeToFile(path: termPath)
+        FileManager.default.createFile(atPath: lockPath, contents: Data())
+
+        HookHandler.cleanupSessionsForProject(
+            sessionsDir: sessionsDir, projectPath: project, currentPid: UInt32(getpid())
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: termPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: lockPath))
+    }
 }

--- a/menubar/CctopMenubarTests/HookEventTests.swift
+++ b/menubar/CctopMenubarTests/HookEventTests.swift
@@ -164,6 +164,13 @@ final class HookEventTests: XCTestCase {
         XCTAssertNil(Transition.forEvent(.idle, event: .unknown))
     }
 
+    // MARK: - Transition.clearsInactiveMarkers()
+
+    func testSubagentHooksDoNotClearInactiveMarkers() {
+        XCTAssertFalse(Transition.clearsInactiveMarkers(event: .subagentStart))
+        XCTAssertFalse(Transition.clearsInactiveMarkers(event: .subagentStop))
+    }
+
     // MARK: - Exhaustive transition test
 
     func testAllTransitionsExhaustive() {
@@ -171,7 +178,8 @@ final class HookEventTests: XCTestCase {
         let allEvents: [HookEvent] = [
             .sessionStart, .userPromptSubmit, .preToolUse, .postToolUse, .postToolUseFailure,
             .stop, .notificationIdle, .notificationPermission, .notificationOther,
-            .permissionRequest, .preCompact, .postCompact, .sessionError, .sessionEnd, .unknown
+            .permissionRequest, .subagentStart, .subagentStop, .preCompact, .postCompact,
+            .sessionError, .sessionEnd, .unknown
         ]
 
         // Every event x status combination should not crash
@@ -200,6 +208,8 @@ final class HookEventTests: XCTestCase {
             XCTAssertNotNil(Transition.forEvent(status, event: .sessionError))
             XCTAssertNil(Transition.forEvent(status, event: .notificationPermission))
             XCTAssertNil(Transition.forEvent(status, event: .notificationOther))
+            XCTAssertNil(Transition.forEvent(status, event: .subagentStart))
+            XCTAssertNil(Transition.forEvent(status, event: .subagentStop))
             XCTAssertNil(Transition.forEvent(status, event: .sessionEnd))
             XCTAssertNil(Transition.forEvent(status, event: .unknown))
         }

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -275,6 +275,28 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertEqual(try loadSession().disconnectedAt, disconnectedAt)
     }
 
+    func testSubagentHooksPreserveEndedAndDisconnectedAt() throws {
+        setenv("__CFBundleIdentifier", HostAppBundleID.claudeDesktop, 1)
+        defer { unsetenv("__CFBundleIdentifier") }
+
+        try handleFixture("SessionStart")
+        try handleFixture("SessionEnd")
+        let endedAt = try XCTUnwrap(try loadSession().endedAt)
+        let disconnectedAt = try XCTUnwrap(try loadSession().disconnectedAt)
+
+        try handleFixture("SubagentStart")
+        var session = try loadSession()
+        XCTAssertEqual(session.endedAt, endedAt)
+        XCTAssertEqual(session.disconnectedAt, disconnectedAt)
+        XCTAssertEqual(session.activeSubagents?.count, 1)
+
+        try handleFixture("SubagentStop")
+        session = try loadSession()
+        XCTAssertEqual(session.endedAt, endedAt)
+        XCTAssertEqual(session.disconnectedAt, disconnectedAt)
+        XCTAssertEqual(session.activeSubagents?.count, 0)
+    }
+
     // MARK: - Source passthrough (opencode)
 
     func testSourcePassthrough() throws {

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -221,6 +221,36 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertNotNil(try loadSession().endedAt)
     }
 
+    func testDesktopSessionEndStampsDisconnectedAt() throws {
+        setenv("__CFBundleIdentifier", HostAppBundleID.claudeDesktop, 1)
+        defer { unsetenv("__CFBundleIdentifier") }
+
+        try handleFixture("SessionStart")
+        XCTAssertNil(try loadSession().disconnectedAt)
+
+        try handleFixture("SessionEnd")
+
+        let session = try loadSession()
+        XCTAssertNotNil(session.endedAt)
+        XCTAssertNotNil(session.disconnectedAt)
+    }
+
+    func testSessionStartClearsEndedAndDisconnectedAt() throws {
+        setenv("__CFBundleIdentifier", HostAppBundleID.claudeDesktop, 1)
+        defer { unsetenv("__CFBundleIdentifier") }
+
+        try handleFixture("SessionStart")
+        try handleFixture("SessionEnd")
+        XCTAssertNotNil(try loadSession().endedAt)
+        XCTAssertNotNil(try loadSession().disconnectedAt)
+
+        try handleFixture("SessionStart")
+
+        let session = try loadSession()
+        XCTAssertNil(session.endedAt)
+        XCTAssertNil(session.disconnectedAt)
+    }
+
     // MARK: - Source passthrough (opencode)
 
     func testSourcePassthrough() throws {

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -251,6 +251,30 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertNil(session.disconnectedAt)
     }
 
+    func testNoOpHooksPreserveEndedAndDisconnectedAt() throws {
+        setenv("__CFBundleIdentifier", HostAppBundleID.claudeDesktop, 1)
+        defer { unsetenv("__CFBundleIdentifier") }
+
+        try handleFixture("SessionStart")
+        try handleFixture("SessionEnd")
+        let endedAt = try XCTUnwrap(try loadSession().endedAt)
+        let disconnectedAt = try XCTUnwrap(try loadSession().disconnectedAt)
+
+        try handleFixture("Notification-permission", hookName: "Notification")
+        XCTAssertEqual(try loadSession().endedAt, endedAt)
+        XCTAssertEqual(try loadSession().disconnectedAt, disconnectedAt)
+
+        try handleHook("""
+        {"session_id":"test-session-001","cwd":"/tmp/test-project","hook_event_name":"Notification","notification_type":"future_type"}
+        """, hookName: "Notification")
+        XCTAssertEqual(try loadSession().endedAt, endedAt)
+        XCTAssertEqual(try loadSession().disconnectedAt, disconnectedAt)
+
+        try handleFixture("SessionStart", hookName: "FutureHook")
+        XCTAssertEqual(try loadSession().endedAt, endedAt)
+        XCTAssertEqual(try loadSession().disconnectedAt, disconnectedAt)
+    }
+
     // MARK: - Source passthrough (opencode)
 
     func testSourcePassthrough() throws {
@@ -482,5 +506,10 @@ final class HookHandlerTests: XCTestCase {
     private func jsonString(_ value: String) throws -> String {
         let data = try JSONEncoder().encode(value)
         return String(decoding: data, as: UTF8.self)
+    }
+
+    private func handleHook(_ json: String, hookName: String) throws {
+        let input = try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
+        try HookHandler.handleHook(hookName: hookName, input: input)
     }
 }

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -432,6 +432,51 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertEqual(result.first?.pid, 200)
     }
 
+    @MainActor
+    func testSessionManagerRemovesFinishedCodexDedupLoserWithoutArchiving() throws {
+        let root = NSTemporaryDirectory() + "cctop-codex-dedup-cleanup-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+
+        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
+        defer {
+            unsetenv("CCTOP_SESSIONS_DIR")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        var oldPidKeyed = Session(
+            sessionId: "conv-a", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo()
+        )
+        oldPidKeyed.source = Session.codexSource
+        oldPidKeyed.pid = 999_999
+        oldPidKeyed.endedAt = Date(timeIntervalSince1970: 100)
+        let oldPath = (sessionsDir as NSString).appendingPathComponent("999999.json")
+        try oldPidKeyed.writeToFile(path: oldPath)
+
+        var desktopKeyed = Session(
+            sessionId: "conv-a", projectPath: "/tmp/p", branch: "main",
+            terminal: TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
+        )
+        desktopKeyed.source = Session.codexSource
+        desktopKeyed.lastActivity = Date()
+        let desktopPath = (sessionsDir as NSString).appendingPathComponent("codex-conv-a.json")
+        try desktopKeyed.writeToFile(path: desktopPath)
+
+        var manager: SessionManager? = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
+        )
+        manager?.loadSessions()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: desktopPath))
+        XCTAssertEqual(manager?.sessions.map(\.sessionId), ["conv-a"])
+        XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
+
+        manager = nil
+    }
+
     // Distinct conversations never collapse.
     func testDedupDifferentSessionIdsStaySeparate() {
         let one = candidate(sessionId: "conv-1", pid: 1, bundleId: Self.desktopBundle, lifecycleRank: 0)

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -475,4 +475,11 @@ final class SessionFileFormatTests: XCTestCase {
     func testLifecycleCodexCliTerminalUsesRealPidNotRecency() {
         XCTAssertEqual(life(lifeSession(source: "codex", agoSeconds: 600), .terminal, alive: true), .active)
     }
+
+    // Ambiguous + Codex with a LIVE pid stays active: ambiguous is the safety bucket, and a Codex
+    // CLI without a recognized bundle id still has a real per-process PID — the shared-PID recency
+    // carve-out applies ONLY to Codex Desktop (hostClass == .desktop), not to ambiguous.
+    func testLifecycleAmbiguousCodexWithLivePidStaysActive() {
+        XCTAssertEqual(life(lifeSession(source: "codex", agoSeconds: 600), .ambiguous, alive: true), .active)
+    }
 }

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -329,20 +329,21 @@ final class SessionFileFormatTests: XCTestCase {
     private func candidate(
         sessionId: String, pid: UInt32, bundleId: String?, lifecycleRank: Int,
         lastActivity: Date = Date(timeIntervalSince1970: 1000),
-        endedAt: Date? = nil, mtime: Date = .distantPast, path: String = "/x.json"
+        endedAt: Date? = nil, disconnectedAt: Date? = nil, mtime: Date = .distantPast, path: String = "/x.json"
     ) -> DedupCandidate {
         var s = Session(sessionId: sessionId, projectPath: "/tmp/p", branch: "main",
                         terminal: TerminalInfo(bundleId: bundleId))
         s.pid = pid
         s.lastActivity = lastActivity
         s.endedAt = endedAt
+        s.disconnectedAt = disconnectedAt
         return DedupCandidate(session: s, lifecycleRank: lifecycleRank, mtime: mtime, path: path)
     }
 
     func testDedupDesktopCollapsesSameSessionIdDifferentPid() {
         let dead = candidate(sessionId: "conv-a", pid: 100, bundleId: Self.desktopBundle, lifecycleRank: 1)
         let live = candidate(sessionId: "conv-a", pid: 200, bundleId: Self.desktopBundle, lifecycleRank: 0)
-        let result = SessionManager.dedupedBySessionId([dead, live])
+        let result = SessionManager.dedupedByLifecycleKey([dead, live])
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first?.pid, 200) // live (rank 0) wins, NOT the dead/newer-file one
     }
@@ -352,7 +353,7 @@ final class SessionFileFormatTests: XCTestCase {
                                      lifecycleRank: 1, lastActivity: Date(timeIntervalSince1970: 9999))
         let liveOlder = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
                                   lifecycleRank: 0, lastActivity: Date(timeIntervalSince1970: 1))
-        let result = SessionManager.dedupedBySessionId([dormantNewer, liveOlder])
+        let result = SessionManager.dedupedByLifecycleKey([dormantNewer, liveOlder])
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first?.pid, 2) // lifecycle rank dominates lastActivity
     }
@@ -360,7 +361,7 @@ final class SessionFileFormatTests: XCTestCase {
     func testDedupDormantBeatsFinished() {
         let finished = candidate(sessionId: "c", pid: 1, bundleId: Self.desktopBundle, lifecycleRank: 2)
         let dormant = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle, lifecycleRank: 1)
-        XCTAssertEqual(SessionManager.dedupedBySessionId([finished, dormant]).first?.pid, 2)
+        XCTAssertEqual(SessionManager.dedupedByLifecycleKey([finished, dormant]).first?.pid, 2)
     }
 
     func testDedupSameRankNewerLastActivityWins() {
@@ -368,7 +369,7 @@ final class SessionFileFormatTests: XCTestCase {
                               lifecycleRank: 1, lastActivity: Date(timeIntervalSince1970: 1))
         let newer = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
                               lifecycleRank: 1, lastActivity: Date(timeIntervalSince1970: 2))
-        XCTAssertEqual(SessionManager.dedupedBySessionId([older, newer]).first?.pid, 2)
+        XCTAssertEqual(SessionManager.dedupedByLifecycleKey([older, newer]).first?.pid, 2)
     }
 
     func testDedupTieBreaksByEffectiveEndDate() {
@@ -377,7 +378,7 @@ final class SessionFileFormatTests: XCTestCase {
                           lifecycleRank: 1, lastActivity: t, endedAt: Date(timeIntervalSince1970: 10))
         let b = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
                           lifecycleRank: 1, lastActivity: t, endedAt: Date(timeIntervalSince1970: 20))
-        XCTAssertEqual(SessionManager.dedupedBySessionId([a, b]).first?.pid, 2) // newer effectiveEndDate
+        XCTAssertEqual(SessionManager.dedupedByLifecycleKey([a, b]).first?.pid, 2) // newer effectiveEndDate
     }
 
     func testDedupFinalTieBreakByPathIsDeterministic() {
@@ -387,8 +388,8 @@ final class SessionFileFormatTests: XCTestCase {
         let b = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
                           lifecycleRank: 1, lastActivity: t, mtime: t, path: "/b.json")
         // Smaller path wins, regardless of input order (total, stable).
-        XCTAssertEqual(SessionManager.dedupedBySessionId([b, a]).first?.pid, 1)
-        XCTAssertEqual(SessionManager.dedupedBySessionId([a, b]).first?.pid, 1)
+        XCTAssertEqual(SessionManager.dedupedByLifecycleKey([b, a]).first?.pid, 1)
+        XCTAssertEqual(SessionManager.dedupedByLifecycleKey([a, b]).first?.pid, 1)
     }
 
     func testDedupMissingMtimeLosesToRealMtime() {
@@ -397,25 +398,28 @@ final class SessionFileFormatTests: XCTestCase {
                                 lifecycleRank: 1, lastActivity: t, mtime: .distantPast)
         let realMtime = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
                                   lifecycleRank: 1, lastActivity: t, mtime: t)
-        XCTAssertEqual(SessionManager.dedupedBySessionId([noMtime, realMtime]).first?.pid, 2)
+        XCTAssertEqual(SessionManager.dedupedByLifecycleKey([noMtime, realMtime]).first?.pid, 2)
     }
 
-    // H2: the same conversation collapses regardless of how each file classifies — even if an
-    // env flicker on restart makes one file look terminal (bundle id present) and one ambiguous
-    // (absent). A hostClass-dependent key would split these into different buckets → duplicate card.
-    func testDedupMixedClassSameSessionIdCollapsesToLive() {
-        let deadTerminal = candidate(sessionId: "shared", pid: 100, bundleId: "com.googlecode.iterm2", lifecycleRank: 1)
-        let liveAmbiguous = candidate(sessionId: "shared", pid: 200, bundleId: nil, lifecycleRank: 0)
-        let result = SessionManager.dedupedBySessionId([deadTerminal, liveAmbiguous])
-        XCTAssertEqual(result.count, 1)
-        XCTAssertEqual(result.first?.pid, 200) // live wins
+    func testDedupTerminalKeepsPidIdentityEvenWithSameSessionId() {
+        let oldPid = candidate(sessionId: "shared", pid: 100, bundleId: "com.googlecode.iterm2", lifecycleRank: 0)
+        let newPid = candidate(sessionId: "shared", pid: 200, bundleId: "com.googlecode.iterm2", lifecycleRank: 0)
+        let result = SessionManager.dedupedByLifecycleKey([oldPid, newPid])
+        XCTAssertEqual(result.compactMap(\.pid).sorted(), [100, 200])
+    }
+
+    func testDedupUnknownHostKeepsPidIdentityEvenWithSameSessionId() {
+        let oldPid = candidate(sessionId: "shared", pid: 100, bundleId: nil, lifecycleRank: 0)
+        let newPid = candidate(sessionId: "shared", pid: 200, bundleId: nil, lifecycleRank: 0)
+        let result = SessionManager.dedupedByLifecycleKey([oldPid, newPid])
+        XCTAssertEqual(result.compactMap(\.pid).sorted(), [100, 200])
     }
 
     // Distinct conversations never collapse.
     func testDedupDifferentSessionIdsStaySeparate() {
         let one = candidate(sessionId: "conv-1", pid: 1, bundleId: Self.desktopBundle, lifecycleRank: 0)
         let two = candidate(sessionId: "conv-2", pid: 2, bundleId: Self.desktopBundle, lifecycleRank: 0)
-        XCTAssertEqual(SessionManager.dedupedBySessionId([one, two]).count, 2)
+        XCTAssertEqual(SessionManager.dedupedByLifecycleKey([one, two]).count, 2)
     }
 
     // MARK: - Lifecycle derivation (Phase 1)
@@ -424,16 +428,47 @@ final class SessionFileFormatTests: XCTestCase {
     private static let activeWin: TimeInterval = 300        // 5 min
     private static let retentionWin: TimeInterval = 86_400  // 24h
 
-    private func lifeSession(source: String? = nil, agoSeconds: TimeInterval) -> Session {
+    private func lifeSession(
+        source: String? = nil,
+        agoSeconds: TimeInterval,
+        disconnectedAgoSeconds: TimeInterval? = nil
+    ) -> Session {
         var session = Session(sessionId: "s", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
         session.source = source
         session.lastActivity = Self.lifeNow.addingTimeInterval(-agoSeconds)
+        if let disconnectedAgoSeconds {
+            session.disconnectedAt = Self.lifeNow.addingTimeInterval(-disconnectedAgoSeconds)
+        }
         return session
     }
 
     private func life(_ session: Session, _ hostClass: SessionHostClass, alive: Bool) -> SessionLifecycle {
         SessionManager.lifecycle(for: session, hostClass: hostClass, processAlive: alive, now: Self.lifeNow,
                                  windows: LifecycleWindows(active: Self.activeWin, retention: Self.retentionWin))
+    }
+
+    private func connection(_ session: Session, _ hostClass: SessionHostClass, alive: Bool) -> SessionConnectionState {
+        SessionManager.connectionState(
+            for: session, hostClass: hostClass, processAlive: alive, now: Self.lifeNow,
+            windows: LifecycleWindows(active: Self.activeWin, retention: Self.retentionWin)
+        )
+    }
+
+    func testConnectionStateUsesEndedAtForAllHosts() {
+        var session = lifeSession(agoSeconds: 60)
+        session.endedAt = Self.lifeNow.addingTimeInterval(-30)
+
+        XCTAssertEqual(connection(session, .desktop, alive: true), .disconnected)
+        XCTAssertEqual(connection(session, .terminal, alive: true), .disconnected)
+        XCTAssertEqual(connection(session, .ambiguous, alive: true), .disconnected)
+    }
+
+    func testLifecycleMapsSameDisconnectedStateByHostPolicy() {
+        let session = lifeSession(agoSeconds: 60, disconnectedAgoSeconds: 30)
+
+        XCTAssertEqual(life(session, .desktop, alive: false), .dormant)
+        XCTAssertEqual(life(session, .terminal, alive: false), .finished)
+        XCTAssertEqual(life(session, .ambiguous, alive: false), .finished)
     }
 
     func testLifecycleDesktopAliveIsActive() {
@@ -445,11 +480,25 @@ final class SessionFileFormatTests: XCTestCase {
     }
 
     func testLifecycleDesktopDeadAndAgedIsFinished() {
-        XCTAssertEqual(life(lifeSession(agoSeconds: 100_000), .desktop, alive: false), .finished)
+        XCTAssertEqual(
+            life(lifeSession(agoSeconds: 100_000, disconnectedAgoSeconds: 100_000), .desktop, alive: false),
+            .finished
+        )
     }
 
-    func testLifecycleAmbiguousDeadButRecentIsDormant() {
-        XCTAssertEqual(life(lifeSession(agoSeconds: 60), .ambiguous, alive: false), .dormant)
+    func testLifecycleDesktopDeadUsesDisconnectedAtInsteadOfLastActivityForRetention() {
+        XCTAssertEqual(
+            life(lifeSession(agoSeconds: 100_000, disconnectedAgoSeconds: 60), .desktop, alive: false),
+            .dormant
+        )
+    }
+
+    func testLifecycleDesktopDeadWithoutDisconnectedAtStartsDormant() {
+        XCTAssertEqual(life(lifeSession(agoSeconds: 100_000), .desktop, alive: false), .dormant)
+    }
+
+    func testLifecycleUnknownHostDeadIsFinishedEvenIfRecent() {
+        XCTAssertEqual(life(lifeSession(agoSeconds: 60), .ambiguous, alive: false), .finished)
     }
 
     func testLifecycleTerminalAliveIsActive() {
@@ -459,6 +508,24 @@ final class SessionFileFormatTests: XCTestCase {
     // A dead terminal session is over — no dormant, even when recent.
     func testLifecycleTerminalDeadIsFinishedEvenIfRecent() {
         XCTAssertEqual(life(lifeSession(agoSeconds: 60), .terminal, alive: false), .finished)
+    }
+
+    func testLifecycleTerminalEndedAtIsFinishedEvenIfPidStillAlive() {
+        var session = lifeSession(agoSeconds: 60)
+        session.endedAt = Self.lifeNow.addingTimeInterval(-30)
+        XCTAssertEqual(life(session, .terminal, alive: true), .finished)
+    }
+
+    func testLifecycleDesktopEndedAtUsesDesktopDormantRules() {
+        var session = lifeSession(agoSeconds: 60, disconnectedAgoSeconds: 30)
+        session.endedAt = Self.lifeNow.addingTimeInterval(-30)
+        XCTAssertEqual(life(session, .desktop, alive: false), .dormant)
+    }
+
+    func testLifecycleDesktopEndedAtBeatsPidLiveness() {
+        var session = lifeSession(agoSeconds: 60, disconnectedAgoSeconds: 30)
+        session.endedAt = Self.lifeNow.addingTimeInterval(-30)
+        XCTAssertEqual(life(session, .desktop, alive: true), .dormant)
     }
 
     // Codex Desktop carve-out: a live SHARED host PID must not keep a stale conversation active.

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -497,6 +497,15 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertEqual(life(lifeSession(agoSeconds: 100_000), .desktop, alive: false), .dormant)
     }
 
+    func testLifecycleClaudeDesktopUsesDesktopDormantPolicy() {
+        var session = lifeSession(agoSeconds: 100_000, disconnectedAgoSeconds: 60)
+        session.terminal = TerminalInfo(bundleId: HostAppBundleID.claudeDesktop)
+
+        XCTAssertEqual(session.hostClass, .desktop)
+        XCTAssertEqual(life(session, session.hostClass, alive: false), .dormant)
+        XCTAssertEqual(life(session, session.hostClass, alive: true), .active)
+    }
+
     func testLifecycleUnknownHostDeadIsFinishedEvenIfRecent() {
         XCTAssertEqual(life(lifeSession(agoSeconds: 60), .ambiguous, alive: false), .finished)
     }

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -321,4 +321,100 @@ final class SessionFileFormatTests: XCTestCase {
 
         manager = nil
     }
+
+    // MARK: - Desktop dedup by session_id (Phase 1, total order)
+
+    private static let desktopBundle = "com.anthropic.claudefordesktop"
+
+    private func candidate(
+        sessionId: String, pid: UInt32, bundleId: String?, lifecycleRank: Int,
+        lastActivity: Date = Date(timeIntervalSince1970: 1000),
+        endedAt: Date? = nil, mtime: Date = .distantPast, path: String = "/x.json"
+    ) -> DedupCandidate {
+        var s = Session(sessionId: sessionId, projectPath: "/tmp/p", branch: "main",
+                        terminal: TerminalInfo(bundleId: bundleId))
+        s.pid = pid
+        s.lastActivity = lastActivity
+        s.endedAt = endedAt
+        return DedupCandidate(session: s, lifecycleRank: lifecycleRank, mtime: mtime, path: path)
+    }
+
+    func testDedupDesktopCollapsesSameSessionIdDifferentPid() {
+        let dead = candidate(sessionId: "conv-a", pid: 100, bundleId: Self.desktopBundle, lifecycleRank: 1)
+        let live = candidate(sessionId: "conv-a", pid: 200, bundleId: Self.desktopBundle, lifecycleRank: 0)
+        let result = SessionManager.dedupedBySessionId([dead, live])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.pid, 200) // live (rank 0) wins, NOT the dead/newer-file one
+    }
+
+    func testDedupLiveBeatsDormantEvenIfDormantNewer() {
+        let dormantNewer = candidate(sessionId: "c", pid: 1, bundleId: Self.desktopBundle,
+                                     lifecycleRank: 1, lastActivity: Date(timeIntervalSince1970: 9999))
+        let liveOlder = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
+                                  lifecycleRank: 0, lastActivity: Date(timeIntervalSince1970: 1))
+        let result = SessionManager.dedupedBySessionId([dormantNewer, liveOlder])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.pid, 2) // lifecycle rank dominates lastActivity
+    }
+
+    func testDedupDormantBeatsFinished() {
+        let finished = candidate(sessionId: "c", pid: 1, bundleId: Self.desktopBundle, lifecycleRank: 2)
+        let dormant = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle, lifecycleRank: 1)
+        XCTAssertEqual(SessionManager.dedupedBySessionId([finished, dormant]).first?.pid, 2)
+    }
+
+    func testDedupSameRankNewerLastActivityWins() {
+        let older = candidate(sessionId: "c", pid: 1, bundleId: Self.desktopBundle,
+                              lifecycleRank: 1, lastActivity: Date(timeIntervalSince1970: 1))
+        let newer = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
+                              lifecycleRank: 1, lastActivity: Date(timeIntervalSince1970: 2))
+        XCTAssertEqual(SessionManager.dedupedBySessionId([older, newer]).first?.pid, 2)
+    }
+
+    func testDedupTieBreaksByEffectiveEndDate() {
+        let t = Date(timeIntervalSince1970: 5)
+        let a = candidate(sessionId: "c", pid: 1, bundleId: Self.desktopBundle,
+                          lifecycleRank: 1, lastActivity: t, endedAt: Date(timeIntervalSince1970: 10))
+        let b = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
+                          lifecycleRank: 1, lastActivity: t, endedAt: Date(timeIntervalSince1970: 20))
+        XCTAssertEqual(SessionManager.dedupedBySessionId([a, b]).first?.pid, 2) // newer effectiveEndDate
+    }
+
+    func testDedupFinalTieBreakByPathIsDeterministic() {
+        let t = Date(timeIntervalSince1970: 5)
+        let a = candidate(sessionId: "c", pid: 1, bundleId: Self.desktopBundle,
+                          lifecycleRank: 1, lastActivity: t, mtime: t, path: "/a.json")
+        let b = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
+                          lifecycleRank: 1, lastActivity: t, mtime: t, path: "/b.json")
+        // Smaller path wins, regardless of input order (total, stable).
+        XCTAssertEqual(SessionManager.dedupedBySessionId([b, a]).first?.pid, 1)
+        XCTAssertEqual(SessionManager.dedupedBySessionId([a, b]).first?.pid, 1)
+    }
+
+    func testDedupMissingMtimeLosesToRealMtime() {
+        let t = Date(timeIntervalSince1970: 5)
+        let noMtime = candidate(sessionId: "c", pid: 1, bundleId: Self.desktopBundle,
+                                lifecycleRank: 1, lastActivity: t, mtime: .distantPast)
+        let realMtime = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
+                                  lifecycleRank: 1, lastActivity: t, mtime: t)
+        XCTAssertEqual(SessionManager.dedupedBySessionId([noMtime, realMtime]).first?.pid, 2)
+    }
+
+    // H2: the same conversation collapses regardless of how each file classifies — even if an
+    // env flicker on restart makes one file look terminal (bundle id present) and one ambiguous
+    // (absent). A hostClass-dependent key would split these into different buckets → duplicate card.
+    func testDedupMixedClassSameSessionIdCollapsesToLive() {
+        let deadTerminal = candidate(sessionId: "shared", pid: 100, bundleId: "com.googlecode.iterm2", lifecycleRank: 1)
+        let liveAmbiguous = candidate(sessionId: "shared", pid: 200, bundleId: nil, lifecycleRank: 0)
+        let result = SessionManager.dedupedBySessionId([deadTerminal, liveAmbiguous])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.pid, 200) // live wins
+    }
+
+    // Distinct conversations never collapse.
+    func testDedupDifferentSessionIdsStaySeparate() {
+        let one = candidate(sessionId: "conv-1", pid: 1, bundleId: Self.desktopBundle, lifecycleRank: 0)
+        let two = candidate(sessionId: "conv-2", pid: 2, bundleId: Self.desktopBundle, lifecycleRank: 0)
+        XCTAssertEqual(SessionManager.dedupedBySessionId([one, two]).count, 2)
+    }
 }

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -75,7 +75,7 @@ final class SessionFileFormatTests: XCTestCase {
         var other = Session(sessionId: "conv-b", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
         other.source = "codex"; other.pid = 31349
 
-        let result = SessionManager.dedupedByID([old, fresh, other])
+        let result = SessionIdentityPolicy.dedupedByDisplayID([old, fresh, other])
         // Two distinct ids survive; the duplicate id keeps the most recently active entry.
         XCTAssertEqual(result.map(\.id).sorted(), ["conv-a", "conv-b"])
         XCTAssertEqual(result.first { $0.id == "conv-a" }?.sessionName, "current")
@@ -342,10 +342,14 @@ final class SessionFileFormatTests: XCTestCase {
         return DedupCandidate(session: s, lifecycleRank: lifecycleRank, mtime: mtime, path: path)
     }
 
+    private func deduped(_ candidates: [DedupCandidate]) -> [Session] {
+        SessionIdentityPolicy.dedupedCandidatesByStableKey(candidates).map(\.session)
+    }
+
     func testDedupDesktopCollapsesSameSessionIdDifferentPid() {
         let dead = candidate(sessionId: "conv-a", pid: 100, bundleId: Self.desktopBundle, lifecycleRank: 1)
         let live = candidate(sessionId: "conv-a", pid: 200, bundleId: Self.desktopBundle, lifecycleRank: 0)
-        let result = SessionManager.dedupedByLifecycleKey([dead, live])
+        let result = deduped([dead, live])
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first?.pid, 200) // live (rank 0) wins, NOT the dead/newer-file one
     }
@@ -355,7 +359,7 @@ final class SessionFileFormatTests: XCTestCase {
                                      lifecycleRank: 1, lastActivity: Date(timeIntervalSince1970: 9999))
         let liveOlder = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
                                   lifecycleRank: 0, lastActivity: Date(timeIntervalSince1970: 1))
-        let result = SessionManager.dedupedByLifecycleKey([dormantNewer, liveOlder])
+        let result = deduped([dormantNewer, liveOlder])
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first?.pid, 2) // lifecycle rank dominates lastActivity
     }
@@ -363,7 +367,7 @@ final class SessionFileFormatTests: XCTestCase {
     func testDedupDormantBeatsFinished() {
         let finished = candidate(sessionId: "c", pid: 1, bundleId: Self.desktopBundle, lifecycleRank: 2)
         let dormant = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle, lifecycleRank: 1)
-        XCTAssertEqual(SessionManager.dedupedByLifecycleKey([finished, dormant]).first?.pid, 2)
+        XCTAssertEqual(deduped([finished, dormant]).first?.pid, 2)
     }
 
     func testDedupSameRankNewerLastActivityWins() {
@@ -371,7 +375,7 @@ final class SessionFileFormatTests: XCTestCase {
                               lifecycleRank: 1, lastActivity: Date(timeIntervalSince1970: 1))
         let newer = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
                               lifecycleRank: 1, lastActivity: Date(timeIntervalSince1970: 2))
-        XCTAssertEqual(SessionManager.dedupedByLifecycleKey([older, newer]).first?.pid, 2)
+        XCTAssertEqual(deduped([older, newer]).first?.pid, 2)
     }
 
     func testDedupTieBreaksByEffectiveEndDate() {
@@ -380,7 +384,7 @@ final class SessionFileFormatTests: XCTestCase {
                           lifecycleRank: 1, lastActivity: t, endedAt: Date(timeIntervalSince1970: 10))
         let b = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
                           lifecycleRank: 1, lastActivity: t, endedAt: Date(timeIntervalSince1970: 20))
-        XCTAssertEqual(SessionManager.dedupedByLifecycleKey([a, b]).first?.pid, 2) // newer effectiveEndDate
+        XCTAssertEqual(deduped([a, b]).first?.pid, 2) // newer effectiveEndDate
     }
 
     func testDedupFinalTieBreakByPathIsDeterministic() {
@@ -390,8 +394,8 @@ final class SessionFileFormatTests: XCTestCase {
         let b = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
                           lifecycleRank: 1, lastActivity: t, mtime: t, path: "/b.json")
         // Smaller path wins, regardless of input order (total, stable).
-        XCTAssertEqual(SessionManager.dedupedByLifecycleKey([b, a]).first?.pid, 1)
-        XCTAssertEqual(SessionManager.dedupedByLifecycleKey([a, b]).first?.pid, 1)
+        XCTAssertEqual(deduped([b, a]).first?.pid, 1)
+        XCTAssertEqual(deduped([a, b]).first?.pid, 1)
     }
 
     func testDedupMissingMtimeLosesToRealMtime() {
@@ -400,20 +404,20 @@ final class SessionFileFormatTests: XCTestCase {
                                 lifecycleRank: 1, lastActivity: t, mtime: .distantPast)
         let realMtime = candidate(sessionId: "c", pid: 2, bundleId: Self.desktopBundle,
                                   lifecycleRank: 1, lastActivity: t, mtime: t)
-        XCTAssertEqual(SessionManager.dedupedByLifecycleKey([noMtime, realMtime]).first?.pid, 2)
+        XCTAssertEqual(deduped([noMtime, realMtime]).first?.pid, 2)
     }
 
     func testDedupTerminalKeepsPidIdentityEvenWithSameSessionId() {
         let oldPid = candidate(sessionId: "shared", pid: 100, bundleId: "com.googlecode.iterm2", lifecycleRank: 0)
         let newPid = candidate(sessionId: "shared", pid: 200, bundleId: "com.googlecode.iterm2", lifecycleRank: 0)
-        let result = SessionManager.dedupedByLifecycleKey([oldPid, newPid])
+        let result = deduped([oldPid, newPid])
         XCTAssertEqual(result.compactMap(\.pid).sorted(), [100, 200])
     }
 
     func testDedupUnknownHostKeepsPidIdentityEvenWithSameSessionId() {
         let oldPid = candidate(sessionId: "shared", pid: 100, bundleId: nil, lifecycleRank: 0)
         let newPid = candidate(sessionId: "shared", pid: 200, bundleId: nil, lifecycleRank: 0)
-        let result = SessionManager.dedupedByLifecycleKey([oldPid, newPid])
+        let result = deduped([oldPid, newPid])
         XCTAssertEqual(result.compactMap(\.pid).sorted(), [100, 200])
     }
 
@@ -427,7 +431,7 @@ final class SessionFileFormatTests: XCTestCase {
             lifecycleRank: 0, source: Session.codexSource, path: "/codex-conv-a.json"
         )
 
-        let result = SessionManager.dedupedByLifecycleKey([oldPidKeyed, desktopKeyed])
+        let result = deduped([oldPidKeyed, desktopKeyed])
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first?.pid, 200)
     }
@@ -481,7 +485,7 @@ final class SessionFileFormatTests: XCTestCase {
     func testDedupDifferentSessionIdsStaySeparate() {
         let one = candidate(sessionId: "conv-1", pid: 1, bundleId: Self.desktopBundle, lifecycleRank: 0)
         let two = candidate(sessionId: "conv-2", pid: 2, bundleId: Self.desktopBundle, lifecycleRank: 0)
-        XCTAssertEqual(SessionManager.dedupedByLifecycleKey([one, two]).count, 2)
+        XCTAssertEqual(deduped([one, two]).count, 2)
     }
 
     // MARK: - Lifecycle derivation (Phase 1)
@@ -505,15 +509,42 @@ final class SessionFileFormatTests: XCTestCase {
     }
 
     private func life(_ session: Session, _ hostClass: SessionHostClass, alive: Bool) -> SessionLifecycle {
-        SessionManager.lifecycle(for: session, hostClass: hostClass, processAlive: alive, now: Self.lifeNow,
-                                 windows: LifecycleWindows(active: Self.activeWin, retention: Self.retentionWin))
+        SessionLifecyclePolicy.lifecycle(
+            for: session,
+            hostClass: hostClass,
+            processAlive: alive,
+            now: Self.lifeNow,
+            windows: LifecycleWindows(active: Self.activeWin, retention: Self.retentionWin)
+        )
     }
 
     private func connection(_ session: Session, _ hostClass: SessionHostClass, alive: Bool) -> SessionConnectionState {
-        SessionManager.connectionState(
+        SessionLifecyclePolicy.connectionState(
             for: session, hostClass: hostClass, processAlive: alive, now: Self.lifeNow,
             windows: LifecycleWindows(active: Self.activeWin, retention: Self.retentionWin)
         )
+    }
+
+    func testIdentityPolicyNamesStableGroupingRules() {
+        var codex = Session(sessionId: "codex-conversation", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        codex.source = Session.codexSource
+        codex.lastActivity = Self.lifeNow.addingTimeInterval(-60)
+        codex.pid = 31349
+
+        var desktop = Session(sessionId: "desktop-conversation", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        desktop.source = "cc"
+        desktop.lastActivity = Self.lifeNow.addingTimeInterval(-60)
+        desktop.terminal = TerminalInfo(bundleId: HostAppBundleID.claudeDesktop)
+        desktop.pid = 99
+
+        var terminal = Session(sessionId: "terminal-conversation", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        terminal.source = "cc"
+        terminal.lastActivity = Self.lifeNow.addingTimeInterval(-60)
+        terminal.pid = 42
+
+        XCTAssertEqual(SessionIdentityPolicy.stableKey(for: codex), "codex:codex-conversation")
+        XCTAssertEqual(SessionIdentityPolicy.stableKey(for: desktop), "desktop:desktop-conversation")
+        XCTAssertEqual(SessionIdentityPolicy.stableKey(for: terminal), "active:42")
     }
 
     func testConnectionStateUsesEndedAtForAllHosts() {

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -328,12 +328,14 @@ final class SessionFileFormatTests: XCTestCase {
 
     private func candidate(
         sessionId: String, pid: UInt32, bundleId: String?, lifecycleRank: Int,
+        source: String? = nil,
         lastActivity: Date = Date(timeIntervalSince1970: 1000),
         endedAt: Date? = nil, disconnectedAt: Date? = nil, mtime: Date = .distantPast, path: String = "/x.json"
     ) -> DedupCandidate {
         var s = Session(sessionId: sessionId, projectPath: "/tmp/p", branch: "main",
                         terminal: TerminalInfo(bundleId: bundleId))
         s.pid = pid
+        s.source = source
         s.lastActivity = lastActivity
         s.endedAt = endedAt
         s.disconnectedAt = disconnectedAt
@@ -413,6 +415,21 @@ final class SessionFileFormatTests: XCTestCase {
         let newPid = candidate(sessionId: "shared", pid: 200, bundleId: nil, lifecycleRank: 0)
         let result = SessionManager.dedupedByLifecycleKey([oldPid, newPid])
         XCTAssertEqual(result.compactMap(\.pid).sorted(), [100, 200])
+    }
+
+    func testDedupMigratedCodexSessionUsesStableConversationIdAcrossHostClass() {
+        let oldPidKeyed = candidate(
+            sessionId: "conv-a", pid: 100, bundleId: nil, lifecycleRank: 2,
+            source: Session.codexSource, path: "/100.json"
+        )
+        let desktopKeyed = candidate(
+            sessionId: "conv-a", pid: 200, bundleId: HostAppBundleID.codexDesktop,
+            lifecycleRank: 0, source: Session.codexSource, path: "/codex-conv-a.json"
+        )
+
+        let result = SessionManager.dedupedByLifecycleKey([oldPidKeyed, desktopKeyed])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.pid, 200)
     }
 
     // Distinct conversations never collapse.

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -417,4 +417,62 @@ final class SessionFileFormatTests: XCTestCase {
         let two = candidate(sessionId: "conv-2", pid: 2, bundleId: Self.desktopBundle, lifecycleRank: 0)
         XCTAssertEqual(SessionManager.dedupedBySessionId([one, two]).count, 2)
     }
+
+    // MARK: - Lifecycle derivation (Phase 1)
+
+    private static let lifeNow = Date(timeIntervalSince1970: 1_000_000)
+    private static let activeWin: TimeInterval = 300        // 5 min
+    private static let retentionWin: TimeInterval = 86_400  // 24h
+
+    private func lifeSession(source: String? = nil, agoSeconds: TimeInterval) -> Session {
+        var session = Session(sessionId: "s", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        session.source = source
+        session.lastActivity = Self.lifeNow.addingTimeInterval(-agoSeconds)
+        return session
+    }
+
+    private func life(_ session: Session, _ hostClass: SessionHostClass, alive: Bool) -> SessionLifecycle {
+        SessionManager.lifecycle(for: session, hostClass: hostClass, processAlive: alive, now: Self.lifeNow,
+                                 windows: LifecycleWindows(active: Self.activeWin, retention: Self.retentionWin))
+    }
+
+    func testLifecycleDesktopAliveIsActive() {
+        XCTAssertEqual(life(lifeSession(agoSeconds: 0), .desktop, alive: true), .active)
+    }
+
+    func testLifecycleDesktopDeadButRecentIsDormant() {
+        XCTAssertEqual(life(lifeSession(agoSeconds: 60), .desktop, alive: false), .dormant)
+    }
+
+    func testLifecycleDesktopDeadAndAgedIsFinished() {
+        XCTAssertEqual(life(lifeSession(agoSeconds: 100_000), .desktop, alive: false), .finished)
+    }
+
+    func testLifecycleAmbiguousDeadButRecentIsDormant() {
+        XCTAssertEqual(life(lifeSession(agoSeconds: 60), .ambiguous, alive: false), .dormant)
+    }
+
+    func testLifecycleTerminalAliveIsActive() {
+        XCTAssertEqual(life(lifeSession(agoSeconds: 0), .terminal, alive: true), .active)
+    }
+
+    // A dead terminal session is over — no dormant, even when recent.
+    func testLifecycleTerminalDeadIsFinishedEvenIfRecent() {
+        XCTAssertEqual(life(lifeSession(agoSeconds: 60), .terminal, alive: false), .finished)
+    }
+
+    // Codex Desktop carve-out: a live SHARED host PID must not keep a stale conversation active.
+    func testLifecycleCodexDesktopIgnoresSharedPidWhenStale() {
+        XCTAssertEqual(life(lifeSession(source: "codex", agoSeconds: 600), .desktop, alive: true), .dormant)
+    }
+
+    // Codex Desktop active comes from recent activity, even with a dead/irrelevant PID.
+    func testLifecycleCodexDesktopRecentIsActiveDespiteDeadPid() {
+        XCTAssertEqual(life(lifeSession(source: "codex", agoSeconds: 30), .desktop, alive: false), .active)
+    }
+
+    // Codex CLI (terminal) uses its REAL per-process PID, not recency — never remove a live silent CLI.
+    func testLifecycleCodexCliTerminalUsesRealPidNotRecency() {
+        XCTAssertEqual(life(lifeSession(source: "codex", agoSeconds: 600), .terminal, alive: true), .active)
+    }
 }

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -434,4 +434,29 @@ final class SessionTests: XCTestCase {
         let term = TerminalInfo(program: "iTerm.app")
         XCTAssertEqual(Session.mock(terminal: term).hostClass, .ambiguous)
     }
+
+    // MARK: - Transient lifecycle field
+
+    // Decoding a normal session file leaves lifecycle at its default (never persisted).
+    func testDecodeDefaultsLifecycleToActive() throws {
+        let json = """
+        {
+            "session_id": "life-1", "project_path": "/tmp", "project_name": "test",
+            "branch": "main", "status": "idle",
+            "last_activity": "2026-02-08T12:00:00Z", "started_at": "2026-02-08T11:00:00Z",
+            "terminal": {"program": "Code"}
+        }
+        """
+        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        XCTAssertEqual(session.lifecycle, .active)
+    }
+
+    // The transient field participates in Equatable, so a dormant flip re-renders the card.
+    func testLifecycleParticipatesInEquatable() {
+        let base = Session.mock(id: "life-eq")
+        var dormant = base
+        dormant.lifecycle = .dormant
+        XCTAssertNotEqual(base, dormant)
+        XCTAssertEqual(base.lifecycle, .active)
+    }
 }

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -345,4 +345,93 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.sessionId, "old-session")
         XCTAssertEqual(session.status, .working)
     }
+
+    // MARK: - Host classification (Phase 1, file-local, bundle-id only)
+
+    func testHostClassClaudeDesktopIsDesktop() {
+        let session = Session.mock(terminal: TerminalInfo(bundleId: "com.anthropic.claudefordesktop"))
+        XCTAssertEqual(session.hostClass, .desktop)
+    }
+
+    func testHostClassCodexDesktopIsDesktop() {
+        let session = Session.mock(terminal: TerminalInfo(bundleId: "com.openai.codex"))
+        XCTAssertEqual(session.hostClass, .desktop)
+    }
+
+    func testHostClassITerm2IsTerminal() {
+        let session = Session.mock(terminal: TerminalInfo(bundleId: "com.googlecode.iterm2"))
+        XCTAssertEqual(session.hostClass, .terminal)
+    }
+
+    func testHostClassVSCodeIsTerminal() {
+        let session = Session.mock(terminal: TerminalInfo(bundleId: "com.microsoft.VSCode"))
+        XCTAssertEqual(session.hostClass, .terminal)
+    }
+
+    func testHostClassNilTerminalIsAmbiguous() {
+        let session = Session.mock(terminal: nil)
+        XCTAssertEqual(session.hostClass, .ambiguous)
+    }
+
+    func testHostClassMissingBundleIdIsAmbiguous() {
+        let session = Session.mock(terminal: TerminalInfo(program: "weird-term"))
+        XCTAssertEqual(session.hostClass, .ambiguous)
+    }
+
+    func testHostClassEmptyBundleIdIsAmbiguous() {
+        let session = Session.mock(terminal: TerminalInfo(bundleId: ""))
+        XCTAssertEqual(session.hostClass, .ambiguous)
+    }
+
+    func testHostClassUnknownBundleIdIsAmbiguous() {
+        let session = Session.mock(terminal: TerminalInfo(bundleId: "com.example.unknownterm"))
+        XCTAssertEqual(session.hostClass, .ambiguous)
+    }
+
+    // `source` must NEVER classify: it cannot tell desktop from CLI.
+    func testHostClassSourceCodexWithoutBundleIdIsAmbiguous() {
+        let session = Session.mock(terminal: nil, source: "codex")
+        XCTAssertEqual(session.hostClass, .ambiguous)
+    }
+
+    func testHostClassSourceCcWithoutBundleIdIsAmbiguous() {
+        let session = Session.mock(terminal: nil, source: "cc")
+        XCTAssertEqual(session.hostClass, .ambiguous)
+    }
+
+    // bundle id wins over source: Codex CLI running inside iTerm2 is terminal.
+    func testHostClassCodexCliInTerminalIsTerminal() {
+        let session = Session.mock(terminal: TerminalInfo(bundleId: "com.googlecode.iterm2"), source: "codex")
+        XCTAssertEqual(session.hostClass, .terminal)
+    }
+
+    // Desktop bundle id takes precedence over a (contrived) multiplexer.
+    func testHostClassDesktopBundleIdWinsOverMultiplexer() {
+        let term = TerminalInfo(bundleId: "com.anthropic.claudefordesktop",
+                                multiplexer: .tmux(socket: "/tmp/s", paneId: "%1", binaryPath: nil))
+        XCTAssertEqual(Session.mock(terminal: term).hostClass, .desktop)
+    }
+
+    // A multiplexer is hard terminal evidence (desktop is returned first, so this can't be desktop).
+    func testHostClassTmuxWithoutBundleIdIsTerminal() {
+        let term = TerminalInfo(multiplexer: .tmux(socket: "/tmp/s", paneId: "%1", binaryPath: nil))
+        XCTAssertEqual(Session.mock(terminal: term).hostClass, .terminal)
+    }
+
+    func testHostClassZellijWithoutBundleIdIsTerminal() {
+        let term = TerminalInfo(multiplexer: .zellij(sessionName: "main", paneId: "0", binaryPath: nil))
+        XCTAssertEqual(Session.mock(terminal: term).hostClass, .terminal)
+    }
+
+    // tty alone is NOT hard evidence — it can be env-copied (env["TTY"]) and inherited by GUI children.
+    func testHostClassTtyOnlyIsAmbiguous() {
+        let term = TerminalInfo(tty: "/dev/ttys003")
+        XCTAssertEqual(Session.mock(terminal: term).hostClass, .ambiguous)
+    }
+
+    // program name alone is env-only and leaks to GUI children → must not classify terminal.
+    func testHostClassProgramOnlyIsAmbiguous() {
+        let term = TerminalInfo(program: "iTerm.app")
+        XCTAssertEqual(Session.mock(terminal: term).hostClass, .ambiguous)
+    }
 }

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -188,6 +188,37 @@ final class SessionTests: XCTestCase {
         XCTAssertNil(session.pidStartTime)
     }
 
+    func testDecodesDisconnectedAt() throws {
+        let json = """
+        {
+            "session_id": "desktop-disconnected",
+            "project_path": "/tmp",
+            "project_name": "test",
+            "branch": "main",
+            "status": "idle",
+            "last_activity": "2026-02-08T12:00:00Z",
+            "started_at": "2026-02-08T11:00:00Z",
+            "terminal": {"program": "", "bundle_id": "com.anthropic.claudefordesktop"},
+            "disconnected_at": "2026-02-08T12:05:00Z"
+        }
+        """
+        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        XCTAssertEqual(
+            session.disconnectedAt,
+            ISO8601DateFormatter().date(from: "2026-02-08T12:05:00Z")
+        )
+    }
+
+    func testEncodesDisconnectedAt() throws {
+        let disconnectedAt = ISO8601DateFormatter().date(from: "2026-02-08T12:05:00Z")!
+        var session = Session.mock(terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop))
+        session.disconnectedAt = disconnectedAt
+
+        let data = try JSONEncoder.sessionEncoder.encode(session)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(object?["disconnected_at"] as? String, "2026-02-08T12:05:00.000Z")
+    }
+
     func testProcessStartTimeReturnsValueForCurrentProcess() {
         let pid = UInt32(getpid())
         let startTime = Session.processStartTime(pid: pid)


### PR DESCRIPTION
## Summary

- Preserves trusted Claude Desktop and Codex Desktop sessions as dormant after disconnect, while terminal or ambiguous sessions continue through the normal finished-session archival path. Sources: https://github.com/st0012/cctop/blob/claude/strange-heisenberg-8777cd/menubar/CctopMenubar/Services/SessionLifecyclePolicy.swift, https://github.com/st0012/cctop/blob/claude/strange-heisenberg-8777cd/menubar/CctopMenubar/Models/HostApp.swift, and https://github.com/st0012/cctop/blob/claude/strange-heisenberg-8777cd/menubar/CctopMenubar/Services/SessionManager.swift
- Stores explicit `ended_at` and `disconnected_at` markers, and only clears them when a hook is real evidence that the session resumed. No-op and subagent hooks preserve the markers. Sources: https://github.com/st0012/cctop/blob/claude/strange-heisenberg-8777cd/menubar/CctopMenubar/Hook/HookHandler.swift, https://github.com/st0012/cctop/blob/claude/strange-heisenberg-8777cd/menubar/CctopMenubar/Models/HookEvent.swift, and https://github.com/st0012/cctop/blob/claude/strange-heisenberg-8777cd/menubar/CctopMenubarTests/HookHandlerTests.swift
- Adds cleanup and migration handling around the new dormant state: aged-out desktop files are garbage-collected, lock files are preserved, and migrated Codex duplicate files are deduplicated by stable conversation identity. Sources: https://github.com/st0012/cctop/blob/claude/strange-heisenberg-8777cd/menubar/CctopMenubar/Services/SessionManager.swift, https://github.com/st0012/cctop/blob/claude/strange-heisenberg-8777cd/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift, and https://github.com/st0012/cctop/blob/claude/strange-heisenberg-8777cd/menubar/CctopMenubarTests/SessionFileFormatTests.swift
- Documents the desktop-vs-CLI lifecycle and cleanup flow with Mermaid diagrams. Source: https://github.com/st0012/cctop/blob/claude/strange-heisenberg-8777cd/docs/session-lifecycle.md

## Verification

- GitHub Actions passed `Swift Lint` and `Swift Build & Test` on the latest head commit. Source: https://github.com/st0012/cctop/actions/runs/26481291464
- The local verification commands used for this branch are defined in the repository Makefile: `make test` for the Xcode test target and `make build` for both the menubar app and standalone `cctop-hook`. Source: https://github.com/st0012/cctop/blob/claude/strange-heisenberg-8777cd/Makefile
- The subagent inactive-marker regression is covered by `HookEventTests` and `HookHandlerTests`. Sources: https://github.com/st0012/cctop/blob/claude/strange-heisenberg-8777cd/menubar/CctopMenubarTests/HookEventTests.swift and https://github.com/st0012/cctop/blob/claude/strange-heisenberg-8777cd/menubar/CctopMenubarTests/HookHandlerTests.swift