### PR TITLE
Detect OpenCode question prompts as permission waits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,8 @@ cctop/
 │   └── skills/cctop-setup/SKILL.md
 ├── plugins/opencode/  # opencode plugin (JS, translates events to cctop-hook calls)
 │   ├── plugin.js      # Event handler, calls cctop-hook binary
-│   └── package.json   # Plugin manifest
+│   ├── package.json   # Plugin manifest and node:test script
+│   └── test/          # node:test coverage for opencode event translation
 ├── plugins/pi/        # pi coding agent extension (TS, translates events to cctop-hook calls)
 │   └── cctop.ts       # Extension entry point, calls cctop-hook binary
 ├── scripts/
@@ -216,7 +217,7 @@ All supported clients use `cctop-hook` as the single entry point for session sta
 # Build both targets (menubar app + cctop-hook CLI)
 make build
 
-# Run all tests
+# Run all tests (OpenCode plugin node:test suite + Swift tests)
 make test
 
 # Lint with swiftlint --strict
@@ -286,6 +287,14 @@ done
 
 The opencode plugin (`plugins/opencode/plugin.js`) is installed via the menubar app when the user clicks "Install Plugin" in Settings > Monitored Tools or via the install banner that appears when opencode is detected (`~/.config/opencode/` exists). The bundled plugin is copied to `~/.config/opencode/plugins/cctop.js`.
 
