### PR TITLE
Fix Codex notification focus routing

### DIFF
--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -302,9 +302,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
-        let pidStr = response.notification.request.content.userInfo["sessionPID"] as? String
+        let userInfo = response.notification.request.content.userInfo
         DispatchQueue.main.async { [weak self] in
-            if let session = self?.sessionManager.sessions.first(where: { $0.id == pidStr }) {
+            guard let self else { return }
+            if let session = SessionIdentityPolicy.session(
+                matchingNotificationUserInfo: userInfo,
+                in: sessionManager.sessions
+            ) {
                 focusTerminal(session: session)
             }
         }

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 enum SessionIdentityPolicy {
+    static let notificationSessionIDKey = "sessionID"
+    static let notificationSessionPIDKey = "sessionPID"
+
     /// GUI environments can leak `__CFBundleIdentifier` into child tools; an explicit
     /// non-desktop harness must not become "Codex Desktop" or "Claude Desktop" because
     /// of inherited env. Other sources keep the previous bundle-first behavior, including
@@ -48,6 +51,32 @@ enum SessionIdentityPolicy {
             return "desktop:\(session.sessionId)"
         }
         return "active:\(displayID(for: session))"
+    }
+
+    static func notificationUserInfo(for session: Session) -> [AnyHashable: Any] {
+        [
+            notificationSessionIDKey: displayID(for: session),
+            notificationSessionPIDKey: session.pid.map(String.init) ?? "",
+        ]
+    }
+
+    static func session(
+        matchingNotificationUserInfo userInfo: [AnyHashable: Any],
+        in sessions: [Session]
+    ) -> Session? {
+        if let sessionID = nonEmptyString(userInfo[notificationSessionIDKey]) {
+            return sessions.first { displayID(for: $0) == sessionID }
+        }
+
+        guard let pid = nonEmptyString(userInfo[notificationSessionPIDKey]) else { return nil }
+        return sessions.first {
+            displayID(for: $0) == pid || $0.pid.map(String.init) == pid
+        }
+    }
+
+    private static func nonEmptyString(_ value: Any?) -> String? {
+        guard let string = value as? String, !string.isEmpty else { return nil }
+        return string
     }
 
     /// Collapse duplicate display ids during migration, keeping the most recently active copy.

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -416,7 +416,7 @@ class SessionManager: ObservableObject {
             content.body = "Needs attention"
         }
         content.sound = .default
-        content.userInfo = ["sessionPID": session.pid.map(String.init) ?? ""]
+        content.userInfo = SessionIdentityPolicy.notificationUserInfo(for: session)
 
         let request = UNNotificationRequest(
             identifier: "session-\(session.id)",

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -166,6 +166,82 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.id, "abc-123")
     }
 
