### PR TITLE
Reduce Claude metadata refresh CPU

### DIFF
--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		CTA000010000000000000001 /* CodexThreadArchiveLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTA000020000000000000001 /* CodexThreadArchiveLookup.swift */; };
 		CDA000010000000000000001 /* ClaudeDesktopSessionArchiveLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA000020000000000000001 /* ClaudeDesktopSessionArchiveLookup.swift */; };
 		SMA000010000000000000001 /* SessionManager+Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = SMA000020000000000000001 /* SessionManager+Archive.swift */; };
+		SML000010000000000000001 /* SessionManager+Loading.swift in Sources */ = {isa = PBXBuildFile; fileRef = SML000020000000000000001 /* SessionManager+Loading.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -131,6 +132,7 @@
 		CTA000020000000000000001 /* CodexThreadArchiveLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexThreadArchiveLookup.swift; sourceTree = "<group>"; };
 		CDA000020000000000000001 /* ClaudeDesktopSessionArchiveLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeDesktopSessionArchiveLookup.swift; sourceTree = "<group>"; };
 		SMA000020000000000000001 /* SessionManager+Archive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionManager+Archive.swift"; sourceTree = "<group>"; };
+		SML000020000000000000001 /* SessionManager+Loading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionManager+Loading.swift"; sourceTree = "<group>"; };
 		D1000000A000000000000001 /* QuitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitButton.swift; sourceTree = "<group>"; };
 		D10000020000000000000001 /* StatusChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusChip.swift; sourceTree = "<group>"; };
 		D10000040000000000000001 /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
@@ -259,6 +261,7 @@
 				CTA000020000000000000001 /* CodexThreadArchiveLookup.swift */,
 				CDA000020000000000000001 /* ClaudeDesktopSessionArchiveLookup.swift */,
 				SMA000020000000000000001 /* SessionManager+Archive.swift */,
+				SML000020000000000000001 /* SessionManager+Loading.swift */,
 				HM0000020000000000000001 /* HistoryManager.swift */,
 				E10000020000000000000001 /* FocusTerminal.swift */,
 				SP0000020000000000000001 /* SparkleUpdater.swift */,
@@ -531,6 +534,7 @@
 				CTA000010000000000000001 /* CodexThreadArchiveLookup.swift in Sources */,
 				CDA000010000000000000001 /* ClaudeDesktopSessionArchiveLookup.swift in Sources */,
 				SMA000010000000000000001 /* SessionManager+Archive.swift in Sources */,
+				SML000010000000000000001 /* SessionManager+Loading.swift in Sources */,
 				D10000010000000000000001 /* StatusChip.swift in Sources */,
 				D10000030000000000000001 /* HeaderView.swift in Sources */,
 				D10000050000000000000001 /* SessionCardView.swift in Sources */,

--- a/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift
@@ -34,28 +34,18 @@ struct ClaudeDesktopSessionArchiveLookup {
 
         var latestBySessionID: [String: ClaudeArchiveMatch] = [:]
         for case let url as URL in enumerator where isClaudeDesktopMetadataURL(url) {
-            guard let data = try? Data(contentsOf: url),
-                  let content = String(data: data, encoding: .utf8) else {
-                return nil
-            }
-            guard sessionIDs.contains(where: { content.contains($0) }) else { continue }
-            guard let metadata = try? JSONDecoder().decode(ClaudeDesktopSessionMetadata.self, from: data) else {
-                return nil
-            }
-            guard let cliSessionId = metadata.cliSessionId,
-                  sessionIDs.contains(cliSessionId) else { continue }
-
-            let match = ClaudeArchiveMatch(
-                isArchived: metadata.isArchived == true,
-                projectName: Self.projectName(originCwd: metadata.originCwd, worktreeName: metadata.worktreeName),
-                recencyKey: metadata.lastActivityAt ?? metadata.createdAt ?? .missing,
-                path: url.path
-            )
-            if let current = latestBySessionID[cliSessionId],
-               !match.isNewer(than: current) {
+            switch metadataMatch(at: url, matching: sessionIDs) {
+            case .skip:
                 continue
+            case .uncertain:
+                return nil
+            case let .match(sessionID, match):
+                if let current = latestBySessionID[sessionID],
+                   !match.isNewer(than: current) {
+                    continue
+                }
+                latestBySessionID[sessionID] = match
             }
-            latestBySessionID[cliSessionId] = match
         }
 
         return ClaudeDesktopSessionMetadataSnapshot(
@@ -70,6 +60,69 @@ struct ClaudeDesktopSessionArchiveLookup {
 
     private func isClaudeDesktopMetadataURL(_ url: URL) -> Bool {
         url.pathExtension == "json" && url.lastPathComponent.hasPrefix("local_")
+    }
+
+    private func metadataMatch(at url: URL, matching sessionIDs: Set<String>) -> ClaudeMetadataFileMatch {
+        guard let data = try? Data(contentsOf: url),
+              let content = String(data: data, encoding: .utf8) else {
+            return .uncertain
+        }
+        guard let candidateSessionID = cliSessionID(in: content) else {
+            if content.contains(#""cliSessionId""#),
+               sessionIDs.contains(where: { content.contains($0) }) {
+                return .uncertain
+            }
+            return .skip
+        }
+        guard sessionIDs.contains(candidateSessionID) else { return .skip }
+        guard let metadata = try? JSONDecoder().decode(ClaudeDesktopSessionMetadata.self, from: data),
+              let cliSessionId = metadata.cliSessionId,
+              sessionIDs.contains(cliSessionId) else {
+            return .uncertain
+        }
+
+        let match = ClaudeArchiveMatch(
+            isArchived: metadata.isArchived == true,
+            projectName: Self.projectName(originCwd: metadata.originCwd, worktreeName: metadata.worktreeName),
+            recencyKey: metadata.lastActivityAt ?? metadata.createdAt ?? .missing,
+            path: url.path
+        )
+        return .match(cliSessionId, match)
+    }
+
+    private func cliSessionID(in content: String) -> String? {
+        guard let keyRange = content.range(of: #""cliSessionId""#),
+              let colonRange = content[keyRange.upperBound...].range(of: ":") else {
+            return nil
+        }
+
+        var cursor = colonRange.upperBound
+        while cursor < content.endIndex, content[cursor].isWhitespace {
+            cursor = content.index(after: cursor)
+        }
+
+        guard cursor < content.endIndex, content[cursor] == "\"" else { return nil }
+        cursor = content.index(after: cursor)
+
+        var value = ""
+        var escaped = false
+        while cursor < content.endIndex {
+            let character = content[cursor]
+            cursor = content.index(after: cursor)
+
+            if escaped {
+                value.append(character)
+                escaped = false
+            } else if character == "\\" {
+                escaped = true
+            } else if character == "\"" {
+                return value
+            } else {
+                value.append(character)
+            }
+        }
+
+        return nil
     }
 
     private static func nonEmpty(_ value: String?) -> String? {
@@ -209,4 +262,10 @@ private struct ClaudeArchiveMatch {
         }
         return path > other.path
     }
+}
+
+private enum ClaudeMetadataFileMatch {
+    case skip
+    case uncertain
+    case match(String, ClaudeArchiveMatch)
 }

--- a/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift
@@ -67,19 +67,26 @@ struct ClaudeDesktopSessionArchiveLookup {
               let content = String(data: data, encoding: .utf8) else {
             return .uncertain
         }
-        guard let candidateSessionID = cliSessionID(in: content) else {
+        let scannedSessionIDs = cliSessionIDs(in: content)
+        guard !scannedSessionIDs.values.isEmpty else {
             if content.contains(#""cliSessionId""#),
                sessionIDs.contains(where: { content.contains($0) }) {
                 return .uncertain
             }
             return .skip
         }
-        guard sessionIDs.contains(candidateSessionID) else { return .skip }
-        guard let metadata = try? JSONDecoder().decode(ClaudeDesktopSessionMetadata.self, from: data),
-              let cliSessionId = metadata.cliSessionId,
-              sessionIDs.contains(cliSessionId) else {
+        guard scannedSessionIDs.values.contains(where: { sessionIDs.contains($0) }) else {
+            if scannedSessionIDs.sawUnparseableValue,
+               sessionIDs.contains(where: { content.contains($0) }) {
+                return .uncertain
+            }
+            return .skip
+        }
+        guard let metadata = try? JSONDecoder().decode(ClaudeDesktopSessionMetadata.self, from: data) else {
             return .uncertain
         }
+        guard let cliSessionId = metadata.cliSessionId,
+              sessionIDs.contains(cliSessionId) else { return .skip }
 
         let match = ClaudeArchiveMatch(
             isArchived: metadata.isArchived == true,
@@ -90,20 +97,37 @@ struct ClaudeDesktopSessionArchiveLookup {
         return .match(cliSessionId, match)
     }
 
-    private func cliSessionID(in content: String) -> String? {
-        guard let keyRange = content.range(of: #""cliSessionId""#),
-              let colonRange = content[keyRange.upperBound...].range(of: ":") else {
-            return nil
-        }
+    private func cliSessionIDs(in content: String) -> ClaudeCLISessionIDScan {
+        var cursor = content.startIndex
+        var values: [String] = []
+        var sawUnparseableValue = false
 
-        var cursor = colonRange.upperBound
-        while cursor < content.endIndex, content[cursor].isWhitespace {
+        while let keyRange = content[cursor...].range(of: #""cliSessionId""#) {
+            cursor = keyRange.upperBound
+            guard let colonRange = content[cursor...].range(of: ":") else {
+                sawUnparseableValue = true
+                continue
+            }
+            cursor = colonRange.upperBound
+            while cursor < content.endIndex, content[cursor].isWhitespace {
+                cursor = content.index(after: cursor)
+            }
+            guard cursor < content.endIndex, content[cursor] == "\"" else {
+                sawUnparseableValue = true
+                continue
+            }
             cursor = content.index(after: cursor)
+            guard let value = quotedValue(in: content, cursor: &cursor) else {
+                sawUnparseableValue = true
+                continue
+            }
+            values.append(value)
         }
 
-        guard cursor < content.endIndex, content[cursor] == "\"" else { return nil }
-        cursor = content.index(after: cursor)
+        return ClaudeCLISessionIDScan(values: values, sawUnparseableValue: sawUnparseableValue)
+    }
 
+    private func quotedValue(in content: String, cursor: inout String.Index) -> String? {
         var value = ""
         var escaped = false
         while cursor < content.endIndex {
@@ -268,4 +292,9 @@ private enum ClaudeMetadataFileMatch {
     case skip
     case uncertain
     case match(String, ClaudeArchiveMatch)
+}
+
+private struct ClaudeCLISessionIDScan {
+    let values: [String]
+    let sawUnparseableValue: Bool
 }

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -25,10 +25,25 @@ struct SessionVisibilitySnapshot {
 extension SessionManager {
     nonisolated static func visibilitySnapshot(in candidates: [DedupCandidate]) -> SessionVisibilitySnapshot {
         let sessions = candidates.map(\.session)
+        let claudeMetadata = claudeDesktopMetadataSnapshot(in: sessions)
+        return visibilitySnapshot(in: candidates, sessions: sessions, claudeMetadata: claudeMetadata)
+    }
+
+    nonisolated static func visibilitySnapshot(
+        in candidates: [DedupCandidate],
+        claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?
+    ) -> SessionVisibilitySnapshot {
+        visibilitySnapshot(in: candidates, sessions: candidates.map(\.session), claudeMetadata: claudeMetadata)
+    }
+
+    private nonisolated static func visibilitySnapshot(
+        in candidates: [DedupCandidate],
+        sessions: [Session],
+        claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?
+    ) -> SessionVisibilitySnapshot {
         let archivedCodexThreadIDs = archivedCodexDesktopThreadIDs(in: sessions)
         let codexSubagentThreadIDs = codexSubagentThreadIDs(in: sessions)
         let codexExecHelperThreadIDs = codexExecHelperThreadIDs(in: sessions)
-        let claudeMetadata = claudeDesktopMetadataSnapshot(in: sessions)
         let archivedClaudeSessionIDs = claudeMetadata?.archivedSessionIDs ?? []
         let codexSubagentCandidates = candidates.filter {
             isCodexSubagentSession($0.session, subagentThreadIDs: codexSubagentThreadIDs)
@@ -213,25 +228,17 @@ extension SessionManager {
     /// Decode each session file, derive its lifecycle, and capture mtime — the inputs the dedup
     /// comparator needs. Pure (no published state), kept off the main class body.
     nonisolated static func buildCandidates(
-        _ jsonFiles: [URL],
+        _ sessionFiles: [(url: URL, session: Session)],
         now: Date,
-        desktopAppConnectionLookup: DesktopAppConnectionLookup = .live
+        desktopAppConnectionLookup: DesktopAppConnectionLookup = .live,
+        claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?
     ) -> [DedupCandidate] {
-        let decodedFiles: [(url: URL, session: Session)] = jsonFiles.compactMap { url in
-            guard let data = try? Data(contentsOf: url) else {
-                sessionManagerLogger.warning("loadSessions: could not read \(url.lastPathComponent, privacy: .public)")
-                return nil
-            }
-            guard let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data) else {
-                sessionManagerLogger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public)")
-                return nil
-            }
-            return (url, session)
-        }
-
-        let projectNames = desktopProjectNamesBySessionID(in: decodedFiles.map(\.session))
+        let projectNames = desktopProjectNamesBySessionID(
+            in: sessionFiles.map(\.session),
+            claudeMetadata: claudeMetadata
+        )
         var candidates: [DedupCandidate] = []
-        for (url, var session) in decodedFiles {
+        for (url, var session) in sessionFiles {
             if let projectName = projectNames[session.sessionId] {
                 session.desktopProjectName = projectName
             }
@@ -248,11 +255,45 @@ extension SessionManager {
         return candidates
     }
 
+    nonisolated static func buildCandidates(
+        _ jsonFiles: [URL],
+        now: Date,
+        desktopAppConnectionLookup: DesktopAppConnectionLookup = .live
+    ) -> [DedupCandidate] {
+        let sessionFiles: [(url: URL, session: Session)] = jsonFiles.compactMap { url in
+            guard let data = try? Data(contentsOf: url) else {
+                sessionManagerLogger.warning("loadSessions: could not read \(url.lastPathComponent, privacy: .public)")
+                return nil
+            }
+            guard let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data) else {
+                sessionManagerLogger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public)")
+                return nil
+            }
+            return (url, session)
+        }
+
+        let claudeMetadata = claudeDesktopMetadataSnapshot(in: sessionFiles.map(\.session))
+        return buildCandidates(
+            sessionFiles,
+            now: now,
+            desktopAppConnectionLookup: desktopAppConnectionLookup,
+            claudeMetadata: claudeMetadata
+        )
+    }
+
     nonisolated static func desktopProjectNamesBySessionID(in sessions: [Session]) -> [String: String] {
+        let claudeSessionIDs = Set(sessions.filter(\.isClaudeDesktopHost).map(\.sessionId))
+        let claudeMetadata = ClaudeDesktopSessionArchiveLookup().metadataSnapshot(matching: claudeSessionIDs)
+        return desktopProjectNamesBySessionID(in: sessions, claudeMetadata: claudeMetadata)
+    }
+
+    nonisolated static func desktopProjectNamesBySessionID(
+        in sessions: [Session],
+        claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?
+    ) -> [String: String] {
         var projectNames: [String: String] = [:]
 
-        let claudeSessionIDs = Set(sessions.filter(\.isClaudeDesktopHost).map(\.sessionId))
-        if let claudeMetadata = ClaudeDesktopSessionArchiveLookup().metadataSnapshot(matching: claudeSessionIDs) {
+        if let claudeMetadata {
             projectNames.merge(claudeMetadata.projectNamesBySessionID) { current, _ in current }
         }
 

--- a/menubar/CctopMenubar/Services/SessionManager+Loading.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Loading.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+struct SessionLoadSummary {
+    let files: Int
+    let decoded: Int
+    let live: Int
+    let hidden: Int
+    let autoHidden: Int
+}
+
+extension SessionManager {
+    func currentStatusesByStableKey() -> [String: SessionStatus] {
+        Dictionary(
+            sessions.map { (SessionIdentityPolicy.stableKey(for: $0), $0.status) },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
+
+    func sessionJSONFiles(in files: [URL]) -> [URL] {
+        files.filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasSuffix(".tmp") }
+    }
+
+    func logLoadSummary(_ summary: SessionLoadSummary, visibility: SessionVisibilitySnapshot) {
+        sessionManagerLogger.info("loadSessions: \(summary.files) files, \(summary.decoded) decoded")
+        sessionManagerLogger.info(
+            "loadSessions: \(summary.live) visible candidates, \(summary.hidden) hidden, \(summary.autoHidden) auto-hidden"
+        )
+        sessionManagerLogger.info("loadSessions: \(visibility.archivedCodexThreadIDs.count) codex-archived")
+        sessionManagerLogger.info("loadSessions: \(visibility.codexSubagentThreadIDs.count) codex-subagent")
+        sessionManagerLogger.info("loadSessions: \(visibility.codexExecHelperThreadIDs.count) codex-exec-helper")
+        sessionManagerLogger.info("loadSessions: \(visibility.archivedClaudeSessionIDs.count) claude-archived")
+    }
+}

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -56,27 +56,31 @@ class SessionManager: ObservableObject {
 
         // Notification transition guards use the same identity policy as dedup: Codex and
         // desktop conversations are stable by session_id; other sessions keep PID identity.
-        let oldStatuses = Dictionary(
-            sessions.map { (SessionIdentityPolicy.stableKey(for: $0), $0.status) },
-            uniquingKeysWith: { first, _ in first }
-        )
+        let oldStatuses = currentStatusesByStableKey()
 
-        let jsonFiles = files.filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasSuffix(".tmp") }
+        let jsonFiles = sessionJSONFiles(in: files)
         let allDecoded = decodedSessions(from: jsonFiles)
         let hidden = allDecoded.filter { $0.session.hidden }
         let autoHidden = allDecoded.filter { !$0.session.hidden && $0.session.shouldAutoHide }
-        let visibleFiles = allDecoded.filter { !$0.session.hidden && !$0.session.shouldAutoHide }.map(\.url)
-        let candidates = Self.buildCandidates(visibleFiles, now: Date(), desktopAppConnectionLookup: desktopAppConnectionLookup)
-        let visibility = Self.visibilitySnapshot(in: candidates)
-        let liveCandidates = visibility.liveCandidates
-        sessionManagerLogger.info("loadSessions: \(jsonFiles.count) files, \(allDecoded.count) decoded")
-        sessionManagerLogger.info(
-            "loadSessions: \(liveCandidates.count) visible candidates, \(hidden.count) hidden, \(autoHidden.count) auto-hidden"
+        let visibleDecoded = allDecoded.filter { !$0.session.hidden && !$0.session.shouldAutoHide }
+        let visibleSessions = visibleDecoded.map(\.session)
+        let claudeMetadata = Self.claudeDesktopMetadataSnapshot(in: visibleSessions)
+        let candidates = Self.buildCandidates(
+            visibleDecoded,
+            now: Date(),
+            desktopAppConnectionLookup: desktopAppConnectionLookup,
+            claudeMetadata: claudeMetadata
         )
-        sessionManagerLogger.info("loadSessions: \(visibility.archivedCodexThreadIDs.count) codex-archived")
-        sessionManagerLogger.info("loadSessions: \(visibility.codexSubagentThreadIDs.count) codex-subagent")
-        sessionManagerLogger.info("loadSessions: \(visibility.codexExecHelperThreadIDs.count) codex-exec-helper")
-        sessionManagerLogger.info("loadSessions: \(visibility.archivedClaudeSessionIDs.count) claude-archived")
+        let visibility = Self.visibilitySnapshot(in: candidates, claudeMetadata: claudeMetadata)
+        let liveCandidates = visibility.liveCandidates
+        let summary = SessionLoadSummary(
+            files: jsonFiles.count,
+            decoded: allDecoded.count,
+            live: liveCandidates.count,
+            hidden: hidden.count,
+            autoHidden: autoHidden.count
+        )
+        logLoadSummary(summary, visibility: visibility)
 
         // Publish active + dormant; finished are hidden (swept below / by GC).
         let winners = SessionIdentityPolicy.dedupedCandidatesByStableKey(liveCandidates)

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -1348,6 +1348,37 @@ final class SessionFileFormatTests: XCTestCase {
         )
     }
 
+    func testArchivedClaudeSessionIDsTreatsMalformedPossibleMatchAsUnreadable() throws {
+        let root = NSTemporaryDirectory() + "cctop-claude-malformed-match-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let malformed = (root as NSString).appendingPathComponent("local_malformed.json")
+        try Data(#"{"cliSessionId":target-session,"title":"broken"}"#.utf8)
+            .write(to: URL(fileURLWithPath: malformed))
+
+        XCTAssertNil(
+            ClaudeDesktopSessionArchiveLookup(sessionsDirectory: root)
+                .archivedSessionIDs(matching: ["target-session"])
+        )
+    }
+
+    func testArchivedClaudeSessionIDsDoesNotMatchTargetOutsideCliSessionID() throws {
+        let root = NSTemporaryDirectory() + "cctop-claude-non-id-match-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let metadata = (root as NSString).appendingPathComponent("local_other.json")
+        try Data(#"{"cliSessionId":"other-session","title":"target-session","isArchived":true}"#.utf8)
+            .write(to: URL(fileURLWithPath: metadata))
+
+        XCTAssertEqual(
+            ClaudeDesktopSessionArchiveLookup(sessionsDirectory: root)
+                .archivedSessionIDs(matching: ["target-session"]),
+            []
+        )
+    }
+
     func testArchivedClaudeSessionIDsAcceptsNumericTimestamps() throws {
         let root = NSTemporaryDirectory() + "cctop-claude-numeric-lookup-\(UUID().uuidString)"
         let claudeDir = (root as NSString).appendingPathComponent("claude-code-sessions")

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -1379,6 +1379,23 @@ final class SessionFileFormatTests: XCTestCase {
         )
     }
 
+    func testArchivedClaudeSessionIDsContinuesPastNestedCliSessionID() throws {
+        let root = NSTemporaryDirectory() + "cctop-claude-nested-cli-session-id-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let metadata = (root as NSString).appendingPathComponent("local_nested.json")
+        try Data(
+            #"{"metadata":{"cliSessionId":"other-session"},"cliSessionId":"target-session","isArchived":true}"#.utf8
+        ).write(to: URL(fileURLWithPath: metadata))
+
+        XCTAssertEqual(
+            ClaudeDesktopSessionArchiveLookup(sessionsDirectory: root)
+                .archivedSessionIDs(matching: ["target-session"]),
+            ["target-session"]
+        )
+    }
+
     func testArchivedClaudeSessionIDsAcceptsNumericTimestamps() throws {
         let root = NSTemporaryDirectory() + "cctop-claude-numeric-lookup-\(UUID().uuidString)"
         let claudeDir = (root as NSString).appendingPathComponent("claude-code-sessions")


### PR DESCRIPTION
## Problem

- cctop refreshes session state on a short liveness timer, and the previous display path could repeat Claude Desktop metadata work while loading the same session set; the changed hot path is in `SessionManager.loadSessions` and the archive helpers in this branch diff: https://github.com/st0012/cctop/pull/150/files
- The previous Claude Desktop metadata filter relied on broad file-content substring checks before decoding matching metadata, which made the refresh cost scale with metadata file size and session count; the replacement code is in `ClaudeDesktopSessionArchiveLookup`: https://github.com/st0012/cctop/blob/codex/investigate-cc-metadata-cpu/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift

## Solution

- Decode session JSON once per load pass, collect one Claude metadata snapshot, and reuse it for candidate building plus archive/orphan visibility checks: https://github.com/st0012/cctop/blob/codex/investigate-cc-metadata-cpu/menubar/CctopMenubar/Services/SessionManager.swift and https://github.com/st0012/cctop/blob/codex/investigate-cc-metadata-cpu/menubar/CctopMenubar/Services/SessionManager%2BArchive.swift
- Scan `cliSessionId` key occurrences before full JSON decoding so unrelated Claude Desktop metadata files can be skipped while still decoding the top-level value when an earlier nested value exists: https://github.com/st0012/cctop/blob/codex/investigate-cc-metadata-cpu/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift
- Move small load-summary helpers into a dedicated extension so the main session-loading method stays inside the SwiftLint function/file limits: https://github.com/st0012/cctop/blob/codex/investigate-cc-metadata-cpu/menubar/CctopMenubar/Services/SessionManager%2BLoading.swift and https://github.com/realm/SwiftLint
- Add regression coverage for malformed possible matches, target IDs that appear outside `cliSessionId`, and nested `cliSessionId` values before the real top-level key: https://github.com/st0012/cctop/blob/codex/investigate-cc-metadata-cpu/menubar/CctopMenubarTests/SessionFileFormatTests.swift

## Verification

- `make lint` ran locally and covers the SwiftLint strict target defined by this repo's Makefile: https://github.com/st0012/cctop/blob/master/Makefile
- `make test` ran locally, including the opencode node tests and Swift test suite wired through this repo's Makefile: https://github.com/st0012/cctop/blob/master/Makefile
- `make build` ran locally after tests to leave the debug app bundle rebuilt without test-only frameworks, using the same Makefile build entry point: https://github.com/st0012/cctop/blob/master/Makefile