### PR TITLE
Show desktop project names for Desktop sessions

### DIFF
--- a/menubar/CctopMenubar/Models/Session+Mock.swift
+++ b/menubar/CctopMenubar/Models/Session+Mock.swift
@@ -15,7 +15,8 @@ extension Session {
         notificationMessage: String? = nil,
         terminal: TerminalInfo? = TerminalInfo(program: "Code", sessionId: nil, tty: nil),
         source: String? = nil,
-        activeSubagents: [SubagentInfo]? = nil
+        activeSubagents: [SubagentInfo]? = nil,
+        desktopProjectName: String? = nil
     ) -> Session {
         var session = Session(
             sessionId: id,
@@ -36,6 +37,7 @@ extension Session {
             activeSubagents: activeSubagents
         )
         session.sessionName = sessionName
+        session.desktopProjectName = desktopProjectName
         return session
     }
 
@@ -162,7 +164,8 @@ extension Session {
             status: .waitingInput,
             lastPrompt: "Should we retry on 5xx or surface to the user?",
             terminal: TerminalInfo(bundleId: "com.openai.codex"),
-            source: "codex"
+            source: "codex",
+            desktopProjectName: "billing-api"
         )
         s2.lastActivity = Date().addingTimeInterval(-180) // "3m ago"
 
@@ -181,7 +184,8 @@ extension Session {
             status: .working, lastTool: "Bash",
             lastToolDetail: "./scripts/run-integration-tests.sh --filter staging",
             terminal: TerminalInfo(bundleId: "com.anthropic.claudefordesktop"),
-            source: nil
+            source: nil,
+            desktopProjectName: "infra-tools"
         )
         s4.lastActivity = Date().addingTimeInterval(-30) // "30s ago"
 

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -175,6 +175,7 @@ struct Session: Codable, Identifiable, Equatable {
     var lastToolDetail: String?
     var notificationMessage: String?
     var sessionName: String?
+    var desktopProjectName: String?
     var workspaceFile: String?
     var source: String?
     var endedAt: Date?
@@ -236,6 +237,7 @@ struct Session: Codable, Identifiable, Equatable {
         case lastToolDetail = "last_tool_detail"
         case notificationMessage = "notification_message"
         case sessionName = "session_name"
+        case desktopProjectName = "desktop_project_name"
         case workspaceFile = "workspace_file"
         case source
         case endedAt = "ended_at"
@@ -266,6 +268,7 @@ struct Session: Codable, Identifiable, Equatable {
         lastToolDetail = try container.decodeIfPresent(String.self, forKey: .lastToolDetail)
         notificationMessage = try container.decodeIfPresent(String.self, forKey: .notificationMessage)
         sessionName = try container.decodeIfPresent(String.self, forKey: .sessionName)
+        desktopProjectName = try container.decodeIfPresent(String.self, forKey: .desktopProjectName)
         workspaceFile = try container.decodeIfPresent(String.self, forKey: .workspaceFile)
         source = try container.decodeIfPresent(String.self, forKey: .source)
         endedAt = try container.decodeIfPresent(Date.self, forKey: .endedAt)
@@ -294,6 +297,7 @@ struct Session: Codable, Identifiable, Equatable {
         lastToolDetail: String?,
         notificationMessage: String?,
         sessionName: String? = nil,
+        desktopProjectName: String? = nil,
         workspaceFile: String? = nil,
         source: String? = nil,
         endedAt: Date? = nil,
@@ -319,6 +323,7 @@ struct Session: Codable, Identifiable, Equatable {
         self.lastToolDetail = lastToolDetail
         self.notificationMessage = notificationMessage
         self.sessionName = sessionName
+        self.desktopProjectName = desktopProjectName
         self.workspaceFile = workspaceFile
         self.source = source
         self.endedAt = endedAt
@@ -347,6 +352,7 @@ struct Session: Codable, Identifiable, Equatable {
         self.lastToolDetail = nil
         self.notificationMessage = nil
         self.sessionName = nil
+        self.desktopProjectName = nil
         self.workspaceFile = nil
         self.source = nil
         self.endedAt = nil
@@ -421,6 +427,7 @@ struct Session: Codable, Identifiable, Equatable {
             lastToolDetail: lastToolDetail,
             notificationMessage: notificationMessage,
             sessionName: sessionName,
+            desktopProjectName: desktopProjectName,
             workspaceFile: workspaceFile,
             source: source,
             endedAt: endedAt,
@@ -470,6 +477,9 @@ struct Session: Codable, Identifiable, Equatable {
     static func extractProjectName(_ path: String) -> String {
         URL(fileURLWithPath: path).lastPathComponent
     }
+}
+
+extension Session {
 
     /// The best available inactive timestamp for ordering retained files.
     var effectiveEndDate: Date {

--- a/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift
@@ -47,6 +47,7 @@ struct ClaudeDesktopSessionArchiveLookup {
 
             let match = ClaudeArchiveMatch(
                 isArchived: metadata.isArchived == true,
+                projectName: Self.projectName(originCwd: metadata.originCwd, worktreeName: metadata.worktreeName),
                 recencyKey: metadata.lastActivityAt ?? metadata.createdAt ?? .missing,
                 path: url.path
             )
@@ -62,6 +63,7 @@ struct ClaudeDesktopSessionArchiveLookup {
             archivedSessionIDs: Set(latestBySessionID.compactMap { sessionID, match in
                 match.isArchived ? sessionID : nil
             }),
+            projectNamesBySessionID: latestBySessionID.compactMapValues(\.projectName),
             isAuthoritative: true
         )
     }
@@ -69,20 +71,40 @@ struct ClaudeDesktopSessionArchiveLookup {
     private func isClaudeDesktopMetadataURL(_ url: URL) -> Bool {
         url.pathExtension == "json" && url.lastPathComponent.hasPrefix("local_")
     }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
+    }
+
+    private static func projectName(originCwd: String?, worktreeName: String?) -> String? {
+        basename(fromPath: originCwd) ?? nonEmpty(worktreeName)
+    }
+
+    private static func basename(fromPath path: String?) -> String? {
+        guard let path = nonEmpty(path) else { return nil }
+        let normalized = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard !normalized.isEmpty else { return nil }
+        return nonEmpty((normalized as NSString).lastPathComponent)
+    }
 }
 
 struct ClaudeDesktopSessionMetadataSnapshot: Equatable {
     let matchedSessionIDs: Set<String>
     let archivedSessionIDs: Set<String>
+    let projectNamesBySessionID: [String: String]
     let isAuthoritative: Bool
 
     init(
         matchedSessionIDs: Set<String> = [],
         archivedSessionIDs: Set<String> = [],
+        projectNamesBySessionID: [String: String] = [:],
         isAuthoritative: Bool = true
     ) {
         self.matchedSessionIDs = matchedSessionIDs
         self.archivedSessionIDs = archivedSessionIDs
+        self.projectNamesBySessionID = projectNamesBySessionID
         self.isAuthoritative = isAuthoritative
     }
 }
@@ -90,12 +112,16 @@ struct ClaudeDesktopSessionMetadataSnapshot: Equatable {
 private struct ClaudeDesktopSessionMetadata: Decodable {
     let cliSessionId: String?
     let isArchived: Bool?
+    let originCwd: String?
+    let worktreeName: String?
     let lastActivityAt: ClaudeArchiveRecencyKey?
     let createdAt: ClaudeArchiveRecencyKey?
 
     private enum CodingKeys: String, CodingKey {
         case cliSessionId
         case isArchived
+        case originCwd
+        case worktreeName
         case lastActivityAt
         case createdAt
     }
@@ -104,6 +130,8 @@ private struct ClaudeDesktopSessionMetadata: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         cliSessionId = try container.decodeIfPresent(String.self, forKey: .cliSessionId)
         isArchived = try container.decodeIfPresent(Bool.self, forKey: .isArchived)
+        originCwd = try container.decodeIfPresent(String.self, forKey: .originCwd)
+        worktreeName = try container.decodeIfPresent(String.self, forKey: .worktreeName)
         lastActivityAt = Self.decodeRecencyKey(from: container, forKey: .lastActivityAt)
         createdAt = Self.decodeRecencyKey(from: container, forKey: .createdAt)
     }
@@ -164,6 +192,7 @@ private struct ClaudeArchiveRecencyKey: Comparable {
 
 private struct ClaudeArchiveMatch {
     let isArchived: Bool
+    let projectName: String?
     let recencyKey: ClaudeArchiveRecencyKey
     let path: String
 

--- a/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift
@@ -130,10 +130,17 @@ private struct ClaudeDesktopSessionMetadata: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         cliSessionId = try container.decodeIfPresent(String.self, forKey: .cliSessionId)
         isArchived = try container.decodeIfPresent(Bool.self, forKey: .isArchived)
-        originCwd = try container.decodeIfPresent(String.self, forKey: .originCwd)
-        worktreeName = try container.decodeIfPresent(String.self, forKey: .worktreeName)
+        originCwd = Self.decodeStringIfPresent(from: container, forKey: .originCwd)
+        worktreeName = Self.decodeStringIfPresent(from: container, forKey: .worktreeName)
         lastActivityAt = Self.decodeRecencyKey(from: container, forKey: .lastActivityAt)
         createdAt = Self.decodeRecencyKey(from: container, forKey: .createdAt)
+    }
+
+    private static func decodeStringIfPresent(
+        from container: KeyedDecodingContainer<CodingKeys>,
+        forKey key: CodingKeys
+    ) -> String? {
+        try? container.decodeIfPresent(String.self, forKey: key)
     }
 
     private static func decodeRecencyKey(

--- a/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
@@ -22,6 +22,65 @@ struct CodexThreadArchiveLookup {
         matchingThreadIDs(matching: threadIDs, whereClause: "thread_source = 'subagent'")
     }
 
+    /// Returns user-facing project names Codex records for threads. cctop uses this
+    /// as display-only metadata for Desktop-hosted sessions, so lookup uncertainty
+    /// returns `nil` and callers should preserve any existing label.
+    func projectNames(matching threadIDs: Set<String>) -> [String: String]? {
+        guard !threadIDs.isEmpty else { return [:] }
+        guard FileManager.default.fileExists(atPath: stateDatabasePath) else { return [:] }
+
+        var database: OpaquePointer?
+        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX
+        guard sqlite3_open_v2(stateDatabasePath, &database, flags, nil) == SQLITE_OK,
+              let database else {
+            if database != nil { sqlite3_close(database) }
+            return nil
+        }
+        defer { sqlite3_close(database) }
+        sqlite3_busy_timeout(database, 50)
+
+        let sortedIDs = threadIDs.sorted()
+        let placeholders = Array(repeating: "?", count: sortedIDs.count).joined(separator: ",")
+        let sql = """
+        SELECT id, git_origin_url, cwd
+        FROM threads
+        WHERE id IN (\(placeholders))
+          AND (
+              (git_origin_url IS NOT NULL AND git_origin_url != '')
+              OR (cwd IS NOT NULL AND cwd != '')
+          )
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            return nil
+        }
+        defer { sqlite3_finalize(statement) }
+
+        guard Self.bind(sortedIDs, to: statement) else { return nil }
+
+        var names: [String: String] = [:]
+        while true {
+            switch sqlite3_step(statement) {
+            case SQLITE_ROW:
+                guard let idText = sqlite3_column_text(statement, 0) else {
+                    continue
+                }
+                let threadID = String(cString: idText)
+                let origin = Self.columnString(statement, 1)
+                let cwd = Self.columnString(statement, 2)
+                if let name = origin.flatMap({ Self.projectName(fromGitOriginURL: $0) })
+                    ?? cwd.flatMap({ Self.projectName(fromPath: $0) }) {
+                    names[threadID] = name
+                }
+            case SQLITE_DONE:
+                return names
+            default:
+                return nil
+            }
+        }
+    }
+
     private func matchingThreadIDs(matching threadIDs: Set<String>, whereClause predicate: String) -> Set<String>? {
         guard !threadIDs.isEmpty else { return [] }
         guard FileManager.default.fileExists(atPath: stateDatabasePath) else { return [] }
@@ -46,11 +105,7 @@ struct CodexThreadArchiveLookup {
         }
         defer { sqlite3_finalize(statement) }
 
-        for (index, threadID) in sortedIDs.enumerated() {
-            guard sqlite3_bind_text(statement, Int32(index + 1), threadID, -1, sqliteTransient) == SQLITE_OK else {
-                return nil
-            }
-        }
+        guard Self.bind(sortedIDs, to: statement) else { return nil }
 
         var archived: Set<String> = []
         while true {
@@ -65,6 +120,49 @@ struct CodexThreadArchiveLookup {
                 return nil   // SQLITE_BUSY / SQLITE_ERROR / etc. — read did not complete
             }
         }
+    }
+
+    private static func projectName(fromGitOriginURL origin: String) -> String? {
+        let trimmed = origin.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let withoutTrailingSlash = trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let lastComponent: String
+        if let slash = withoutTrailingSlash.lastIndex(of: "/") {
+            lastComponent = String(withoutTrailingSlash[withoutTrailingSlash.index(after: slash)...])
+        } else if let colon = withoutTrailingSlash.lastIndex(of: ":") {
+            lastComponent = String(withoutTrailingSlash[withoutTrailingSlash.index(after: colon)...])
+        } else {
+            lastComponent = withoutTrailingSlash
+        }
+
+        let name = lastComponent.hasSuffix(".git") ? String(lastComponent.dropLast(4)) : lastComponent
+        return name.isEmpty ? nil : name
+    }
+
+    private static func projectName(fromPath path: String) -> String? {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let normalized = trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard !normalized.isEmpty else { return nil }
+        let name = (normalized as NSString).lastPathComponent
+        return name.isEmpty ? nil : name
+    }
+
+    private static func columnString(_ statement: OpaquePointer, _ index: Int32) -> String? {
+        guard let text = sqlite3_column_text(statement, index) else { return nil }
+        let value = String(cString: text).trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    private static func bind(_ threadIDs: [String], to statement: OpaquePointer) -> Bool {
+        for (index, threadID) in threadIDs.enumerated() {
+            guard sqlite3_bind_text(statement, Int32(index + 1), threadID, -1, sqliteTransient) == SQLITE_OK else {
+                return false
+            }
+        }
+        return true
     }
 }
 

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -195,15 +195,23 @@ extension SessionManager {
         now: Date,
         desktopAppConnectionLookup: DesktopAppConnectionLookup = .live
     ) -> [DedupCandidate] {
-        var candidates: [DedupCandidate] = []
-        for url in jsonFiles {
+        let decodedFiles: [(url: URL, session: Session)] = jsonFiles.compactMap { url in
             guard let data = try? Data(contentsOf: url) else {
                 sessionManagerLogger.warning("loadSessions: could not read \(url.lastPathComponent, privacy: .public)")
-                continue
+                return nil
             }
-            guard var session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data) else {
+            guard let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data) else {
                 sessionManagerLogger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public)")
-                continue
+                return nil
+            }
+            return (url, session)
+        }
+
+        let projectNames = desktopProjectNamesBySessionID(in: decodedFiles.map(\.session))
+        var candidates: [DedupCandidate] = []
+        for (url, var session) in decodedFiles {
+            if let projectName = projectNames[session.sessionId] {
+                session.desktopProjectName = projectName
             }
             session.lifecycle = SessionLifecyclePolicy.lifecycle(
                 for: session, hostClass: session.hostClass, processAlive: session.isAlive,
@@ -216,5 +224,21 @@ extension SessionManager {
                                              mtime: mtime, path: url.path))
         }
         return candidates
+    }
+
+    nonisolated static func desktopProjectNamesBySessionID(in sessions: [Session]) -> [String: String] {
+        var projectNames: [String: String] = [:]
+
+        let claudeSessionIDs = Set(sessions.filter(\.isClaudeDesktopHost).map(\.sessionId))
+        if let claudeMetadata = ClaudeDesktopSessionArchiveLookup().metadataSnapshot(matching: claudeSessionIDs) {
+            projectNames.merge(claudeMetadata.projectNamesBySessionID) { current, _ in current }
+        }
+
+        let codexThreadIDs = Set(sessions.filter(\.isCodexDesktopHost).map(\.sessionId))
+        if let codexProjectNames = CodexThreadArchiveLookup().projectNames(matching: codexThreadIDs) {
+            projectNames.merge(codexProjectNames) { current, _ in current }
+        }
+
+        return projectNames
     }
 }

--- a/menubar/CctopMenubar/Views/SessionCardView.swift
+++ b/menubar/CctopMenubar/Views/SessionCardView.swift
@@ -78,11 +78,27 @@ struct SessionCardView: View {
     private var metaRow: some View {
         // For Desktop sessions, folder + branch are usually noise (worktree dirs,
         // "unknown" branches), and the long "Claude Desktop" chip causes the row
-        // to wrap when combined with them. Show just the source badge instead.
+        // to wrap when combined with them. Show only the Desktop app's own project
+        // label plus the source badge.
         if session.agentBadge.isDesktop {
-            if showSourceBadge {
+            if session.desktopProjectName != nil || showSourceBadge {
                 HStack(spacing: 5) {
-                    SourceBadgeView(badge: session.agentBadge)
+                    if let desktopProjectName = session.desktopProjectName {
+                        Text(desktopProjectName)
+                            .font(.system(size: 11))
+                            .foregroundStyle(Color.textSecondary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                    if showSourceBadge {
+                        if session.desktopProjectName != nil {
+                            Text("·")
+                                .font(.system(size: 10))
+                                .foregroundStyle(Color.textMuted.opacity(0.6))
+                        }
+                        SourceBadgeView(badge: session.agentBadge)
+                            .fixedSize(horizontal: true, vertical: false)
+                    }
                     Spacer(minLength: 0)
                 }
             }

--- a/menubar/CctopMenubarTests/QASnapshotTests.swift
+++ b/menubar/CctopMenubarTests/QASnapshotTests.swift
@@ -66,6 +66,10 @@ final class QASnapshotTests: XCTestCase {
         try renderSnapshot(sessions: Session.qaLongSessionNames, name: "09b-long-session-names")
     }
 
+    func testDesktopProjectNames() throws {
+        try renderSnapshot(sessions: Session.qaShowcase, name: "09c-desktop-project-names")
+    }
+
     // MARK: - Dark mode
 
     func testFiveSessionsDark() throws {

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -5,16 +5,29 @@ final class SessionFileFormatTests: XCTestCase {
     private func writeCodexStateDatabase(
         path: String,
         archivedThreads: Set<String>,
-        subagentThreads: Set<String> = []
+        subagentThreads: Set<String> = [],
+        gitOrigins: [String: String] = [:],
+        cwds: [String: String] = [:]
     ) throws {
+        func sqlValue(_ value: String?) -> String {
+            guard let value else { return "NULL" }
+            return "'\(value.replacingOccurrences(of: "'", with: "''"))'"
+        }
+
         let archivedRows = archivedThreads.map {
             """
-            INSERT INTO threads (id, archived, thread_source) VALUES ('\($0)', 1, 'user');
+            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd) VALUES (\(sqlValue($0)), 1, 'user', NULL, NULL);
             """
         }.joined(separator: "\n")
         let subagentRows = subagentThreads.map {
             """
-            INSERT INTO threads (id, archived, thread_source) VALUES ('\($0)', 0, 'subagent');
+            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd) VALUES (\(sqlValue($0)), 0, 'subagent', NULL, NULL);
+            """
+        }.joined(separator: "\n")
+        let metadataRows = Set(gitOrigins.keys).union(cwds.keys).map { threadID in
+            """
+            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd)
+            VALUES (\(sqlValue(threadID)), 0, 'user', \(sqlValue(gitOrigins[threadID])), \(sqlValue(cwds[threadID])));
             """
         }.joined(separator: "\n")
         let sql = """
@@ -22,10 +35,13 @@ final class SessionFileFormatTests: XCTestCase {
         CREATE TABLE threads (
             id TEXT PRIMARY KEY,
             archived INTEGER NOT NULL DEFAULT 0,
-            thread_source TEXT
+            thread_source TEXT,
+            git_origin_url TEXT,
+            cwd TEXT
         );
         \(archivedRows)
         \(subagentRows)
+        \(metadataRows)
         """
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
@@ -82,7 +98,9 @@ final class SessionFileFormatTests: XCTestCase {
         root: String,
         cliSessionId: String,
         isArchived: Bool,
-        lastActivityAt: Any? = nil
+        lastActivityAt: Any? = nil,
+        originCwd: String? = nil,
+        worktreeName: String? = nil
     ) throws {
         let sessionDir = (root as NSString).appendingPathComponent("account/project")
         try FileManager.default.createDirectory(atPath: sessionDir, withIntermediateDirectories: true)
@@ -96,6 +114,12 @@ final class SessionFileFormatTests: XCTestCase {
         ]
         if let lastActivityAt {
             payload["lastActivityAt"] = lastActivityAt
+        }
+        if let originCwd {
+            payload["originCwd"] = originCwd
+        }
+        if let worktreeName {
+            payload["worktreeName"] = worktreeName
         }
         let data = try JSONSerialization.data(withJSONObject: payload)
         try data.write(to: URL(fileURLWithPath: metadataPath))
@@ -1186,6 +1210,128 @@ final class SessionFileFormatTests: XCTestCase {
                 .archivedSessionIDs(matching: ["numeric-order-session"]),
             ["numeric-order-session"]
         )
+    }
+
+    func testClaudeDesktopMetadataSnapshotIncludesProjectNameFromOriginCwd() throws {
+        let root = NSTemporaryDirectory() + "cctop-claude-project-name-\(UUID().uuidString)"
+        let claudeDir = (root as NSString).appendingPathComponent("claude-code-sessions")
+        try writeClaudeDesktopSessionMetadata(
+            root: claudeDir,
+            cliSessionId: "claude-desktop-project",
+            isArchived: false,
+            originCwd: "/Users/dev/projects/cctop",
+            worktreeName: "generated-worktree"
+        )
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let snapshot = ClaudeDesktopSessionArchiveLookup(sessionsDirectory: claudeDir)
+            .metadataSnapshot(matching: ["claude-desktop-project"])
+        XCTAssertEqual(snapshot?.projectNamesBySessionID["claude-desktop-project"], "cctop")
+    }
+
+    func testClaudeDesktopMetadataSnapshotFallsBackToWorktreeName() throws {
+        let root = NSTemporaryDirectory() + "cctop-claude-project-name-fallback-\(UUID().uuidString)"
+        let claudeDir = (root as NSString).appendingPathComponent("claude-code-sessions")
+        try writeClaudeDesktopSessionMetadata(
+            root: claudeDir,
+            cliSessionId: "claude-desktop-project",
+            isArchived: false,
+            worktreeName: "cctop"
+        )
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let snapshot = ClaudeDesktopSessionArchiveLookup(sessionsDirectory: claudeDir)
+            .metadataSnapshot(matching: ["claude-desktop-project"])
+        XCTAssertEqual(snapshot?.projectNamesBySessionID["claude-desktop-project"], "cctop")
+    }
+
+    func testCodexThreadLookupDerivesProjectNameFromGitOriginURL() throws {
+        let root = NSTemporaryDirectory() + "cctop-codex-project-name-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
+        try writeCodexStateDatabase(
+            path: stateDB,
+            archivedThreads: [],
+            gitOrigins: ["codex-desktop-project": "git@github.com:st0012/cctop.git"]
+        )
+
+        XCTAssertEqual(
+            CodexThreadArchiveLookup(stateDatabasePath: stateDB)
+                .projectNames(matching: ["codex-desktop-project"]),
+            ["codex-desktop-project": "cctop"]
+        )
+    }
+
+    func testCodexThreadLookupFallsBackToCwdBasename() throws {
+        let root = NSTemporaryDirectory() + "cctop-codex-project-name-cwd-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
+        try writeCodexStateDatabase(
+            path: stateDB,
+            archivedThreads: [],
+            cwds: ["codex-desktop-project": "/Users/dev/projects/local-tool"]
+        )
+
+        XCTAssertEqual(
+            CodexThreadArchiveLookup(stateDatabasePath: stateDB)
+                .projectNames(matching: ["codex-desktop-project"]),
+            ["codex-desktop-project": "local-tool"]
+        )
+    }
+
+    func testBuildCandidatesEnrichesDesktopProjectNameFromExternalMetadata() throws {
+        let root = NSTemporaryDirectory() + "cctop-desktop-project-enrich-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let claudeDir = (root as NSString).appendingPathComponent("claude-code-sessions")
+        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        setenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR", claudeDir, 1)
+        setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
+        defer {
+            unsetenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR")
+            unsetenv("CCTOP_CODEX_STATE_DB")
+        }
+
+        try writeClaudeDesktopSessionMetadata(
+            root: claudeDir,
+            cliSessionId: "claude-desktop-project",
+            isArchived: false,
+            originCwd: "/Users/dev/projects/cctop",
+            worktreeName: "generated-worktree"
+        )
+        try writeCodexStateDatabase(
+            path: stateDB,
+            archivedThreads: [],
+            cwds: ["codex-desktop-project": "/Users/dev/projects/rdoc"]
+        )
+
+        let claudePath = (sessionsDir as NSString).appendingPathComponent("claude.json")
+        try claudeDesktopSession(
+            sessionId: "claude-desktop-project",
+            projectPath: "/tmp/generated-worktree"
+        ).writeToFile(path: claudePath)
+
+        let codexPath = (sessionsDir as NSString).appendingPathComponent("codex.json")
+        try codexDesktopSession(
+            sessionId: "codex-desktop-project",
+            projectPath: "/tmp/other-generated-worktree"
+        ).writeToFile(path: codexPath)
+
+        let candidates = SessionManager.buildCandidates(
+            [URL(fileURLWithPath: claudePath), URL(fileURLWithPath: codexPath)],
+            now: Date(),
+            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true }
+        )
+        let namesByID = Dictionary(uniqueKeysWithValues: candidates.map { ($0.session.sessionId, $0.session.desktopProjectName) })
+
+        XCTAssertEqual(namesByID["claude-desktop-project"]!, "cctop")
+        XCTAssertEqual(namesByID["codex-desktop-project"]!, "rdoc")
     }
 
     // Blocker #1: when the archive DB exists but cannot be read, GC must NOT delete a finished

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -99,8 +99,8 @@ final class SessionFileFormatTests: XCTestCase {
         cliSessionId: String,
         isArchived: Bool,
         lastActivityAt: Any? = nil,
-        originCwd: String? = nil,
-        worktreeName: String? = nil
+        originCwd: Any? = nil,
+        worktreeName: Any? = nil
     ) throws {
         let sessionDir = (root as NSString).appendingPathComponent("account/project")
         try FileManager.default.createDirectory(atPath: sessionDir, withIntermediateDirectories: true)
@@ -1243,6 +1243,24 @@ final class SessionFileFormatTests: XCTestCase {
         let snapshot = ClaudeDesktopSessionArchiveLookup(sessionsDirectory: claudeDir)
             .metadataSnapshot(matching: ["claude-desktop-project"])
         XCTAssertEqual(snapshot?.projectNamesBySessionID["claude-desktop-project"], "cctop")
+    }
+
+    func testClaudeDesktopMetadataSnapshotIgnoresNonStringProjectNameFields() throws {
+        let root = NSTemporaryDirectory() + "cctop-claude-project-name-lossy-\(UUID().uuidString)"
+        let claudeDir = (root as NSString).appendingPathComponent("claude-code-sessions")
+        try writeClaudeDesktopSessionMetadata(
+            root: claudeDir,
+            cliSessionId: "claude-desktop-project",
+            isArchived: true,
+            originCwd: 123,
+            worktreeName: ["generated-worktree"]
+        )
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let snapshot = ClaudeDesktopSessionArchiveLookup(sessionsDirectory: claudeDir)
+            .metadataSnapshot(matching: ["claude-desktop-project"])
+        XCTAssertEqual(snapshot?.archivedSessionIDs, ["claude-desktop-project"])
+        XCTAssertEqual(snapshot?.projectNamesBySessionID, [:])
     }
 
     func testCodexThreadLookupDerivesProjectNameFromGitOriginURL() throws {

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -126,6 +126,26 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.displayName, "refactor auth")
     }
 
+    func testDecodesDesktopProjectName() throws {
+        let json = """
+        {
+            "session_id": "desktop-project-1",
+            "project_path": "/private/var/folders/codex-worktree",
+            "project_name": "codex-worktree",
+            "desktop_project_name": "cctop",
+            "branch": "main",
+            "status": "working",
+            "last_activity": "2026-02-08T12:00:00Z",
+            "started_at": "2026-02-08T11:00:00Z",
+            "terminal": {"program": "", "bundle_id": "com.openai.codex"},
+            "source": "codex"
+        }
+        """
+        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        XCTAssertEqual(session.desktopProjectName, "cctop")
+        XCTAssertEqual(session.displayName, "codex-worktree")
+    }
+
     func testDecodesWithoutSessionName() throws {
         let json = """
         {


### PR DESCRIPTION
## Problem

- Desktop session cards intentionally avoid raw folder and branch metadata because Desktop hosts often use generated worktree directories and long app badges can make the meta row wrap, but that also left Desktop sessions without a stable project label in the CLI-folder-name slot. [Source](https://github.com/st0012/cctop/blob/5dba0668f3632c31faac1f37e8fe5f5637515df4/menubar/CctopMenubar/Views/SessionCardView.swift#L78-L82)

## Solution

- Add a display-only `desktop_project_name` field to `Session` and enrich decoded Desktop sessions before lifecycle/dedup candidate creation. [Session model](https://github.com/st0012/cctop/blob/5dba0668f3632c31faac1f37e8fe5f5637515df4/menubar/CctopMenubar/Models/Session.swift#L175-L240), [candidate enrichment](https://github.com/st0012/cctop/blob/5dba0668f3632c31faac1f37e8fe5f5637515df4/menubar/CctopMenubar/Services/SessionManager%2BArchive.swift#L198-L239)
- Derive Claude Desktop labels from `originCwd` basename with `worktreeName` fallback, and derive Codex Desktop labels from `git_origin_url` with `cwd` fallback. [Claude lookup](https://github.com/st0012/cctop/blob/5dba0668f3632c31faac1f37e8fe5f5637515df4/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift#L48-L89), [Codex lookup](https://github.com/st0012/cctop/blob/5dba0668f3632c31faac1f37e8fe5f5637515df4/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift#L25-L80)
- Render the Desktop project label in the existing meta row with tail truncation while keeping the Desktop source badge fixed-size. [Source](https://github.com/st0012/cctop/blob/5dba0668f3632c31faac1f37e8fe5f5637515df4/menubar/CctopMenubar/Views/SessionCardView.swift#L83-L100)
- Cover Claude metadata, Codex thread metadata, app-side enrichment, and the QA screenshot path with focused tests. [Metadata/enrichment tests](https://github.com/st0012/cctop/blob/5dba0668f3632c31faac1f37e8fe5f5637515df4/menubar/CctopMenubarTests/SessionFileFormatTests.swift#L1215-L1335), [QA snapshot test](https://github.com/st0012/cctop/blob/5dba0668f3632c31faac1f37e8fe5f5637515df4/menubar/CctopMenubarTests/QASnapshotTests.swift#L69-L70)

## Verification

- `swiftlint lint --strict` [Makefile source](https://github.com/st0012/cctop/blob/5dba0668f3632c31faac1f37e8fe5f5637515df4/Makefile#L22-L23)
- `make contract` [Makefile source](https://github.com/st0012/cctop/blob/5dba0668f3632c31faac1f37e8fe5f5637515df4/Makefile#L25-L27)
- `npm --prefix plugins/opencode test` [Makefile source](https://github.com/st0012/cctop/blob/5dba0668f3632c31faac1f37e8fe5f5637515df4/Makefile#L18-L20)
- `xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -configuration Debug -derivedDataPath menubar/build -skip-testing:CctopMenubarTests/SnapshotTests -skip-testing:CctopMenubarTests/QASnapshotTests CODE_SIGN_IDENTITY="-"` [Makefile source](https://github.com/st0012/cctop/blob/5dba0668f3632c31faac1f37e8fe5f5637515df4/Makefile#L18-L20)