+    // MARK: - Notification identity
+
+    func testNotificationUserInfoStoresStableCodexSessionID() {
+        let session = Session.mock(id: "codex-thread-1", pid: 12345, source: "codex")
+
+        let userInfo = SessionIdentityPolicy.notificationUserInfo(for: session)
+
+        XCTAssertEqual(
+            userInfo[SessionIdentityPolicy.notificationSessionIDKey] as? String,
+            "codex-thread-1"
+        )
+        XCTAssertEqual(
+            userInfo[SessionIdentityPolicy.notificationSessionPIDKey] as? String,
+            "12345"
+        )
+    }
+
+    func testNotificationLookupPrefersStableSessionIDOverSharedCodexPID() {
+        let first = Session.mock(id: "codex-thread-1", pid: 12345, source: "codex")
+        let second = Session.mock(id: "codex-thread-2", pid: 12345, source: "codex")
+        let userInfo: [AnyHashable: Any] = [
+            SessionIdentityPolicy.notificationSessionIDKey: "codex-thread-2",
+            SessionIdentityPolicy.notificationSessionPIDKey: "12345",
+        ]
+
+        let matched = SessionIdentityPolicy.session(
+            matchingNotificationUserInfo: userInfo,
+            in: [first, second]
+        )
+
+        XCTAssertEqual(matched?.sessionId, "codex-thread-2")
+    }
+
+    func testNotificationLookupDoesNotFallBackWhenStableSessionIDMisses() {
+        let session = Session.mock(id: "codex-thread-1", pid: 12345, source: "codex")
+        let userInfo: [AnyHashable: Any] = [
+            SessionIdentityPolicy.notificationSessionIDKey: "codex-thread-2",
+            SessionIdentityPolicy.notificationSessionPIDKey: "12345",
+        ]
+
+        let matched = SessionIdentityPolicy.session(
+            matchingNotificationUserInfo: userInfo,
+            in: [session]
+        )
+
+        XCTAssertNil(matched)
+    }
+
+    func testNotificationLookupKeepsLegacyPIDFallbackForNonCodex() {
+        let session = Session.mock(id: "claude-thread-1", pid: 12345)
+        let userInfo: [AnyHashable: Any] = [
+            SessionIdentityPolicy.notificationSessionPIDKey: "12345",
+        ]
+
+        let matched = SessionIdentityPolicy.session(
+            matchingNotificationUserInfo: userInfo,
+            in: [session]
+        )
+
+        XCTAssertEqual(matched?.sessionId, "claude-thread-1")
+    }
+
+    func testNotificationLookupKeepsBestEffortLegacyPIDFallbackForCodex() {
+        let session = Session.mock(id: "codex-thread-1", pid: 12345, source: "codex")
+        let userInfo: [AnyHashable: Any] = [
+            SessionIdentityPolicy.notificationSessionPIDKey: "12345",
+        ]
+
+        let matched = SessionIdentityPolicy.session(
+            matchingNotificationUserInfo: userInfo,
+            in: [session]
+        )
+
+        XCTAssertEqual(matched?.sessionId, "codex-thread-1")
+    }
+
     func testDecodesPidStartTime() throws {
         let json = """
         {


### PR DESCRIPTION
## Problem

- Codex conversations are identified by `session_id` because `Session.id` returns `sessionId` for Codex while other sessions fall back to PID. [source](https://github.com/st0012/cctop/blob/master/menubar/CctopMenubar/Models/Session.swift#L209-L214)
- The notification payload on `master` only records `sessionPID`, and the notification response handler compares that PID string against `session.id`. [payload source](https://github.com/st0012/cctop/blob/master/menubar/CctopMenubar/Services/SessionManager.swift#L418-L419), [handler source](https://github.com/st0012/cctop/blob/master/menubar/CctopMenubar/AppDelegate.swift#L305-L308)

## Solution

- Add notification identity helpers that write stable `sessionID` plus legacy `sessionPID`, resolve non-empty `sessionID` authoritatively, and reserve PID fallback for legacy PID-only payloads. [source](https://github.com/st0012/cctop/blob/29ec39036bdbc31f4cb8f76138c1bd78c4879b0b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift#L56-L74)
- Route notification clicks through the policy helper instead of comparing `sessionPID` directly to `session.id`. [source](https://github.com/st0012/cctop/blob/29ec39036bdbc31f4cb8f76138c1bd78c4879b0b/menubar/CctopMenubar/AppDelegate.swift#L305-L313)
- Cover Codex shared-PID routing, stale stable-id no-op behavior, and legacy PID fallback in `SessionTests`. [source](https://github.com/st0012/cctop/blob/29ec39036bdbc31f4cb8f76138c1bd78c4879b0b/menubar/CctopMenubarTests/SessionTests.swift#L171-L243)

## Validation

- Ran `make build`; the target builds `CctopMenubar`, builds `cctop-hook`, and copies bundled plugin resources. [target source](https://github.com/st0012/cctop/blob/29ec39036bdbc31f4cb8f76138c1bd78c4879b0b/Makefile#L9-L16)
- Ran `make test`, `make lint`, and `make contract`; those targets run the opencode Node tests, the Xcode test suite, SwiftLint strict mode, and hook/fixture validation scripts. [test target source](https://github.com/st0012/cctop/blob/29ec39036bdbc31f4cb8f76138c1bd78c4879b0b/Makefile#L18-L20), [lint and contract target source](https://github.com/st0012/cctop/blob/29ec39036bdbc31f4cb8f76138c1bd78c4879b0b/Makefile#L22-L27)
