### PR TITLE
Use desktop app liveness for dormant sessions

### DIFF
--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -126,7 +126,7 @@ Claude Desktop and Codex Desktop both enter the desktop lifecycle path only thro
 - Claude Desktop: `com.anthropic.claudefordesktop`
 - Codex Desktop: `com.openai.codex`
 
-Once a validated desktop host is disconnected, cctop keeps the session as dormant while `disconnected_at` is inside the retention window, then the slow GC removes the stale `.json` file.
+Once a validated desktop app is not running, cctop keeps its visible sessions as dormant while `disconnected_at` is inside the retention window, then the slow GC removes stale `.json` files. When that desktop app is running again, its visible sessions are active display records, so their stored status can render as Idle, Working, Compacting, Waiting, Permission, or Attention instead of Dormant.
 
 The archive metadata source is host-specific:
 
@@ -135,10 +135,11 @@ The archive metadata source is host-specific:
 
 Claude Desktop records are validated against readable Claude metadata keyed by `cliSessionId`. If the metadata store is readable but has no matching metadata and the cctop record has already ended or disconnected, cctop treats it as an orphan startup hook record and hides it without mutating or deleting the `.json`. This covers launch-time records that start and end before Claude Desktop writes durable session metadata. If the metadata store is missing, display fails open and the record follows the normal lifecycle. If matching metadata cannot be read, display fails open for that pass while GC keeps the `.json` rather than deleting uncertain state.
 
-The active liveness evidence is not identical:
+The active liveness evidence is layered:
 
-- Claude Desktop uses the normal process liveness check unless `ended_at` is present.
-- Codex Desktop uses recent hook activity instead of PID liveness, because Codex Desktop can report multiple conversations from a shared host process.
+- Claude Desktop and Codex Desktop use app-level bundle liveness when the bundle is known.
+- If app-level liveness is not available, Codex Desktop falls back to recent hook activity instead of PID liveness, because Codex Desktop can report multiple conversations from a shared host process.
+- Non-desktop sessions keep using their own process liveness and terminal-style cleanup.
 
 Both hosts still use the same disconnected-state policy after the shared connection step.
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -1,100 +1,78 @@
 # Session Lifecycle
 
-This flow documents how cctop turns a session file into a connection state and then into a UI/cleanup lifecycle.
-The desktop path applies to both Claude Desktop and Codex Desktop.
+This flow documents how cctop turns a session file into one display-time lifecycle:
+`active`, `dormant`, or `finished`. The desktop path applies to both Claude Desktop and Codex Desktop.
 
 The key split is intentional:
 
 - File presence means cctop has a record to evaluate. It is not itself proof that the session is live.
-- Desktop archive state comes from each app's local metadata and hides the session before lifecycle publishing.
-- `ended_at` is an explicit disconnect signal written by hook events.
+- Visibility filters decide whether a decoded record can be displayed at all.
+- Connection evidence decides whether the host is connected right now.
+- Lifecycle decides how cctop should treat a visible record.
+- Persistence actions update `disconnected_at`, remove stale files, or archive finished CLI work.
 - `disconnected_at` is the retention clock for known desktop sessions, including Claude Desktop and Codex Desktop, that have become dormant.
 - CLI and ambiguous sessions do not use dormant retention. Once disconnected, they become finished.
 
+## Display Pipeline
+
 ```mermaid
 flowchart TD
-    A["Session file exists"] --> B["Evaluate persisted fields"]
-    B --> C{"ended_at present?"}
+    A["Session .json files"] --> B["Decode non-hidden records"]
+    B --> C["Derive lifecycle<br/>active / dormant / finished"]
+    C --> D{"Visibility filter"}
 
-    C -->|yes| D["Connection state: disconnected"]
-    C -->|no| E["Run host-specific liveness check"]
+    D -->|"archived desktop session"| E["Hide for this pass<br/>preserve .json"]
+    D -->|"Claude orphan startup record"| E
+    D -->|"visible record"| F["Deduplicate by stable key"]
 
-    E --> F{"Host class"}
-    F -->|"Known desktop app"| G["Desktop liveness evidence"]
-    F -->|"Terminal / CLI"| H["Real process liveness"]
-    F -->|"Ambiguous"| I["Conservative process liveness"]
+    F --> G{"Winner lifecycle"}
+    G -->|active| H["Publish active session"]
+    G -->|dormant| I["Publish dormant session<br/>neutral status, no notifications"]
+    G -->|finished| J["Do not publish"]
+```
 
-    G --> G1{"Desktop host"}
-    G1 -->|"Codex Desktop"| G2["Recent hook activity within active window"]
-    G1 -->|"Claude Desktop"| G3["Process liveness unless SessionEnd already set ended_at"]
-    G1 -->|"Other desktop app"| G4["Process liveness"]
+## Lifecycle Derivation
 
-    H --> J{"Live?"}
-    I --> J
-    G2 --> J
-    G3 --> J
-    G4 --> J
+```mermaid
+flowchart TD
+    A["Decoded visible record"] --> B{"Trusted desktop host?"}
 
-    J -->|yes| K["Connection state: connected"]
-    J -->|no| D
+    B -->|yes| C{"Owning desktop app running?"}
+    C -->|yes| D["Lifecycle: active"]
+    C -->|no| E{"disconnected_at missing<br/>or inside retention?"}
+    E -->|yes| F["Lifecycle: dormant"]
+    E -->|no| G["Lifecycle: finished"]
 
-    K --> L["Lifecycle: active"]
+    B -->|no| H{"Connected by process<br/>or fallback recency?"}
+    H -->|yes| D
+    H -->|no| G
+```
 
