### PR TITLE
Hide subagent-owned sessions

### DIFF
--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -17,3 +17,13 @@ When `hidden` is `true`, cctop reads the session file but does not show that ses
 Use `hidden` for real session records that should remain on disk for liveness, debugging, or ownership tracking, but should not appear as user-facing work. Current examples include Codex Desktop memory-maintenance sessions and Codex Desktop title-generation helper sessions. Future cases can use the same attribute for background or delegated review sessions, such as Codex sessions summoned by Claude for review.
 
 Do not use file deletion as the hiding signal. Delete a session file only when the session is genuinely obsolete and no longer useful as state.
+
+### `is_subagent`
+
+Type: `boolean`
+
+Default: `false` when omitted.
+
+When `is_subagent` is `true`, the session file represents a delegated subagent's own workspace rather than the user's top-level conversation. cctop marks these records `hidden` and keeps the file on disk. This is distinct from `active_subagents`, which belongs on the parent user-facing session to show how many delegated agents it currently owns.
+
+Clients that can identify subagent-owned sessions should set `is_subagent: true` in their hook payloads. cctop also derives the same marker for Codex sessions whose local thread state reports `thread_source = "subagent"`, so Codex CLI and Codex Desktop subagent threads are hidden even when the hook payload does not include `is_subagent`.

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -22,6 +22,7 @@ flowchart TD
     C --> D{"Visibility filter"}
 
     D -->|"archived desktop session"| E["Hide for this pass<br/>preserve .json"]
+    D -->|"subagent-owned session"| K["Mark hidden<br/>preserve .json"]
     D -->|"Claude orphan startup record"| E
     D -->|"visible record"| F["Deduplicate by stable key"]
 
@@ -97,6 +98,8 @@ CLI sessions do not need `disconnected_at` because disconnected CLI sessions bec
 Session files are deduplicated by a stable identity key before publishing. `SessionIdentityPolicy` owns that grouping rule. Codex sessions use `session_id` across both old PID-keyed files and newer `codex-<session_id>` files. Known desktop sessions also use `session_id`; other terminal or ambiguous sessions keep PID identity.
 
 Archived desktop sessions are filtered from the active/dormant list before dedup and cleanup. cctop does not persist `hidden = true` for this case and does not remove the `.json`, so a later app-level unarchive can make the same session file visible again. The slow GC re-reads desktop archive state at the per-file deletion decision rather than from the pass-level snapshot, so a session archived mid-pass is never reaped out from under a pending unarchive.
+
+Subagent-owned sessions are filtered before dedup and cleanup, then persisted as `hidden = true`. Any client can mark a session file with `is_subagent = true`; Codex sessions also inherit that marker from Codex's local thread database when `thread_source = 'subagent'`. The parent session's `active_subagents` list remains visible, because it describes delegated work owned by the user-facing session rather than making the parent itself a subagent.
 
 Finished terminal or ambiguous sessions that survive dedup are archived to Recent Projects and then removed. Finished non-desktop duplicates that lose dedup are migration debris, so cctop removes their stale `.json` files without archiving them as separate recent sessions.
 

--- a/hook-input.schema.json
+++ b/hook-input.schema.json
@@ -41,6 +41,10 @@
     "is_interrupt":     { "type": "boolean" },
     "agent_id":         { "type": "string" },
     "agent_type":       { "type": "string" },
