### PR TITLE
Clarify desktop onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Works with your existing editor, terminal, and workflow.
 
 | Tool | Status | How it connects |
 |------|--------|-----------------|
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Supported | Shell hooks → `cctop-hook` CLI |
+| [Claude Code / Claude Desktop](https://docs.anthropic.com/en/docs/claude-code) | Supported | Shell hooks → `cctop-hook` CLI |
 | [opencode](https://opencode.ai) | Supported | JS plugin → `cctop-hook` CLI |
 | [pi](https://github.com/badlogic/pi-mono) | Supported | TS extension → `cctop-hook` CLI |
-| [Codex CLI](https://github.com/openai/codex) | Supported | Shell hooks → `cctop-hook` CLI |
+| [Codex CLI / Codex Desktop](https://github.com/openai/codex) | Supported | Shell hooks → `cctop-hook` CLI |
 
 ### Supported Editors & Terminals
 
@@ -113,9 +113,9 @@ brew install --cask st0012/cctop/cctop
 
 ### Step 2: Connect your tools
 
-The app auto-detects installed coding tools. For **opencode**, **pi**, and **Codex CLI**, click *Install Plugin* in Settings > Monitored Tools.
+The app auto-detects installed coding tools. For **opencode** and **pi**, click *Install Plugin* in Settings > Monitored Tools. For **Codex CLI or Codex Desktop**, click *Install Hooks*.
 
-For **Claude Code**, run this one-liner in your terminal (the app also exposes a *Copy Install Command* button under Settings > Monitored Tools):
+For **Claude Code or Claude Desktop**, run this one-liner in your terminal (the app also exposes a *Copy Install Command* button under Settings > Monitored Tools):
 
 ```bash
 claude plugin marketplace add st0012/cctop && claude plugin install cctop
@@ -187,7 +187,7 @@ cctop releases up to and including v0.15.2 shipped an appcast that confused Spar
 # Remove the menubar app
 rm -rf /Applications/cctop.app
 
-# Remove the Claude Code plugin
+# Remove the Claude Code / Claude Desktop plugin
 claude plugin remove cctop
 claude plugin marketplace remove cctop
 
@@ -197,7 +197,7 @@ rm ~/.config/opencode/plugins/cctop.js
 # Remove the pi extension
 rm ~/.pi/agent/extensions/cctop.ts
 
-# Remove the Codex CLI plugin
+# Remove the Codex CLI / Codex Desktop hooks
 rm ~/.codex/cctop-shim.sh
 # Then remove cctop entries from ~/.codex/hooks.json (or delete it if cctop was the only user)
 
@@ -214,8 +214,8 @@ All tools go through `cctop-hook` — a single native binary that manages all se
 
 ```
 ┌─────────────┐    hook fires     ┌────────────┐
-│ Claude Code │ ────────────────> │ cctop-hook │ ──┐
-│             │  SessionStart,    │  (Swift)   │   │
+│Claude Code /│ ────────────────> │ cctop-hook │ ──┐
+│  Desktop    │  SessionStart,    │  (Swift)   │   │
 └─────────────┘  Stop, PreTool,…  └────────────┘   │
                                        ▲           │  writes JSON
 ┌─────────────┐   plugin event    ┌────┴───────┐   │  per-session

--- a/menubar/CctopMenubar/Services/CodexPluginInstaller.swift
+++ b/menubar/CctopMenubar/Services/CodexPluginInstaller.swift
@@ -3,7 +3,7 @@ import os.log
 
 private let logger = Logger(subsystem: "com.st0012.CctopMenubar", category: "CodexPluginInstaller")
 
-/// Installs, updates, and removes cctop's Codex CLI hook entries.
+/// Installs, updates, and removes cctop's Codex hook entries.
 /// Installs a shim to `~/.codex/cctop-shim.sh`, merges 5 hook entries into
 /// `~/.codex/hooks.json` (preserving user hooks), and patches
 /// `~/.codex/config.toml` only when needed — Codex defaults `[features].hooks`

--- a/menubar/CctopMenubar/Services/PluginManager.swift
+++ b/menubar/CctopMenubar/Services/PluginManager.swift
@@ -14,7 +14,6 @@ class PluginManager: ObservableObject {
     @Published var codexInstalled: Bool = false
     @Published var codexNeedsUpdate: Bool = false
     @Published var codexConfigExists: Bool = false
-    @Published var codexFlagAlreadyEnabled: Bool = false
 
     static let ccInstallCommand =
         "claude plugin marketplace add st0012/cctop && claude plugin install cctop"
@@ -60,8 +59,6 @@ class PluginManager: ObservableObject {
 
         codexNeedsUpdate = codexInstalled
             && Self.codexInstallStale(configText: codexConfigText)
-        codexFlagAlreadyEnabled = codexConfigText
-            .map(CodexPluginInstaller.isFeatureFlagEnabled) ?? false
     }
 
     /// Cache layout is `<marketplace>/<plugin>/<version>/`. Claude Code writes a `.orphaned_at`
@@ -92,9 +89,7 @@ class PluginManager: ObservableObject {
     /// installed one OR the supplied config.toml content still contains the
     /// deprecated `[features].codex_hooks` key. The install action handles
     /// both: it rewrites the shim and migrates the TOML key in one click.
-    /// Takes the config text as a parameter so callers can dedupe the disk
-    /// read with their own (e.g. `refresh()` reads the file once for the
-    /// `codexFlagAlreadyEnabled` check too).
+    /// Takes the config text as a parameter so callers can dedupe the disk read.
     private static func codexInstallStale(configText: String?) -> Bool {
         if let data = loadBundledResource(name: "codex-shim", ext: "sh"),
            CodexPluginInstaller.needsUpdate(bundledShim: data) {

--- a/menubar/CctopMenubar/Views/EmptyStateView.swift
+++ b/menubar/CctopMenubar/Views/EmptyStateView.swift
@@ -1,18 +1,14 @@
 import SwiftUI
 
 /// First-run / no-sessions view. Shows a small branded hero and a single
-/// install card that always lists every supported agent — Claude Code,
-/// opencode, pi, Codex CLI — with its identity color and current state.
+/// install card that always lists every supported agent — Claude Code/Desktop,
+/// opencode, pi, Codex CLI/Desktop — with its identity color and current state.
 /// Agents not detected on this machine render with a muted "Not detected"
 /// trailing label so users always see the full set of supported tools.
 struct EmptyStateView: View {
     @ObservedObject var pluginManager: PluginManager
     @State private var justInstalled: Set<AgentKind> = []
     @State private var failedAgent: AgentKind?
-    @State private var showCodexFlagAlert = false
-    private static let codexFlagWarning =
-        "Codex CLI requires the codex_hooks feature flag, which is "
-        + "experimental. Codex will show a startup warning."
 
     var body: some View {
         VStack(spacing: 14) {
@@ -26,12 +22,6 @@ struct EmptyStateView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 18)
         .frame(maxWidth: .infinity)
-        .alert("Enable experimental feature?", isPresented: $showCodexFlagAlert) {
-            Button("Cancel", role: .cancel) { }
-            Button("Enable & Install") { performCodexInstall() }
-        } message: {
-            Text(Self.codexFlagWarning)
-        }
     }
 
     // MARK: - Hero
@@ -72,7 +62,7 @@ struct EmptyStateView: View {
         if allConnected {
             return "Start a session \u{2014} it will appear here automatically."
         }
-        return "Install the plugin for your AI tool to see live status here."
+        return "Install the plugin or hooks for your AI tool to see live status here."
     }
 
     // MARK: - Agent card
@@ -221,19 +211,9 @@ struct EmptyStateView: View {
         case .pi:
             success = pluginManager.installPiPlugin()
         case .codex:
-            if pluginManager.codexFlagAlreadyEnabled {
-                success = pluginManager.installCodexPlugin()
-            } else {
-                showCodexFlagAlert = true
-                return
-            }
+            success = pluginManager.installCodexPlugin()
         }
         handleInstallResult(agent: agent, success: success)
-    }
-
-    private func performCodexInstall() {
-        let success = pluginManager.installCodexPlugin()
-        handleInstallResult(agent: .codex, success: success)
     }
 
     private func handleInstallResult(agent: AgentKind, success: Bool) {
@@ -297,10 +277,10 @@ private enum AgentKind: String, CaseIterable, Hashable {
 
     var displayName: String {
         switch self {
-        case .claudeCode: return "Claude Code"
+        case .claudeCode: return "Claude Code / Desktop"
         case .opencode:   return "opencode"
         case .pi:         return "pi"
-        case .codex:      return "Codex CLI"
+        case .codex:      return "Codex CLI / Desktop"
         }
     }
 

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -278,6 +278,7 @@ private struct MonitoredToolsView: View {
 
 private struct PluginRowView: View {
     let name: String; let installed: Bool; var needsUpdate: Bool = false
+    var installLabel = "Install Plugin"; var updateLabel = "Update Plugin"
     @Binding var installFailed: Bool
     let install: () -> Bool; let remove: () -> Bool
     @State private var justInstalled = false; @State private var removeHovered = false
@@ -313,8 +314,8 @@ private struct PluginRowView: View {
         }
     }
 
-    private var updateButton: some View { actionButton("Update Plugin") }
-    private var installButton: some View { actionButton("Install Plugin") }
+    private var updateButton: some View { actionButton(updateLabel) }
+    private var installButton: some View { actionButton(installLabel) }
 
     private func actionButton(_ label: String) -> some View {
         Button {
@@ -343,7 +344,7 @@ private struct ClaudeCodePluginRowView: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            Text("Claude Code")
+            Text("Claude Code / Desktop")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(Color.textPrimary)
             Spacer()
@@ -409,33 +410,14 @@ struct ClaudeCodeInstallButton: View {
 private struct CodexPluginRowView: View {
     @ObservedObject var pluginManager: PluginManager
     @Binding var installFailed: Bool
-    @State private var showFlagAlert = false
-    private static let flagWarning = "Codex CLI requires the codex_hooks feature flag, "
-        + "which is experimental. Codex will show a startup warning."
     var body: some View {
         PluginRowView(
-            name: "Codex CLI", installed: pluginManager.codexInstalled,
-            needsUpdate: pluginManager.codexNeedsUpdate, installFailed: $installFailed,
-            install: { onInstall() }, remove: { pluginManager.removeCodexPlugin() })
-        .alert("Enable experimental feature?", isPresented: $showFlagAlert) {
-            Button("Cancel", role: .cancel) { }
-            Button("Enable & Install") { doInstall() }
-        } message: { Text(Self.flagWarning) }
-    }
-    private func onInstall() -> Bool {
-        if pluginManager.codexFlagAlreadyEnabled { return pluginManager.installCodexPlugin() }
-        showFlagAlert = true
-        // PluginRowView interprets false as failure and flashes an error banner.
-        // Suppress it on the next run loop so it never renders.
-        DispatchQueue.main.async { installFailed = false }
-        return false
-    }
-    private func doInstall() {
-        guard pluginManager.installCodexPlugin() else {
-            installFailed = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3) { installFailed = false }
-            return
-        }
+            name: "Codex CLI / Desktop", installed: pluginManager.codexInstalled,
+            needsUpdate: pluginManager.codexNeedsUpdate,
+            installLabel: "Install Hooks", updateLabel: "Update Hooks",
+            installFailed: $installFailed,
+            install: { pluginManager.installCodexPlugin() },
+            remove: { pluginManager.removeCodexPlugin() })
     }
 }
 

--- a/menubar/CctopMenubarTests/SnapshotTests.swift
+++ b/menubar/CctopMenubarTests/SnapshotTests.swift
@@ -26,7 +26,7 @@ final class SnapshotTests: XCTestCase {
     }
 
     /// Renders the EmptyStateView in its first-run "nothing installed yet" form
-    /// — all four supported agents (Claude Code, opencode, pi, Codex CLI) detected
+    /// — all four supported agents (Claude Code/Desktop, opencode, pi, Codex CLI/Desktop) detected
     /// on the machine with their respective install CTAs — for use in the README
     /// and marketing site. Shows the full breadth of agent support in one shot.
     ///
@@ -48,6 +48,47 @@ final class SnapshotTests: XCTestCase {
         let view = EmptyStateView(pluginManager: pm)
         try renderScreenshot(view: view, colorScheme: .light, filename: "empty-state-light.png")
         try renderScreenshot(view: view, colorScheme: .dark, filename: "empty-state-dark.png")
+    }
+
+    func testGenerateOnboardingSettingsScreenshot() throws {
+        let pm = PluginManager()
+        pm.ccInstalled = false
+        pm.ocInstalled = false
+        pm.ocConfigExists = true
+        pm.ocNeedsUpdate = false
+        pm.piInstalled = false
+        pm.piConfigExists = true
+        pm.codexInstalled = false
+        pm.codexConfigExists = true
+        pm.codexNeedsUpdate = false
+
+        let view = SettingsSection(updater: DisabledUpdater(), pluginManager: pm)
+        try renderScreenshot(view: view, colorScheme: .light, filename: "onboarding-settings-light.png", width: 360)
+        try renderScreenshot(view: view, colorScheme: .dark, filename: "onboarding-settings-dark.png", width: 360)
+    }
+
+    func testOnboardingCopyNamesDesktopHostsAndOmitsLegacyCodexFlag() throws {
+        let repo = try repoRoot()
+        let checkedFiles = [
+            "menubar/CctopMenubar/Views/EmptyStateView.swift",
+            "menubar/CctopMenubar/Views/SettingsSection.swift",
+            "README.md",
+            "site/index.html",
+            "plugins/codex/cctop-shim.sh",
+        ]
+
+        let combined = try checkedFiles.map { path in
+            try String(contentsOf: repo.appendingPathComponent(path), encoding: .utf8)
+        }.joined(separator: "\n")
+
+        XCTAssertFalse(combined.contains("codex_hooks feature flag"))
+        XCTAssertFalse(combined.contains("Enable experimental feature?"))
+        XCTAssertFalse(combined.contains("will show a startup warning"))
+        XCTAssertTrue(combined.contains("Claude Code / Desktop"))
+        XCTAssertTrue(combined.contains("Codex CLI / Desktop"))
+        XCTAssertTrue(combined.contains("Claude Desktop"))
+        XCTAssertTrue(combined.contains("Codex Desktop"))
+        XCTAssertTrue(combined.contains("Install Hooks"))
     }
 
     func testGenerateRecentProjectsScreenshot() throws {
@@ -118,5 +159,17 @@ final class SnapshotTests: XCTestCase {
 
         try pngData.write(to: URL(fileURLWithPath: outputPath))
         print("Screenshot saved to: \(outputPath)")
+    }
+
+    private func repoRoot() throws -> URL {
+        var url = URL(fileURLWithPath: #filePath)
+        while url.path != "/" {
+            let candidate = url.appendingPathComponent("menubar/CctopMenubar.xcodeproj")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return url
+            }
+            url.deleteLastPathComponent()
+        }
+        throw XCTSkip("Could not locate repository root")
     }
 }

--- a/plugins/cctop/skills/cctop-setup/SKILL.md
+++ b/plugins/cctop/skills/cctop-setup/SKILL.md
@@ -48,6 +48,6 @@ open /Applications/cctop.app
 
 ## After Installation
 
-The hooks registered by this plugin will now work. Session data will be written to `~/.cctop/sessions/` when Claude Code hooks fire.
+The hooks registered by this plugin will now work. Session data will be written to `~/.cctop/sessions/` when Claude Code or Claude Desktop hooks fire.
 
 The menubar app will show session status in the macOS menu bar.

--- a/site/index.html
+++ b/site/index.html
@@ -4,9 +4,9 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <title>cctop — monitor and jump between AI coding sessions</title>
-<meta name="description" content="A keyboard-first macOS menubar app to monitor and jump between AI coding sessions. Works with Claude Code, opencode, pi, and Codex CLI." />
+<meta name="description" content="A keyboard-first macOS menubar app to monitor and jump between AI coding sessions. Works with Claude Code, Claude Desktop, opencode, pi, Codex CLI, and Codex Desktop." />
 <meta property="og:title" content="cctop — monitor and jump between AI coding sessions" />
-<meta property="og:description" content="A keyboard-first macOS menubar app. Works with Claude Code, opencode, pi, and Codex CLI." />
+<meta property="og:description" content="A keyboard-first macOS menubar app. Works with Claude Code, Claude Desktop, opencode, pi, Codex CLI, and Codex Desktop." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://cctop.app/" />
 <meta property="og:image" content="https://cctop.app/og.png" />
@@ -512,8 +512,8 @@
       </div>
       <div class="tools">
         <a class="tool-card reveal" style="--rd:0ms" href="https://docs.anthropic.com/en/docs/claude-code" target="_blank" rel="noopener noreferrer">
-          <div class="name">Claude Code <span class="arr"><svg width="12" height="12" aria-hidden="true"><use href="#i-ext"/></svg></span></div>
-          <div class="conn">Anthropic's CLI agent</div>
+          <div class="name">Claude Code / Desktop <span class="arr"><svg width="12" height="12" aria-hidden="true"><use href="#i-ext"/></svg></span></div>
+          <div class="conn">Claude Code and Claude Desktop hooks</div>
         </a>
         <a class="tool-card reveal" style="--rd:60ms" href="https://opencode.ai" target="_blank" rel="noopener noreferrer">
           <div class="name">opencode <span class="arr"><svg width="12" height="12" aria-hidden="true"><use href="#i-ext"/></svg></span></div>
@@ -524,8 +524,8 @@
           <div class="conn">Open-source agent by Mario Zechner</div>
         </a>
         <a class="tool-card reveal" style="--rd:180ms" href="https://github.com/openai/codex" target="_blank" rel="noopener noreferrer">
-          <div class="name">Codex CLI <span class="arr"><svg width="12" height="12" aria-hidden="true"><use href="#i-ext"/></svg></span></div>
-          <div class="conn">OpenAI's open-source agent</div>
+          <div class="name">Codex CLI / Desktop <span class="arr"><svg width="12" height="12" aria-hidden="true"><use href="#i-ext"/></svg></span></div>
+          <div class="conn">Codex CLI and Codex Desktop hooks</div>
         </a>
       </div>
     </div>
@@ -687,7 +687,7 @@
     <div class="install-card reveal" style="--rd:120ms">
       <div>
         <h3>Step 1 — Install the app</h3>
-        <p>Signed and notarized by Apple. Runs on macOS 13+. <strong style="color:var(--fg)">Step 2:</strong> follow the app's instructions to connect your tools — it auto-detects what you have installed and offers one-click plugin install.</p>
+        <p>Signed and notarized by Apple. Runs on macOS 13+. <strong style="color:var(--fg)">Step 2:</strong> follow the app's instructions to connect your tools — it auto-detects what you have installed and offers plugin or hook install.</p>
         <div class="cta-row">
           <a class="pill primary lg" href="https://github.com/st0012/cctop/releases/latest/download/cctop-macOS-arm64.dmg">
             <svg width="14" height="14" aria-hidden="true"><use href="#i-download"/></svg>


### PR DESCRIPTION
## Problem
- cctop already lists Claude Desktop and Codex Desktop as supported desktop/editor targets, but the onboarding table and install copy still emphasized `Claude Code` and `Codex CLI` names in the primary setup flow. [README supported tools](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/README.md#L53-L56) [README desktop targets](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/README.md#L69-L70) [README install copy](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/README.md#L116-L118)
- The Codex installer owns hook config repair, including deprecated `codex_hooks` removal and explicit `hooks = false` override, so a separate onboarding warning path is stale UI surface. [CodexPluginInstaller](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/menubar/CctopMenubar/Services/CodexPluginInstaller.swift#L6-L12) [PluginManager status comment](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/menubar/CctopMenubar/Services/PluginManager.swift#L90-L93)

## Solution
- Update first-run onboarding to name `Claude Code / Desktop` and `Codex CLI / Desktop`, with Codex presented as a hook install instead of a generic plugin install. [EmptyStateView](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/menubar/CctopMenubar/Views/EmptyStateView.swift#L280-L283)
- Update Settings > Monitored Tools with the same desktop-inclusive names and `Install Hooks` / `Update Hooks` Codex actions. [SettingsSection](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/menubar/CctopMenubar/Views/SettingsSection.swift#L347-L418)
- Update public/docs copy so README setup, the website agent cards, and the Claude setup skill all mention the desktop hosts where the hook paths apply. [README install copy](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/README.md#L116-L118) [site tool cards](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/site/index.html#L515-L528) [Claude setup skill](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/plugins/cctop/skills/cctop-setup/SKILL.md#L51)
- Add screenshot generation for the onboarding Settings state and regression coverage that checks desktop host names are present while the legacy Codex flag warning copy is absent. [SnapshotTests screenshot case](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/menubar/CctopMenubarTests/SnapshotTests.swift#L58-L67) [SnapshotTests copy assertions](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/menubar/CctopMenubarTests/SnapshotTests.swift#L70-L91)

## Verification
- `make build`
- `make test` after `make build`; the run completed with the opencode node:test suite and Swift `CctopMenubarTests` passing. [Makefile test target](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/Makefile#L24-L28) [opencode test target](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/plugins/opencode/package.json#L8-L10)
- `make lint` completed with SwiftLint strict mode. [Makefile lint target](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/Makefile#L30-L32) [.swiftlint.yml](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/.swiftlint.yml)
- `git diff --check` completed without whitespace errors. [Git diff check docs](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---check)
- Focused copy regression: `xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -configuration Debug -derivedDataPath menubar/build -only-testing:CctopMenubarTests/SnapshotTests/testOnboardingCopyNamesDesktopHostsAndOmitsLegacyCodexFlag CODE_SIGN_IDENTITY="-"`. [SnapshotTests copy assertions](https://github.com/st0012/cctop/blob/87524b7a8257d2ac05a3620ffff1162dbc81afaa/menubar/CctopMenubarTests/SnapshotTests.swift#L70-L91)