### PR TITLE
Hide Codex exec helper sessions

### DIFF
--- a/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
@@ -81,6 +81,12 @@ struct CodexThreadArchiveLookup {
         }
     }
 
+    /// Returns Codex one-shot exec helper threads that were not initiated as normal user-visible
+    /// conversations. Older state DB schemas do not have these columns; prepare failure returns nil.
+    func execHelperThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        matchingThreadIDs(matching: threadIDs, whereClause: "source = 'exec' AND has_user_event = 0")
+    }
+
     private func matchingThreadIDs(matching threadIDs: Set<String>, whereClause predicate: String) -> Set<String>? {
         guard !threadIDs.isEmpty else { return [] }
         guard FileManager.default.fileExists(atPath: stateDatabasePath) else { return [] }

--- a/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
@@ -81,13 +81,57 @@ struct CodexThreadArchiveLookup {
         }
     }
 
-    /// Returns Codex one-shot exec helper threads that were not initiated as normal user-visible
-    /// conversations. Older state DB schemas do not have these columns; prepare failure returns nil.
+    /// Returns Codex Desktop-owned one-shot exec helper threads. `source = 'exec'`
+    /// alone also covers user-run `codex exec`, so verify the rollout originator before hiding.
     func execHelperThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
-        matchingThreadIDs(
-            matching: threadIDs,
-            whereClause: "source = 'exec' AND has_user_event = 0 AND (first_user_message IS NULL OR TRIM(first_user_message) = '')"
-        )
+        guard !threadIDs.isEmpty else { return [] }
+        guard FileManager.default.fileExists(atPath: stateDatabasePath) else { return [] }
+
+        var database: OpaquePointer?
+        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX
+        guard sqlite3_open_v2(stateDatabasePath, &database, flags, nil) == SQLITE_OK,
+              let database else {
+            if database != nil { sqlite3_close(database) }
+            return nil
+        }
+        defer { sqlite3_close(database) }
+        sqlite3_busy_timeout(database, 50)
+
+        let sortedIDs = threadIDs.sorted()
+        let placeholders = Array(repeating: "?", count: sortedIDs.count).joined(separator: ",")
+        let sql = """
+        SELECT id, rollout_path
+        FROM threads
+        WHERE source = 'exec'
+          AND has_user_event = 0
+          AND id IN (\(placeholders))
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            return nil
+        }
+        defer { sqlite3_finalize(statement) }
+
+        guard Self.bind(sortedIDs, to: statement) else { return nil }
+
+        var helpers: Set<String> = []
+        while true {
+            switch sqlite3_step(statement) {
+            case SQLITE_ROW:
+                guard let idText = sqlite3_column_text(statement, 0) else { continue }
+                let threadID = String(cString: idText)
+                guard let rolloutPath = Self.columnString(statement, 1),
+                      Self.rolloutOriginator(at: rolloutPath) == "Codex Desktop" else {
+                    continue
+                }
+                helpers.insert(threadID)
+            case SQLITE_DONE:
+                return helpers
+            default:
+                return nil
+            }
+        }
     }
 
     private func matchingThreadIDs(matching threadIDs: Set<String>, whereClause predicate: String) -> Set<String>? {
@@ -157,6 +201,22 @@ struct CodexThreadArchiveLookup {
         guard !normalized.isEmpty else { return nil }
         let name = (normalized as NSString).lastPathComponent
         return name.isEmpty ? nil : name
+    }
+
+    private static func rolloutOriginator(at path: String) -> String? {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+            return nil
+        }
+        for line in contents.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let data = String(line).data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  object["type"] as? String == "session_meta",
+                  let payload = object["payload"] as? [String: Any] else {
+                continue
+            }
+            return payload["originator"] as? String
+        }
+        return nil
     }
 
     private static func columnString(_ statement: OpaquePointer, _ index: Int32) -> String? {

--- a/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
@@ -204,19 +204,39 @@ struct CodexThreadArchiveLookup {
     }
 
     private static func rolloutOriginator(at path: String) -> String? {
-        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+        guard let handle = try? FileHandle(forReadingFrom: URL(fileURLWithPath: path)) else {
             return nil
         }
-        for line in contents.split(separator: "\n", omittingEmptySubsequences: true) {
-            guard let data = String(line).data(using: .utf8),
-                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  object["type"] as? String == "session_meta",
-                  let payload = object["payload"] as? [String: Any] else {
-                continue
+        defer { try? handle.close() }
+
+        var buffered = Data()
+        while true {
+            guard let chunk = try? handle.read(upToCount: 8_192) else {
+                return nil
             }
-            return payload["originator"] as? String
+            guard !chunk.isEmpty else {
+                return sessionMetaOriginator(from: buffered)
+            }
+
+            buffered.append(chunk)
+            while let newline = buffered.firstIndex(of: 0x0a) {
+                let line = buffered[..<newline]
+                buffered.removeSubrange(...newline)
+                if let originator = sessionMetaOriginator(from: Data(line)) {
+                    return originator
+                }
+            }
         }
-        return nil
+    }
+
+    private static func sessionMetaOriginator(from data: Data) -> String? {
+        guard !data.isEmpty,
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              object["type"] as? String == "session_meta",
+              let payload = object["payload"] as? [String: Any] else {
+            return nil
+        }
+        return payload["originator"] as? String
     }
 
     private static func columnString(_ statement: OpaquePointer, _ index: Int32) -> String? {

--- a/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
@@ -84,7 +84,10 @@ struct CodexThreadArchiveLookup {
     /// Returns Codex one-shot exec helper threads that were not initiated as normal user-visible
     /// conversations. Older state DB schemas do not have these columns; prepare failure returns nil.
     func execHelperThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
-        matchingThreadIDs(matching: threadIDs, whereClause: "source = 'exec' AND has_user_event = 0")
+        matchingThreadIDs(
+            matching: threadIDs,
+            whereClause: "source = 'exec' AND has_user_event = 0 AND (first_user_message IS NULL OR TRIM(first_user_message) = '')"
+        )
     }
 
     private func matchingThreadIDs(matching threadIDs: Set<String>, whereClause predicate: String) -> Set<String>? {

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -16,8 +16,10 @@ struct DesktopAppConnectionLookup {
 struct SessionVisibilitySnapshot {
     let archivedCodexThreadIDs: Set<String>
     let codexSubagentThreadIDs: Set<String>
+    let codexExecHelperThreadIDs: Set<String>
     let archivedClaudeSessionIDs: Set<String>
     let codexSubagentCandidates: [DedupCandidate]
+    let codexExecHelperCandidates: [DedupCandidate]
     let liveCandidates: [DedupCandidate]
 }
 
@@ -26,22 +28,29 @@ extension SessionManager {
         let sessions = candidates.map(\.session)
         let archivedCodexThreadIDs = archivedCodexDesktopThreadIDs(in: sessions)
         let codexSubagentThreadIDs = codexSubagentThreadIDs(in: sessions)
+        let codexExecHelperThreadIDs = codexExecHelperThreadIDs(in: sessions)
         let claudeMetadata = claudeDesktopMetadataSnapshot(in: sessions)
         let archivedClaudeSessionIDs = claudeMetadata?.archivedSessionIDs ?? []
         let codexSubagentCandidates = candidates.filter {
             isCodexSubagentSession($0.session, subagentThreadIDs: codexSubagentThreadIDs)
         }
+        let codexExecHelperCandidates = candidates.filter {
+            isCodexExecHelperSession($0.session, execHelperThreadIDs: codexExecHelperThreadIDs)
+        }
         let liveCandidates = candidates.filter {
             !isArchivedCodexDesktopSession($0.session, archivedThreadIDs: archivedCodexThreadIDs)
                 && !isCodexSubagentSession($0.session, subagentThreadIDs: codexSubagentThreadIDs)
+                && !isCodexExecHelperSession($0.session, execHelperThreadIDs: codexExecHelperThreadIDs)
                 && !isArchivedClaudeDesktopSession($0.session, archivedSessionIDs: archivedClaudeSessionIDs)
                 && !isOrphanedEndedClaudeDesktopSession($0.session, metadataSnapshot: claudeMetadata)
         }
         return SessionVisibilitySnapshot(
             archivedCodexThreadIDs: archivedCodexThreadIDs,
             codexSubagentThreadIDs: codexSubagentThreadIDs,
+            codexExecHelperThreadIDs: codexExecHelperThreadIDs,
             archivedClaudeSessionIDs: archivedClaudeSessionIDs,
             codexSubagentCandidates: codexSubagentCandidates,
+            codexExecHelperCandidates: codexExecHelperCandidates,
             liveCandidates: liveCandidates
         )
     }
@@ -82,6 +91,24 @@ extension SessionManager {
         (session.isCodex || session.isCodexDesktopHost) && subagentThreadIDs.contains(session.sessionId)
     }
 
+    /// Codex Desktop can launch short-lived `codex exec` helper threads. They are useful as
+    /// rollout artifacts but should not appear as user-visible cctop sessions.
+    nonisolated static func codexExecHelperThreadIDs(in sessions: [Session]) -> Set<String> {
+        let threadIDs = Set(
+            sessions
+                .filter { $0.isCodex || $0.isCodexDesktopHost }
+                .map(\.sessionId)
+        )
+        return CodexThreadArchiveLookup().execHelperThreadIDs(matching: threadIDs) ?? []
+    }
+
+    nonisolated static func isCodexExecHelperSession(
+        _ session: Session,
+        execHelperThreadIDs: Set<String>
+    ) -> Bool {
+        (session.isCodex || session.isCodexDesktopHost) && execHelperThreadIDs.contains(session.sessionId)
+    }
+
     /// Fresh single-session check used before persisting a hidden flag for a Codex subagent
     /// thread. Lookup uncertainty fails OPEN: if we cannot prove it is a subagent, leave it
     /// visible rather than permanently hiding the file.
@@ -94,6 +121,21 @@ extension SessionManager {
             return nil
         }
         latest.isSubagentSession = true
+        latest.hidden = true
+        return latest
+    }
+
+    /// Fresh single-session check used before persisting a hidden flag for Codex one-shot exec
+    /// helpers. Lookup uncertainty fails OPEN: if the Codex state DB is unreadable or too old to
+    /// expose this metadata, leave the session visible rather than permanently hiding the file.
+    nonisolated static func codexExecHelperHiddenSessionSnapshot(path: String) throws -> Session? {
+        guard FileManager.default.fileExists(atPath: path) else { return nil }
+        var latest = try Session.fromFile(path: path)
+        guard !latest.hidden, latest.isCodex || latest.isCodexDesktopHost else { return nil }
+        guard let execHelperIDs = CodexThreadArchiveLookup().execHelperThreadIDs(matching: [latest.sessionId]),
+              execHelperIDs.contains(latest.sessionId) else {
+            return nil
+        }
         latest.hidden = true
         return latest
     }
@@ -122,6 +164,27 @@ extension SessionManager {
                 let sessionId = candidate.session.sessionId
                 sessionManagerLogger.warning(
                     "skipping Codex subagent hide for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+    }
+
+    func hideCodexExecHelperSessions(_ candidates: [DedupCandidate]) {
+        for candidate in candidates {
+            sessionManagerLogger.info(
+                "hiding Codex exec helper session \(candidate.session.sessionId, privacy: .public)"
+            )
+            do {
+                try withSessionLock(sessionPath: candidate.path) {
+                    guard let hiddenSession = try Self.codexExecHelperHiddenSessionSnapshot(path: candidate.path) else {
+                        return
+                    }
+                    try hiddenSession.writeToFile(path: candidate.path)
+                }
+            } catch {
+                let sessionId = candidate.session.sessionId
+                sessionManagerLogger.warning(
+                    "skipping Codex exec helper hide for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)"
                 )
             }
         }

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -19,7 +19,6 @@ struct SessionVisibilitySnapshot {
     let codexExecHelperThreadIDs: Set<String>
     let archivedClaudeSessionIDs: Set<String>
     let codexSubagentCandidates: [DedupCandidate]
-    let codexExecHelperCandidates: [DedupCandidate]
     let liveCandidates: [DedupCandidate]
 }
 
@@ -34,9 +33,6 @@ extension SessionManager {
         let codexSubagentCandidates = candidates.filter {
             isCodexSubagentSession($0.session, subagentThreadIDs: codexSubagentThreadIDs)
         }
-        let codexExecHelperCandidates = candidates.filter {
-            isCodexExecHelperSession($0.session, execHelperThreadIDs: codexExecHelperThreadIDs)
-        }
         let liveCandidates = candidates.filter {
             !isArchivedCodexDesktopSession($0.session, archivedThreadIDs: archivedCodexThreadIDs)
                 && !isCodexSubagentSession($0.session, subagentThreadIDs: codexSubagentThreadIDs)
@@ -50,7 +46,6 @@ extension SessionManager {
             codexExecHelperThreadIDs: codexExecHelperThreadIDs,
             archivedClaudeSessionIDs: archivedClaudeSessionIDs,
             codexSubagentCandidates: codexSubagentCandidates,
-            codexExecHelperCandidates: codexExecHelperCandidates,
             liveCandidates: liveCandidates
         )
     }
@@ -125,21 +120,6 @@ extension SessionManager {
         return latest
     }
 
-    /// Fresh single-session check used before persisting a hidden flag for Codex one-shot exec
-    /// helpers. Lookup uncertainty fails OPEN: if the Codex state DB is unreadable or too old to
-    /// expose this metadata, leave the session visible rather than permanently hiding the file.
-    nonisolated static func codexExecHelperHiddenSessionSnapshot(path: String) throws -> Session? {
-        guard FileManager.default.fileExists(atPath: path) else { return nil }
-        var latest = try Session.fromFile(path: path)
-        guard !latest.hidden, latest.isCodex || latest.isCodexDesktopHost else { return nil }
-        guard let execHelperIDs = CodexThreadArchiveLookup().execHelperThreadIDs(matching: [latest.sessionId]),
-              execHelperIDs.contains(latest.sessionId) else {
-            return nil
-        }
-        latest.hidden = true
-        return latest
-    }
-
     nonisolated static func autoHiddenSessionSnapshot(path: String) throws -> Session? {
         guard FileManager.default.fileExists(atPath: path) else { return nil }
         var latest = try Session.fromFile(path: path)
@@ -164,27 +144,6 @@ extension SessionManager {
                 let sessionId = candidate.session.sessionId
                 sessionManagerLogger.warning(
                     "skipping Codex subagent hide for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)"
-                )
-            }
-        }
-    }
-
-    func hideCodexExecHelperSessions(_ candidates: [DedupCandidate]) {
-        for candidate in candidates {
-            sessionManagerLogger.info(
-                "hiding Codex exec helper session \(candidate.session.sessionId, privacy: .public)"
-            )
-            do {
-                try withSessionLock(sessionPath: candidate.path) {
-                    guard let hiddenSession = try Self.codexExecHelperHiddenSessionSnapshot(path: candidate.path) else {
-                        return
-                    }
-                    try hiddenSession.writeToFile(path: candidate.path)
-                }
-            } catch {
-                let sessionId = candidate.session.sessionId
-                sessionManagerLogger.warning(
-                    "skipping Codex exec helper hide for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)"
                 )
             }
         }

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -95,7 +95,6 @@ class SessionManager: ObservableObject {
 
         hideAutoHiddenSessions(autoHidden)
         hideCodexSubagentSessions(visibility.codexSubagentCandidates)
-        hideCodexExecHelperSessions(visibility.codexExecHelperCandidates)
         clearReconnectedDesktopSessions(liveCandidates, now: Date())
         stampDisconnectedDesktopSessions(liveCandidates, now: Date())
 

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -75,6 +75,7 @@ class SessionManager: ObservableObject {
         )
         sessionManagerLogger.info("loadSessions: \(visibility.archivedCodexThreadIDs.count) codex-archived")
         sessionManagerLogger.info("loadSessions: \(visibility.codexSubagentThreadIDs.count) codex-subagent")
+        sessionManagerLogger.info("loadSessions: \(visibility.codexExecHelperThreadIDs.count) codex-exec-helper")
         sessionManagerLogger.info("loadSessions: \(visibility.archivedClaudeSessionIDs.count) claude-archived")
 
         // Publish active + dormant; finished are hidden (swept below / by GC).
@@ -94,6 +95,7 @@ class SessionManager: ObservableObject {
 
         hideAutoHiddenSessions(autoHidden)
         hideCodexSubagentSessions(visibility.codexSubagentCandidates)
+        hideCodexExecHelperSessions(visibility.codexExecHelperCandidates)
         clearReconnectedDesktopSessions(liveCandidates, now: Date())
         stampDisconnectedDesktopSessions(liveCandidates, now: Date())
 

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -30,46 +30,67 @@ final class SessionFileFormatTests: XCTestCase {
             return "'\(value.replacingOccurrences(of: "'", with: "''"))'"
         }
 
+        let rolloutDir = ((path as NSString).deletingLastPathComponent as NSString).appendingPathComponent("rollouts")
+        try FileManager.default.createDirectory(atPath: rolloutDir, withIntermediateDirectories: true)
+        func rolloutPath(threadID: String, originator: String) throws -> String {
+            let filePath = (rolloutDir as NSString).appendingPathComponent("\(threadID).jsonl")
+            let object: [String: Any] = [
+                "type": "session_meta",
+                "payload": [
+                    "id": threadID,
+                    "originator": originator,
+                    "source": "exec"
+                ]
+            ]
+            var data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+            data.append(0x0a)
+            try data.write(to: URL(fileURLWithPath: filePath), options: .atomic)
+            return filePath
+        }
+
         let archivedRows = archivedThreads.map {
             """
