### PR TITLE
Hide orphan Claude Desktop hook sessions

### DIFF
--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -61,12 +61,13 @@ flowchart TD
     A1 -->|"Claude Desktop"| CL1{"Claude metadata found by cliSessionId?"}
     A1 -->|"Codex Desktop"| CX1{"Codex thread row found?"}
     CL1 -->|yes| CL2{"isArchived true?"}
-    CL1 -->|no| CL3["No Claude archive signal; continue normal lifecycle"]
+    CL1 -->|no| CL3{"Already ended/disconnected?"}
     CX1 -->|yes| CX2{"archived true?"}
     CX1 -->|no| CX3["No Codex archive signal; continue normal lifecycle"]
     CL2 -->|yes| A2["Hide without mutating or deleting .json"]
     CL2 -->|no| Y
-    CL3 --> Y
+    CL3 -->|yes| A2
+    CL3 -->|no| Y
     CX2 -->|yes| A2
     CX2 -->|no| Y
     CX3 --> Y
@@ -125,14 +126,14 @@ Claude Desktop and Codex Desktop both enter the desktop lifecycle path only thro
 - Claude Desktop: `com.anthropic.claudefordesktop`
 - Codex Desktop: `com.openai.codex`
 
-Once either host is disconnected, the behavior is the same: cctop keeps the session as dormant while `disconnected_at` is inside the retention window, then the slow GC removes the stale `.json` file.
+Once a validated desktop host is disconnected, cctop keeps the session as dormant while `disconnected_at` is inside the retention window, then the slow GC removes the stale `.json` file.
 
 The archive metadata source is host-specific:
 
 - Claude Desktop archive state is read from Claude Desktop's `claude-code-sessions` metadata files, keyed by `cliSessionId`.
 - Codex Desktop archive state is read from Codex's local thread database, keyed by thread id.
 
-Claude Desktop records without matching `cliSessionId` metadata do not have an archive signal. cctop keeps those records on the normal desktop lifecycle path: `ended_at` makes them disconnected, `disconnected_at` starts dormant retention, and the slow GC removes them after retention expires. This includes launch-time hook records that start and end before Claude Desktop writes durable session metadata. If matching metadata exists but cannot be read, display fails open for that pass while GC keeps the `.json` rather than deleting uncertain state.
+Claude Desktop records are validated against readable Claude metadata keyed by `cliSessionId`. If the metadata store is readable but has no matching metadata and the cctop record has already ended or disconnected, cctop treats it as an orphan startup hook record and hides it without mutating or deleting the `.json`. This covers launch-time records that start and end before Claude Desktop writes durable session metadata. If the metadata store is missing, display fails open and the record follows the normal lifecycle. If matching metadata cannot be read, display fails open for that pass while GC keeps the `.json` rather than deleting uncertain state.
 
 The active liveness evidence is not identical:
 