-    D --> M{"Host policy"}
-    M -->|"Known desktop app"| N{"disconnected_at present?"}
-    M -->|"Terminal / CLI"| O["Lifecycle: finished"]
-    M -->|"Ambiguous"| O
+## Persistence Actions
 
-    N -->|no| P["Stamp disconnected_at now"]
-    P --> Q["Lifecycle: dormant"]
-    N -->|yes| R{"Retention expired?"}
-    R -->|no| Q
-    R -->|yes| S["Lifecycle: finished"]
+```mermaid
+flowchart TD
+    A["Derived candidates"] --> B{"Active desktop<br/>has disconnected_at?"}
+    B -->|yes| C["Clear stale disconnected_at"]
+    B -->|no| D{"Dormant desktop<br/>missing disconnected_at?"}
 
-    L --> A0{"Trusted desktop host?"}
-    Q --> A0
-    S --> A0
-    O --> A0
+    D -->|yes| E["Stamp disconnected_at now"]
+    D -->|no| F{"Finished desktop<br/>past retention?"}
 
-    A0 -->|no| Y["Deduplicate by stable lifecycle key"]
-    A0 -->|yes| A1{"Archive metadata source"}
-    A1 -->|"Claude Desktop"| CL1{"Claude metadata found by cliSessionId?"}
-    A1 -->|"Codex Desktop"| CX1{"Codex thread row found?"}
-    CL1 -->|yes| CL2{"isArchived true?"}
-    CL1 -->|no| CL3{"Already ended/disconnected?"}
-    CX1 -->|yes| CX2{"archived true?"}
-    CX1 -->|no| CX3["No Codex archive signal; continue normal lifecycle"]
-    CL2 -->|yes| A2["Hide without mutating or deleting .json"]
-    CL2 -->|no| Y
-    CL3 -->|yes| A2
-    CL3 -->|no| Y
-    CX2 -->|yes| A2
-    CX2 -->|no| Y
-    CX3 --> Y
+    F -->|yes| G["Slow GC re-checks archive state<br/>then removes .json only"]
+    F -->|no| H{"Finished non-desktop?"}
 
-    Y --> Z{"Survives dedup?"}
-    Z -->|yes| AA{"Lifecycle after dedup"}
-    Z -->|no| AB{"Finished non-desktop duplicate?"}
-
-    AA -->|"active"| AC["Show active session"]
-    AA -->|"dormant"| T["Show dormant session"]
-    AA -->|"finished desktop"| V["Desktop GC removes stale .json later"]
-    AA -->|"finished terminal / ambiguous"| W["Archive and remove .json promptly"]
-
-    T --> U["No notifications; neutral display status"]
-    AB -->|yes| AD["Remove stale duplicate .json without archiving"]
-    AB -->|no| AE["Ignore duplicate; winner owns display/cleanup"]
-
-    V --> X["Never remove .lock files"]
-    W --> X
-    AD --> X
+    H -->|yes| I["Archive to Recent Projects<br/>then remove .json"]
+    H -->|no| J["No persistence change"]
 ```
 
 ## Field Meanings
 
 ### `ended_at`
 
-`ended_at` is set when a hook observes `SessionEnd`. It is read before any PID or recency check. If it is present, every host class is considered disconnected.
+`ended_at` is set when a hook observes `SessionEnd`. For terminal, CLI, ambiguous, and fallback desktop records it is an explicit disconnect signal.
+
+For trusted desktop records with app-level liveness available, the owning app's running state is the connection source. A running desktop app can therefore make the record active again even if the older hook record still has `ended_at`.
 
 New activity clears `ended_at` so a resumed session can become connected again.
 
@@ -106,6 +84,8 @@ It can be set in two ways:
 
 - A desktop `SessionEnd` stamps it at the same time as `ended_at`.
 - The menubar app stamps it when it first observes a known desktop session as dormant and the field is missing.
+
+The menubar app clears it when the same trusted desktop app is observed running again.
 
 CLI sessions do not need `disconnected_at` because disconnected CLI sessions become finished immediately.
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -35,16 +35,19 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    A["Decoded visible record"] --> B{"Trusted desktop host?"}
+    A["Decoded visible record"] --> B{"ended_at present?"}
 
-    B -->|yes| C{"Owning desktop app running?"}
-    C -->|yes| D["Lifecycle: active"]
-    C -->|no| E{"disconnected_at missing<br/>or inside retention?"}
+    B -->|yes| E{"Trusted desktop host<br/>and disconnected_at missing<br/>or inside retention?"}
+    B -->|no| C{"Trusted desktop host?"}
+
+    C -->|yes| D{"Owning desktop app running?"}
+    D -->|yes| I["Lifecycle: active"]
+    D -->|no| E
     E -->|yes| F["Lifecycle: dormant"]
     E -->|no| G["Lifecycle: finished"]
 