-            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
-            VALUES (\(sqlValue($0)), 1, 'user', NULL, NULL, 'vscode', 1, '');
+            INSERT INTO threads (id, rollout_path, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
+            VALUES (\(sqlValue($0)), '', 1, 'user', NULL, NULL, 'vscode', 1, '');
             """
         }.joined(separator: "\n")
         let subagentRows = subagentThreads.map {
             """
-            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
-            VALUES (\(sqlValue($0)), 0, 'subagent', NULL, NULL, 'vscode', 0, '');
+            INSERT INTO threads (id, rollout_path, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
+            VALUES (\(sqlValue($0)), '', 0, 'subagent', NULL, NULL, 'vscode', 0, '');
             """
         }.joined(separator: "\n")
         let metadataRows = Set(gitOrigins.keys).union(cwds.keys).map { threadID in
             """
-            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
-            VALUES (\(sqlValue(threadID)), 0, 'user', \(sqlValue(gitOrigins[threadID])), \(sqlValue(cwds[threadID])), 'vscode', 1, '');
+            INSERT INTO threads (id, rollout_path, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
+            VALUES (\(sqlValue(threadID)), '', 0, 'user', \(sqlValue(gitOrigins[threadID])), \(sqlValue(cwds[threadID])), 'vscode', 1, '');
             """
         }.joined(separator: "\n")
-        let execHelperRows = execHelperThreads.map {
-            """
-            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
-            VALUES (\(sqlValue($0)), 0, '', NULL, NULL, 'exec', 0, '');
+        let execHelperRows = try execHelperThreads.map {
+            let rollout = try rolloutPath(threadID: $0, originator: "Codex Desktop")
+            return """
+            INSERT INTO threads (id, rollout_path, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
+            VALUES (\(sqlValue($0)), \(sqlValue(rollout)), 0, '', NULL, NULL, 'exec', 0, 'Review the release diff');
             """
         }.joined(separator: "\n")
-        let execFirstMessageRows = execThreadsWithFirstUserMessage.map { threadID, firstUserMessage in
-            """
-            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
-            VALUES (\(sqlValue(threadID)), 0, '', NULL, NULL, 'exec', 0, \(sqlValue(firstUserMessage)));
+        let execFirstMessageRows = try execThreadsWithFirstUserMessage.map { threadID, firstUserMessage in
+            let rollout = try rolloutPath(threadID: threadID, originator: "codex_exec")
+            return """
+            INSERT INTO threads (id, rollout_path, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
+            VALUES (\(sqlValue(threadID)), \(sqlValue(rollout)), 0, '', NULL, NULL, 'exec', 0, \(sqlValue(firstUserMessage)));
             """
         }.joined(separator: "\n")
         let userExecRows = userExecThreads.map {
             """
-            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
-            VALUES (\(sqlValue($0)), 0, '', NULL, NULL, 'exec', 1, '');
+            INSERT INTO threads (id, rollout_path, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
+            VALUES (\(sqlValue($0)), '', 0, '', NULL, NULL, 'exec', 1, '');
             """
         }.joined(separator: "\n")
         let sql = """
         DROP TABLE IF EXISTS threads;
         CREATE TABLE threads (
             id TEXT PRIMARY KEY,
+            rollout_path TEXT NOT NULL DEFAULT '',
             archived INTEGER NOT NULL DEFAULT 0,
             thread_source TEXT,
             git_origin_url TEXT,
@@ -605,55 +626,6 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath + ".lock"))
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
-
-        manager = nil
-    }
-
-    @MainActor
-    func testSessionManagerRestoresCodexExecThreadWhenUserMessageArrives() throws {
-        let root = NSTemporaryDirectory() + "cctop-codex-exec-helper-restore-\(UUID().uuidString)"
-        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
-        let historyDir = (root as NSString).appendingPathComponent("history")
-        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
-        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
-        try writeCodexStateDatabase(
-            path: stateDB,
-            archivedThreads: [],
-            execHelperThreads: ["codex-exec-late-message"]
-        )
-
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
-        setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
-        defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
-            unsetenv("CCTOP_CODEX_STATE_DB")
-            try? FileManager.default.removeItem(atPath: root)
-        }
-
-        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-codex-exec-late-message.json")
-        try codexDesktopSession(
-            sessionId: "codex-exec-late-message",
-            projectPath: (root as NSString).appendingPathComponent("projects/cctop")
-        ).writeToFile(path: sessionPath)
-
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
-            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true }
-        )
-        manager?.loadSessions()
-
-        XCTAssertEqual(manager?.sessions, [])
-        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
-
-        try executeSQLite(
-            "UPDATE threads SET first_user_message = 'Review this diff' WHERE id = 'codex-exec-late-message';",
-            path: stateDB
-        )
-        manager?.loadSessions()
-
-        XCTAssertEqual(manager?.sessions.map(\.sessionId), ["codex-exec-late-message"])
-        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
 
         manager = nil
     }

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -7,7 +7,9 @@ final class SessionFileFormatTests: XCTestCase {
         archivedThreads: Set<String>,
         subagentThreads: Set<String> = [],
         gitOrigins: [String: String] = [:],
-        cwds: [String: String] = [:]
+        cwds: [String: String] = [:],
+        execHelperThreads: Set<String> = [],
+        userExecThreads: Set<String> = []
     ) throws {
         func sqlValue(_ value: String?) -> String {
             guard let value else { return "NULL" }
@@ -16,18 +18,32 @@ final class SessionFileFormatTests: XCTestCase {
 
         let archivedRows = archivedThreads.map {
             """
-            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd) VALUES (\(sqlValue($0)), 1, 'user', NULL, NULL);
+            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event)
+            VALUES (\(sqlValue($0)), 1, 'user', NULL, NULL, 'vscode', 1);
             """
         }.joined(separator: "\n")
         let subagentRows = subagentThreads.map {
             """
-            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd) VALUES (\(sqlValue($0)), 0, 'subagent', NULL, NULL);
+            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event)
+            VALUES (\(sqlValue($0)), 0, 'subagent', NULL, NULL, 'vscode', 0);
             """
         }.joined(separator: "\n")
         let metadataRows = Set(gitOrigins.keys).union(cwds.keys).map { threadID in
             """
-            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd)
-            VALUES (\(sqlValue(threadID)), 0, 'user', \(sqlValue(gitOrigins[threadID])), \(sqlValue(cwds[threadID])));
+            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event)
+            VALUES (\(sqlValue(threadID)), 0, 'user', \(sqlValue(gitOrigins[threadID])), \(sqlValue(cwds[threadID])), 'vscode', 1);
+            """
+        }.joined(separator: "\n")
+        let execHelperRows = execHelperThreads.map {
+            """
+            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event)
+            VALUES (\(sqlValue($0)), 0, '', NULL, NULL, 'exec', 0);
+            """
+        }.joined(separator: "\n")
+        let userExecRows = userExecThreads.map {
+            """
+            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event)
+            VALUES (\(sqlValue($0)), 0, '', NULL, NULL, 'exec', 1);
             """
         }.joined(separator: "\n")
         let sql = """
@@ -37,11 +53,15 @@ final class SessionFileFormatTests: XCTestCase {
             archived INTEGER NOT NULL DEFAULT 0,
             thread_source TEXT,
             git_origin_url TEXT,
-            cwd TEXT
+            cwd TEXT,
+            source TEXT NOT NULL DEFAULT '',
+            has_user_event INTEGER NOT NULL DEFAULT 0
         );
         \(archivedRows)
         \(subagentRows)
         \(metadataRows)
+        \(execHelperRows)
+        \(userExecRows)
         """
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
@@ -528,6 +548,90 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertTrue(try Session.fromFile(path: cliPath).hidden)
         XCTAssertTrue(try Session.fromFile(path: desktopPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
+
+        manager = nil
+    }
+
+    @MainActor
+    func testSessionManagerHidesCodexExecHelperThreadsWithoutRemovingFiles() throws {
+        let root = NSTemporaryDirectory() + "cctop-codex-exec-helper-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        try writeCodexStateDatabase(
+            path: stateDB,
+            archivedThreads: [],
+            execHelperThreads: ["codex-exec-helper"]
+        )
+
+        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
+        setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
+        defer {
+            unsetenv("CCTOP_SESSIONS_DIR")
+            unsetenv("CCTOP_CODEX_STATE_DB")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-codex-exec-helper.json")
+        try codexDesktopSession(
+            sessionId: "codex-exec-helper",
+            projectPath: (root as NSString).appendingPathComponent("projects/cctop")
+        ).writeToFile(path: sessionPath)
+        FileManager.default.createFile(atPath: sessionPath + ".lock", contents: nil)
+
+        var manager: SessionManager? = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true }
+        )
+        manager?.loadSessions()
+
+        XCTAssertEqual(manager?.sessions, [])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath + ".lock"))
+        XCTAssertTrue(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
+
+        manager = nil
+    }
+
+    @MainActor
+    func testSessionManagerKeepsUserVisibleCodexExecThreads() throws {
+        let root = NSTemporaryDirectory() + "cctop-codex-user-exec-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        try writeCodexStateDatabase(
+            path: stateDB,
+            archivedThreads: [],
+            userExecThreads: ["codex-user-exec"]
+        )
+
+        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
+        setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
+        defer {
+            unsetenv("CCTOP_SESSIONS_DIR")
+            unsetenv("CCTOP_CODEX_STATE_DB")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-codex-user-exec.json")
+        try codexDesktopSession(
+            sessionId: "codex-user-exec",
+            projectPath: (root as NSString).appendingPathComponent("projects/cctop")
+        ).writeToFile(path: sessionPath)
+
+        var manager: SessionManager? = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true }
+        )
+        manager?.loadSessions()
+
+        XCTAssertEqual(manager?.sessions.map(\.sessionId), ["codex-user-exec"])
+        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
 
         manager = nil
     }

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -9,6 +9,7 @@ final class SessionFileFormatTests: XCTestCase {
         gitOrigins: [String: String] = [:],
         cwds: [String: String] = [:],
         execHelperThreads: Set<String> = [],
+        execThreadsWithFirstUserMessage: [String: String] = [:],
         userExecThreads: Set<String> = []
     ) throws {
         func sqlValue(_ value: String?) -> String {
@@ -18,32 +19,38 @@ final class SessionFileFormatTests: XCTestCase {
 
         let archivedRows = archivedThreads.map {
             """
-            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event)
-            VALUES (\(sqlValue($0)), 1, 'user', NULL, NULL, 'vscode', 1);
+            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
+            VALUES (\(sqlValue($0)), 1, 'user', NULL, NULL, 'vscode', 1, '');
             """
         }.joined(separator: "\n")
         let subagentRows = subagentThreads.map {
             """
-            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event)
-            VALUES (\(sqlValue($0)), 0, 'subagent', NULL, NULL, 'vscode', 0);
+            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
+            VALUES (\(sqlValue($0)), 0, 'subagent', NULL, NULL, 'vscode', 0, '');
             """
         }.joined(separator: "\n")
         let metadataRows = Set(gitOrigins.keys).union(cwds.keys).map { threadID in
             """
-            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event)
-            VALUES (\(sqlValue(threadID)), 0, 'user', \(sqlValue(gitOrigins[threadID])), \(sqlValue(cwds[threadID])), 'vscode', 1);
+            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
+            VALUES (\(sqlValue(threadID)), 0, 'user', \(sqlValue(gitOrigins[threadID])), \(sqlValue(cwds[threadID])), 'vscode', 1, '');
             """
         }.joined(separator: "\n")
         let execHelperRows = execHelperThreads.map {
             """
-            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event)
-            VALUES (\(sqlValue($0)), 0, '', NULL, NULL, 'exec', 0);
+            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
+            VALUES (\(sqlValue($0)), 0, '', NULL, NULL, 'exec', 0, '');
+            """
+        }.joined(separator: "\n")
+        let execFirstMessageRows = execThreadsWithFirstUserMessage.map { threadID, firstUserMessage in
+            """
+            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
+            VALUES (\(sqlValue(threadID)), 0, '', NULL, NULL, 'exec', 0, \(sqlValue(firstUserMessage)));
             """
         }.joined(separator: "\n")
         let userExecRows = userExecThreads.map {
             """
-            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event)
-            VALUES (\(sqlValue($0)), 0, '', NULL, NULL, 'exec', 1);
+            INSERT INTO threads (id, archived, thread_source, git_origin_url, cwd, source, has_user_event, first_user_message)
+            VALUES (\(sqlValue($0)), 0, '', NULL, NULL, 'exec', 1, '');
             """
         }.joined(separator: "\n")
         let sql = """
@@ -55,12 +62,14 @@ final class SessionFileFormatTests: XCTestCase {
             git_origin_url TEXT,
             cwd TEXT,
             source TEXT NOT NULL DEFAULT '',
-            has_user_event INTEGER NOT NULL DEFAULT 0
+            has_user_event INTEGER NOT NULL DEFAULT 0,
+            first_user_message TEXT NOT NULL DEFAULT ''
         );
         \(archivedRows)
         \(subagentRows)
         \(metadataRows)
         \(execHelperRows)
+        \(execFirstMessageRows)
         \(userExecRows)
         """
         let process = Process()
@@ -631,6 +640,46 @@ final class SessionFileFormatTests: XCTestCase {
         manager?.loadSessions()
 
         XCTAssertEqual(manager?.sessions.map(\.sessionId), ["codex-user-exec"])
+        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
+
+        manager = nil
+    }
+
+    @MainActor
+    func testSessionManagerKeepsCodexExecThreadsWithFirstUserMessageVisible() throws {
+        let root = NSTemporaryDirectory() + "cctop-codex-exec-first-message-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        try writeCodexStateDatabase(
+            path: stateDB,
+            archivedThreads: [],
+            execThreadsWithFirstUserMessage: ["codex-exec-first-message": "Review this diff"]
+        )
+
+        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
+        setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
+        defer {
+            unsetenv("CCTOP_SESSIONS_DIR")
+            unsetenv("CCTOP_CODEX_STATE_DB")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-codex-exec-first-message.json")
+        try codexDesktopSession(
+            sessionId: "codex-exec-first-message",
+            projectPath: (root as NSString).appendingPathComponent("projects/cctop")
+        ).writeToFile(path: sessionPath)
+
+        var manager: SessionManager? = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true }
+        )
+        manager?.loadSessions()
+
+        XCTAssertEqual(manager?.sessions.map(\.sessionId), ["codex-exec-first-message"])
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
 
         manager = nil

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -2,6 +2,19 @@ import XCTest
 @testable import CctopMenubar
 
 final class SessionFileFormatTests: XCTestCase {
+    private func executeSQLite(_ sql: String, path: String) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
+        process.arguments = [path]
+        let stdin = Pipe()
+        process.standardInput = stdin
+        try process.run()
+        stdin.fileHandleForWriting.write(Data(sql.utf8))
+        try stdin.fileHandleForWriting.close()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0)
+    }
+
     private func writeCodexStateDatabase(
         path: String,
         archivedThreads: Set<String>,
@@ -72,16 +85,7 @@ final class SessionFileFormatTests: XCTestCase {
         \(execFirstMessageRows)
         \(userExecRows)
         """
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
-        process.arguments = [path]
-        let stdin = Pipe()
-        process.standardInput = stdin
-        try process.run()
-        stdin.fileHandleForWriting.write(Data(sql.utf8))
-        try stdin.fileHandleForWriting.close()
-        process.waitUntilExit()
-        XCTAssertEqual(process.terminationStatus, 0)
+        try executeSQLite(sql, path: path)
     }
 
     private func codexTerminalSession(sessionId: String, projectPath: String) -> Session {
@@ -562,7 +566,7 @@ final class SessionFileFormatTests: XCTestCase {
     }
 
     @MainActor
-    func testSessionManagerHidesCodexExecHelperThreadsWithoutRemovingFiles() throws {
+    func testSessionManagerFiltersCodexExecHelperThreadsWithoutRemovingFiles() throws {
         let root = NSTemporaryDirectory() + "cctop-codex-exec-helper-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")
         let historyDir = (root as NSString).appendingPathComponent("history")
@@ -599,8 +603,57 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertEqual(manager?.sessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath + ".lock"))
-        XCTAssertTrue(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
+
+        manager = nil
+    }
+
+    @MainActor
+    func testSessionManagerRestoresCodexExecThreadWhenUserMessageArrives() throws {
+        let root = NSTemporaryDirectory() + "cctop-codex-exec-helper-restore-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        try writeCodexStateDatabase(
+            path: stateDB,
+            archivedThreads: [],
+            execHelperThreads: ["codex-exec-late-message"]
+        )
+
+        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
+        setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
+        defer {
+            unsetenv("CCTOP_SESSIONS_DIR")
+            unsetenv("CCTOP_CODEX_STATE_DB")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-codex-exec-late-message.json")
+        try codexDesktopSession(
+            sessionId: "codex-exec-late-message",
+            projectPath: (root as NSString).appendingPathComponent("projects/cctop")
+        ).writeToFile(path: sessionPath)
+
+        var manager: SessionManager? = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true }
+        )
+        manager?.loadSessions()
+
+        XCTAssertEqual(manager?.sessions, [])
+        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
+
+        try executeSQLite(
+            "UPDATE threads SET first_user_message = 'Review this diff' WHERE id = 'codex-exec-late-message';",
+            path: stateDB
+        )
+        manager?.loadSessions()
+
+        XCTAssertEqual(manager?.sessions.map(\.sessionId), ["codex-exec-late-message"])
+        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
 
         manager = nil
     }


### PR DESCRIPTION
## Problem

- cctop publishes the SwiftUI session list from `visibility.liveCandidates`, so any Codex helper that survives the visibility snapshot can appear as a normal visible session. [SessionManager.swift](https://github.com/st0012/cctop/blob/14cdb902fd3a3631ebcab6a9908664395e0c6e4f/menubar/CctopMenubar/Services/SessionManager.swift#L64-L99), [SessionManager+Archive.swift](https://github.com/st0012/cctop/blob/14cdb902fd3a3631ebcab6a9908664395e0c6e4f/menubar/CctopMenubar/Services/SessionManager%2BArchive.swift#L16-L50)
- `source = 'exec'` and `has_user_event = 0` are only a candidate shape, not proof of Codex Desktop ownership, because the tests encode user-visible exec rows with that same broad shape. [SessionFileFormatTests.swift](https://github.com/st0012/cctop/blob/14cdb902fd3a3631ebcab6a9908664395e0c6e4f/menubar/CctopMenubarTests/SessionFileFormatTests.swift#L76-L88), [SessionFileFormatTests.swift](https://github.com/st0012/cctop/blob/14cdb902fd3a3631ebcab6a9908664395e0c6e4f/menubar/CctopMenubarTests/SessionFileFormatTests.swift#L674-L710)

## Solution

- Detect exec helpers by first querying candidate `exec` threads from Codex state, then streaming each candidate's rollout JSONL until `session_meta.payload.originator == "Codex Desktop"` is found. [CodexThreadArchiveLookup.swift](https://github.com/st0012/cctop/blob/14cdb902fd3a3631ebcab6a9908664395e0c6e4f/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift#L84-L135), [CodexThreadArchiveLookup.swift](https://github.com/st0012/cctop/blob/14cdb902fd3a3631ebcab6a9908664395e0c6e4f/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift#L206-L240)
- Filter confirmed Codex Desktop exec helpers out of `liveCandidates` so they are hidden from the UI without persisting `hidden = true` to the cctop session JSON. [SessionManager+Archive.swift](https://github.com/st0012/cctop/blob/14cdb902fd3a3631ebcab6a9908664395e0c6e4f/menubar/CctopMenubar/Services/SessionManager%2BArchive.swift#L36-L40), [SessionFileFormatTests.swift](https://github.com/st0012/cctop/blob/14cdb902fd3a3631ebcab6a9908664395e0c6e4f/menubar/CctopMenubarTests/SessionFileFormatTests.swift#L591-L630)
- Keep user-run exec sessions visible, including the case where `source = 'exec'`, `has_user_event = 0`, and `first_user_message` is populated, when rollout originator is `codex_exec`. [SessionFileFormatTests.swift](https://github.com/st0012/cctop/blob/14cdb902fd3a3631ebcab6a9908664395e0c6e4f/menubar/CctopMenubarTests/SessionFileFormatTests.swift#L33-L82), [SessionFileFormatTests.swift](https://github.com/st0012/cctop/blob/14cdb902fd3a3631ebcab6a9908664395e0c6e4f/menubar/CctopMenubarTests/SessionFileFormatTests.swift#L674-L710)

## Verification

- `xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -configuration Debug -derivedDataPath menubar/build CODE_SIGN_IDENTITY="-" -only-testing:CctopMenubarTests/SessionFileFormatTests/testSessionManagerFiltersCodexExecHelperThreadsWithoutRemovingFiles -only-testing:CctopMenubarTests/SessionFileFormatTests/testSessionManagerKeepsCodexExecThreadsWithFirstUserMessageVisible -only-testing:CctopMenubarTests/SessionFileFormatTests/testSessionManagerKeepsUserVisibleCodexExecThreads` covered the corrected helper and user-exec cases. [SessionFileFormatTests.swift](https://github.com/st0012/cctop/blob/14cdb902fd3a3631ebcab6a9908664395e0c6e4f/menubar/CctopMenubarTests/SessionFileFormatTests.swift#L591-L710)
- `xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -configuration Debug -derivedDataPath menubar/build CODE_SIGN_IDENTITY="-" -only-testing:CctopMenubarTests/SessionFileFormatTests` covered the full session-file test class. [SessionFileFormatTests.swift](https://github.com/st0012/cctop/blob/14cdb902fd3a3631ebcab6a9908664395e0c6e4f/menubar/CctopMenubarTests/SessionFileFormatTests.swift)
- `make lint` ran the repository's strict SwiftLint target. [Makefile](https://github.com/st0012/cctop/blob/14cdb902fd3a3631ebcab6a9908664395e0c6e4f/Makefile#L22-L23)
- `make build` ran the debug app and hook build targets. [Makefile](https://github.com/st0012/cctop/blob/14cdb902fd3a3631ebcab6a9908664395e0c6e4f/Makefile#L9-L15)
