### PR TITLE
Fix Ghostty jump landing on the wrong session when the hostname is not the short gethostname value

### DIFF
--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -308,6 +308,14 @@ private func executeGhosttyFocusScript(workingDirectory: String) -> Bool {
     """)
 }
 
+/// Host for the OSC 7 reports written by `primeGhosttyCWD`. Ghostty treats a cwd
+/// report as local only when the host is exactly "localhost" or matches
+/// `gethostname()` (ghostty src/os/hostname.zig); anything else is silently
+/// discarded. `ProcessInfo.hostName` can return an FQDN (VPN / corporate DNS) or
+/// a ".local" name that fails that check, so sending it makes priming a no-op and
+/// the jump lands on Ghostty's last-active window instead of the target session.
+let ghosttyOSC7PrimingHost = "localhost"
+
 /// Bytes written to the slave (`/dev/ttysNNN`) appear on the PTY master where Ghostty
 /// parses them; the shell does not see them. Best-effort — silently no-ops if the TTY
 /// has closed (session just ended).
@@ -318,8 +326,7 @@ private func primeGhosttyCWD(tty: String, workingDirectory: String) {
     guard tty.range(of: #"^/dev/ttys\d+$"#, options: .regularExpression) != nil else { return }
     guard let attrs = try? FileManager.default.attributesOfItem(atPath: tty),
           (attrs[.type] as? FileAttributeType) == .typeCharacterSpecial else { return }
-    let host = ProcessInfo.processInfo.hostName
-    let osc = buildOSC7CWD(host: host, workingDirectory: workingDirectory)
+    let osc = buildOSC7CWD(host: ghosttyOSC7PrimingHost, workingDirectory: workingDirectory)
     guard let data = osc.data(using: .utf8) else { return }
     guard let handle = FileHandle(forWritingAtPath: tty) else { return }
     defer { try? handle.close() }

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -334,8 +334,21 @@ final class FocusStrategyTests: XCTestCase {
     }
 
     func testBuildOSC7EmptyHostAllowed() {
-        // file:///path is valid (empty authority). Some terminals only care about path.
+        // file:///path is a valid URI (empty authority), but Ghostty ignores it —
+        // its locality check only accepts "localhost" or the gethostname() value.
+        // This pins builder formatting only; never use an empty host for priming.
         let osc = buildOSC7CWD(host: "", workingDirectory: "/x")
         XCTAssertEqual(osc, "\u{1B}]7;file:///x\u{07}")
+    }
+
+    func testGhosttyPrimingHostIsLocalhost() {
+        // Ghostty only honors OSC 7 cwd reports whose host is "localhost" or the
+        // exact gethostname() value. ProcessInfo.hostName can be an FQDN (VPN /
+        // corporate DNS) or a ".local" name, which Ghostty silently drops — the
+        // priming no-ops and the jump raises the last-active window instead of
+        // the requested session. Pin the host so it never regresses.
+        XCTAssertEqual(ghosttyOSC7PrimingHost, "localhost")
+        let osc = buildOSC7CWD(host: ghosttyOSC7PrimingHost, workingDirectory: "/x")
+        XCTAssertEqual(osc, "\u{1B}]7;file://localhost/x\u{07}")
     }
 }


### PR DESCRIPTION
## Problem

Jumping to a Ghostty-hosted session could focus the wrong session — whichever Ghostty surface was most recently active, usually the one the user just came from.

The Ghostty focus strategy matches the target surface by working directory, and `focusTerminal` primes the target TTY with an OSC 7 cwd report right before matching (`primeGhosttyCWD`). That report's host came from `ProcessInfo.processInfo.hostName`, but Ghostty treats an OSC 7 cwd report as local only when the host is exactly `localhost` or exactly matches `gethostname()` ([`src/os/hostname.zig`](https://github.com/ghostty-org/ghostty/blob/main/src/os/hostname.zig)); everything else is silently discarded. `ProcessInfo.hostName` returns a resolved DNS name, which can be an FQDN (VPN / corporate DNS) or a `.local` name and is not guaranteed to match `gethostname()` — verified on a stock machine where `ProcessInfo.hostName` is `macbook-air.local` while `gethostname()` is `Mac`. When they differ, priming no-ops, the working-directory match finds nothing, and the script's leading `activate` raises Ghostty's last-active window.

Fixes #153

## Solution

Send the literal `localhost` as the OSC 7 host, which Ghostty always accepts as local regardless of hostname configuration. The host is extracted into a `ghosttyOSC7PrimingHost` constant so a regression test can pin both the value and the emitted byte sequence. Also corrected the comment on `testBuildOSC7EmptyHostAllowed`, which implied an empty host is accepted; it pins string formatting only — Ghostty ignores empty-host reports.

The issue's secondary observations (a zero-match AppleScript run reported as success, and cwd not being a unique surface key) are intentionally out of scope; the durable fix for both is surface-id matching once [ghostty-org/ghostty#10603](https://github.com/ghostty-org/ghostty/issues/10603) ships, as already noted in the code comments.

## Verification

- New regression test `testGhosttyPrimingHostIsLocalhost` fails to compile without the fix and passes with it; full `FocusStrategyTests` suite passes.
- Empirically verified on Ghostty 1.3.1 by writing the exact OSC 7 byte sequences to a live surface's TTY and reading back `working directory` over AppleScript: a `.local`/FQDN host (what `ProcessInfo.hostName` returns) leaves the cwd unchanged (report dropped); `localhost` updates it.
- `swiftlint --strict`: 0 violations. Full test suite: the only failures are 4 pre-existing `ForkSessionTests` failures that reproduce on a clean `origin/master` checkout on the same machine and are unrelated to this change.