+    "is_subagent":      {
+      "type": "boolean",
+      "description": "Whether this payload belongs to a subagent-owned session rather than a user-facing session"
+    },
     "source":           { "type": "string", "description": "Tool that created this session (e.g. \"opencode\")" },
     "harness_name":     {
       "type": "string",

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -45,6 +45,7 @@ enum HookHandler {
 
             let (oldStatus, newStatus) = applyTransition(&session, event: event, input: input, branch: branch, terminal: terminal)
             applySideEffects(event: event, session: &session, input: input, sessionsDir: sessionsDir, safeId: safeId)
+            if input.isSubagentSession == true { session.isSubagentSession = true }
             if session.shouldAutoHide { session.hidden = true }
 
             let suffix = newStatus == nil ? " (preserved)" : ""
@@ -375,6 +376,8 @@ extension HookHandler {
             // app and are reaped only by its lock-held GC. The hook must NOT delete them here, or
             // resuming one conversation would reap its dormant same-project siblings.
             guard !isDesktopBundleId(session.terminal?.bundleId) else { return }
+
+            guard !session.hidden, !session.shouldAutoHide else { return }
 
             let isStale: Bool
             if let pid = session.pid {

--- a/menubar/CctopMenubar/Hook/HookInput.swift
+++ b/menubar/CctopMenubar/Hook/HookInput.swift
@@ -19,6 +19,7 @@ struct HookInput: Codable {
     var isInterrupt: Bool?
     var agentId: String?
     var agentType: String?
+    var isSubagentSession: Bool?
     var source: String?
     var harnessName: String?
     var sessionName: String?
@@ -37,6 +38,7 @@ struct HookInput: Codable {
         case isInterrupt = "is_interrupt"
         case agentId = "agent_id"
         case agentType = "agent_type"
+        case isSubagentSession = "is_subagent"
         case source
         case harnessName = "harness_name"
         case sessionName = "session_name"
@@ -59,6 +61,7 @@ struct HookInput: Codable {
         isInterrupt = try container.decodeIfPresent(Bool.self, forKey: .isInterrupt)
         agentId = try container.decodeIfPresent(String.self, forKey: .agentId)
         agentType = try container.decodeIfPresent(String.self, forKey: .agentType)
+        isSubagentSession = try container.decodeIfPresent(Bool.self, forKey: .isSubagentSession)
         source = try container.decodeIfPresent(String.self, forKey: .source)
         harnessName = try container.decodeIfPresent(String.self, forKey: .harnessName)
         sessionName = try container.decodeIfPresent(String.self, forKey: .sessionName)

--- a/menubar/CctopMenubar/Models/Config.swift
+++ b/menubar/CctopMenubar/Models/Config.swift
@@ -107,6 +107,6 @@ extension Session {
     }
 
     var shouldAutoHide: Bool {
-        isCodexMemoryMaintenanceSession || isCodexDesktopTitleGenerationSession
+        isSubagentSession || isCodexMemoryMaintenanceSession || isCodexDesktopTitleGenerationSession
     }
 }

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -180,6 +180,7 @@ struct Session: Codable, Identifiable, Equatable {
     var endedAt: Date?
     var disconnectedAt: Date?
     var activeSubagents: [SubagentInfo]?
+    var isSubagentSession: Bool
     var hidden: Bool
 
     /// Display-only lifecycle, derived on each load. Deliberately NOT in `CodingKeys`, so the
@@ -229,6 +230,7 @@ struct Session: Codable, Identifiable, Equatable {
         case endedAt = "ended_at"
         case disconnectedAt = "disconnected_at"
         case activeSubagents = "active_subagents"
+        case isSubagentSession = "is_subagent"
         case hidden
     }
 
@@ -256,6 +258,7 @@ struct Session: Codable, Identifiable, Equatable {
         endedAt = try container.decodeIfPresent(Date.self, forKey: .endedAt)
         disconnectedAt = try container.decodeIfPresent(Date.self, forKey: .disconnectedAt)
         activeSubagents = try container.decodeIfPresent([SubagentInfo].self, forKey: .activeSubagents)
+        isSubagentSession = try container.decodeIfPresent(Bool.self, forKey: .isSubagentSession) ?? false
         hidden = try container.decodeIfPresent(Bool.self, forKey: .hidden) ?? false
     }
 
@@ -281,6 +284,7 @@ struct Session: Codable, Identifiable, Equatable {
         endedAt: Date? = nil,
         disconnectedAt: Date? = nil,
         activeSubagents: [SubagentInfo]? = nil,
+        isSubagentSession: Bool = false,
         hidden: Bool = false
     ) {
         self.sessionId = sessionId
@@ -303,6 +307,7 @@ struct Session: Codable, Identifiable, Equatable {
         self.endedAt = endedAt
         self.disconnectedAt = disconnectedAt
         self.activeSubagents = activeSubagents
+        self.isSubagentSession = isSubagentSession
         self.hidden = hidden
     }
 
@@ -328,6 +333,7 @@ struct Session: Codable, Identifiable, Equatable {
         self.endedAt = nil
         self.disconnectedAt = nil
         self.activeSubagents = nil
+        self.isSubagentSession = false
         self.hidden = false
     }
 
@@ -394,6 +400,7 @@ struct Session: Codable, Identifiable, Equatable {
             endedAt: endedAt,
             disconnectedAt: disconnectedAt,
             activeSubagents: activeSubagents,
+            isSubagentSession: isSubagentSession,
             hidden: hidden
         )
     }

--- a/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
@@ -13,6 +13,16 @@ struct CodexThreadArchiveLookup {
     /// step). Callers that delete files must treat `nil` as "unknown — keep", never as "not
     /// archived". A missing database returns `[]` (no Codex state ⇒ nothing archived), not `nil`.
     func archivedThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        matchingThreadIDs(matching: threadIDs, whereClause: "archived = 1")
+    }
+
+    /// Returns the subset of `threadIDs` Codex marks as subagent-owned. This is display-only
+    /// metadata, so callers should fail OPEN when the lookup returns `nil`.
+    func subagentThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        matchingThreadIDs(matching: threadIDs, whereClause: "thread_source = 'subagent'")
+    }
+
+    private func matchingThreadIDs(matching threadIDs: Set<String>, whereClause predicate: String) -> Set<String>? {
         guard !threadIDs.isEmpty else { return [] }
         guard FileManager.default.fileExists(atPath: stateDatabasePath) else { return [] }
 
@@ -28,7 +38,7 @@ struct CodexThreadArchiveLookup {
 
         let sortedIDs = threadIDs.sorted()
         let placeholders = Array(repeating: "?", count: sortedIDs.count).joined(separator: ",")
-        let sql = "SELECT id FROM threads WHERE archived = 1 AND id IN (\(placeholders))"
+        let sql = "SELECT id FROM threads WHERE \(predicate) AND id IN (\(placeholders))"
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
               let statement else {

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -13,7 +13,39 @@ struct DesktopAppConnectionLookup {
     }
 }
 
+struct SessionVisibilitySnapshot {
+    let archivedCodexThreadIDs: Set<String>
+    let codexSubagentThreadIDs: Set<String>
+    let archivedClaudeSessionIDs: Set<String>
+    let codexSubagentCandidates: [DedupCandidate]
+    let liveCandidates: [DedupCandidate]
+}
+
 extension SessionManager {
+    nonisolated static func visibilitySnapshot(in candidates: [DedupCandidate]) -> SessionVisibilitySnapshot {
+        let sessions = candidates.map(\.session)
+        let archivedCodexThreadIDs = archivedCodexDesktopThreadIDs(in: sessions)
+        let codexSubagentThreadIDs = codexSubagentThreadIDs(in: sessions)
+        let claudeMetadata = claudeDesktopMetadataSnapshot(in: sessions)
+        let archivedClaudeSessionIDs = claudeMetadata?.archivedSessionIDs ?? []
+        let codexSubagentCandidates = candidates.filter {
+            isCodexSubagentSession($0.session, subagentThreadIDs: codexSubagentThreadIDs)
+        }
+        let liveCandidates = candidates.filter {
+            !isArchivedCodexDesktopSession($0.session, archivedThreadIDs: archivedCodexThreadIDs)
+                && !isCodexSubagentSession($0.session, subagentThreadIDs: codexSubagentThreadIDs)
+                && !isArchivedClaudeDesktopSession($0.session, archivedSessionIDs: archivedClaudeSessionIDs)
+                && !isOrphanedEndedClaudeDesktopSession($0.session, metadataSnapshot: claudeMetadata)
+        }
+        return SessionVisibilitySnapshot(
+            archivedCodexThreadIDs: archivedCodexThreadIDs,
+            codexSubagentThreadIDs: codexSubagentThreadIDs,
+            archivedClaudeSessionIDs: archivedClaudeSessionIDs,
+            codexSubagentCandidates: codexSubagentCandidates,
+            liveCandidates: liveCandidates
+        )
+    }
+
     /// Batch snapshot for the display path. This never deletes files, so unreadable external state
     /// fails OPEN: at worst an archived session shows for one pass.
     nonisolated static func archivedCodexDesktopThreadIDs(in sessions: [Session]) -> Set<String> {
@@ -30,6 +62,69 @@ extension SessionManager {
         archivedThreadIDs: Set<String>
     ) -> Bool {
         session.isCodexDesktopHost && archivedThreadIDs.contains(session.sessionId)
+    }
+
+    /// Codex records whether a thread is user-owned or subagent-owned in its local thread
+    /// database. That signal applies across Codex hosts: Desktop and terminal Codex CLI.
+    nonisolated static func codexSubagentThreadIDs(in sessions: [Session]) -> Set<String> {
+        let threadIDs = Set(
+            sessions
+                .filter { $0.isCodex || $0.isCodexDesktopHost }
+                .map(\.sessionId)
+        )
+        return CodexThreadArchiveLookup().subagentThreadIDs(matching: threadIDs) ?? []
+    }
+
+    nonisolated static func isCodexSubagentSession(
+        _ session: Session,
+        subagentThreadIDs: Set<String>
+    ) -> Bool {
+        (session.isCodex || session.isCodexDesktopHost) && subagentThreadIDs.contains(session.sessionId)
+    }
+
+    /// Fresh single-session check used before persisting a hidden flag for a Codex subagent
+    /// thread. Lookup uncertainty fails OPEN: if we cannot prove it is a subagent, leave it
+    /// visible rather than permanently hiding the file.
+    nonisolated static func codexSubagentHiddenSessionSnapshot(path: String) throws -> Session? {
+        guard FileManager.default.fileExists(atPath: path) else { return nil }
+        var latest = try Session.fromFile(path: path)
+        guard !latest.hidden, latest.isCodex || latest.isCodexDesktopHost else { return nil }
+        guard let subagentIDs = CodexThreadArchiveLookup().subagentThreadIDs(matching: [latest.sessionId]),
+              subagentIDs.contains(latest.sessionId) else {
+            return nil
+        }
+        latest.isSubagentSession = true
+        latest.hidden = true
+        return latest
+    }
+
+    nonisolated static func autoHiddenSessionSnapshot(path: String) throws -> Session? {
+        guard FileManager.default.fileExists(atPath: path) else { return nil }
+        var latest = try Session.fromFile(path: path)
+        guard !latest.hidden, latest.shouldAutoHide else { return nil }
+        latest.hidden = true
+        return latest
+    }
+
+    func hideCodexSubagentSessions(_ candidates: [DedupCandidate]) {
+        for candidate in candidates {
+            sessionManagerLogger.info(
+                "hiding Codex subagent session \(candidate.session.sessionId, privacy: .public)"
+            )
+            do {
+                try withSessionLock(sessionPath: candidate.path) {
+                    guard let hiddenSession = try Self.codexSubagentHiddenSessionSnapshot(path: candidate.path) else {
+                        return
+                    }
+                    try hiddenSession.writeToFile(path: candidate.path)
+                }
+            } catch {
+                let sessionId = candidate.session.sessionId
+                sessionManagerLogger.warning(
+                    "skipping Codex subagent hide for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
     }
 
     /// Batch snapshot for the display path. This mirrors the Codex behavior: archive metadata read

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -67,20 +67,15 @@ class SessionManager: ObservableObject {
         let autoHidden = allDecoded.filter { !$0.session.hidden && $0.session.shouldAutoHide }
         let visibleFiles = allDecoded.filter { !$0.session.hidden && !$0.session.shouldAutoHide }.map(\.url)
         let candidates = Self.buildCandidates(visibleFiles, now: Date(), desktopAppConnectionLookup: desktopAppConnectionLookup)
-        let archivedCodexThreadIDs = Self.archivedCodexDesktopThreadIDs(in: candidates.map(\.session))
-        let claudeMetadata = Self.claudeDesktopMetadataSnapshot(in: candidates.map(\.session))
-        let archivedClaudeSessionIDs = claudeMetadata?.archivedSessionIDs ?? []
-        let liveCandidates = candidates.filter {
-            !Self.isArchivedCodexDesktopSession($0.session, archivedThreadIDs: archivedCodexThreadIDs)
-                && !Self.isArchivedClaudeDesktopSession($0.session, archivedSessionIDs: archivedClaudeSessionIDs)
-                && !Self.isOrphanedEndedClaudeDesktopSession($0.session, metadataSnapshot: claudeMetadata)
-        }
+        let visibility = Self.visibilitySnapshot(in: candidates)
+        let liveCandidates = visibility.liveCandidates
         sessionManagerLogger.info("loadSessions: \(jsonFiles.count) files, \(allDecoded.count) decoded")
         sessionManagerLogger.info(
             "loadSessions: \(liveCandidates.count) visible candidates, \(hidden.count) hidden, \(autoHidden.count) auto-hidden"
         )
-        sessionManagerLogger.info("loadSessions: \(archivedCodexThreadIDs.count) codex-archived")
-        sessionManagerLogger.info("loadSessions: \(archivedClaudeSessionIDs.count) claude-archived")
+        sessionManagerLogger.info("loadSessions: \(visibility.archivedCodexThreadIDs.count) codex-archived")
+        sessionManagerLogger.info("loadSessions: \(visibility.codexSubagentThreadIDs.count) codex-subagent")
+        sessionManagerLogger.info("loadSessions: \(visibility.archivedClaudeSessionIDs.count) claude-archived")
 
         // Publish active + dormant; finished are hidden (swept below / by GC).
         let winners = SessionIdentityPolicy.dedupedCandidatesByStableKey(liveCandidates)
@@ -98,6 +93,7 @@ class SessionManager: ObservableObject {
         }
 
         hideAutoHiddenSessions(autoHidden)
+        hideCodexSubagentSessions(visibility.codexSubagentCandidates)
         clearReconnectedDesktopSessions(liveCandidates, now: Date())
         stampDisconnectedDesktopSessions(liveCandidates, now: Date())
 
@@ -154,6 +150,7 @@ class SessionManager: ObservableObject {
     }
 
     private func autoHideReason(for session: Session) -> String {
+        if session.isSubagentSession { return "subagent-owned" }
         if session.isCodexMemoryMaintenanceSession { return "Codex memory maintenance" }
         if session.isCodexDesktopTitleGenerationSession { return "Codex title generation" }
         return "maintenance"
@@ -482,15 +479,5 @@ extension SessionManager {
             return nil
         }
         return lookup.isRunning(bundleID)
-    }
-}
-
-extension SessionManager {
-    nonisolated static func autoHiddenSessionSnapshot(path: String) throws -> Session? {
-        guard FileManager.default.fileExists(atPath: path) else { return nil }
-        var latest = try Session.fromFile(path: path)
-        guard !latest.hidden, latest.shouldAutoHide else { return nil }
-        latest.hidden = true
-        return latest
     }
 }

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -39,14 +39,17 @@ final class HookHandlerTests: XCTestCase {
     }
 
     private func loadSession() throws -> Session {
+        try Session.fromFile(path: sessionFilePath())
+    }
+
+    private func sessionFilePath() throws -> String {
         let entries = try FileManager.default.contentsOfDirectory(atPath: sessionsDir)
         let jsonFiles = entries.filter { $0.hasSuffix(".json") }
         XCTAssertEqual(
             jsonFiles.count, 1,
             "Expected exactly 1 session file, found \(jsonFiles.count): \(jsonFiles)"
         )
-        let path = (sessionsDir as NSString).appendingPathComponent(jsonFiles[0])
-        return try Session.fromFile(path: path)
+        return (sessionsDir as NSString).appendingPathComponent(jsonFiles[0])
     }
 
     private func sessionFileExists() -> Bool {
@@ -498,6 +501,50 @@ final class HookHandlerTests: XCTestCase {
         """
         try handle(promptJSON, "UserPromptSubmit")
         XCTAssertTrue(try loadSession().hidden)
+    }
+
+    func testHookInputMarkedSubagentWritesHiddenSession() throws {
+        let json = """
+        {
+          "session_id": "delegated-agent-session",
+          "cwd": "/tmp/p",
+          "hook_event_name": "SessionStart",
+          "harness_name": "opencode",
+          "is_subagent": true
+        }
+        """
+        let input = try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
+        try HookHandler.handleHook(hookName: "SessionStart", input: input)
+
+        XCTAssertTrue(try loadSession().hidden)
+    }
+
+    func testProjectCleanupPreservesHookMarkedSubagentSession() throws {
+        let project = "/tmp/cctop-subagent-cleanup-\(UUID().uuidString)"
+        let json = """
+        {
+          "session_id": "delegated-agent-session",
+          "cwd": "\(project)",
+          "hook_event_name": "SessionStart",
+          "harness_name": "opencode",
+          "is_subagent": true
+        }
+        """
+        let input = try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
+        try HookHandler.handleHook(hookName: "SessionStart", input: input)
+
+        let path = try sessionFilePath()
+        var session = try Session.fromFile(path: path)
+        session.pid = 999_999
+        try session.writeToFile(path: path)
+
+        HookHandler.cleanupSessionsForProject(
+            sessionsDir: sessionsDir,
+            projectPath: project,
+            currentPid: UInt32(getpid())
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path))
     }
 
     /// Codex Desktop fires every conversation's hooks from one shared host process, so

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -2,19 +2,30 @@ import XCTest
 @testable import CctopMenubar
 
 final class SessionFileFormatTests: XCTestCase {
-    private func writeCodexStateDatabase(path: String, archivedThreads: Set<String>) throws {
+    private func writeCodexStateDatabase(
+        path: String,
+        archivedThreads: Set<String>,
+        subagentThreads: Set<String> = []
+    ) throws {
         let archivedRows = archivedThreads.map {
             """
-            INSERT INTO threads (id, archived) VALUES ('\($0)', 1);
+            INSERT INTO threads (id, archived, thread_source) VALUES ('\($0)', 1, 'user');
+            """
+        }.joined(separator: "\n")
+        let subagentRows = subagentThreads.map {
+            """
+            INSERT INTO threads (id, archived, thread_source) VALUES ('\($0)', 0, 'subagent');
             """
         }.joined(separator: "\n")
         let sql = """
         DROP TABLE IF EXISTS threads;
         CREATE TABLE threads (
             id TEXT PRIMARY KEY,
-            archived INTEGER NOT NULL DEFAULT 0
+            archived INTEGER NOT NULL DEFAULT 0,
+            thread_source TEXT
         );
         \(archivedRows)
+        \(subagentRows)
         """
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
@@ -26,6 +37,19 @@ final class SessionFileFormatTests: XCTestCase {
         try stdin.fileHandleForWriting.close()
         process.waitUntilExit()
         XCTAssertEqual(process.terminationStatus, 0)
+    }
+
+    private func codexTerminalSession(sessionId: String, projectPath: String) -> Session {
+        var session = Session(
+            sessionId: sessionId,
+            projectPath: projectPath,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh", bundleId: "com.googlecode.iterm2")
+        )
+        session.source = Session.codexSource
+        session.pid = UInt32(ProcessInfo.processInfo.processIdentifier)
+        session.status = .waitingInput
+        return session
     }
 
     private func codexDesktopSession(sessionId: String, projectPath: String) -> Session {
@@ -380,6 +404,146 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertEqual(manager?.sessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: hiddenPath))
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
+
+        manager = nil
+    }
+
+    @MainActor
+    func testSessionManagerHidesGenericSubagentSessionFilesWithoutArchivingOrRemovingThem() throws {
+        let root = NSTemporaryDirectory() + "cctop-generic-subagent-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+
+        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
+        defer {
+            unsetenv("CCTOP_SESSIONS_DIR")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("12345.json")
+        let now = ISO8601DateFormatter().string(from: Date())
+        let json = """
+        {
+          "session_id": "delegated-review",
+          "project_path": "\(root)/projects/cctop",
+          "project_name": "cctop",
+          "branch": "main",
+          "status": "working",
+          "last_activity": "\(now)",
+          "started_at": "\(now)",
+          "terminal": {"program": "zsh"},
+          "pid": \(ProcessInfo.processInfo.processIdentifier),
+          "source": "opencode",
+          "is_subagent": true
+        }
+        """
+        try json.write(toFile: sessionPath, atomically: true, encoding: .utf8)
+        FileManager.default.createFile(atPath: sessionPath + ".lock", contents: nil)
+
+        var manager: SessionManager? = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
+        )
+        manager?.loadSessions()
+
+        XCTAssertEqual(manager?.sessions, [])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath + ".lock"))
+        XCTAssertTrue(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
+
+        manager = nil
+    }
+
+    @MainActor
+    func testSessionManagerHidesCodexSubagentThreadsForAnyCodexHostWithoutRemovingFiles() throws {
+        let root = NSTemporaryDirectory() + "cctop-codex-subagents-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        try writeCodexStateDatabase(
+            path: stateDB,
+            archivedThreads: [],
+            subagentThreads: ["codex-cli-subagent", "codex-desktop-subagent"]
+        )
+
+        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
+        setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
+        defer {
+            unsetenv("CCTOP_SESSIONS_DIR")
+            unsetenv("CCTOP_CODEX_STATE_DB")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        let cliPath = (sessionsDir as NSString).appendingPathComponent("codex-codex-cli-subagent.json")
+        let desktopPath = (sessionsDir as NSString).appendingPathComponent("codex-codex-desktop-subagent.json")
+        try codexTerminalSession(
+            sessionId: "codex-cli-subagent",
+            projectPath: (root as NSString).appendingPathComponent("projects/cctop")
+        ).writeToFile(path: cliPath)
+        try codexDesktopSession(
+            sessionId: "codex-desktop-subagent",
+            projectPath: (root as NSString).appendingPathComponent("projects/cctop")
+        ).writeToFile(path: desktopPath)
+        FileManager.default.createFile(atPath: cliPath + ".lock", contents: nil)
+        FileManager.default.createFile(atPath: desktopPath + ".lock", contents: nil)
+
+        var manager: SessionManager? = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
+        )
+        manager?.loadSessions()
+
+        XCTAssertEqual(manager?.sessions, [])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cliPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: desktopPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cliPath + ".lock"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: desktopPath + ".lock"))
+        XCTAssertTrue(try Session.fromFile(path: cliPath).hidden)
+        XCTAssertTrue(try Session.fromFile(path: desktopPath).hidden)
+        XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
+
+        manager = nil
+    }
+
+    @MainActor
+    func testSessionManagerKeepsParentSessionWithActiveSubagentsVisible() throws {
+        let root = NSTemporaryDirectory() + "cctop-parent-subagents-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        try writeCodexStateDatabase(path: stateDB, archivedThreads: [])
+
+        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
+        setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
+        defer {
+            unsetenv("CCTOP_SESSIONS_DIR")
+            unsetenv("CCTOP_CODEX_STATE_DB")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-parent-thread.json")
+        var session = codexDesktopSession(
+            sessionId: "parent-thread",
+            projectPath: (root as NSString).appendingPathComponent("projects/cctop")
+        )
+        session.activeSubagents = [
+            SubagentInfo(agentId: "agent-1", agentType: "reviewer", startedAt: Date(timeIntervalSince1970: 100))
+        ]
+        try session.writeToFile(path: sessionPath)
+
+        var manager: SessionManager? = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true }
+        )
+        manager?.loadSessions()
+
+        XCTAssertEqual(manager?.sessions.map(\.sessionId), ["parent-thread"])
+        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
 
         manager = nil
     }


### PR DESCRIPTION
## Summary

- Adds a client-neutral `is_subagent` hook/session marker so clients can identify delegated agents' own sessions separately from user-facing parent sessions. [schema](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/hook-input.schema.json), [session model](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/menubar/CctopMenubar/Models/Session.swift), [hook input](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/menubar/CctopMenubar/Hook/HookInput.swift)
- Auto-hides subagent-owned session files while keeping those files on disk for liveness and debugging state. [visibility policy](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/menubar/CctopMenubar/Services/SessionManager%2BArchive.swift), [manager](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/menubar/CctopMenubar/Services/SessionManager.swift), [session docs](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/docs/session-files.md)
- Derives the same subagent marker for Codex CLI and Codex Desktop sessions when Codex's local thread store reports `thread_source = 'subagent'`. [Codex lookup](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift), [visibility policy](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/menubar/CctopMenubar/Services/SessionManager%2BArchive.swift)
- Keeps parent sessions with `active_subagents` visible, so delegated work can still be represented on the parent card. [regression test](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/menubar/CctopMenubarTests/SessionFileFormatTests.swift), [card display](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/menubar/CctopMenubar/Views/SessionCardView.swift)
- Documents the difference between child session ownership and parent-session `active_subagents` display state. [session-file docs](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/docs/session-files.md), [lifecycle docs](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/docs/session-lifecycle.md)
- Adds regressions for generic subagent hiding, Codex subagent hiding across CLI/Desktop hosts, parent-session visibility, and hook payload parsing. [session tests](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/menubar/CctopMenubarTests/SessionFileFormatTests.swift), [hook tests](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/menubar/CctopMenubarTests/HookHandlerTests.swift)

## Validation Coverage

- The repository pull-request workflow defines SwiftLint and Swift build/test jobs for PR validation. [workflow](https://github.com/st0012/cctop/blob/codex/hide-subagent-owned-sessions/.github/workflows/ci.yml)
