### PR TITLE
Add documentation comments to RecentProject struct

### DIFF
--- a/menubar/CctopMenubar/Models/RecentProject.swift
+++ b/menubar/CctopMenubar/Models/RecentProject.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// Represents a recently accessed project with metadata like path, name, last session, and editor information.
+/// - Important: Used for tracking project history in the menubar.
 struct RecentProject: Identifiable {
     let projectPath: String
     let projectName: String


### PR DESCRIPTION
## Problem Background
The `RecentProject` struct, being a public API, lacked documentation comments. Public APIs should have clear docstrings to improve code maintainability, readability, and usability for other developers.

## Changes
- Added a documentation comment (`///`) to the `RecentProject` struct in `menubar/CctopMenubar/Models/RecentProject.swift`. This comment describes the struct's purpose and highlights its importance for tracking project history in the menubar.

## Verification
- Review the added documentation for accuracy and clarity.
- Ensure the code compiles without errors (this change is purely documentation and does not affect functionality).
- Verify that the comment aligns with existing code style and naming conventions in the repository.