### PR TITLE
Avoid creating notch pill while active

### DIFF
--- a/menubar/CctopMenubar/Services/NotchStatusController.swift
+++ b/menubar/CctopMenubar/Services/NotchStatusController.swift
@@ -84,11 +84,9 @@ class NotchStatusController {
         statusItemOccluded: Bool
     ) -> NotchPillAction {
         guard hasNotch, hasBuiltinScreen else { return .tearDown }
-        // When cctop is active, its minimal menubar frees space and
-        // isStatusItemOccluded may return false even though the status
-        // item will be re-occluded once the previous app's menubar returns.
-        // Preserve an existing pill; let the deactivation check decide.
-        if appIsActive, pillExists { return .keep }
+        // While cctop is active, menu bar status-item visibility can be transient.
+        // Keep an existing pill, but do not create one until cctop is inactive.
+        if appIsActive { return pillExists ? .keep : .tearDown }
         return statusItemOccluded ? .show : .tearDown
     }
 }

--- a/menubar/CctopMenubarTests/NotchVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/NotchVisibilityTests.swift
@@ -68,15 +68,16 @@ final class NotchVisibilityTests: XCTestCase {
         XCTAssertEqual(action, .keep)
     }
 
-    // MARK: - App active without existing pill → normal check
+    // MARK: - App active without existing pill → do not create
 
-    func testActiveNoPillOccludedShows() {
-        // No pill yet but occluded → show it
+    func testActiveNoPillOccludedTearsDown() {
+        // Occlusion measurements can be transient while cctop is active.
+        // Do not create a new pill until the app is inactive.
         let action = NotchStatusController.resolveVisibility(
             hasNotch: true, hasBuiltinScreen: true,
             appIsActive: true, pillExists: false, statusItemOccluded: true
         )
-        XCTAssertEqual(action, .show)
+        XCTAssertEqual(action, .tearDown)
     }
 
     func testActiveNoPillNotOccludedTearsDown() {


### PR DESCRIPTION
## Problem

Fixes #146.

The notch pill can appear unexpectedly while cctop is active, then disappear after the user clicks another app/window. One plausible path is a transient `statusItemOccluded == true` measurement while cctop owns the active menu bar: the current visibility resolver creates a new pill even though cctop is active and no pill existed before. A later inactive measurement can tear it down again.

## Solution

- Keep an existing notch pill while cctop is active, preserving the intended behavior from the previous fix.
- Do not create a new notch pill while cctop is active; wait until cctop is inactive and the status item occlusion measurement is stable again.
- Update the notch visibility test that previously expected active/no-pill/occluded to create a pill.

## Verification

- Ran a local strategy-case script covering the `NotchStatusController.resolveVisibility` branches.
- `git diff --check`
- `python3 scripts/validate-hook-contract.py fixtures`
- `python3 scripts/validate-hook-contract.py hooks`
- `npm --prefix plugins/opencode test`

Could not run full `xcodebuild test` or `swiftlint --strict` locally because this machine has Command Line Tools only (`xcode-select -p` is `/Library/Developer/CommandLineTools`) and no `swiftlint` binary installed.