### PR TITLE
Jump iTerm2 sessions to turn marks

### DIFF
--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -6,6 +6,7 @@ private let maxToolDetailLen = 120
 enum HostAppBundleID {
     static let claudeDesktop = "com.anthropic.claudefordesktop"
     static let codexDesktop = "com.openai.codex"
+    static let iterm2 = "com.googlecode.iterm2"
 }
 
 enum HookHandler {
@@ -29,6 +30,7 @@ enum HookHandler {
         let branch = getCurrentBranch(cwd: input.cwd)
         let terminal = captureTerminalInfo()
         let startTime = Session.processStartTime(pid: pid)
+        markITerm2TurnStartIfNeeded(event: event, terminal: terminal)
 
         // Lock the session file for the entire read-modify-write cycle.
         // Without this, concurrent hook processes (e.g. SubagentStart + PreToolUse
@@ -71,6 +73,23 @@ enum HookHandler {
         session.lastToolDetail = nil
         session.notificationMessage = nil
     }
+
+    /// Marks the start of a new iTerm2 agent turn in scrollback.
+    ///
+    /// iTerm2 parses `OSC 1337;SetMark` from the PTY stream and records the
+    /// current scrollback location. This gives the menubar app a terminal-native
+    /// anchor it can jump back to after focusing a waiting session.
+    private static func markITerm2TurnStartIfNeeded(event: HookEvent, terminal: TerminalInfo) {
+        guard shouldMarkITerm2TurnStart(event: event, terminal: terminal),
+              let tty = terminal.tty,
+              let attrs = try? FileManager.default.attributesOfItem(atPath: tty),
+              (attrs[.type] as? FileAttributeType) == .typeCharacterSpecial,
+              let data = buildITerm2SetMarkSequence().data(using: .utf8),
+              let handle = FileHandle(forWritingAtPath: tty) else { return }
+        defer { try? handle.close() }
+        try? handle.write(contentsOf: data)
+    }
+
     private static func applySubagentEvent(event: HookEvent, session: inout Session, input: HookInput) {
         switch event {
         case .subagentStart:
@@ -434,6 +453,32 @@ extension HookHandler {
     private static func isPIDAlive(_ pid: UInt32) -> Bool {
         kill(Int32(pid), 0) == 0 || errno == EPERM
     }
+}
+
+/// Returns the iTerm2 escape sequence for setting a mark at the current scrollback location.
+func buildITerm2SetMarkSequence() -> String {
+    "\u{1B}]1337;SetMark\u{07}"
+}
+
+/// Returns whether a hook event should create an iTerm2 turn-start mark.
+func shouldMarkITerm2TurnStart(event: HookEvent, terminal: TerminalInfo) -> Bool {
+    guard event == .userPromptSubmit,
+          isITerm2Terminal(terminal),
+          let tty = terminal.tty,
+          isSafePTYSlavePath(tty)
+    else { return false }
+    return true
+}
+
+/// Returns whether terminal metadata identifies an iTerm2 session.
+func isITerm2Terminal(_ terminal: TerminalInfo) -> Bool {
+    if terminal.bundleId == HostAppBundleID.iterm2 { return true }
+    return terminal.program.lowercased().contains("iterm")
+}
+
+/// Returns whether a path is a macOS PTY slave path captured from a terminal session.
+func isSafePTYSlavePath(_ tty: String) -> Bool {
+    tty.range(of: #"^/dev/ttys\d+$"#, options: .regularExpression) != nil
 }
 
 // MARK: - Session File Locking

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -465,7 +465,7 @@ func shouldMarkITerm2TurnStart(event: HookEvent, terminal: TerminalInfo) -> Bool
     guard event == .userPromptSubmit,
           isITerm2Terminal(terminal),
           let tty = terminal.tty,
-          isSafePTYSlavePath(tty)
+          isSafePTYDevicePath(tty)
     else { return false }
     return true
 }
@@ -476,8 +476,11 @@ func isITerm2Terminal(_ terminal: TerminalInfo) -> Bool {
     return terminal.program.lowercased().contains("iterm")
 }
 
-/// Returns whether a path is a macOS PTY slave path captured from a terminal session.
-func isSafePTYSlavePath(_ tty: String) -> Bool {
+/// Returns whether a path is a safe macOS PTY device path captured from a terminal session.
+///
+/// - Parameter tty: Terminal path captured from hook terminal metadata.
+/// - Returns: `true` when the path is a `/dev/ttysNNN` character device path shape.
+func isSafePTYDevicePath(_ tty: String) -> Bool {
     tty.range(of: #"^/dev/ttys\d+$"#, options: .regularExpression) != nil
 }
 

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -149,8 +149,8 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
         }
 
     case .iTerm2(let guid, let jumpToMark):
-        let focused = runScriptOrActivate(.iterm2) { executeITerm2Script(guid: guid) }
-        if focused && jumpToMark {
+        let didMatchSession = runScriptOrActivate(.iterm2) { executeITerm2Script(guid: guid) }
+        if shouldJumpToITerm2Mark(didMatchSession: didMatchSession, jumpToMark: jumpToMark) {
             executeITerm2JumpToMarkScript()
         }
 
@@ -179,7 +179,12 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
     }
 }
 
-/// Run a focus script for `host`; if it fails, fall back to activating the host by bundle ID.
+/// Runs a focus script and falls back to activating the host by bundle ID.
+///
+/// - Parameters:
+///   - host: Host app to activate when the focused session cannot be matched.
+///   - script: Focus operation that returns `true` only when it matched the target session.
+/// - Returns: `true` when the script matched its target session; otherwise `false`.
 @discardableResult
 private func runScriptOrActivate(_ host: HostApp, script: () -> Bool) -> Bool {
     if script() {
@@ -205,8 +210,38 @@ private func runAppleScript(_ source: String) -> Bool {
     return error == nil
 }
 
+/// Runs AppleScript that returns an explicit Boolean result.
+///
+/// - Parameter source: AppleScript source expected to return `true` for a target match.
+/// - Returns: The script's Boolean result, or `false` when execution fails.
+private func runAppleScriptReturningBool(_ source: String) -> Bool {
+    var error: NSDictionary?
+    guard let result = NSAppleScript(source: source)?.executeAndReturnError(&error),
+          error == nil else { return false }
+    return result.booleanValue
+}
+
+/// Returns whether the iTerm2 mark jump should run after a focus attempt.
+///
+/// - Parameters:
+///   - didMatchSession: Whether the focus script found and selected the saved iTerm2 GUID.
+///   - jumpToMark: Whether the session status calls for jumping to the latest turn mark.
+/// - Returns: `true` only when both the session matched and mark jumping was requested.
+func shouldJumpToITerm2Mark(didMatchSession: Bool, jumpToMark: Bool) -> Bool {
+    didMatchSession && jumpToMark
+}
+
 private func executeITerm2Script(guid: String) -> Bool {
-    runAppleScript("""
+    runAppleScriptReturningBool(buildITerm2FocusScript(guid: guid))
+}
+
+/// Builds AppleScript that focuses a specific iTerm2 session by GUID.
+///
+/// - Parameter guid: iTerm2 session unique ID captured from terminal metadata.
+/// - Returns: AppleScript source that returns `true` on GUID match and `false` otherwise.
+func buildITerm2FocusScript(guid: String) -> String {
+    let escapedGUID = escapeAppleScriptString(guid)
+    return """
     tell application "iTerm2"
         activate
         repeat with w in windows
@@ -214,20 +249,21 @@ private func executeITerm2Script(guid: String) -> Bool {
                 repeat with t in tabs
                     tell t
                         repeat with s in sessions
-                            if (unique id of s) is equal to "\(guid)" then
+                            if (unique id of s) is equal to "\(escapedGUID)" then
                                 set miniaturized of w to false
                                 set index of w to 1
                                 select t
                                 tell s to select
-                                return
+                                return true
                             end if
                         end repeat
                     end tell
                 end repeat
             end tell
         end repeat
+        return false
     end tell
-    """)
+    """
 }
 
 /// Best-effort jump to the latest iTerm2 mark after a session has been focused.
@@ -335,11 +371,11 @@ private func executeGhosttyFocusScript(workingDirectory: String) -> Bool {
     """)
 }
 
-/// Bytes written to the slave (`/dev/ttysNNN`) appear on the PTY master where Ghostty
+/// Bytes written to the terminal device (`/dev/ttysNNN`) appear on the PTY master where Ghostty
 /// parses them; the shell does not see them. Best-effort — silently no-ops if the TTY
 /// has closed (session just ended).
 private func primeGhosttyCWD(tty: String, workingDirectory: String) {
-    // Allow only PTY slaves (`/dev/ttys<digits>`) — that's the only shape
+    // Allow only PTY terminal devices (`/dev/ttys<digits>`) — that's the only shape
     // cctop-hook captures from `ps -o tty=`. This rejects /dev/cu.*, /dev/console,
     // and arbitrary file paths a tampered session JSON might supply.
     guard tty.range(of: #"^/dev/ttys\d+$"#, options: .regularExpression) != nil else { return }

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -180,11 +180,7 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
 }
 
 /// Runs a focus script and falls back to activating the host by bundle ID.
-///
-/// - Parameters:
-///   - host: Host app to activate when the focused session cannot be matched.
-///   - script: Focus operation that returns `true` only when it matched the target session.
-/// - Returns: `true` when the script matched its target session; otherwise `false`.
+/// - Returns: `true` only when the script matched its target session.
 @discardableResult
 private func runScriptOrActivate(_ host: HostApp, script: () -> Bool) -> Bool {
     if script() {
@@ -211,33 +207,20 @@ private func runAppleScript(_ source: String) -> Bool {
 }
 
 /// Runs AppleScript that returns an explicit Boolean result.
-///
-/// - Parameter source: AppleScript source expected to return `true` for a target match.
 /// - Returns: The script's Boolean result, or `false` when execution fails.
 private func runAppleScriptReturningBool(_ source: String) -> Bool {
     var error: NSDictionary?
-    guard let result = NSAppleScript(source: source)?.executeAndReturnError(&error),
-          error == nil else { return false }
+    guard let result = NSAppleScript(source: source)?.executeAndReturnError(&error), error == nil else { return false }
     return result.booleanValue
 }
 
 /// Returns whether the iTerm2 mark jump should run after a focus attempt.
-///
-/// - Parameters:
-///   - didMatchSession: Whether the focus script found and selected the saved iTerm2 GUID.
-///   - jumpToMark: Whether the session status calls for jumping to the latest turn mark.
-/// - Returns: `true` only when both the session matched and mark jumping was requested.
-func shouldJumpToITerm2Mark(didMatchSession: Bool, jumpToMark: Bool) -> Bool {
-    didMatchSession && jumpToMark
-}
-
+/// - Returns: `true` only when the target session matched and mark jumping was requested.
+func shouldJumpToITerm2Mark(didMatchSession: Bool, jumpToMark: Bool) -> Bool { didMatchSession && jumpToMark }
 private func executeITerm2Script(guid: String) -> Bool {
     runAppleScriptReturningBool(buildITerm2FocusScript(guid: guid))
 }
-
 /// Builds AppleScript that focuses a specific iTerm2 session by GUID.
-///
-/// - Parameter guid: iTerm2 session unique ID captured from terminal metadata.
 /// - Returns: AppleScript source that returns `true` on GUID match and `false` otherwise.
 func buildITerm2FocusScript(guid: String) -> String {
     let escapedGUID = escapeAppleScriptString(guid)

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 
 // MARK: - Strategy (testable, pure logic)
 
@@ -7,7 +8,7 @@ enum FocusStrategy: Equatable {
     /// Open a file/folder with a specific app via its bundle ID.
     case openWithApp(bundleID: String, target: String)
     /// Focus an iTerm2 session by its unique GUID, with a bundle ID fallback.
-    case iTerm2(guid: String)
+    case iTerm2(guid: String, jumpToMark: Bool)
     /// Focus a Kitty window via remote control socket, with bundle ID fallback.
     case kitty(socket: String, windowId: String, binaryPath: String)
     /// Focus a Ghostty terminal by matching its working directory, with a bundle ID fallback.
@@ -58,7 +59,7 @@ func resolveFocusStrategy(session: Session) -> FocusStrategy {
     if hostApp == .iterm2,
        let guid = extractITermGUID(from: terminal.sessionId),
        guid.range(of: #"^[0-9a-fA-F-]+$"#, options: .regularExpression) != nil {
-        return .iTerm2(guid: guid)
+        return .iTerm2(guid: guid, jumpToMark: session.status.needsAttention)
     }
 
     // Kitty → remote control to focus the specific window (pane in Kitty's terms)
@@ -147,8 +148,11 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
             NSWorkspace.shared.open(URL(fileURLWithPath: target))
         }
 
-    case .iTerm2(let guid):
-        runScriptOrActivate(.iterm2) { executeITerm2Script(guid: guid) }
+    case .iTerm2(let guid, let jumpToMark):
+        let focused = runScriptOrActivate(.iterm2) { executeITerm2Script(guid: guid) }
+        if focused && jumpToMark {
+            executeITerm2JumpToMarkScript()
+        }
 
     case .kitty(let socket, let windowId, let binaryPath):
         runScriptOrActivate(.kitty) {
@@ -176,10 +180,15 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
 }
 
 /// Run a focus script for `host`; if it fails, fall back to activating the host by bundle ID.
-private func runScriptOrActivate(_ host: HostApp, script: () -> Bool) {
-    if !script(), let bundleID = host.bundleID {
+@discardableResult
+private func runScriptOrActivate(_ host: HostApp, script: () -> Bool) -> Bool {
+    if script() {
+        return true
+    }
+    if let bundleID = host.bundleID {
         activateAppByBundleID(bundleID)
     }
+    return false
 }
 
 // MARK: - iTerm2 AppleScript
@@ -217,6 +226,24 @@ private func executeITerm2Script(guid: String) -> Bool {
                 end repeat
             end tell
         end repeat
+    end tell
+    """)
+}
+
+/// Best-effort jump to the latest iTerm2 mark after a session has been focused.
+private func executeITerm2JumpToMarkScript() {
+    guard AXIsProcessTrusted() else { return }
+    _ = runAppleScript("""
+    tell application "System Events"
+        try
+            tell process "iTerm2"
+                tell menu "Edit" of menu bar item "Edit" of menu bar 1
+                    tell menu item "Marks and Annotations"
+                        click menu item "Jump to Mark" of menu 1
+                    end tell
+                end tell
+            end tell
+        end try
     end tell
     """)
 }

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -84,7 +84,17 @@ final class FocusStrategyTests: XCTestCase {
             sessionId: "w0t0p0:ABC123-DEF-456"
         )
         let strategy = resolveFocusStrategy(session: session)
-        XCTAssertEqual(strategy, .iTerm2(guid: "ABC123-DEF-456"))
+        XCTAssertEqual(strategy, .iTerm2(guid: "ABC123-DEF-456", jumpToMark: false))
+    }
+
+    func testITerm2WaitingSessionJumpsToMark() {
+        var session = makeSession(
+            program: "iTerm2",
+            sessionId: "w0t0p0:ABC123-DEF-456"
+        )
+        session.status = .waitingInput
+        let strategy = resolveFocusStrategy(session: session)
+        XCTAssertEqual(strategy, .iTerm2(guid: "ABC123-DEF-456", jumpToMark: true))
     }
 
     func testITerm2WithoutGUIDFallsBackToActivate() {

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -97,6 +97,22 @@ final class FocusStrategyTests: XCTestCase {
         XCTAssertEqual(strategy, .iTerm2(guid: "ABC123-DEF-456", jumpToMark: true))
     }
 
+    func testITerm2DoesNotJumpToMarkWhenFocusDoesNotMatchSession() {
+        XCTAssertFalse(shouldJumpToITerm2Mark(didMatchSession: false, jumpToMark: true))
+    }
+
+    func testITerm2JumpsToMarkWhenFocusMatchesWaitingSession() {
+        XCTAssertTrue(shouldJumpToITerm2Mark(didMatchSession: true, jumpToMark: true))
+    }
+
+    func testITerm2FocusScriptReturnsExplicitMatchSentinel() {
+        let script = buildITerm2FocusScript(guid: #"ABC"123"#)
+
+        XCTAssertTrue(script.contains("return true"))
+        XCTAssertTrue(script.contains("return false"))
+        XCTAssertTrue(script.contains(#"ABC\"123"#))
+    }
+
     func testITerm2WithoutGUIDFallsBackToActivate() {
         let session = makeSession(program: "iTerm2")
         let strategy = resolveFocusStrategy(session: session)

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -64,6 +64,45 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertEqual(HostApp.codexDesktop.bundleID, HostAppBundleID.codexDesktop)
     }
 
+    // MARK: - iTerm2 turn-start marks
+
+    func testITerm2BundleIDIsSharedWithHostApp() {
+        XCTAssertEqual(HostApp.iterm2.bundleID, HostAppBundleID.iterm2)
+    }
+
+    func testBuildITerm2SetMarkSequence() {
+        XCTAssertEqual(buildITerm2SetMarkSequence(), "\u{1B}]1337;SetMark\u{07}")
+    }
+
+    func testShouldMarkITerm2TurnStartForPromptSubmit() {
+        let terminal = TerminalInfo(
+            program: "iTerm2",
+            sessionId: "w0t0p0:ABC123",
+            tty: "/dev/ttys123",
+            bundleId: HostAppBundleID.iterm2
+        )
+
+        XCTAssertTrue(shouldMarkITerm2TurnStart(event: .userPromptSubmit, terminal: terminal))
+    }
+
+    func testShouldNotMarkNonITerm2TurnStart() {
+        let terminal = TerminalInfo(program: "Terminal", tty: "/dev/ttys123")
+
+        XCTAssertFalse(shouldMarkITerm2TurnStart(event: .userPromptSubmit, terminal: terminal))
+    }
+
+    func testShouldNotMarkITerm2WhenTTYIsUnsafe() {
+        let terminal = TerminalInfo(program: "iTerm2", tty: "/tmp/not-a-tty")
+
+        XCTAssertFalse(shouldMarkITerm2TurnStart(event: .userPromptSubmit, terminal: terminal))
+    }
+
+    func testShouldNotMarkITerm2ForStopEvent() {
+        let terminal = TerminalInfo(program: "iTerm2", tty: "/dev/ttys123")
+
+        XCTAssertFalse(shouldMarkITerm2TurnStart(event: .stop, terminal: terminal))
+    }
+
     // MARK: - SessionStart creates idle session
 
     func testSessionStartCreatesIdleSession() throws {


### PR DESCRIPTION
## Problem

When an iTerm2-backed session needs attention, cctop can focus the correct window, tab, and pane, but the terminal remains wherever the user last scrolled. For long agent turns, users still have to manually scroll back to find the beginning of the latest response.

## Solution

- Set an iTerm2 mark at each `UserPromptSubmit` boundary by writing `OSC 1337;SetMark` to the captured PTY.
- When focusing an attention-state iTerm2 session, first focus the existing GUID target as before, then best-effort jump to the latest mark.
- Guard the menu-based jump behind `AXIsProcessTrusted()` so users without Accessibility permission keep the existing focus behavior without a new prompt.
- Keep the change iTerm2-only; other terminal focus strategies are unchanged.

## Verification

- `xcrun swiftc -typecheck -parse-as-library -target arm64-apple-macos13.0 ... HookHandler.swift FocusTerminal.swift`
- `python3 scripts/validate-hook-contract.py fixtures`
- `python3 scripts/validate-hook-contract.py hooks`
- `npm --prefix plugins/opencode test`
- Manual iTerm2 check: wrote `OSC 1337;SetMark` to the active PTY and confirmed the focus+Jump to Mark AppleScript returned `FOCUS_AND_JUMP_OK`.

Could not run full `xcodebuild test` or `swiftlint --strict` locally because this machine has Command Line Tools only (`xcode-select -p` is `/Library/Developer/CommandLineTools`) and no `swiftlint` binary installed.