--- a/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift
@@ -11,12 +11,18 @@ struct ClaudeDesktopSessionArchiveLookup {
     /// or `nil` when a matching metadata read is uncertain. A missing metadata directory returns
     /// `[]` so machines without Claude Desktop keep the normal lifecycle behavior.
     func archivedSessionIDs(matching sessionIDs: Set<String>) -> Set<String>? {
-        guard !sessionIDs.isEmpty else { return [] }
+        metadataSnapshot(matching: sessionIDs)?.archivedSessionIDs
+    }
+
+    /// Returns Claude metadata matches for validation and archive filtering, or `nil` when the
+    /// metadata store exists but cannot be read safely.
+    func metadataSnapshot(matching sessionIDs: Set<String>) -> ClaudeDesktopSessionMetadataSnapshot? {
+        guard !sessionIDs.isEmpty else { return ClaudeDesktopSessionMetadataSnapshot() }
 
         let rootURL = URL(fileURLWithPath: sessionsDirectory)
         var isDirectory = ObjCBool(false)
         guard FileManager.default.fileExists(atPath: rootURL.path, isDirectory: &isDirectory) else {
-            return []
+            return ClaudeDesktopSessionMetadataSnapshot(isAuthoritative: false)
         }
         guard isDirectory.boolValue,
               let enumerator = FileManager.default.enumerator(
@@ -51,13 +57,33 @@ struct ClaudeDesktopSessionArchiveLookup {
             latestBySessionID[cliSessionId] = match
         }
 
-        return Set(latestBySessionID.compactMap { sessionID, match in
-            match.isArchived ? sessionID : nil
-        })
+        return ClaudeDesktopSessionMetadataSnapshot(
+            matchedSessionIDs: Set(latestBySessionID.keys),
+            archivedSessionIDs: Set(latestBySessionID.compactMap { sessionID, match in
+                match.isArchived ? sessionID : nil
+            }),
+            isAuthoritative: true
+        )
     }
 
     private func isClaudeDesktopMetadataURL(_ url: URL) -> Bool {
         url.pathExtension == "json" && url.lastPathComponent.hasPrefix("local_")
+    }
+}
+
+struct ClaudeDesktopSessionMetadataSnapshot: Equatable {
+    let matchedSessionIDs: Set<String>
+    let archivedSessionIDs: Set<String>
+    let isAuthoritative: Bool
+
+    init(
+        matchedSessionIDs: Set<String> = [],
+        archivedSessionIDs: Set<String> = [],
+        isAuthoritative: Bool = true
+    ) {
+        self.matchedSessionIDs = matchedSessionIDs
+        self.archivedSessionIDs = archivedSessionIDs
+        self.isAuthoritative = isAuthoritative
     }
 }
 

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -22,12 +22,16 @@ extension SessionManager {
     /// Batch snapshot for the display path. This mirrors the Codex behavior: archive metadata read
     /// uncertainty fails OPEN because this path never deletes files.
     nonisolated static func archivedClaudeDesktopSessionIDs(in sessions: [Session]) -> Set<String> {
+        claudeDesktopMetadataSnapshot(in: sessions)?.archivedSessionIDs ?? []
+    }
+
+    nonisolated static func claudeDesktopMetadataSnapshot(in sessions: [Session]) -> ClaudeDesktopSessionMetadataSnapshot? {
         let sessionIDs = Set(
             sessions
                 .filter(\.isClaudeDesktopHost)
                 .map(\.sessionId)
         )
-        return ClaudeDesktopSessionArchiveLookup().archivedSessionIDs(matching: sessionIDs) ?? []
+        return ClaudeDesktopSessionArchiveLookup().metadataSnapshot(matching: sessionIDs)
     }
 
     nonisolated static func isArchivedClaudeDesktopSession(
@@ -35,6 +39,18 @@ extension SessionManager {
         archivedSessionIDs: Set<String>
     ) -> Bool {
         session.isClaudeDesktopHost && archivedSessionIDs.contains(session.sessionId)
+    }
+
+    nonisolated static func isOrphanedEndedClaudeDesktopSession(
+        _ session: Session,
+        metadataSnapshot: ClaudeDesktopSessionMetadataSnapshot?
+    ) -> Bool {
+        guard session.isClaudeDesktopHost,
+              session.endedAt != nil || session.disconnectedAt != nil,
+              metadataSnapshot?.isAuthoritative == true else {
+            return false
+        }
+        return metadataSnapshot?.matchedSessionIDs.contains(session.sessionId) == false
     }
 
     /// Fresh single-session archive check for the GC deletion decision. Unlike the batch snapshot

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -65,10 +65,12 @@ class SessionManager: ObservableObject {
             .map(\.url)
         let candidates = Self.buildCandidates(visibleFiles, now: Date())
         let archivedCodexThreadIDs = Self.archivedCodexDesktopThreadIDs(in: candidates.map(\.session))
-        let archivedClaudeSessionIDs = Self.archivedClaudeDesktopSessionIDs(in: candidates.map(\.session))
+        let claudeMetadata = Self.claudeDesktopMetadataSnapshot(in: candidates.map(\.session))
+        let archivedClaudeSessionIDs = claudeMetadata?.archivedSessionIDs ?? []
         let liveCandidates = candidates.filter {
             !Self.isArchivedCodexDesktopSession($0.session, archivedThreadIDs: archivedCodexThreadIDs)
                 && !Self.isArchivedClaudeDesktopSession($0.session, archivedSessionIDs: archivedClaudeSessionIDs)
+                && !Self.isOrphanedEndedClaudeDesktopSession($0.session, metadataSnapshot: claudeMetadata)
         }
         logger.info("loadSessions: \(jsonFiles.count) files, \(allDecoded.count) decoded")
         logger.info(

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -720,6 +720,50 @@ final class SessionFileFormatTests: XCTestCase {
         manager = nil
     }
 
+    @MainActor
+    func testSessionManagerHidesEndedClaudeDesktopSessionWithoutMatchingMetadata() throws {
+        let root = NSTemporaryDirectory() + "cctop-claude-orphan-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        let claudeDir = (root as NSString).appendingPathComponent("claude-code-sessions")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        try writeClaudeDesktopSessionMetadata(
+            root: claudeDir,
+            cliSessionId: "different-claude-session",
+            isArchived: false
+        )
+
+        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
+        setenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR", claudeDir, 1)
+        defer {
+            unsetenv("CCTOP_SESSIONS_DIR")
+            unsetenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("orphan-claude-session.json")
+        var session = claudeDesktopSession(sessionId: "orphan-claude-session", projectPath: "/tmp/p")
+        let ended = Date()
+        session.source = nil
+        session.pid = nil
+        session.endedAt = ended
+        session.disconnectedAt = ended
+        try session.writeToFile(path: sessionPath)
+
+        var manager: SessionManager? = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
+        )
+        manager?.loadSessions()
+
+        XCTAssertEqual(manager?.sessions.map(\.sessionId), [])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
+        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
+
+        manager = nil
+    }
+
     // The GC deletion decision must read live Codex archive state on every call, not a snapshot,
     // so a thread archived between a GC scan and its delete keeps its file. Calling the helper
     // twice across a DB change proves it never caches.


### PR DESCRIPTION
## Summary

- Addresses the orphan Claude Desktop hook-session case reported in issue #131 by hiding ended/disconnected Claude Desktop records when readable Claude metadata has no matching `cliSessionId`. [Issue #131](https://github.com/st0012/cctop/issues/131), [display filter](https://github.com/st0012/cctop/blob/codex/hide-orphan-claude-desktop-sessions/menubar/CctopMenubar/Services/SessionManager.swift), [archive helper](https://github.com/st0012/cctop/blob/codex/hide-orphan-claude-desktop-sessions/menubar/CctopMenubar/Services/SessionManager%2BArchive.swift)
- Extends the Claude Desktop metadata lookup so callers can distinguish matched session IDs, archived session IDs, and non-authoritative metadata reads. [metadata lookup](https://github.com/st0012/cctop/blob/codex/hide-orphan-claude-desktop-sessions/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift)
- Adds a regression covering a mismatched Claude metadata record while preserving the cctop session file and history directory. [test](https://github.com/st0012/cctop/blob/codex/hide-orphan-claude-desktop-sessions/menubar/CctopMenubarTests/SessionFileFormatTests.swift)
- Updates lifecycle documentation for the missing-metadata orphan path and fail-open behavior when metadata is missing or uncertain. [docs](https://github.com/st0012/cctop/blob/codex/hide-orphan-claude-desktop-sessions/docs/session-lifecycle.md)

## Validation Coverage

- The repository pull-request workflow defines SwiftLint and Swift build/test jobs for PR validation. [workflow](https://github.com/st0012/cctop/blob/codex/hide-orphan-claude-desktop-sessions/.github/workflows/ci.yml)