+Automated plugin tests live under `plugins/opencode/test/` and use Node's built-in `node:test` runner. Run them directly when changing `plugins/opencode/plugin.js`:
+
+```bash
+npm --prefix plugins/opencode test
+```
+
+`make test` runs the opencode plugin tests before the Swift test suite. For hook event mapping changes, also run `make contract`; it verifies the hook schema, fixtures, Swift parser, and plugin hook calls stay in sync.
+
 For local development, you can manually copy your modified plugin to override the installed version:
 
 ```bash
@@ -346,6 +355,9 @@ The opencode plugin (`plugin.js`) translates opencode events to cctop-hook calls
 | session.error | SessionError |
 | session.status (retry) | SessionError |
 | permission.ask | PermissionRequest |
+| question.asked | PermissionRequest |
+| question.replied | PostToolUse |
+| question.rejected | PostToolUse |
 | experimental.session.compacting | PreCompact |
 | session.compacted | PostCompact |
 | session.updated | (stores session_name locally, passed in subsequent calls) |

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ build:
 	cp plugins/codex/hooks.json $(DERIVED)/Build/Products/Debug/CctopMenubar.app/Contents/Resources/codex-hooks.json
 
 test:
+	npm --prefix plugins/opencode test
 	xcodebuild test -project $(PROJECT) -scheme CctopMenubar -configuration Debug -derivedDataPath $(DERIVED) $(SIGN)
 
 lint:

--- a/fixtures/PermissionRequest-opencode-question.json
+++ b/fixtures/PermissionRequest-opencode-question.json
@@ -1,0 +1,8 @@
+{
+  "session_id": "opencode-12345",
+  "cwd": "/tmp/test-project",
+  "hook_event_name": "PermissionRequest",
+  "title": "Which direction should I take?",
+  "harness_name": "opencode",
+  "source": "opencode"
+}

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -478,7 +478,7 @@ struct Session: Codable, Identifiable, Equatable {
         case .waitingPermission:
             return notificationMessage ?? "Permission needed"
         case .waitingInput, .needsAttention:
-            return promptSnippet
+            return notificationMessage ?? promptSnippet
         case .working:
             if let tool = lastTool {
                 return formatToolDisplay(tool: tool, detail: lastToolDetail)

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -189,6 +189,17 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertEqual(session.status, .waitingInput)
     }
 
+    func testOpencodeQuestionPermissionRequestSetsWaitingPermission() throws {
+        try handleFixture("SessionStart-opencode")
+        try handleFixture("UserPromptSubmit-opencode")
+        try handleFixture("PermissionRequest-opencode-question")
+
+        let session = try loadSession()
+        XCTAssertEqual(session.status, .waitingPermission)
+        XCTAssertEqual(session.source, "opencode")
+        XCTAssertEqual(session.notificationMessage, "Which direction should I take?")
+    }
+
     // MARK: - Notification (permission) preserves status
 
     func testNotificationPermissionPreservesStatus() throws {

--- a/menubar/CctopMenubarTests/HookInputTests.swift
+++ b/menubar/CctopMenubarTests/HookInputTests.swift
@@ -95,6 +95,18 @@ final class HookInputTests: XCTestCase {
         XCTAssertEqual(input.message, "Permission needed for Bash")
     }
 
+    func testDecodeOpencodeQuestionPermissionRequest() throws {
+        let input = try JSONDecoder().decode(
+            HookInput.self,
+            from: loadFixture("PermissionRequest-opencode-question")
+        )
+        XCTAssertEqual(input.hookEventName, "PermissionRequest")
+        XCTAssertEqual(input.title, "Which direction should I take?")
+        XCTAssertEqual(input.harnessName, "opencode")
+        XCTAssertEqual(input.source, "opencode")
+        XCTAssertEqual(input.resolvedHarnessName, "opencode")
+    }
+
     // MARK: - SubagentStart
 
     func testDecodeSubagentStart() throws {

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -85,6 +85,23 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.contextLine, "Permission needed")
     }
 
+    func testContextLineWaitingInputPrefersNotificationMessage() {
+        let session = Session.mock(
+            status: .waitingInput,
+            lastPrompt: "Original user prompt",
+            notificationMessage: "Which direction should I take?"
+        )
+        XCTAssertEqual(session.contextLine, "Which direction should I take?")
+    }
+
+    func testContextLineWaitingInputFallsBackToPromptSnippet() {
+        let session = Session.mock(
+            status: .waitingInput,
+            lastPrompt: "Original user prompt"
+        )
+        XCTAssertEqual(session.contextLine, "\"Original user prompt\"")
+    }
+
     func testContextLineCompacting() {
         let session = Session.mock(status: .compacting)
         XCTAssertEqual(session.contextLine, "Compacting context...")

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -2,7 +2,11 @@
   "name": "cctop-opencode",
   "version": "0.16.0",
   "description": "cctop session monitor plugin for opencode",
+  "type": "module",
   "main": "plugin.js",
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
   "license": "MIT",
   "author": "Stan Lo",
   "repository": "https://github.com/st0012/cctop"

--- a/plugins/opencode/plugin.js
+++ b/plugins/opencode/plugin.js
@@ -52,6 +52,17 @@ function normalizeToolInput(args) {
   return result;
 }
 
+function questionMessage(properties) {
+  const first = Array.isArray(properties?.questions) ? properties.questions[0] : null;
+  const question = typeof first?.question === "string" ? first.question.trim() : "";
+  if (question) return question;
+
+  const header = typeof first?.header === "string" ? first.header.trim() : "";
+  if (header) return header;
+
+  return "Waiting for opencode question response";
+}
+
 function callHook(hookBin, eventName, payload) {
   try {
     const json = JSON.stringify({ ...payload, hook_event_name: eventName });
@@ -90,6 +101,18 @@ export const cctop = async ({ directory }) => {
       if (!event || !event.type) return;
 
       switch (event.type) {
+        case "question.asked":
+          callHook(hookBin, "PermissionRequest", {
+            ...basePayload(),
+            title: questionMessage(event.properties),
+          });
+          break;
+
+        case "question.replied":
+        case "question.rejected":
+          callHook(hookBin, "PostToolUse", basePayload());
+          break;
+
         case "session.created":
           callHook(hookBin, "SessionStart", basePayload());
           break;

--- a/plugins/opencode/test/plugin.test.mjs
+++ b/plugins/opencode/test/plugin.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { cctop } from "../plugin.js";
+
+function createHookHome() {
+  const home = mkdtempSync(join(tmpdir(), "cctop-opencode-plugin-"));
+  const hookDir = join(home, ".cctop", "bin");
+  mkdirSync(hookDir, { recursive: true });
+
+  const hookLog = join(home, "hook.log");
+  const hookBin = join(hookDir, "cctop-hook");
+  writeFileSync(
+    hookBin,
+    `#!/bin/sh
+printf '%s\\t' "$1" >> ${JSON.stringify(hookLog)}
+cat >> ${JSON.stringify(hookLog)}
+printf '\\n' >> ${JSON.stringify(hookLog)}
+`,
+  );
+  chmodSync(hookBin, 0o755);
+
+  return { home, hookLog };
+}
+
+async function loadPlugin({ cwd = "/tmp/test-project" } = {}) {
+  const { home, hookLog } = createHookHome();
+  const previousHome = process.env.HOME;
+  process.env.HOME = home;
+
+  const hooks = await cctop({
+    directory: cwd,
+    client: {},
+    project: {},
+    worktree: undefined,
+    serverUrl: "http://localhost:4096",
+    $: undefined,
+  });
+
+  return {
+    hooks,
+    readCalls() {
+      const log = readFileSync(hookLog, "utf8").trim();
+      if (!log) return [];
+
+      return log.split("\n").map((line) => {
+        const [eventName, json] = line.split("\t");
+        return { eventName, payload: JSON.parse(json) };
+      });
+    },
+    restore() {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+    },
+  };
+}
+
+function eventNames(calls) {
+  return calls.map((call) => call.eventName);
+}
+
+test("registers hooks and emits SessionStart on load", async () => {
+  const plugin = await loadPlugin();
+
+  try {
+    assert.equal(typeof plugin.hooks.event, "function");
+    assert.equal(typeof plugin.hooks["chat.message"], "function");
+    assert.equal(typeof plugin.hooks["tool.execute.before"], "function");
+    assert.equal(typeof plugin.hooks["tool.execute.after"], "function");
+    assert.equal(typeof plugin.hooks["permission.ask"], "function");
+    assert.equal(typeof plugin.hooks["experimental.session.compacting"], "function");
+
+    const calls = plugin.readCalls();
+    assert.deepEqual(eventNames(calls), ["SessionStart"]);
+    assert.equal(calls[0].payload.session_id.startsWith("opencode-"), true);
+    assert.equal(calls[0].payload.cwd, "/tmp/test-project");
+    assert.equal(calls[0].payload.harness_name, "opencode");
+    assert.equal(calls[0].payload.source, "opencode");
+  } finally {
+    plugin.restore();
+  }
+});
+
+test("maps opencode plugin callbacks to cctop prompt and tool hooks", async () => {
+  const plugin = await loadPlugin();
+
+  try {
+    await plugin.hooks["chat.message"]({}, { message: { content: "make it so" } });
+    await plugin.hooks["tool.execute.before"]({}, {
+      tool: "read",
+      args: { filePath: "/tmp/test-project/README.md", ignored: true },
+    });
+    await plugin.hooks["tool.execute.after"]();
+    await plugin.hooks["permission.ask"]({
+      tool: "bash",
+      title: "Run command?",
+      args: { command: "make test" },
+    });
+    await plugin.hooks["experimental.session.compacting"]();
+
+    const calls = plugin.readCalls();
+
+    assert.deepEqual(
+      eventNames(calls),
+      [
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PermissionRequest",
+        "PreCompact",
+      ],
+    );
+    assert.equal(calls[1].payload.prompt, "make it so");
+    assert.equal(calls[2].payload.tool_name, "Read");
+    assert.deepEqual(calls[2].payload.tool_input, { file_path: "/tmp/test-project/README.md" });
+    assert.equal(calls[4].payload.tool_name, "Bash");
+    assert.equal(calls[4].payload.title, "Run command?");
+    assert.deepEqual(calls[4].payload.tool_input, { command: "make test" });
+  } finally {
+    plugin.restore();
+  }
+});
+
+test("maps opencode session events to cctop lifecycle hooks", async () => {
+  const plugin = await loadPlugin();
+
+  try {
+    await plugin.hooks.event({
+      event: { type: "session.updated", properties: { info: { title: "opencode session" } } },
+    });
+    await plugin.hooks.event({ event: { type: "session.created" } });
+    await plugin.hooks.event({ event: { type: "session.idle" } });
+    await plugin.hooks.event({ event: { type: "session.compacted" } });
+    await plugin.hooks.event({ event: { type: "session.status", properties: { status: { type: "retry" } } } });
+    await plugin.hooks.event({ event: { type: "session.status", properties: { status: { type: "busy" } } } });
+    await plugin.hooks.event({ event: { type: "session.error", error: { message: "boom" } } });
+    await plugin.hooks.event({ event: { type: "session.deleted" } });
+    await plugin.hooks.event({ event: { type: "permission.replied" } });
+
+    const calls = plugin.readCalls();
+
+    assert.deepEqual(
+      eventNames(calls),
+      ["SessionStart", "SessionStart", "Stop", "PostCompact", "SessionError", "SessionError"],
+    );
+    assert.equal(calls[1].payload.session_name, "opencode session");
+    assert.equal(calls[4].payload.error, "Retry");
+    assert.equal(calls[5].payload.error, "boom");
+  } finally {
+    plugin.restore();
+  }
+});
+
+test("maps opencode question events to cctop permission wait hooks", async () => {
+  const plugin = await loadPlugin();
+
+  try {
+    await plugin.hooks.event({
+      event: {
+        type: "question.asked",
+        properties: {
+          questions: [
+            {
+              header: "Direction",
+              question: "Which direction should I take?",
+              options: [
+                { label: "A", description: "First option" },
+                { label: "B", description: "Second option" },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    await plugin.hooks.event({
+      event: {
+        type: "question.asked",
+        properties: {
+          questions: [{ header: "Fallback", options: [] }],
+        },
+      },
+    });
+    await plugin.hooks.event({ event: { type: "question.replied", properties: { answers: [["A"]] } } });
+    await plugin.hooks.event({ event: { type: "question.rejected", properties: {} } });
+
+    const calls = plugin.readCalls();
+
+    assert.deepEqual(
+      eventNames(calls),
+      ["SessionStart", "PermissionRequest", "PermissionRequest", "PostToolUse", "PostToolUse"],
+    );
+
+    assert.equal(calls[1].payload.title, "Which direction should I take?");
+    assert.equal(calls[1].payload.harness_name, "opencode");
+    assert.equal(calls[1].payload.source, "opencode");
+    assert.equal(calls[1].payload.notification_type, undefined);
+    assert.equal(calls[2].payload.title, "Fallback");
+    assert.equal(calls[3].payload.notification_type, undefined);
+    assert.equal(calls[4].payload.notification_type, undefined);
+  } finally {
+    plugin.restore();
+  }
+});


### PR DESCRIPTION
## Problem

- Fixes #136: OpenCode question/choice prompts can leave a cctop session looking active even though the reported state is blocked on a user response. The issue and follow-up comment identify this as the interactive multiple-choice `question` prompt path, not ordinary output pause. [Issue #136](https://github.com/st0012/cctop/issues/136), [issue comment](https://github.com/st0012/cctop/issues/136#issuecomment-4585883584)
- OpenCode exposes plugin event hooks and its question module emits `question.asked`, `question.replied`, and `question.rejected`, which gives cctop a more specific signal than generic tool execution. [OpenCode plugin docs](https://dev.opencode.ai/docs/plugins/#events), [OpenCode question events](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/question/index.ts#L840-L846)

## Solution

- Translate `question.asked` in the OpenCode plugin to cctop's generic `PermissionRequest` hook with the question text as `title`, and translate `question.replied` / `question.rejected` to `PostToolUse` so the wait state clears after the user responds. [question event cases](https://github.com/st0012/cctop/blob/codex/opencode-question-waiting-input/plugins/opencode/plugin.js#L103-L114), [question message helper](https://github.com/st0012/cctop/blob/codex/opencode-question-waiting-input/plugins/opencode/plugin.js#L55-L64)
- Reuse the existing cctop `PermissionRequest -> waitingPermission` transition instead of adding OpenCode-specific Swift UI checks. [HookEvent transition](https://github.com/st0012/cctop/blob/codex/opencode-question-waiting-input/menubar/CctopMenubar/Models/HookEvent.swift#L46-L53)
- Add a contract fixture, Swift hook/status tests, and package-local OpenCode plugin tests covering startup, prompt/tool callbacks, session events, and question events. [fixture](https://github.com/st0012/cctop/blob/codex/opencode-question-waiting-input/fixtures/PermissionRequest-opencode-question.json), [OpenCode plugin tests](https://github.com/st0012/cctop/blob/codex/opencode-question-waiting-input/plugins/opencode/test/plugin.test.mjs#L67-L209), [plugin test script](https://github.com/st0012/cctop/blob/codex/opencode-question-waiting-input/plugins/opencode/package.json#L5-L9)
- Wire the package-local OpenCode plugin test target into the top-level test command. [Makefile](https://github.com/st0012/cctop/blob/codex/opencode-question-waiting-input/Makefile#L18-L20)

## Verification

- `make lint`
- `make contract`
- `make test`
- `git diff --check`
