### PR TITLE
Ignore leaked desktop bundle IDs for non-desktop sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ This file is the canonical guide for agents helping develop cctop. cctop itself 
 - For wrong source, wrong grouping, stale status, duplicate display, or unexpected dormant/idle behavior, inspect the session JSON before changing display logic.
 - `created_by_hook_version` missing or null on a file that should have been created by hook `0.16.0+` is strong evidence of a pre-metadata or stale hook writer.
 - `last_written_by_hook_version` tells you the latest hook that touched the file, not necessarily the original creator.
+- For explicit non-desktop harnesses such as `opencode` and `pi`, do not classify inherited Claude/Codex Desktop `terminal.bundle_id` values as desktop proof. Treat those bundle IDs as leaked launcher environment unless the harness is desktop-compatible or missing.
 - If hook provenance is current, inspect resolved harness/source, client event delivery/logs, PID/app liveness, and visibility/lifecycle classification as relevant to the symptom.
 - Apply lifecycle and hook fixes consistently across all supported clients unless the problem is explicitly client-specific.
 
@@ -156,8 +157,8 @@ The script uses Chrome headless (auto-detected on macOS, override with `CHROME_B
 | Claude Desktop | Yes | Same Claude plugin hook path, hosted by the Claude Desktop app | `source: "cc"` plus trusted bundle ID `com.anthropic.claudefordesktop`; PID-keyed file; title/archive metadata read from `~/Library/Application Support/Claude/claude-code-sessions` | Desktop app liveness applies unless `ended_at` is set; disconnected sessions stay dormant during retention; archived/orphaned metadata filters visibility; no deep link, so jump-to-session activates the app |
 | Codex CLI | Yes | `~/.codex/hooks.json` → `~/.codex/cctop-shim.sh` → `cctop-hook --harness codex` | `source: "codex"`; session-id-keyed `codex-<session_id>.json` because one host PID can emit multiple conversations | Uses session ID for display/dedup; subagent ownership from `~/.codex/state_5.sqlite` hides subagent-owned sessions |
 | Codex Desktop | Yes | Same Codex hook shim path, hosted by the Codex Desktop app | `source: "codex"` plus trusted bundle ID `com.openai.codex`; session-id-keyed `codex-<session_id>.json`; titles read from `~/.codex/session_index.jsonl` | Desktop app liveness/recency applies unless `ended_at` is set; disconnected sessions stay dormant during retention; archived/subagent-owned threads from `~/.codex/state_5.sqlite` filter visibility; memory/title helper sessions auto-hide; deep links use `codex://threads/<uuid>` |
-| opencode | Yes | JS plugin → `cctop-hook` CLI via `execFileSync` | `source: "opencode"`; PID-keyed `<pid>.json`; installed at `~/.config/opencode/plugins/cctop.js` | Plugin load and `session.created` start tracking; PID liveness decides finished state |
-| pi | Yes | TS extension → `cctop-hook` CLI via `execFileSync` | `source: "pi"`; PID-keyed `<pid>.json`; installed at `~/.pi/agent/extensions/cctop.ts` | Skips non-interactive sessions (`ctx.hasUI === false`); `session_shutdown` sends `SessionEnd`; PID liveness decides finished state |
+| opencode | Yes | JS plugin → `cctop-hook` CLI via `execFileSync` | `source: "opencode"`; PID-keyed `<pid>.json`; installed at `~/.config/opencode/plugins/cctop.js`; explicit source wins over inherited Claude/Codex Desktop bundle IDs | Plugin load and `session.created` start tracking; PID liveness decides finished state |
+| pi | Yes | TS extension → `cctop-hook` CLI via `execFileSync` | `source: "pi"`; PID-keyed `<pid>.json`; installed at `~/.pi/agent/extensions/cctop.ts`; explicit source wins over inherited Claude/Codex Desktop bundle IDs | Skips non-interactive sessions (`ctx.hasUI === false`); `session_shutdown` sends `SessionEnd`; PID liveness decides finished state |
 | Aider | No | — | — | — |
 | Goose | No | — | — | — |
 | Amp | No | — | — | — |
@@ -473,6 +474,7 @@ cat ~/.cctop/sessions/<session-file>.json \
 - `created_by_hook_version == null` or missing means the file was probably created by a pre-metadata/outdated hook. Check whether `~/.cctop/bin/cctop-hook` points at the current app-bundled hook and whether the app launch repair path ran.
 - `created_by_hook_version` missing but `last_written_by_hook_version` current means a legacy file was later updated by a current hook; do not infer the original writer.
 - Both fields current means the hook writer is probably not stale; inspect resolved harness/source, client event delivery/logs, PID/app liveness, and visibility/lifecycle classification as relevant to the symptom.
+- If `source` is `opencode` or `pi` but `terminal.bundle_id` is `com.openai.codex` or `com.anthropic.claudefordesktop`, keep the opencode/pi identity and debug plugin process lifecycle. Those explicit non-desktop harnesses can inherit GUI bundle IDs from the launching environment.
 
 ### Quick Commands
 

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -359,7 +359,7 @@ extension HookHandler {
             if var session = try? Session.fromFile(path: path) {
                 let endedAt = Date()
                 session.endedAt = endedAt
-                if isDesktopBundleId(session.terminal?.bundleId) {
+                if hasTrustedDesktopBundle(session, sourceOverride: input.resolvedHarnessName) {
                     session.disconnectedAt = session.disconnectedAt ?? endedAt
                 }
                 session.markWrittenByHook(version: Config.hookVersion, isNewSessionFile: false)
@@ -379,7 +379,7 @@ extension HookHandler {
             // Desktop-app conversations survive host-app restarts as dormant cards in the menubar
             // app and are reaped only by its lock-held GC. The hook must NOT delete them here, or
             // resuming one conversation would reap its dormant same-project siblings.
-            guard !isDesktopBundleId(session.terminal?.bundleId) else { return }
+            guard !hasTrustedDesktopBundle(session) else { return }
 
             guard !session.hidden, !session.shouldAutoHide else { return }
 
@@ -407,6 +407,12 @@ extension HookHandler {
 
     private static func isDesktopBundleId(_ bundleId: String?) -> Bool {
         bundleId == HostAppBundleID.claudeDesktop || bundleId == HostAppBundleID.codexDesktop
+    }
+
+    private static func hasTrustedDesktopBundle(_ session: Session, sourceOverride: String? = nil) -> Bool {
+        let source = session.source ?? sourceOverride
+        guard !Session.isExplicitNonDesktopHarness(source) else { return false }
+        return isDesktopBundleId(session.terminal?.bundleId)
     }
 
     private static func forEachSession(in dir: String, body: (String, Session) -> Void) {

--- a/menubar/CctopMenubar/Models/AgentBadge.swift
+++ b/menubar/CctopMenubar/Models/AgentBadge.swift
@@ -35,16 +35,11 @@ enum AgentBadge: Equatable {
 extension Session {
     /// Classify the session's source + host app into one of six badge kinds.
     ///
-    /// The bundle ID is the most authoritative signal — it tells us exactly
-    /// which Desktop app is hosting the session. We check it first so a
-    /// Codex Desktop session whose `harness_name` field is missing (e.g. the
-    /// shim didn't pass `--harness codex`, or the hook fired before the
-    /// harness was established) still classifies as `.codexDesktop` instead
-    /// of falling into the `.claudeDesktop` default. The `source` string is
-    /// only consulted for non-Desktop sessions.
+    /// A trusted Desktop bundle ID wins so pre-harness Desktop records still classify correctly.
+    /// Explicit non-desktop harnesses keep their harness badge even if a GUI bundle ID leaked
+    /// through the environment.
     var agentBadge: AgentBadge {
-        // Desktop bundle ID wins — it's the most authoritative signal.
-        switch HostApp.from(bundleIdentifier: terminal?.bundleId) {
+        switch SessionIdentityPolicy.trustedHostApp(for: self) {
         case .claudeDesktop: return .claudeDesktop
         case .codexDesktop: return .codexDesktop
         default: break

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -135,21 +135,19 @@ extension Session {
     /// rather than a terminal/editor. These sessions have no project folder worth reopening,
     /// so they're excluded from Recent Projects.
     var isHostedByDesktopApp: Bool {
-        guard let bundleId = terminal?.bundleId else { return false }
-        return HostApp.from(bundleIdentifier: bundleId)?.isDesktopApp == true
+        SessionIdentityPolicy.trustedHostApp(for: self)?.isDesktopApp == true
     }
 
-    /// True when the session is hosted by the Codex Desktop app, by trusted bundle id alone —
-    /// independent of `source`, which may be nil for pre-harness-migration files. This is the
-    /// authoritative "is this a Codex Desktop session" signal for archive filtering and the
-    /// shared-PID recency lifecycle carve-out.
+    /// True when the session is hosted by the Codex Desktop app, after validating the bundle ID
+    /// against the resolved harness. Nil-source legacy files may still use the bundle alone.
     var isCodexDesktopHost: Bool {
-        HostApp.from(bundleIdentifier: terminal?.bundleId) == .codexDesktop
+        SessionIdentityPolicy.trustedHostApp(for: self) == .codexDesktop
     }
 
-    /// True when the session is hosted by the Claude Desktop app, by trusted bundle id alone.
+    /// True when the session is hosted by the Claude Desktop app, after validating the bundle ID
+    /// against the resolved harness. Nil-source legacy files may still use the bundle alone.
     var isClaudeDesktopHost: Bool {
-        HostApp.from(bundleIdentifier: terminal?.bundleId) == .claudeDesktop
+        SessionIdentityPolicy.trustedHostApp(for: self) == .claudeDesktop
     }
 }
 

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -194,8 +194,17 @@ struct Session: Codable, Identifiable, Equatable {
 
     /// Harness id Codex reports (CLI and Desktop both pass `--harness codex`).
     static let codexSource = "codex"
+    static let opencodeSource = "opencode"
+    static let piSource = "pi"
 
     var isCodex: Bool { source == Self.codexSource }
+
+    /// Harnesses that never run inside Claude Desktop or Codex Desktop. Their
+    /// subprocesses can inherit GUI bundle IDs from a launcher environment, so
+    /// those desktop bundle IDs are not trusted for identity or lifecycle.
+    static func isExplicitNonDesktopHarness(_ source: String?) -> Bool {
+        source == Self.opencodeSource || source == Self.piSource
+    }
 
     // Codex multiplexes many conversations onto one host process, so the PID is not unique
     // per conversation — identify Codex sessions by session_id (matching their codex-<id>

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -31,9 +31,10 @@ func resolveFocusStrategy(session: Session) -> FocusStrategy {
         return .openInFinder(session.projectPath)
     }
 
-    // Prefer bundle_id (from __CFBundleIdentifier) over program name — it
-    // unambiguously identifies VS Code forks that all set TERM_PROGRAM=vscode.
-    let hostApp = HostApp.from(bundleIdentifier: terminal.bundleId)
+    // Prefer trusted bundle_id (from __CFBundleIdentifier) over program name: it
+    // identifies VS Code forks that all set TERM_PROGRAM=vscode. Explicit non-desktop
+    // harnesses ignore leaked AI desktop bundle IDs before this fallback.
+    let hostApp = SessionIdentityPolicy.trustedHostApp(for: session)
         ?? HostApp.from(editorName: terminal.program)
     let target = session.workspaceFile ?? session.projectPath
 

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -1,10 +1,22 @@
 import Foundation
 
 enum SessionIdentityPolicy {
-    /// File-local host classification. Deliberately strict: `source` never classifies desktop
+    /// GUI environments can leak `__CFBundleIdentifier` into child tools; an explicit
+    /// non-desktop harness must not become "Codex Desktop" or "Claude Desktop" because
+    /// of inherited env. Other sources keep the previous bundle-first behavior, including
+    /// nil-source legacy desktop records.
+    static func trustedHostApp(for session: Session) -> HostApp? {
+        guard let app = HostApp.from(bundleIdentifier: session.terminal?.bundleId) else { return nil }
+        if app.isDesktopApp && Session.isExplicitNonDesktopHarness(session.source) {
+            return nil
+        }
+        return app
+    }
+
+    /// File-local host classification. Deliberately strict: source alone never classifies desktop
     /// vs CLI because both integrations share source strings with their desktop counterparts.
     static func hostClass(for session: Session) -> SessionHostClass {
-        if let app = HostApp.from(bundleIdentifier: session.terminal?.bundleId) {
+        if let app = trustedHostApp(for: session) {
             return app.isDesktopApp ? .desktop : .terminal
         }
         if session.terminal?.multiplexer != nil { return .terminal }

--- a/menubar/CctopMenubarTests/AgentBadgeTests.swift
+++ b/menubar/CctopMenubarTests/AgentBadgeTests.swift
@@ -85,8 +85,24 @@ final class AgentBadgeTests: XCTestCase {
         XCTAssertEqual(session.agentBadge, .opencode)
     }
 
+    func testOpencodeSource_ignoresLeakedCodexDesktopBundle() {
+        let session = Session.mock(
+            terminal: TerminalInfo(bundleId: "com.openai.codex"),
+            source: "opencode"
+        )
+        XCTAssertEqual(session.agentBadge, .opencode)
+    }
+
     func testPiSource_returnsPi() {
         let session = Session.mock(source: "pi")
+        XCTAssertEqual(session.agentBadge, .pi)
+    }
+
+    func testPiSource_ignoresLeakedClaudeDesktopBundle() {
+        let session = Session.mock(
+            terminal: TerminalInfo(bundleId: "com.anthropic.claudefordesktop"),
+            source: "pi"
+        )
         XCTAssertEqual(session.agentBadge, .pi)
     }
 

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -269,6 +269,18 @@ final class FocusStrategyTests: XCTestCase {
         XCTAssertEqual(strategy, .activateByBundleID(bundleID))
     }
 
+    func testOpencodeIgnoresLeakedCodexDesktopBundleForFocus() {
+        var session = makeSession(
+            program: "", bundleId: HostApp.codexDesktop.bundleID!,
+            sessionUuid: "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
+        )
+        session.source = "opencode"
+
+        let strategy = resolveFocusStrategy(session: session)
+
+        XCTAssertEqual(strategy, .openInFinder(projectPath))
+    }
+
     // MARK: - No terminal info falls back to Finder
 
     func testNoTerminalInfoOpensInFinder() {

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -288,6 +288,23 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertNotNil(session.disconnectedAt)
     }
 
+    func testOpencodeSessionEndIgnoresLeakedCodexDesktopBundle() throws {
+        setenv("__CFBundleIdentifier", HostAppBundleID.codexDesktop, 1)
+        defer { unsetenv("__CFBundleIdentifier") }
+
+        try handleFixture("SessionStart-opencode")
+        XCTAssertEqual(try loadSession().source, "opencode")
+        XCTAssertNil(try loadSession().disconnectedAt)
+
+        try handleHook("""
+        {"session_id":"opencode-12345","cwd":"/tmp/test-project","hook_event_name":"SessionEnd","harness_name":"opencode"}
+        """, hookName: "SessionEnd")
+
+        let session = try loadSession()
+        XCTAssertNotNil(session.endedAt)
+        XCTAssertNil(session.disconnectedAt)
+    }
+
     func testSessionStartClearsEndedAndDisconnectedAt() throws {
         setenv("__CFBundleIdentifier", HostAppBundleID.claudeDesktop, 1)
         defer { unsetenv("__CFBundleIdentifier") }
@@ -595,6 +612,34 @@ final class HookHandlerTests: XCTestCase {
         )
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: path))
+    }
+
+    func testProjectCleanupRemovesStaleOpencodeWithLeakedCodexDesktopBundle() throws {
+        let project = "/tmp/cctop-opencode-cleanup-\(UUID().uuidString)"
+        setenv("__CFBundleIdentifier", HostAppBundleID.codexDesktop, 1)
+        defer { unsetenv("__CFBundleIdentifier") }
+
+        try handleHook("""
+        {
+          "session_id": "opencode-stale",
+          "cwd": "\(project)",
+          "hook_event_name": "SessionStart",
+          "harness_name": "opencode"
+        }
+        """, hookName: "SessionStart")
+
+        let path = try sessionFilePath()
+        var session = try Session.fromFile(path: path)
+        session.pid = 999_999
+        try session.writeToFile(path: path)
+
+        HookHandler.cleanupSessionsForProject(
+            sessionsDir: sessionsDir,
+            projectPath: project,
+            currentPid: UInt32(getpid())
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: path))
     }
 
     /// Codex Desktop fires every conversation's hooks from one shared host process, so

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -975,6 +975,26 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertFalse(SessionManager.isCodexDesktopThreadArchived(terminalSession))
     }
 
+    func testIsCodexDesktopThreadArchivedIgnoresOpencodeWithLeakedCodexDesktopBundle() throws {
+        let root = NSTemporaryDirectory() + "cctop-codex-archived-opencode-\(UUID().uuidString)"
+        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
+        try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
+        try writeCodexStateDatabase(path: stateDB, archivedThreads: ["opencode-39189"])
+        setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
+        defer {
+            unsetenv("CCTOP_CODEX_STATE_DB")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        var session = Session(
+            sessionId: "opencode-39189", projectPath: "/tmp/p", branch: "main",
+            terminal: TerminalInfo(bundleId: "com.openai.codex")
+        )
+        session.source = "opencode"
+
+        XCTAssertFalse(SessionManager.isCodexDesktopThreadArchived(session))
+    }
+
     // The Claude archive check is also gated on the Claude Desktop bundle ID. A terminal Claude
     // Code session sharing an archived Desktop cliSessionId must stay on the normal lifecycle path.
     func testIsClaudeDesktopSessionArchivedIgnoresNonClaudeDesktopHosts() throws {

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -451,6 +451,26 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.hostClass, .desktop)
     }
 
+    func testHostClassOpencodeIgnoresLeakedCodexDesktopBundle() {
+        let session = Session.mock(
+            terminal: TerminalInfo(bundleId: "com.openai.codex"),
+            source: "opencode"
+        )
+        XCTAssertEqual(session.hostClass, .ambiguous)
+        XCTAssertFalse(session.isHostedByDesktopApp)
+        XCTAssertFalse(session.isCodexDesktopHost)
+    }
+
+    func testHostClassPiIgnoresLeakedClaudeDesktopBundle() {
+        let session = Session.mock(
+            terminal: TerminalInfo(bundleId: "com.anthropic.claudefordesktop"),
+            source: "pi"
+        )
+        XCTAssertEqual(session.hostClass, .ambiguous)
+        XCTAssertFalse(session.isHostedByDesktopApp)
+        XCTAssertFalse(session.isClaudeDesktopHost)
+    }
+
     func testHostClassITerm2IsTerminal() {
         let session = Session.mock(terminal: TerminalInfo(bundleId: "com.googlecode.iterm2"))
         XCTAssertEqual(session.hostClass, .terminal)


### PR DESCRIPTION
## Problem

- `opencode` and `pi` sessions are explicit non-desktop harnesses: their integrations send `harness_name`/`source` values for `opencode` and `pi`, and opencode also fires `SessionStart` on plugin load. [opencode plugin](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/plugins/opencode/plugin.js#L83-L97), [pi extension](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/plugins/pi/cctop.ts#L79-L90)
- The regression shape is an explicit `opencode` or `pi` source paired with an inherited Claude/Codex Desktop bundle ID; the new tests cover badge, host class, focus, SessionEnd, cleanup, and Codex archive gating for that mixed identity. [badge test](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/menubar/CctopMenubarTests/AgentBadgeTests.swift#L88-L94), [host class tests](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/menubar/CctopMenubarTests/SessionTests.swift#L454-L472), [focus test](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/menubar/CctopMenubarTests/FocusStrategyTests.swift#L272-L282), [hook tests](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/menubar/CctopMenubarTests/HookHandlerTests.swift#L291-L306), [cleanup test](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/menubar/CctopMenubarTests/HookHandlerTests.swift#L622-L642), [archive test](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/menubar/CctopMenubarTests/SessionFileFormatTests.swift#L978-L994)

## Solution

- Add a shared explicit non-desktop harness predicate for `opencode` and `pi`, then centralize trusted host-app resolution so leaked desktop bundle IDs are ignored only for those harnesses while legacy desktop-compatible records keep the existing bundle-first behavior. [Session source constants](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/menubar/CctopMenubar/Models/Session.swift#L195-L207), [identity policy](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift#L3-L24)
- Route UI badge identity, desktop-host helpers, and focus resolution through trusted host-app classification so explicit non-desktop harnesses keep their harness identity and do not deep-link into Codex Desktop. [badge routing](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/menubar/CctopMenubar/Models/AgentBadge.swift#L36-L54), [desktop host helpers](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/menubar/CctopMenubar/Models/HostApp.swift#L133-L150), [focus routing](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/menubar/CctopMenubar/Services/FocusTerminal.swift#L29-L39)
- Route hook-side SessionEnd and stale project cleanup through the same trusted desktop check, so leaked desktop bundle IDs do not stamp `disconnected_at` or preserve stale opencode/pi files as desktop sessions. [HookHandler SessionEnd and cleanup](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/menubar/CctopMenubar/Hook/HookHandler.swift#L352-L416)
- Update agent guidance to document that explicit `opencode`/`pi` sources win over inherited Claude/Codex Desktop bundle IDs during future session identity debugging. [debugging rule](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/AGENTS.md#L36-L40), [integration table](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/AGENTS.md#L154-L161), [diagnosis note](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/AGENTS.md#L469-L477)

## Verification

- `git diff --cached --check`
- `make test` locally; the target runs opencode plugin tests and the Swift/Xcode test suite. [Makefile test target](https://github.com/st0012/cctop/blob/6030376587a1170446f9b6f5994a6f3b2d512d58/Makefile#L18-L20)