-    B -->|no| H{"Connected by process<br/>or fallback recency?"}
-    H -->|yes| D
+    C -->|no| H{"Connected by process<br/>or fallback recency?"}
+    H -->|yes| I["Lifecycle: active"]
     H -->|no| G
 ```
 
@@ -70,9 +73,9 @@ flowchart TD
 
 ### `ended_at`
 
-`ended_at` is set when a hook observes `SessionEnd`. For terminal, CLI, ambiguous, and fallback desktop records it is an explicit disconnect signal.
+`ended_at` is set when a hook observes `SessionEnd`. It is an explicit disconnect signal for every host class.
 
-For trusted desktop records with app-level liveness available, the owning app's running state is the connection source. A running desktop app can therefore make the record active again even if the older hook record still has `ended_at`.
+For trusted desktop records, `ended_at` still wins over app-level liveness. A running desktop app keeps non-ended visible records active, but it does not make an older ended hook record active again.
 
 New activity clears `ended_at` so a resumed session can become connected again.
 
@@ -85,7 +88,7 @@ It can be set in two ways:
 - A desktop `SessionEnd` stamps it at the same time as `ended_at`.
 - The menubar app stamps it when it first observes a known desktop session as dormant and the field is missing.
 
-The menubar app clears it when the same trusted desktop app is observed running again.
+The menubar app clears it when the same trusted desktop app is observed running again and the session has not explicitly ended.
 
 CLI sessions do not need `disconnected_at` because disconnected CLI sessions become finished immediately.
 

--- a/menubar/CctopMenubar/Services/SessionLifecyclePolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionLifecyclePolicy.swift
@@ -12,7 +12,7 @@ struct DedupCandidate {
 
 /// Tunable windows for lifecycle derivation.
 struct LifecycleWindows {
-    let active: TimeInterval     // Codex Desktop "recent activity counts as active" threshold
+    let active: TimeInterval     // fallback "recent activity counts as active" threshold
     let retention: TimeInterval  // dormant desktop -> finished age-out from disconnected_at
 }
 
@@ -24,10 +24,14 @@ enum SessionConnectionState: Equatable {
 enum SessionLifecyclePolicy {
     /// Pure connection derivation. Every host class goes through this same first step:
     /// decide whether the session record still represents a connected session.
+    /// Desktop app liveness wins when known because those sessions share one app-level connection.
     static func connectionState(
         for session: Session, hostClass: SessionHostClass, processAlive: Bool,
-        now: Date, windows: LifecycleWindows
+        now: Date, windows: LifecycleWindows, desktopAppRunning: Bool? = nil
     ) -> SessionConnectionState {
+        if hostClass == .desktop, let desktopAppRunning {
+            return desktopAppRunning ? .connected : .disconnected
+        }
         if session.endedAt != nil { return .disconnected }
         // The shared-PID recency carve-out is Codex Desktop's, identified by source ("codex") OR by
         // the trusted Codex Desktop bundle id — the latter covers pre-harness-migration files whose
@@ -41,10 +45,15 @@ enum SessionLifecyclePolicy {
     /// decides what disconnected means for desktop versus non-desktop sessions.
     static func lifecycle(
         for session: Session, hostClass: SessionHostClass, processAlive: Bool,
-        now: Date, windows: LifecycleWindows
+        now: Date, windows: LifecycleWindows, desktopAppRunning: Bool? = nil
     ) -> SessionLifecycle {
         let connection = connectionState(
-            for: session, hostClass: hostClass, processAlive: processAlive, now: now, windows: windows
+            for: session,
+            hostClass: hostClass,
+            processAlive: processAlive,
+            now: now,
+            windows: windows,
+            desktopAppRunning: desktopAppRunning
         )
         if connection == .connected { return .active }
         guard hostClass == .desktop else { return .finished }

--- a/menubar/CctopMenubar/Services/SessionLifecyclePolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionLifecyclePolicy.swift
@@ -24,15 +24,16 @@ enum SessionConnectionState: Equatable {
 enum SessionLifecyclePolicy {
     /// Pure connection derivation. Every host class goes through this same first step:
     /// decide whether the session record still represents a connected session.
-    /// Desktop app liveness wins when known because those sessions share one app-level connection.
+    /// Ended sessions stay disconnected even while their owning desktop app is still running.
+    /// Otherwise, desktop app liveness wins when known because those sessions share one app-level connection.
     static func connectionState(
         for session: Session, hostClass: SessionHostClass, processAlive: Bool,
         now: Date, windows: LifecycleWindows, desktopAppRunning: Bool? = nil
     ) -> SessionConnectionState {
+        if session.endedAt != nil { return .disconnected }
         if hostClass == .desktop, let desktopAppRunning {
             return desktopAppRunning ? .connected : .disconnected
         }
-        if session.endedAt != nil { return .disconnected }
         // The shared-PID recency carve-out is Codex Desktop's, identified by source ("codex") OR by
         // the trusted Codex Desktop bundle id — the latter covers pre-harness-migration files whose
         // source is nil, which would otherwise fall back to (unreliable, shared) PID liveness.

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -1,4 +1,17 @@
+import AppKit
 import Foundation
+
+struct DesktopAppConnectionLookup {
+    let isRunning: (String) -> Bool
+
+    init(_ isRunning: @escaping (String) -> Bool) {
+        self.isRunning = isRunning
+    }
+
+    static let live = DesktopAppConnectionLookup { bundleID in
+        NSWorkspace.shared.runningApplications.contains { $0.bundleIdentifier == bundleID }
+    }
+}
 
 extension SessionManager {
     /// Batch snapshot for the display path. This never deletes files, so unreadable external state
@@ -78,5 +91,35 @@ extension SessionManager {
 
     nonisolated static func isArchivedDesktopSession(_ session: Session) -> Bool {
         isCodexDesktopThreadArchived(session) || isClaudeDesktopSessionArchived(session)
+    }
+
+    /// Decode each session file, derive its lifecycle, and capture mtime — the inputs the dedup
+    /// comparator needs. Pure (no published state), kept off the main class body.
+    nonisolated static func buildCandidates(
+        _ jsonFiles: [URL],
+        now: Date,
+        desktopAppConnectionLookup: DesktopAppConnectionLookup = .live
+    ) -> [DedupCandidate] {
+        var candidates: [DedupCandidate] = []
+        for url in jsonFiles {
+            guard let data = try? Data(contentsOf: url) else {
+                sessionManagerLogger.warning("loadSessions: could not read \(url.lastPathComponent, privacy: .public)")
+                continue
+            }
+            guard var session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data) else {
+                sessionManagerLogger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public)")
+                continue
+            }
+            session.lifecycle = SessionLifecyclePolicy.lifecycle(
+                for: session, hostClass: session.hostClass, processAlive: session.isAlive,
+                now: now, windows: lifecycleWindows,
+                desktopAppRunning: desktopAppRunning(for: session, lookup: desktopAppConnectionLookup)
+            )
+            let mtime = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate ?? .distantPast
+            candidates.append(DedupCandidate(session: session, lifecycleRank: session.lifecycle.rawValue,
+                                             mtime: mtime, path: url.path))
+        }
+        return candidates
     }
 }

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -4,7 +4,7 @@ import Foundation
 import UserNotifications
 import os.log
 
-private let logger = Logger(subsystem: "com.st0012.CctopMenubar", category: "SessionManager")
+let sessionManagerLogger = Logger(subsystem: "com.st0012.CctopMenubar", category: "SessionManager")
 private typealias SessionFile = (url: URL, session: Session)
 
 @MainActor
@@ -15,17 +15,22 @@ class SessionManager: ObservableObject {
     let historyManager: HistoryManager
 
     private let sessionsDir: URL
+    private let desktopAppConnectionLookup: DesktopAppConnectionLookup
     private var source: DispatchSourceFileSystemObject?
     private var debounceTask: DispatchWorkItem?
     private var livenessTimer: Timer?
     private var gcTimer: Timer?
 
-    /// Lifecycle windows: Codex Desktop counts as active within `active` of last activity;
-    /// a non-active desktop session stays dormant within `retention` after first observed disconnect.
+    /// Lifecycle windows: desktop app liveness decides connection when available; `active` is the
+    /// fallback recency threshold and `retention` controls dormant desktop cleanup.
     nonisolated static let lifecycleWindows = LifecycleWindows(active: 600, retention: 1_209_600)
 
-    init(historyManager: HistoryManager) {
+    init(
+        historyManager: HistoryManager,
+        desktopAppConnectionLookup: DesktopAppConnectionLookup = .live
+    ) {
         self.historyManager = historyManager
+        self.desktopAppConnectionLookup = desktopAppConnectionLookup
         self.sessionsDir = URL(fileURLWithPath: Config.sessionsDir())
         loadSessions()
         startWatching()
@@ -44,7 +49,7 @@ class SessionManager: ObservableObject {
             at: sessionsDir,
             includingPropertiesForKeys: [.contentModificationDateKey]
         ) else {
-            logger.warning("loadSessions: could not read directory")
+            sessionManagerLogger.warning("loadSessions: could not read directory")
             sessions = []
             return
         }
@@ -60,10 +65,8 @@ class SessionManager: ObservableObject {
         let allDecoded = decodedSessions(from: jsonFiles)
         let hidden = allDecoded.filter { $0.session.hidden }
         let autoHidden = allDecoded.filter { !$0.session.hidden && $0.session.shouldAutoHide }
-        let visibleFiles = allDecoded
-            .filter { !$0.session.hidden && !$0.session.shouldAutoHide }
-            .map(\.url)
-        let candidates = Self.buildCandidates(visibleFiles, now: Date())
+        let visibleFiles = allDecoded.filter { !$0.session.hidden && !$0.session.shouldAutoHide }.map(\.url)
+        let candidates = Self.buildCandidates(visibleFiles, now: Date(), desktopAppConnectionLookup: desktopAppConnectionLookup)
         let archivedCodexThreadIDs = Self.archivedCodexDesktopThreadIDs(in: candidates.map(\.session))
         let claudeMetadata = Self.claudeDesktopMetadataSnapshot(in: candidates.map(\.session))
         let archivedClaudeSessionIDs = claudeMetadata?.archivedSessionIDs ?? []
@@ -72,12 +75,12 @@ class SessionManager: ObservableObject {
                 && !Self.isArchivedClaudeDesktopSession($0.session, archivedSessionIDs: archivedClaudeSessionIDs)
                 && !Self.isOrphanedEndedClaudeDesktopSession($0.session, metadataSnapshot: claudeMetadata)
         }
-        logger.info("loadSessions: \(jsonFiles.count) files, \(allDecoded.count) decoded")
-        logger.info(
+        sessionManagerLogger.info("loadSessions: \(jsonFiles.count) files, \(allDecoded.count) decoded")
+        sessionManagerLogger.info(
             "loadSessions: \(liveCandidates.count) visible candidates, \(hidden.count) hidden, \(autoHidden.count) auto-hidden"
         )
-        logger.info("loadSessions: \(archivedCodexThreadIDs.count) codex-archived")
-        logger.info("loadSessions: \(archivedClaudeSessionIDs.count) claude-archived")
+        sessionManagerLogger.info("loadSessions: \(archivedCodexThreadIDs.count) codex-archived")
+        sessionManagerLogger.info("loadSessions: \(archivedClaudeSessionIDs.count) claude-archived")
 
         // Publish active + dormant; finished are hidden (swept below / by GC).
         let winners = SessionIdentityPolicy.dedupedCandidatesByStableKey(liveCandidates)
@@ -89,12 +92,13 @@ class SessionManager: ObservableObject {
         // Only publish when data actually changed to avoid unnecessary SwiftUI re-renders.
         if newSessions != sessions {
             if newSessions.count != sessions.count {
-                logger.info("loadSessions: session count \(self.sessions.count) -> \(newSessions.count)")
+                sessionManagerLogger.info("loadSessions: session count \(self.sessions.count) -> \(newSessions.count)")
             }
             sessions = newSessions
         }
 
         hideAutoHiddenSessions(autoHidden)
+        clearReconnectedDesktopSessions(liveCandidates, now: Date())
         stampDisconnectedDesktopSessions(liveCandidates, now: Date())
 
         // Non-desktop finished sessions keep today's behavior: archive to Recent Projects and
@@ -118,14 +122,14 @@ class SessionManager: ObservableObject {
     private func decodedSessions(from jsonFiles: [URL]) -> [SessionFile] {
         jsonFiles.compactMap { url in
             guard let data = try? Data(contentsOf: url) else {
-                logger.warning("loadSessions: could not read \(url.lastPathComponent, privacy: .public)")
+                sessionManagerLogger.warning("loadSessions: could not read \(url.lastPathComponent, privacy: .public)")
                 return nil
             }
             do {
                 let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: data)
                 return (url, session)
             } catch {
-                logger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public): \(error, privacy: .public)")
+                sessionManagerLogger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public): \(error, privacy: .public)")
                 return nil
             }
         }
@@ -133,7 +137,7 @@ class SessionManager: ObservableObject {
 
     private func hideAutoHiddenSessions(_ sessions: [(URL, Session)]) {
         for (url, session) in sessions {
-            logger.info(
+            sessionManagerLogger.info(
                 "hiding \(self.autoHideReason(for: session), privacy: .public) session \(session.sessionId, privacy: .public)"
             )
             do {
@@ -142,7 +146,7 @@ class SessionManager: ObservableObject {
                     try hiddenSession.writeToFile(path: url.path)
                 }
             } catch {
-                logger.warning(
+                sessionManagerLogger.warning(
                     "skipping auto-hide update for \(session.sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)"
                 )
             }
@@ -177,13 +181,39 @@ class SessionManager: ObservableObject {
         if historyManager.archiveSession(session) {
             try? FileManager.default.removeItem(atPath: candidate.path)
         } else {
-            logger.warning("skipping removal of \(session.sessionId, privacy: .public) — archive failed")
+            sessionManagerLogger.warning("skipping removal of \(session.sessionId, privacy: .public) — archive failed")
         }
     }
 
     private func removeStaleDuplicate(_ candidate: DedupCandidate) {
-        logger.info("removing stale duplicate session file \(candidate.path, privacy: .public)")
+        sessionManagerLogger.info("removing stale duplicate session file \(candidate.path, privacy: .public)")
         try? FileManager.default.removeItem(atPath: candidate.path)
+    }
+
+    private func clearReconnectedDesktopSessions(_ candidates: [DedupCandidate], now: Date) {
+        for candidate in candidates {
+            guard candidate.session.hostClass == .desktop,
+                  candidate.session.lifecycle == .active,
+                  candidate.session.disconnectedAt != nil else { continue }
+            try? withSessionLock(sessionPath: candidate.path) {
+                guard var session = try? Session.fromFile(path: candidate.path),
+                      session.hostClass == .desktop,
+                      session.disconnectedAt != nil else {
+                    return
+                }
+                let lifecycle = SessionLifecyclePolicy.lifecycle(
+                    for: session,
+                    hostClass: SessionHostClass.desktop,
+                    processAlive: session.isAlive,
+                    now: now,
+                    windows: Self.lifecycleWindows,
+                    desktopAppRunning: Self.desktopAppRunning(for: session, lookup: desktopAppConnectionLookup)
+                )
+                guard lifecycle == .active else { return }
+                session.disconnectedAt = nil
+                try? session.writeToFile(path: candidate.path)
+            }
+        }
     }
 
     private func stampDisconnectedDesktopSessions(_ candidates: [DedupCandidate], now: Date) {
@@ -198,8 +228,12 @@ class SessionManager: ObservableObject {
                     return
                 }
                 let lifecycle = SessionLifecyclePolicy.lifecycle(
-                    for: session, hostClass: SessionHostClass.desktop, processAlive: session.isAlive,
-                    now: now, windows: Self.lifecycleWindows
+                    for: session,
+                    hostClass: SessionHostClass.desktop,
+                    processAlive: session.isAlive,
+                    now: now,
+                    windows: Self.lifecycleWindows,
+                    desktopAppRunning: Self.desktopAppRunning(for: session, lookup: desktopAppConnectionLookup)
                 )
                 guard lifecycle == .dormant else { return }
                 session.disconnectedAt = now
@@ -231,8 +265,12 @@ class SessionManager: ObservableObject {
                 let hostClass = session.hostClass
                 guard hostClass == .desktop else { return }   // non-desktop handled on the fast path
                 let life = SessionLifecyclePolicy.lifecycle(
-                    for: session, hostClass: hostClass, processAlive: session.isAlive,
-                    now: now, windows: Self.lifecycleWindows
+                    for: session,
+                    hostClass: hostClass,
+                    processAlive: session.isAlive,
+                    now: now,
+                    windows: Self.lifecycleWindows,
+                    desktopAppRunning: Self.desktopAppRunning(for: session, lookup: desktopAppConnectionLookup)
                 )
                 guard life == .finished else { return }
                 // Re-read external desktop archive state under the lock, right before deleting. A session
@@ -328,9 +366,9 @@ class SessionManager: ObservableObject {
 
                     center.requestAuthorization(options: [.alert, .sound]) { granted, error in
                         if let error {
-                            logger.error("Notification permission error: \(error, privacy: .public)")
+                            sessionManagerLogger.error("Notification permission error: \(error, privacy: .public)")
                         }
-                        logger.info("Notification permission granted: \(granted, privacy: .public)")
+                        sessionManagerLogger.info("Notification permission granted: \(granted, privacy: .public)")
                         DispatchQueue.main.async {
                             if wasAccessory { NSApplication.shared.setActivationPolicy(.accessory) }
                         }
@@ -355,7 +393,7 @@ class SessionManager: ObservableObject {
             case .notDetermined:
                 center.requestAuthorization(options: [.alert, .sound]) { granted, error in
                     if let error {
-                        logger.error("Notification permission error: \(error, privacy: .public)")
+                        sessionManagerLogger.error("Notification permission error: \(error, privacy: .public)")
                     }
                     if granted {
                         self.postNotification(for: session)
@@ -390,7 +428,7 @@ class SessionManager: ObservableObject {
         )
         UNUserNotificationCenter.current().add(request) { error in
             if let error {
-                logger.error("Failed to send notification: \(error, privacy: .public)")
+                sessionManagerLogger.error("Failed to send notification: \(error, privacy: .public)")
             }
         }
     }
@@ -435,29 +473,15 @@ extension SessionManager {
         HostApp.isUUID(stem)
     }
 
-    /// Decode each session file, derive its lifecycle, and capture mtime — the inputs the dedup
-    /// comparator needs. Pure (no published state), kept off the main class body.
-    nonisolated static func buildCandidates(_ jsonFiles: [URL], now: Date) -> [DedupCandidate] {
-        var candidates: [DedupCandidate] = []
-        for url in jsonFiles {
-            guard let data = try? Data(contentsOf: url) else {
-                logger.warning("loadSessions: could not read \(url.lastPathComponent, privacy: .public)")
-                continue
-            }
-            guard var session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data) else {
-                logger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public)")
-                continue
-            }
-            session.lifecycle = SessionLifecyclePolicy.lifecycle(
-                for: session, hostClass: session.hostClass, processAlive: session.isAlive,
-                now: now, windows: lifecycleWindows
-            )
-            let mtime = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
-                .contentModificationDate ?? .distantPast
-            candidates.append(DedupCandidate(session: session, lifecycleRank: session.lifecycle.rawValue,
-                                             mtime: mtime, path: url.path))
+    nonisolated static func desktopAppRunning(
+        for session: Session,
+        lookup: DesktopAppConnectionLookup
+    ) -> Bool? {
+        guard session.hostClass == .desktop,
+              let bundleID = session.terminal?.bundleId else {
+            return nil
         }
-        return candidates
+        return lookup.isRunning(bundleID)
     }
 }
 

--- a/menubar/CctopMenubar/Views/SessionCardView.swift
+++ b/menubar/CctopMenubar/Views/SessionCardView.swift
@@ -22,7 +22,7 @@ struct SessionCardView: View {
         .cardSelectionStyle(
             isSelected: isSelected, isHovered: isHovered, cornerRadius: 0
         )
-        // Dormant = backgrounded (no live process); mute it so live work reads first.
+        // Dormant = desktop host app is not running; mute it so live work reads first.
         .opacity(session.lifecycle == .dormant ? 0.62 : 1.0)
         .contentShape(Rectangle())
         .onHover { isHovered = $0 }

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -1161,6 +1161,42 @@ final class SessionFileFormatTests: XCTestCase {
         manager = nil
     }
 
+    @MainActor
+    func testSessionManagerKeepsEndedDesktopSessionDormantWhenHostAppIsRunning() throws {
+        let root = NSTemporaryDirectory() + "cctop-ended-desktop-running-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+
+        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
+        defer {
+            unsetenv("CCTOP_SESSIONS_DIR")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-ended.json")
+        var session = lifeSession(source: Session.codexSource, agoSeconds: 10_000, disconnectedAgoSeconds: 10_000)
+        session.terminal = TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
+        session.pid = nil
+        let disconnectedAt = Date(timeIntervalSince1970: floor(Date().timeIntervalSince1970) - 60)
+        session.endedAt = disconnectedAt.addingTimeInterval(30)
+        session.disconnectedAt = disconnectedAt
+        try session.writeToFile(path: sessionPath)
+
+        var manager: SessionManager? = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            desktopAppConnectionLookup: DesktopAppConnectionLookup { bundleID in
+                bundleID == HostAppBundleID.codexDesktop
+            }
+        )
+
+        XCTAssertEqual(manager?.sessions.map(\.lifecycle), [.dormant])
+        XCTAssertEqual(try Session.fromFile(path: sessionPath).disconnectedAt, disconnectedAt)
+
+        manager = nil
+    }
+
     func testIdentityPolicyNamesStableGroupingRules() {
         var codex = Session(sessionId: "codex-conversation", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
         codex.source = Session.codexSource
@@ -1266,11 +1302,12 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertEqual(life(session, .desktop, alive: true), .dormant)
     }
 
-    func testLifecycleDesktopAppRunningOverridesEndedAtForDesktopHosts() {
+    func testLifecycleDesktopEndedAtBeatsDesktopAppRunning() {
         var session = lifeSession(agoSeconds: 60, disconnectedAgoSeconds: 30)
         session.terminal = TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
         session.endedAt = Self.lifeNow.addingTimeInterval(-30)
-        XCTAssertEqual(life(session, .desktop, alive: false, desktopAppRunning: true), .active)
+        XCTAssertEqual(connection(session, .desktop, alive: false, desktopAppRunning: true), .disconnected)
+        XCTAssertEqual(life(session, .desktop, alive: false, desktopAppRunning: true), .dormant)
     }
 
     func testLifecycleDesktopAppRunningKeepsStaleCodexSessionActive() {

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -859,7 +859,8 @@ final class SessionFileFormatTests: XCTestCase {
         try session.writeToFile(path: sessionPath)
 
         var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in false }
         )
 
         try writeCodexStateDatabase(path: stateDB, archivedThreads: ["finished-thread"])
@@ -900,7 +901,8 @@ final class SessionFileFormatTests: XCTestCase {
         try session.writeToFile(path: sessionPath)
 
         var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in false }
         )
 
         try writeClaudeDesktopSessionMetadata(
@@ -1032,7 +1034,8 @@ final class SessionFileFormatTests: XCTestCase {
         // DB present but unparseable → lookup returns nil → GC fails safe and keeps the file.
         try Data("not a database".utf8).write(to: URL(fileURLWithPath: stateDB))
         var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in false }
         )
         manager?.garbageCollectFinished()
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
@@ -1074,21 +1077,88 @@ final class SessionFileFormatTests: XCTestCase {
         return session
     }
 
-    private func life(_ session: Session, _ hostClass: SessionHostClass, alive: Bool) -> SessionLifecycle {
+    private func life(
+        _ session: Session,
+        _ hostClass: SessionHostClass,
+        alive: Bool,
+        desktopAppRunning: Bool? = nil
+    ) -> SessionLifecycle {
         SessionLifecyclePolicy.lifecycle(
             for: session,
             hostClass: hostClass,
             processAlive: alive,
             now: Self.lifeNow,
-            windows: LifecycleWindows(active: Self.activeWin, retention: Self.retentionWin)
+            windows: LifecycleWindows(active: Self.activeWin, retention: Self.retentionWin),
+            desktopAppRunning: desktopAppRunning
         )
     }
 
-    private func connection(_ session: Session, _ hostClass: SessionHostClass, alive: Bool) -> SessionConnectionState {
+    private func connection(
+        _ session: Session,
+        _ hostClass: SessionHostClass,
+        alive: Bool,
+        desktopAppRunning: Bool? = nil
+    ) -> SessionConnectionState {
         SessionLifecyclePolicy.connectionState(
             for: session, hostClass: hostClass, processAlive: alive, now: Self.lifeNow,
-            windows: LifecycleWindows(active: Self.activeWin, retention: Self.retentionWin)
+            windows: LifecycleWindows(active: Self.activeWin, retention: Self.retentionWin),
+            desktopAppRunning: desktopAppRunning
         )
+    }
+
+    func testBuildCandidatesKeepsDesktopSessionActiveWhenHostAppIsRunning() throws {
+        let root = NSTemporaryDirectory() + "cctop-running-desktop-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let sessionPath = (root as NSString).appendingPathComponent("codex-stale.json")
+        var session = lifeSession(source: Session.codexSource, agoSeconds: 10_000, disconnectedAgoSeconds: 10_000)
+        session.terminal = TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
+        session.pid = nil
+        try session.writeToFile(path: sessionPath)
+
+        let candidates = SessionManager.buildCandidates(
+            [URL(fileURLWithPath: sessionPath)],
+            now: Self.lifeNow,
+            desktopAppConnectionLookup: DesktopAppConnectionLookup { bundleID in
+                bundleID == HostAppBundleID.codexDesktop
+            }
+        )
+
+        XCTAssertEqual(candidates.map(\.session.lifecycle), [.active])
+    }
+
+    @MainActor
+    func testSessionManagerClearsDisconnectedAtWhenDesktopHostAppIsRunning() throws {
+        let root = NSTemporaryDirectory() + "cctop-desktop-reconnected-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+
+        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
+        defer {
+            unsetenv("CCTOP_SESSIONS_DIR")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-reconnected.json")
+        var session = lifeSession(source: Session.codexSource, agoSeconds: 10_000, disconnectedAgoSeconds: 10_000)
+        session.terminal = TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
+        session.pid = nil
+        try session.writeToFile(path: sessionPath)
+
+        var manager: SessionManager? = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            desktopAppConnectionLookup: DesktopAppConnectionLookup { bundleID in
+                bundleID == HostAppBundleID.codexDesktop
+            }
+        )
+
+        XCTAssertEqual(manager?.sessions.map(\.lifecycle), [.active])
+        XCTAssertNil(try Session.fromFile(path: sessionPath).disconnectedAt)
+
+        manager = nil
     }
 
     func testIdentityPolicyNamesStableGroupingRules() {
@@ -1196,13 +1266,40 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertEqual(life(session, .desktop, alive: true), .dormant)
     }
 
-    // Codex Desktop carve-out: a live SHARED host PID must not keep a stale conversation active.
-    func testLifecycleCodexDesktopIgnoresSharedPidWhenStale() {
+    func testLifecycleDesktopAppRunningOverridesEndedAtForDesktopHosts() {
+        var session = lifeSession(agoSeconds: 60, disconnectedAgoSeconds: 30)
+        session.terminal = TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
+        session.endedAt = Self.lifeNow.addingTimeInterval(-30)
+        XCTAssertEqual(life(session, .desktop, alive: false, desktopAppRunning: true), .active)
+    }
+
+    func testLifecycleDesktopAppRunningKeepsStaleCodexSessionActive() {
+        var session = lifeSession(source: "codex", agoSeconds: 600, disconnectedAgoSeconds: 60)
+        session.terminal = TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
+        XCTAssertEqual(life(session, .desktop, alive: false, desktopAppRunning: true), .active)
+    }
+
+    func testLifecycleDesktopAppStoppedMakesRecentCodexSessionDormant() {
+        var session = lifeSession(source: "codex", agoSeconds: 30, disconnectedAgoSeconds: 60)
+        session.terminal = TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
+        XCTAssertEqual(life(session, .desktop, alive: false, desktopAppRunning: false), .dormant)
+    }
+
+    func testLifecycleDesktopAppSignalDoesNotAffectCodexCliTerminal() {
+        XCTAssertEqual(
+            life(lifeSession(source: "codex", agoSeconds: 30), .terminal, alive: false, desktopAppRunning: true),
+            .finished
+        )
+    }
+
+    // Codex Desktop fallback: without app-level liveness, a live SHARED host PID must not keep a
+    // stale conversation active.
+    func testLifecycleCodexDesktopWithoutAppLivenessFallsBackToRecencyWhenStale() {
         XCTAssertEqual(life(lifeSession(source: "codex", agoSeconds: 600), .desktop, alive: true), .dormant)
     }
 
-    // Codex Desktop active comes from recent activity, even with a dead/irrelevant PID.
-    func testLifecycleCodexDesktopRecentIsActiveDespiteDeadPid() {
+    // Codex Desktop fallback: without app-level liveness, recent activity still keeps the record active.
+    func testLifecycleCodexDesktopWithoutAppLivenessFallsBackToRecentActivity() {
         XCTAssertEqual(life(lifeSession(source: "codex", agoSeconds: 30), .desktop, alive: false), .active)
     }
 
@@ -1218,9 +1315,9 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertEqual(life(lifeSession(source: "codex", agoSeconds: 600), .ambiguous, alive: true), .active)
     }
 
-    // Blocker #2: a Codex Desktop session with source == nil (pre-harness-migration files) must still
-    // get the shared-PID recency carve-out via its trusted bundle id — not fall back to raw PID liveness.
-    func testLifecycleCodexDesktopWithoutSourceUsesRecency() {
+    // Fallback blocker: a Codex Desktop session with source == nil (pre-harness-migration files)
+    // must still get the recency carve-out via its trusted bundle id when app liveness is absent.
+    func testLifecycleCodexDesktopWithoutSourceUsesRecencyFallback() {
         var stale = lifeSession(agoSeconds: 600)   // source nil, stale activity
         stale.terminal = TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
         // A live SHARED host PID must not keep a stale conversation active.


### PR DESCRIPTION
## Summary

- Builds on the already-merged PR #132 so the dormant app-liveness change follows the Claude orphan metadata fix now present on `master`. [PR #132](https://github.com/st0012/cctop/pull/132)
- Adds an injectable desktop app connection lookup that treats trusted desktop-host sessions as connected when their owning bundle is running. [lookup](https://github.com/st0012/cctop/blob/codex/app-level-desktop-dormant/menubar/CctopMenubar/Services/SessionManager%2BArchive.swift), [policy](https://github.com/st0012/cctop/blob/codex/app-level-desktop-dormant/menubar/CctopMenubar/Services/SessionLifecyclePolicy.swift)
- Applies the desktop app liveness signal during display candidate building, disconnected stamping, finished-file cleanup, and stale `disconnected_at` clearing. [manager](https://github.com/st0012/cctop/blob/codex/app-level-desktop-dormant/menubar/CctopMenubar/Services/SessionManager.swift)
- Keeps dormant sessions visually distinct while simplifying the lifecycle diagrams around app-level liveness. [card view](https://github.com/st0012/cctop/blob/codex/app-level-desktop-dormant/menubar/CctopMenubar/Views/SessionCardView.swift), [lifecycle docs](https://github.com/st0012/cctop/blob/codex/app-level-desktop-dormant/docs/session-lifecycle.md)
- Adds lifecycle and manager regressions for app-running, app-stopped, reconnect cleanup, and Codex CLI isolation. [tests](https://github.com/st0012/cctop/blob/codex/app-level-desktop-dormant/menubar/CctopMenubarTests/SessionFileFormatTests.swift)

## Validation Coverage

- The repository pull-request workflow defines SwiftLint and Swift build/test jobs for PR validation. [workflow](https://github.com/st0012/cctop/blob/codex/app-level-desktop-dormant/.github/workflows/ci.yml)
