### PR TITLE
Decouple session, hook, and panel logic behind injected seams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,11 @@ cctop/
 │   │   ├── Models/                # Session, SessionStatus, HookEvent, Config (shared)
 │   │   ├── Views/                 # PopupView, SessionCardView, QuitButton, etc.
 │   │   ├── Services/              # SessionManager, FocusTerminal
-│   │   └── Hook/                  # cctop-hook CLI target only
+│   │   └── Hook/                  # cctop-hook CLI core (HookMain is CLI-only; the rest also compile into the app)
 │   │       ├── HookMain.swift     # CLI entry point (stdin, args, dispatch)
 │   │       ├── HookInput.swift    # Codable struct for cctop-hook input JSON from all integrations
 │   │       ├── HookHandler.swift       # Core logic (transitions, cleanup, PID)
+│   │       ├── HookDependencies.swift  # Injected seams: process probing, paths, name lookups, logger, session file lock
 │   │       ├── SessionNameLookup.swift # Session name from transcript/index
 │   │       └── HookLogger.swift        # Per-session logging
 │   └── CctopMenubarTests/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ swiftlint lint --strict
 - `Models/` — Shared between both Swift targets (Session, SessionStatus, HookEvent, Config)
 - `Views/` — Menubar app only (SwiftUI views)
 - `Services/` — Menubar app only (SessionManager, FocusTerminal)
-- `Hook/` — cctop-hook CLI only (HookMain, HookHandler, HookInput, HookLogger)
+- `Hook/` — cctop-hook CLI core (HookMain is CLI-only; HookHandler, HookInput, HookDependencies, HookLogger, and SessionNameLookup also compile into the app)
 
 **opencode plugin** (in `plugins/opencode/`). A single JS file that runs in-process in Bun.
 

--- a/hook-input.schema.json
+++ b/hook-input.schema.json
@@ -56,6 +56,11 @@
   "additionalProperties": true,
   "x-cctop": {
     "harnesses": ["cc", "codex", "opencode", "pi"],
+    "binary_locations": [
+      "~/.cctop/bin/cctop-hook",
+      "/Applications/cctop.app/Contents/MacOS/cctop-hook",
+      "~/Applications/cctop.app/Contents/MacOS/cctop-hook"
+    ],
     "events_by_harness": {
       "cc": [
         "SessionStart",

--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		HH0000010000000000000001 /* HookHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = HH0000020000000000000001 /* HookHandlerTests.swift */; };
 		HH0000030000000000000001 /* HookHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = P10000060000000000000001 /* HookHandler.swift */; };
 		HH0000050000000000000001 /* HookLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = P10000080000000000000001 /* HookLogger.swift */; };
+		HD0000010000000000000001 /* HookDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = HD0000030000000000000001 /* HookDependencies.swift */; };
+		HD0000020000000000000001 /* HookDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = HD0000030000000000000001 /* HookDependencies.swift */; };
 		HT0000010000000000000001 /* HookEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = HT0000020000000000000001 /* HookEventTests.swift */; };
 		J10000010000000000000001 /* SettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = J10000020000000000000001 /* SettingsSection.swift */; };
 		CDXROW010000000000000001 /* CodexPluginRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDXROW020000000000000001 /* CodexPluginRowView.swift */; };
@@ -185,6 +187,7 @@
 		P10000040000000000000001 /* HookInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInput.swift; sourceTree = "<group>"; };
 		P10000060000000000000001 /* HookHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookHandler.swift; sourceTree = "<group>"; };
 		P10000080000000000000001 /* HookLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookLogger.swift; sourceTree = "<group>"; };
+		HD0000030000000000000001 /* HookDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookDependencies.swift; sourceTree = "<group>"; };
 		HM0000020000000000000001 /* HistoryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryManager.swift; sourceTree = "<group>"; };
 		JM0000020000000000000001 /* NavigateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateController.swift; sourceTree = "<group>"; };
 		PC0000020000000000000001 /* PanelCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelCoordinator.swift; sourceTree = "<group>"; };
@@ -376,6 +379,7 @@
 				P10000020000000000000001 /* HookMain.swift */,
 				P10000040000000000000001 /* HookInput.swift */,
 				P10000060000000000000001 /* HookHandler.swift */,
+				HD0000030000000000000001 /* HookDependencies.swift */,
 				P10000080000000000000001 /* HookLogger.swift */,
 				SN0000020000000000000001 /* SessionNameLookup.swift */,
 			);
@@ -580,6 +584,7 @@
 				N10000030000000000000001 /* HookEvent.swift in Sources */,
 				FX0000030000000000000001 /* HookInput.swift in Sources */,
 				HH0000030000000000000001 /* HookHandler.swift in Sources */,
+				HD0000010000000000000001 /* HookDependencies.swift in Sources */,
 				HH0000050000000000000001 /* HookLogger.swift in Sources */,
 				N10000050000000000000001 /* Config.swift in Sources */,
 				SN0000050000000000000001 /* SessionNameLookup.swift in Sources */,
@@ -608,6 +613,7 @@
 				P10000010000000000000001 /* HookMain.swift in Sources */,
 				P10000030000000000000001 /* HookInput.swift in Sources */,
 				P10000050000000000000001 /* HookHandler.swift in Sources */,
+				HD0000020000000000000001 /* HookDependencies.swift in Sources */,
 				P10000070000000000000001 /* HookLogger.swift in Sources */,
 				SN0000010000000000000001 /* SessionNameLookup.swift in Sources */,
 				P10000090000000000000001 /* Session.swift in Sources */,

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -251,18 +251,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     // MARK: - Custom panel position (per-screen)
 
-    private func saveCustomPanelPosition(originX: CGFloat, topY: CGFloat, forScreenKey key: String) {
-        panelGeometry.saveCustomPosition(originX: originX, topY: topY, forScreenKey: key)
-    }
-
-    private func clearCustomPanelPosition(forScreenKey key: String) {
-        panelGeometry.clearCustomPosition(forScreenKey: key)
-    }
-
-    private func savedPanelPositions() -> [String: (originX: CGFloat, topY: CGFloat)] {
-        panelGeometry.savedPositions()
-    }
-
     /// The screen key for the screen the panel is currently on.
     @MainActor private func panelScreenKey() -> String? {
         guard let panelScreen = panel.screen ?? NSScreen.main else { return nil }
@@ -281,7 +269,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         let topY = ud.double(forKey: PanelPositionKeys.legacyTopY)
         let point = NSPoint(x: originX, y: topY)
         let key = screenKey(at: point) ?? NSScreen.main?.screenKey ?? "builtin"
-        saveCustomPanelPosition(originX: CGFloat(originX), topY: CGFloat(topY), forScreenKey: key)
+        panelGeometry.saveCustomPosition(originX: CGFloat(originX), topY: CGFloat(topY), forScreenKey: key)
         ud.removeObject(forKey: PanelPositionKeys.legacyOriginX)
         ud.removeObject(forKey: PanelPositionKeys.legacyTopY)
     }
@@ -320,8 +308,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         guard let size = panelFittingSize() else { return }
         let clickKey = focusLocation.flatMap { screenKey(at: $0) }
             ?? panelScreenKey()
-        if let frame = PanelPositioning.resolveShowPosition(
-            savedPositions: savedPanelPositions(),
+        if let frame = panelGeometry.showFrame(
             clickScreenKey: clickKey,
             clickLocation: focusLocation,
             anchorRect: anchorRect(),
@@ -351,7 +338,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         let panelIdx = (panel.screen ?? NSScreen.main).flatMap { screen in
             layouts.firstIndex { $0.frame == ScreenLayout(screen).frame }
         }
-        if let frame = PanelPositioning.resolveResetPosition(
+        if let frame = panelGeometry.resetFrame(
             anchorRect: anchorRect(),
             panelScreenIndex: panelIdx,
             panelSize: size,
@@ -384,13 +371,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             guard self.panel.isVisible else { return }
             self.positionPanel(animate: false)
             // Update saved position if it was clamped to new screen bounds
-            if let key = self.panelScreenKey(),
-               self.savedPanelPositions()[key] != nil {
-                let frame = self.panel.frame
-                self.saveCustomPanelPosition(
-                    originX: frame.origin.x, topY: frame.maxY, forScreenKey: key
-                )
-            }
+            self.panelGeometry.resaveAfterScreenChange(
+                panelScreenKey: self.panelScreenKey(), panelFrame: self.panel.frame
+            )
         }
         screenChangeWork = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: work)
@@ -399,22 +382,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     @MainActor private func resizePanel(animate: Bool = false) {
         guard !suppressResize else { return }
         guard let size = panelFittingSize() else { return }
-        let oldFrame = panel.frame
-        let hasPositionOnCurrentScreen = panelScreenKey().map { savedPanelPositions()[$0] != nil } ?? false
-        let newFrame: NSRect
-        if hasPositionOnCurrentScreen {
-            // Keep top-left corner stable
-            newFrame = NSRect(
-                x: oldFrame.origin.x, y: oldFrame.maxY - size.height,
-                width: size.width, height: size.height
-            )
-        } else {
-            // Keep midX centered, top edge stable
-            newFrame = NSRect(
-                x: oldFrame.midX - size.width / 2, y: oldFrame.maxY - size.height,
-                width: size.width, height: size.height
-            )
-        }
+        let newFrame = panelGeometry.resizedFrame(
+            from: panel.frame, to: size, panelScreenKey: panelScreenKey()
+        )
         setPanelFrame(newFrame, animate: animate)
     }
 
@@ -496,7 +466,7 @@ extension AppDelegate {
                 if let click = focusLocation,
                    let clickKey = screenKey(at: click),
                    panelScreenKey() != clickKey {
-                    clearCustomPanelPosition(forScreenKey: clickKey)
+                    panelGeometry.clearCustomPosition(forScreenKey: clickKey)
                     positionPanel()
                 }
             case .activateApp:
@@ -587,12 +557,12 @@ extension AppDelegate {
 extension AppDelegate: FloatingPanelDelegate {
     @MainActor func panelDidDrag(originX: CGFloat, topY: CGFloat) {
         guard let key = panelScreenKey() else { return }
-        saveCustomPanelPosition(originX: originX, topY: topY, forScreenKey: key)
+        panelGeometry.saveCustomPosition(originX: originX, topY: topY, forScreenKey: key)
     }
 
     @MainActor func panelDidRequestReset() {
         if let key = panelScreenKey() {
-            clearCustomPanelPosition(forScreenKey: key)
+            panelGeometry.clearCustomPosition(forScreenKey: key)
         }
         resetPanelToCurrentScreen(animate: true)
     }

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -480,12 +480,8 @@ extension AppDelegate {
                 if let prev = previousApp, prev != NSRunningApplication.current {
                     lastExternalApp = prev
                 }
-            case .startNavigateMode(let panelWasClosed):
-                navigateController.activate(
-                    sessions: sessionManager.sessions,
-                    previousApp: NSWorkspace.shared.frontmostApplication,
-                    panelWasClosed: panelWasClosed
-                )
+            case .startNavigateMode:
+                navigateController.activate(sessions: sessionManager.sessions)
                 navigateController.startTimeout { [weak self] in
                     self?.handleEvent(.navigateTimedOut)
                 }

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -29,8 +29,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     private var cancellables: Set<AnyCancellable> = []
     @AppStorage("appearanceMode") var appearanceMode: String = "system"
 
+    private let panelGeometry = PanelGeometryModel(store: UserDefaultsPanelPositionStore())
+
     private enum PanelPositionKeys {
-        static let positions = "panelPositions"
         // MIGRATION(v0.12.0→v0.13.0): Remove legacyOriginX, legacyTopY, migrateLegacyPanelPosition
         static let legacyOriginX = "panelCustomX"
         static let legacyTopY = "panelCustomTopY"
@@ -251,27 +252,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     // MARK: - Custom panel position (per-screen)
 
     private func saveCustomPanelPosition(originX: CGFloat, topY: CGFloat, forScreenKey key: String) {
-        var dict = savedPanelPositionsDict()
-        dict[key] = ["originX": originX, "topY": topY]
-        UserDefaults.standard.set(dict, forKey: PanelPositionKeys.positions)
+        panelGeometry.saveCustomPosition(originX: originX, topY: topY, forScreenKey: key)
     }
 
     private func clearCustomPanelPosition(forScreenKey key: String) {
-        var dict = savedPanelPositionsDict()
-        dict.removeValue(forKey: key)
-        UserDefaults.standard.set(dict, forKey: PanelPositionKeys.positions)
+        panelGeometry.clearCustomPosition(forScreenKey: key)
     }
 
     private func savedPanelPositions() -> [String: (originX: CGFloat, topY: CGFloat)] {
-        savedPanelPositionsDict().compactMapValues { entry in
-            guard let originX = entry["originX"], let topY = entry["topY"] else { return nil }
-            return (originX: originX, topY: topY)
-        }
-    }
-
-    private func savedPanelPositionsDict() -> [String: [String: CGFloat]] {
-        UserDefaults.standard.dictionary(forKey: PanelPositionKeys.positions)
-            as? [String: [String: CGFloat]] ?? [:]
+        panelGeometry.savedPositions()
     }
 
     /// The screen key for the screen the panel is currently on.

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -43,6 +43,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         installHookBinaryIfNeeded()
         UNUserNotificationCenter.current().delegate = self
         notchController = NotchStatusController()
+        notchController.onPillClicked = { [weak self] in self?.togglePanel() }
         historyManager = HistoryManager()
         sessionManager = SessionManager(historyManager: historyManager)
         updater = makeUpdater()
@@ -56,7 +57,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             historyManager: historyManager,
             updater: updater,
             pluginManager: pluginManager,
-            navigate: navigateController
+            navigate: navigateController,
+            onLayoutChanged: { [weak self] in self?.resizePanel(animate: true) }
         )
         let hostingView = NSHostingView(rootView: contentView)
         hostingView.wantsLayer = true
@@ -98,9 +100,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         nc.addObserver(
             forName: UserDefaults.didChangeNotification, object: nil, queue: .main
         ) { [weak self] _ in self?.applyAppearance() }
-        nc.addObserver(
-            forName: .layoutChanged, object: nil, queue: .main
-        ) { [weak self] _ in self?.resizePanel(animate: true) }
         NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didDeactivateApplicationNotification, object: nil, queue: .main
         ) { [weak self] notification in
@@ -124,11 +123,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             forName: NSWorkspace.activeSpaceDidChangeNotification, object: nil, queue: .main
         ) { [weak self] _ in
             self?.updateNotchVisibility()
-        }
-        nc.addObserver(
-            forName: .notchPillClicked, object: nil, queue: .main
-        ) { [weak self] _ in
-            self?.togglePanel()
         }
     }
 

--- a/menubar/CctopMenubar/Hook/HookDependencies.swift
+++ b/menubar/CctopMenubar/Hook/HookDependencies.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+// MARK: - Process Probing
+
+/// Probes the live process tree: parent PID resolution, process start times,
+/// liveness checks, and the controlling TTY. Injected into HookHandler so tests
+/// can script process identity instead of inheriting the test runner's.
+protocol ProcessProbing {
+    func parentPID() -> UInt32
+    func startTime(pid: UInt32) -> TimeInterval?
+    func isAlive(pid: UInt32) -> Bool
+    func controllingTTY() -> String?
+}
+
+/// Production prober backed by getppid/sysctl/kill via the existing helpers.
+struct LiveProcessProber: ProcessProbing {
+    func parentPID() -> UInt32 { HookHandler.getParentPID() }
+    func startTime(pid: UInt32) -> TimeInterval? { Session.processStartTime(pid: pid) }
+    func isAlive(pid: UInt32) -> Bool { HookHandler.isPIDAlive(pid) }
+    func controllingTTY() -> String? { HookHandler.findTTY() }
+}
+
+// MARK: - Session Name Resolution
+
+/// Resolves user-visible session names from harness-specific local sources
+/// (Codex's session index, Claude Desktop's session metadata, CC transcripts).
+protocol SessionNameResolving {
+    func codexThreadName(sessionId: String) -> String?
+    func claudeDesktopTitle(cliSessionId: String) -> String?
+    func transcriptSessionName(transcriptPath: String?, sessionId: String) -> String?
+}
+
+/// Production resolver delegating to SessionNameLookup. The source paths are
+/// injectable so tests can stage fixture files in temporary directories.
+struct LiveSessionNameResolver: SessionNameResolving {
+    var codexIndexPath: String = Config.codexSessionIndexPath()
+    var claudeSessionsDir: String = Config.claudeCodeSessionsDir()
+
+    func codexThreadName(sessionId: String) -> String? {
+        SessionNameLookup.lookupCodexThreadName(sessionId: sessionId, indexPath: codexIndexPath)
+    }
+
+    func claudeDesktopTitle(cliSessionId: String) -> String? {
+        SessionNameLookup.lookupClaudeDesktopTitle(cliSessionId: cliSessionId, baseDir: claudeSessionsDir)
+    }
+
+    func transcriptSessionName(transcriptPath: String?, sessionId: String) -> String? {
+        SessionNameLookup.lookupSessionName(transcriptPath: transcriptPath, sessionId: sessionId)
+    }
+}
+
+// MARK: - Hook Dependencies
+
+/// The full dependency seam for HookHandler: every file-IO path, environment
+/// read, subprocess spawn, and process probe goes through this struct. The
+/// `.live` value reproduces production behavior (including CCTOP_* env-var
+/// overrides honored by the Config accessors).
+struct HookDependencies {
+    var sessionsDir: () -> String
+    var environment: () -> [String: String]
+    var currentBranch: (String) -> String
+    var process: any ProcessProbing
+    var names: any SessionNameResolving
+    var logger: HookLogger
+
+    /// Computed (not stored) so each hook invocation re-reads the environment,
+    /// preserving the env-var override behavior of the Config accessors.
+    static var live: HookDependencies {
+        HookDependencies(
+            sessionsDir: { Config.sessionsDir() },
+            environment: { ProcessInfo.processInfo.environment },
+            currentBranch: { getCurrentBranch(cwd: $0) },
+            process: LiveProcessProber(),
+            names: LiveSessionNameResolver(),
+            logger: HookLogger()
+        )
+    }
+}
+
+// MARK: - Session File Locking
+
+/// Acquire an exclusive flock on a `.lock` file alongside the session file.
+/// This serializes concurrent hook processes operating on the same session,
+/// preventing read-modify-write races when multiple hooks fire simultaneously.
+func withSessionLock(
+    sessionPath: String,
+    onError: (String) -> Void = { HookLogger().logError($0) },
+    body: () throws -> Void
+) throws {
+    let lockPath = sessionPath + ".lock"
+    let fd = open(lockPath, O_CREAT | O_WRONLY, 0o600)
+    guard fd >= 0 else {
+        let err = errno
+        onError("withSessionLock: open(\(lockPath)) failed: \(err)")
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(err),
+                      userInfo: [NSLocalizedDescriptionKey: "Failed to open lock file: \(lockPath)"])
+    }
+    defer { close(fd) }
+    guard flock(fd, LOCK_EX) == 0 else {
+        let err = errno
+        onError("withSessionLock: flock(\(lockPath)) failed: \(err)")
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(err),
+                      userInfo: [NSLocalizedDescriptionKey: "Failed to acquire lock: \(lockPath)"])
+    }
+    defer { flock(fd, LOCK_UN) }
+    try body()
+}

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 import Foundation
 
 private let maxToolDetailLen = 120
@@ -327,7 +326,7 @@ enum HookHandler {
     /// Walk up the process tree to find the first ancestor with a controlling terminal.
     /// The hook subprocess itself has no tty (stdin is piped JSON), but ancestor
     /// processes (claude, shell) do.
-    private static func findTTY() -> String? {
+    static func findTTY() -> String? {
         var pid = getppid()
         for _ in 0..<6 {
             if pid <= 1 { break }
@@ -431,38 +430,9 @@ extension HookHandler {
         HookLogger().cleanupSessionLog(sessionId: sessionId)
     }
 
-    private static func isPIDAlive(_ pid: UInt32) -> Bool {
+    static func isPIDAlive(_ pid: UInt32) -> Bool {
         kill(Int32(pid), 0) == 0 || errno == EPERM
     }
-}
-
-// MARK: - Session File Locking
-
-/// Acquire an exclusive flock on a `.lock` file alongside the session file.
-/// This serializes concurrent hook processes operating on the same session,
-/// preventing read-modify-write races when multiple hooks fire simultaneously.
-func withSessionLock(
-    sessionPath: String,
-    onError: (String) -> Void = { HookLogger().logError($0) },
-    body: () throws -> Void
-) throws {
-    let lockPath = sessionPath + ".lock"
-    let fd = open(lockPath, O_CREAT | O_WRONLY, 0o600)
-    guard fd >= 0 else {
-        let err = errno
-        onError("withSessionLock: open(\(lockPath)) failed: \(err)")
-        throw NSError(domain: NSPOSIXErrorDomain, code: Int(err),
-                      userInfo: [NSLocalizedDescriptionKey: "Failed to open lock file: \(lockPath)"])
-    }
-    defer { close(fd) }
-    guard flock(fd, LOCK_EX) == 0 else {
-        let err = errno
-        onError("withSessionLock: flock(\(lockPath)) failed: \(err)")
-        throw NSError(domain: NSPOSIXErrorDomain, code: Int(err),
-                      userInfo: [NSLocalizedDescriptionKey: "Failed to acquire lock: \(lockPath)"])
-    }
-    defer { flock(fd, LOCK_UN) }
-    try body()
 }
 
 // MARK: - Session File Naming

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -52,7 +52,7 @@ enum HookHandler {
             session.markWrittenByHook(version: Config.hookVersion, isNewSessionFile: isNewSessionFile)
 
             let suffix = newStatus == nil ? " (preserved)" : ""
-            HookLogger.appendHookLog(
+            HookLogger().appendHookLog(
                 sessionId: safeId, event: hookName, label: label,
                 transition: "\(oldStatus) -> \(session.status.rawValue)\(suffix)"
             )
@@ -364,9 +364,9 @@ extension HookHandler {
                 }
                 session.markWrittenByHook(version: Config.hookVersion, isNewSessionFile: false)
                 try? session.writeToFile(path: path)
-                HookLogger.appendHookLog(sessionId: safeId, event: hookName, label: label, transition: "-> ended")
+                HookLogger().appendHookLog(sessionId: safeId, event: hookName, label: label, transition: "-> ended")
             } else {
-                HookLogger.appendHookLog(sessionId: safeId, event: hookName, label: label, transition: "-> removed")
+                HookLogger().appendHookLog(sessionId: safeId, event: hookName, label: label, transition: "-> removed")
                 removeSession(at: path, sessionId: safeId)
             }
         }
@@ -428,7 +428,7 @@ extension HookHandler {
     private static func removeSession(at path: String, sessionId: String) {
         try? FileManager.default.removeItem(atPath: path)
         // Never remove the .lock here: unlinking a held lock splits the flock inode.
-        HookLogger.cleanupSessionLog(sessionId: sessionId)
+        HookLogger().cleanupSessionLog(sessionId: sessionId)
     }
 
     private static func isPIDAlive(_ pid: UInt32) -> Bool {
@@ -441,19 +441,23 @@ extension HookHandler {
 /// Acquire an exclusive flock on a `.lock` file alongside the session file.
 /// This serializes concurrent hook processes operating on the same session,
 /// preventing read-modify-write races when multiple hooks fire simultaneously.
-func withSessionLock(sessionPath: String, body: () throws -> Void) throws {
+func withSessionLock(
+    sessionPath: String,
+    onError: (String) -> Void = { HookLogger().logError($0) },
+    body: () throws -> Void
+) throws {
     let lockPath = sessionPath + ".lock"
     let fd = open(lockPath, O_CREAT | O_WRONLY, 0o600)
     guard fd >= 0 else {
         let err = errno
-        HookLogger.logError("withSessionLock: open(\(lockPath)) failed: \(err)")
+        onError("withSessionLock: open(\(lockPath)) failed: \(err)")
         throw NSError(domain: NSPOSIXErrorDomain, code: Int(err),
                       userInfo: [NSLocalizedDescriptionKey: "Failed to open lock file: \(lockPath)"])
     }
     defer { close(fd) }
     guard flock(fd, LOCK_EX) == 0 else {
         let err = errno
-        HookLogger.logError("withSessionLock: flock(\(lockPath)) failed: \(err)")
+        onError("withSessionLock: flock(\(lockPath)) failed: \(err)")
         throw NSError(domain: NSPOSIXErrorDomain, code: Int(err),
                       userInfo: [NSLocalizedDescriptionKey: "Failed to acquire lock: \(lockPath)"])
     }

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 
 private let maxToolDetailLen = 120
@@ -11,29 +12,29 @@ enum HookHandler {
     // MIGRATION(v0.6.0): Remove after all users have migrated to PID-keyed sessions.
     private static let noPIDMaxAge: TimeInterval = 300
 
-    static func handleHook(hookName: String, input: HookInput) throws {
+    static func handleHook(hookName: String, input: HookInput, deps: HookDependencies = .live) throws {
         let event = HookEvent.parse(hookName: hookName, notificationType: input.notificationType)
 
         if event == .sessionEnd {
-            handleSessionEnd(hookName: hookName, input: input)
+            handleSessionEnd(hookName: hookName, input: input, deps: deps)
             return
         }
 
-        let sessionsDir = Config.sessionsDir()
+        let sessionsDir = deps.sessionsDir()
         let safeId = Session.sanitizeSessionId(raw: input.sessionId)
-        let pid = getParentPID()
+        let pid = deps.process.parentPID()
         let label = HookLogger.sessionLabel(cwd: input.cwd, sessionId: safeId)
         let sessionPath = (sessionsDir as NSString).appendingPathComponent(sessionFileName(input: input, pid: pid, safeSessionId: safeId))
 
-        let branch = getCurrentBranch(cwd: input.cwd)
-        let terminal = captureTerminalInfo()
-        let startTime = Session.processStartTime(pid: pid)
+        let branch = deps.currentBranch(input.cwd)
+        let terminal = captureTerminalInfo(env: deps.environment(), process: deps.process)
+        let startTime = deps.process.startTime(pid: pid)
 
         // Lock the session file for the entire read-modify-write cycle.
         // Without this, concurrent hook processes (e.g. SubagentStart + PreToolUse
         // firing simultaneously) race: both read the old file, apply changes
         // independently, and the last writer wins — clobbering the first writer's changes.
-        try withSessionLock(sessionPath: sessionPath) {
+        try withSessionLock(sessionPath: sessionPath, onError: deps.logger.logError) {
             let freshSession = Session(sessionId: safeId, projectPath: input.cwd, branch: branch, terminal: terminal)
             let loaded = loadOrCreateSession(
                 path: sessionPath, event: event, startTime: startTime, fresh: freshSession
@@ -45,13 +46,14 @@ enum HookHandler {
             session.pidStartTime = startTime
 
             let (oldStatus, newStatus) = applyTransition(&session, event: event, input: input, branch: branch, terminal: terminal)
+            applySessionName(&session, event: event, input: input, names: deps.names)
             applySideEffects(event: event, session: &session, input: input, sessionsDir: sessionsDir, safeId: safeId)
             if input.isSubagentSession == true { session.isSubagentSession = true }
             if session.shouldAutoHide { session.hidden = true }
             session.markWrittenByHook(version: Config.hookVersion, isNewSessionFile: isNewSessionFile)
 
             let suffix = newStatus == nil ? " (preserved)" : ""
-            HookLogger().appendHookLog(
+            deps.logger.appendHookLog(
                 sessionId: safeId, event: hookName, label: label,
                 transition: "\(oldStatus) -> \(session.status.rawValue)\(suffix)"
             )
@@ -61,7 +63,10 @@ enum HookHandler {
         // Cleanup runs outside the lock — it scans all session files and makes
         // sysctl calls per file, which would unnecessarily hold the lock.
         if event == .sessionStart {
-            cleanupSessionsForProject(sessionsDir: sessionsDir, projectPath: input.cwd, currentPid: pid)
+            cleanupSessionsForProject(
+                sessionsDir: sessionsDir, projectPath: input.cwd, currentPid: pid,
+                process: deps.process, logger: deps.logger
+            )
         }
     }
 
@@ -109,6 +114,14 @@ enum HookHandler {
         // Renaming the JSON key would require a reader-side migration in SessionManager.
         // Do that in a future PR once `harness_name` is settled.
         if let harness = input.resolvedHarnessName { session.source = harness }
+        return (oldStatus, newStatus)
+    }
+
+    /// Update the user-visible session name. Runs right after applyTransition, once
+    /// source/terminal are current, since the lookup strategy depends on both.
+    private static func applySessionName(
+        _ session: inout Session, event: HookEvent, input: HookInput, names: any SessionNameResolving
+    ) {
         if let name = input.sessionName {
             session.sessionName = name
         } else if event == .sessionStart || event == .userPromptSubmit || event == .stop
@@ -126,11 +139,11 @@ enum HookHandler {
             //   - terminal CC:    the transcript JSONL `custom-title` entry
             let lookedUp: String?
             if session.source == "codex" {
-                lookedUp = SessionNameLookup.lookupCodexThreadName(sessionId: input.sessionId)
+                lookedUp = names.codexThreadName(sessionId: input.sessionId)
             } else if session.terminal?.bundleId == HostAppBundleID.claudeDesktop {
-                lookedUp = SessionNameLookup.lookupClaudeDesktopTitle(cliSessionId: input.sessionId)
+                lookedUp = names.claudeDesktopTitle(cliSessionId: input.sessionId)
             } else {
-                lookedUp = SessionNameLookup.lookupSessionName(
+                lookedUp = names.transcriptSessionName(
                     transcriptPath: input.transcriptPath, sessionId: input.sessionId
                 )
             }
@@ -138,7 +151,6 @@ enum HookHandler {
                 session.sessionName = name
             }
         }
-        return (oldStatus, newStatus)
     }
 
     private static func applySideEffects(
@@ -256,13 +268,12 @@ enum HookHandler {
         }
     }
 
-    static func captureTerminalInfo() -> TerminalInfo {
-        let env = ProcessInfo.processInfo.environment
+    static func captureTerminalInfo(env: [String: String], process: any ProcessProbing) -> TerminalInfo {
         let program = env["TERM_PROGRAM"] ?? ""
         let sessionId = sanitizeTerminalSessionId(
             env["ITERM_SESSION_ID"] ?? env["KITTY_WINDOW_ID"]
         )
-        let tty = env["TTY"] ?? findTTY()
+        let tty = env["TTY"] ?? process.controllingTTY()
         let bundleId = env["__CFBundleIdentifier"]
         // Remote-control socket for pane focusing.
         // Currently only Kitty (https://sw.kovidgoyal.net/kitty/remote-control/).
@@ -348,13 +359,13 @@ enum HookHandler {
 extension HookHandler {
     // MARK: - Cleanup
 
-    private static func handleSessionEnd(hookName: String, input: HookInput) {
-        let pid = getParentPID()
+    private static func handleSessionEnd(hookName: String, input: HookInput, deps: HookDependencies) {
+        let pid = deps.process.parentPID()
         let safeId = Session.sanitizeSessionId(raw: input.sessionId)
-        let path = (Config.sessionsDir() as NSString).appendingPathComponent(sessionFileName(input: input, pid: pid, safeSessionId: safeId))
+        let path = (deps.sessionsDir() as NSString).appendingPathComponent(sessionFileName(input: input, pid: pid, safeSessionId: safeId))
         let label = HookLogger.sessionLabel(cwd: input.cwd, sessionId: safeId)
         // Stamp endedAt instead of deleting — the menubar app archives to history on next poll.
-        try? withSessionLock(sessionPath: path) {
+        try? withSessionLock(sessionPath: path, onError: deps.logger.logError) {
             if var session = try? Session.fromFile(path: path) {
                 let endedAt = Date()
                 session.endedAt = endedAt
@@ -363,15 +374,18 @@ extension HookHandler {
                 }
                 session.markWrittenByHook(version: Config.hookVersion, isNewSessionFile: false)
                 try? session.writeToFile(path: path)
-                HookLogger().appendHookLog(sessionId: safeId, event: hookName, label: label, transition: "-> ended")
+                deps.logger.appendHookLog(sessionId: safeId, event: hookName, label: label, transition: "-> ended")
             } else {
-                HookLogger().appendHookLog(sessionId: safeId, event: hookName, label: label, transition: "-> removed")
-                removeSession(at: path, sessionId: safeId)
+                deps.logger.appendHookLog(sessionId: safeId, event: hookName, label: label, transition: "-> removed")
+                removeSession(at: path, sessionId: safeId, logger: deps.logger)
             }
         }
     }
 
-    static func cleanupSessionsForProject(sessionsDir: String, projectPath: String, currentPid: UInt32?) {
+    static func cleanupSessionsForProject(
+        sessionsDir: String, projectPath: String, currentPid: UInt32?,
+        process: any ProcessProbing = LiveProcessProber(), logger: HookLogger = HookLogger()
+    ) {
         forEachSession(in: sessionsDir) { path, session in
             guard session.projectPath == projectPath, session.pid != currentPid else { return }
 
@@ -384,10 +398,10 @@ extension HookHandler {
 
             let isStale: Bool
             if let pid = session.pid {
-                if !isPIDAlive(pid) {
+                if !process.isAlive(pid: pid) {
                     isStale = true
                 } else if let storedStart = session.pidStartTime,
-                          let currentStart = Session.processStartTime(pid: pid),
+                          let currentStart = process.startTime(pid: pid),
                           abs(storedStart - currentStart) > 1.0 {
                     isStale = true  // PID reused by a different process
                 } else {
@@ -399,7 +413,7 @@ extension HookHandler {
             }
 
             if isStale {
-                removeSession(at: path, sessionId: session.sessionId)
+                removeSession(at: path, sessionId: session.sessionId, logger: logger)
             }
         }
     }
@@ -424,10 +438,10 @@ extension HookHandler {
         }
     }
 
-    private static func removeSession(at path: String, sessionId: String) {
+    private static func removeSession(at path: String, sessionId: String, logger: HookLogger) {
         try? FileManager.default.removeItem(atPath: path)
         // Never remove the .lock here: unlinking a held lock splits the flock inode.
-        HookLogger().cleanupSessionLog(sessionId: sessionId)
+        logger.cleanupSessionLog(sessionId: sessionId)
     }
 
     static func isPIDAlive(_ pid: UInt32) -> Bool {

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -3,11 +3,6 @@ import Foundation
 
 private let maxToolDetailLen = 120
 
-enum HostAppBundleID {
-    static let claudeDesktop = "com.anthropic.claudefordesktop"
-    static let codexDesktop = "com.openai.codex"
-}
-
 enum HookHandler {
     // MIGRATION(v0.6.0): Remove after all users have migrated to PID-keyed sessions.
     private static let noPIDMaxAge: TimeInterval = 300
@@ -451,8 +446,10 @@ extension HookHandler {
 
 // MARK: - Session File Naming
 
-/// Session files are keyed by PID, except Codex where one host process can emit hooks
-/// for multiple conversations. The `codex-` prefix avoids legacy UUID-file cleanup.
+/// The single writer-side source of truth for session file naming. Files are keyed by
+/// PID, except Codex where one host process can emit hooks for multiple conversations.
+/// The `codex-` prefix also keeps Codex files out of the reader-side legacy UUID-file
+/// sweep (`SessionManager.isLegacyUUIDFilename`) — keep both sides in sync.
 func sessionFileName(input: HookInput, pid: UInt32, safeSessionId: String) -> String {
     if input.resolvedHarnessName == Session.codexSource {
         return "codex-\(safeSessionId).json"

--- a/menubar/CctopMenubar/Hook/HookLogger.swift
+++ b/menubar/CctopMenubar/Hook/HookLogger.swift
@@ -1,21 +1,25 @@
 import Foundation
 
-enum HookLogger {
+/// Writes per-session hook logs and the error log under `logsDir`
+/// (default: `~/.cctop/logs`). Construct with a custom directory to keep
+/// test runs out of the real home directory.
+struct HookLogger {
+    let logsDir: String
+
+    init(logsDir: String = HookLogger.defaultLogsDir()) {
+        self.logsDir = logsDir
+    }
+
+    static func defaultLogsDir() -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return (home as NSString).appendingPathComponent(".cctop/logs")
+    }
+
     private static let dateFormatter: ISO8601DateFormatter = {
         let fmt = ISO8601DateFormatter()
         fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return fmt
     }()
-
-    private static func logsDir() -> String? {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return (home as NSString).appendingPathComponent(".cctop/logs")
-    }
-
-    private static func sessionLogPath(sessionId: String) -> String? {
-        guard let dir = logsDir() else { return nil }
-        return (dir as NSString).appendingPathComponent("\(sessionId).log")
-    }
 
     static func sessionLabel(cwd: String, sessionId: String) -> String {
         let project = URL(fileURLWithPath: cwd).lastPathComponent
@@ -23,25 +27,43 @@ enum HookLogger {
         return "\(project):\(abbrev)"
     }
 
-    static func appendHookLog(
+    /// Convenience for call sites without an injected logger (e.g. HookMain's
+    /// argument/stdin errors, before any dependencies are constructed).
+    /// Writes to the default logs directory.
+    static func logError(_ msg: String) {
+        HookLogger().logError(msg)
+    }
+
+    // Temporary shim while call sites migrate to instance loggers.
+    static func cleanupSessionLog(sessionId: String) {
+        HookLogger().cleanupSessionLog(sessionId: sessionId)
+    }
+
+    func appendHookLog(
         sessionId: String,
         event: String,
         label: String,
         transition: String
     ) {
-        guard let logPath = sessionLogPath(sessionId: sessionId) else { return }
-        let timestamp = dateFormatter.string(from: Date())
-        appendLine("\(timestamp) HOOK \(event) \(label) \(transition)\n", to: logPath)
+        let timestamp = Self.dateFormatter.string(from: Date())
+        appendLine("\(timestamp) HOOK \(event) \(label) \(transition)\n", to: sessionLogPath(sessionId: sessionId))
     }
 
-    static func logError(_ msg: String) {
-        guard let dir = logsDir() else { return }
-        let logPath = (dir as NSString).appendingPathComponent("_errors.log")
-        let timestamp = dateFormatter.string(from: Date())
+    func logError(_ msg: String) {
+        let logPath = (logsDir as NSString).appendingPathComponent("_errors.log")
+        let timestamp = Self.dateFormatter.string(from: Date())
         appendLine("\(timestamp) ERROR \(msg)\n", to: logPath)
     }
 
-    private static func appendLine(_ line: String, to path: String) {
+    func cleanupSessionLog(sessionId: String) {
+        try? FileManager.default.removeItem(atPath: sessionLogPath(sessionId: sessionId))
+    }
+
+    private func sessionLogPath(sessionId: String) -> String {
+        (logsDir as NSString).appendingPathComponent("\(sessionId).log")
+    }
+
+    private func appendLine(_ line: String, to path: String) {
         let fm = FileManager.default
         let dir = (path as NSString).deletingLastPathComponent
         try? fm.createDirectory(
@@ -56,10 +78,5 @@ enum HookLogger {
         } else {
             fm.createFile(atPath: path, contents: Data(line.utf8), attributes: [.posixPermissions: 0o600])
         }
-    }
-
-    static func cleanupSessionLog(sessionId: String) {
-        guard let logPath = sessionLogPath(sessionId: sessionId) else { return }
-        try? FileManager.default.removeItem(atPath: logPath)
     }
 }

--- a/menubar/CctopMenubar/Hook/HookLogger.swift
+++ b/menubar/CctopMenubar/Hook/HookLogger.swift
@@ -34,11 +34,6 @@ struct HookLogger {
         HookLogger().logError(msg)
     }
 
-    // Temporary shim while call sites migrate to instance loggers.
-    static func cleanupSessionLog(sessionId: String) {
-        HookLogger().cleanupSessionLog(sessionId: sessionId)
-    }
-
     func appendHookLog(
         sessionId: String,
         event: String,

--- a/menubar/CctopMenubar/Models/AgentBadge.swift
+++ b/menubar/CctopMenubar/Models/AgentBadge.swift
@@ -39,7 +39,7 @@ extension Session {
     /// Explicit non-desktop harnesses keep their harness badge even if a GUI bundle ID leaked
     /// through the environment.
     var agentBadge: AgentBadge {
-        switch SessionIdentityPolicy.trustedHostApp(for: self) {
+        switch trustedHostApp {
         case .claudeDesktop: return .claudeDesktop
         case .codexDesktop: return .codexDesktop
         default: break

--- a/menubar/CctopMenubar/Models/Config.swift
+++ b/menubar/CctopMenubar/Models/Config.swift
@@ -86,7 +86,6 @@ enum Config {
 }
 
 extension Session {
-    private static let codexDesktopBundleID = "com.openai.codex"
     private static let codexTitleGenerationPromptPrefix =
         "You are a helpful assistant. You will be presented with a user prompt, and your job is to provide a short title"
 
@@ -94,7 +93,7 @@ extension Session {
     /// artifacts, not user workspace sessions, so cctop marks their live files hidden.
     var isCodexMemoryMaintenanceSession: Bool {
         source == Session.codexSource
-            && terminal?.bundleId == Self.codexDesktopBundleID
+            && terminal?.bundleId == HostAppBundleID.codexDesktop
             && Config.standardizedPath(projectPath) == Config.standardizedPath(Config.codexMemoriesDir())
     }
 
@@ -102,7 +101,7 @@ extension Session {
     /// hook-visible conversations in the current project, but are not user workspace sessions.
     var isCodexDesktopTitleGenerationSession: Bool {
         source == Session.codexSource
-            && terminal?.bundleId == Self.codexDesktopBundleID
+            && terminal?.bundleId == HostAppBundleID.codexDesktop
             && (sessionName?.isEmpty ?? true)
             && (lastPrompt?.hasPrefix(Self.codexTitleGenerationPromptPrefix) == true)
             && (lastPrompt?.contains("Generate a concise UI title") == true)

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Classifies the application hosting a coding session (editor or terminal).
 /// Used by focusTerminal, openInEditor, and editorIcon.
-enum HostApp {
+enum HostApp: CaseIterable {
     case vscode
     case cursor
     case windsurf
@@ -106,17 +106,13 @@ enum HostApp {
         }
     }
 
-    /// Reverse lookup: bundle ID → HostApp.
-    static let allByBundleID: [String: HostApp] = {
-        let all: [HostApp] = [
-            .vscode, .cursor, .windsurf, .zed,
-            .iterm2, .warp, .terminal, .ghostty, .kitty,
-            .claudeDesktop, .codexDesktop
-        ]
-        return Dictionary(uniqueKeysWithValues: all.compactMap { app in
+    /// Reverse lookup: bundle ID → HostApp. Derived from `allCases` so a newly added
+    /// case can't be silently forgotten; `.unknown` has no bundle ID and drops out.
+    static let allByBundleID: [String: HostApp] = Dictionary(
+        uniqueKeysWithValues: allCases.compactMap { app in
             app.bundleID.map { ($0, app) }
-        })
-    }()
+        }
+    )
 
     /// CLI command name for opening files (used by focusTerminal for active sessions).
     var cliCommand: String? {

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -131,23 +131,35 @@ enum HostApp {
 }
 
 extension Session {
+    /// GUI environments can leak `__CFBundleIdentifier` into child tools; an explicit
+    /// non-desktop harness must not become "Codex Desktop" or "Claude Desktop" because
+    /// of inherited env. Other sources keep the previous bundle-first behavior, including
+    /// nil-source legacy desktop records.
+    var trustedHostApp: HostApp? {
+        guard let app = HostApp.from(bundleIdentifier: terminal?.bundleId) else { return nil }
+        if app.isDesktopApp && Session.isExplicitNonDesktopHarness(source) {
+            return nil
+        }
+        return app
+    }
+
     /// True when the session is hosted by an AI desktop app (Claude Desktop, Codex Desktop)
     /// rather than a terminal/editor. These sessions have no project folder worth reopening,
     /// so they're excluded from Recent Projects.
     var isHostedByDesktopApp: Bool {
-        SessionIdentityPolicy.trustedHostApp(for: self)?.isDesktopApp == true
+        trustedHostApp?.isDesktopApp == true
     }
 
     /// True when the session is hosted by the Codex Desktop app, after validating the bundle ID
     /// against the resolved harness. Nil-source legacy files may still use the bundle alone.
     var isCodexDesktopHost: Bool {
-        SessionIdentityPolicy.trustedHostApp(for: self) == .codexDesktop
+        trustedHostApp == .codexDesktop
     }
 
     /// True when the session is hosted by the Claude Desktop app, after validating the bundle ID
     /// against the resolved harness. Nil-source legacy files may still use the bundle alone.
     var isClaudeDesktopHost: Bool {
-        SessionIdentityPolicy.trustedHostApp(for: self) == .claudeDesktop
+        trustedHostApp == .claudeDesktop
     }
 }
 
@@ -169,7 +181,11 @@ extension Session {
     /// above, so a leaked `TMUX` env can't misclassify a desktop session here. Everything
     /// else (no/unknown bundle id, only env-copyable `tty` or program name) → ambiguous.
     var hostClass: SessionHostClass {
-        SessionIdentityPolicy.hostClass(for: self)
+        if let app = trustedHostApp {
+            return app.isDesktopApp ? .desktop : .terminal
+        }
+        if terminal?.multiplexer != nil { return .terminal }
+        return .ambiguous
     }
 }
 

--- a/menubar/CctopMenubar/Models/PanelPositioning.swift
+++ b/menubar/CctopMenubar/Models/PanelPositioning.swift
@@ -19,6 +19,70 @@ struct ScreenLayout: Equatable {
     }
 }
 
+/// Persistence seam for per-screen custom panel positions.
+///
+/// The stored shape is the established `panelPositions` UserDefaults format:
+/// `[screenKey: ["originX": x, "topY": y]]`.
+protocol PanelPositionStoring: AnyObject {
+    var positionsDict: [String: [String: CGFloat]] { get set }
+}
+
+/// Persists panel positions in UserDefaults under the existing
+/// "panelPositions" key, with the exact encoding existing installs have on disk.
+final class UserDefaultsPanelPositionStore: PanelPositionStoring {
+    static let positionsKey = "panelPositions"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var positionsDict: [String: [String: CGFloat]] {
+        get {
+            defaults.dictionary(forKey: Self.positionsKey) as? [String: [String: CGFloat]] ?? [:]
+        }
+        set {
+            defaults.set(newValue, forKey: Self.positionsKey)
+        }
+    }
+}
+
+/// Owns the panel's per-screen position persistence and geometry decisions,
+/// so AppDelegate only gathers inputs (screens, frames, sizes) and applies frames.
+struct PanelGeometryModel {
+    let store: PanelPositionStoring
+
+    // MARK: - Position persistence
+
+    /// All saved custom positions, keyed by screen key.
+    func savedPositions() -> [String: (originX: CGFloat, topY: CGFloat)] {
+        store.positionsDict.compactMapValues { entry in
+            guard let originX = entry["originX"], let topY = entry["topY"] else { return nil }
+            return (originX: originX, topY: topY)
+        }
+    }
+
+    /// Save a custom position for a screen.
+    func saveCustomPosition(originX: CGFloat, topY: CGFloat, forScreenKey key: String) {
+        var dict = store.positionsDict
+        dict[key] = ["originX": originX, "topY": topY]
+        store.positionsDict = dict
+    }
+
+    /// Remove the custom position for a screen.
+    func clearCustomPosition(forScreenKey key: String) {
+        var dict = store.positionsDict
+        dict.removeValue(forKey: key)
+        store.positionsDict = dict
+    }
+
+    /// Whether a custom position is saved for a screen.
+    func hasCustomPosition(forScreenKey key: String) -> Bool {
+        savedPositions()[key] != nil
+    }
+}
+
 /// Pure positioning math for the floating panel.
 enum PanelPositioning {
     static let margin: CGFloat = 4

--- a/menubar/CctopMenubar/Models/PanelPositioning.swift
+++ b/menubar/CctopMenubar/Models/PanelPositioning.swift
@@ -81,6 +81,69 @@ struct PanelGeometryModel {
     func hasCustomPosition(forScreenKey key: String) -> Bool {
         savedPositions()[key] != nil
     }
+
+    // MARK: - Geometry decisions
+
+    /// Resolve the frame for showing the panel, preferring the click screen's
+    /// saved custom position and falling back to the anchor.
+    func showFrame(
+        clickScreenKey: String?,
+        clickLocation: NSPoint?,
+        anchorRect: NSRect?,
+        panelSize: NSSize,
+        screens: [ScreenLayout]
+    ) -> NSRect? {
+        PanelPositioning.resolveShowPosition(
+            savedPositions: savedPositions(),
+            clickScreenKey: clickScreenKey,
+            clickLocation: clickLocation,
+            anchorRect: anchorRect,
+            panelSize: panelSize,
+            screens: screens
+        )
+    }
+
+    /// Resolve the frame after a content resize. If the panel's screen has a
+    /// custom saved position, keep the top-left corner stable; otherwise keep
+    /// midX centered with the top edge stable.
+    func resizedFrame(from oldFrame: NSRect, to size: NSSize, panelScreenKey: String?) -> NSRect {
+        let hasPositionOnCurrentScreen = panelScreenKey.map { savedPositions()[$0] != nil } ?? false
+        if hasPositionOnCurrentScreen {
+            // Keep top-left corner stable
+            return NSRect(
+                x: oldFrame.origin.x, y: oldFrame.maxY - size.height,
+                width: size.width, height: size.height
+            )
+        }
+        // Keep midX centered, top edge stable
+        return NSRect(
+            x: oldFrame.midX - size.width / 2, y: oldFrame.maxY - size.height,
+            width: size.width, height: size.height
+        )
+    }
+
+    /// Resolve where the panel lands on double-click reset.
+    func resetFrame(
+        anchorRect: NSRect?,
+        panelScreenIndex: Int?,
+        panelSize: NSSize,
+        screens: [ScreenLayout]
+    ) -> NSRect? {
+        PanelPositioning.resolveResetPosition(
+            anchorRect: anchorRect,
+            panelScreenIndex: panelScreenIndex,
+            panelSize: panelSize,
+            screens: screens
+        )
+    }
+
+    /// After a screen-parameter change, overwrite the saved position for the
+    /// panel's screen with the panel's current (possibly clamped) frame — but
+    /// only if a custom position already exists for that screen key.
+    func resaveAfterScreenChange(panelScreenKey: String?, panelFrame: NSRect) {
+        guard let key = panelScreenKey, savedPositions()[key] != nil else { return }
+        saveCustomPosition(originX: panelFrame.origin.x, topY: panelFrame.maxY, forScreenKey: key)
+    }
 }
 
 /// Pure positioning math for the floating panel.

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -160,7 +160,7 @@ enum SessionLifecycle: Int, Equatable {
 }
 
 struct Session: Codable, Identifiable, Equatable {
-    let sessionId: String
+    var sessionId: String
     let projectPath: String
     let projectName: String
     var branch: String
@@ -410,34 +410,14 @@ struct Session: Codable, Identifiable, Equatable {
 
     /// Returns a copy with a new session_id (and optionally updated branch/terminal).
     /// Used when the same OS process gets a new CC session_id on resume.
+    /// Copy-mutation preserves every other field by construction, so fields added
+    /// to `Session` later can never be silently dropped on session-id rotation.
     func withSessionId(_ newId: String, branch: String? = nil, terminal: TerminalInfo? = nil) -> Session {
-        Session(
-            sessionId: newId,
-            projectPath: projectPath,
-            projectName: projectName,
-            branch: branch ?? self.branch,
-            status: status,
-            lastPrompt: lastPrompt,
-            lastActivity: lastActivity,
-            startedAt: startedAt,
-            terminal: terminal ?? self.terminal,
-            pid: pid,
-            pidStartTime: pidStartTime,
-            lastTool: lastTool,
-            lastToolDetail: lastToolDetail,
-            notificationMessage: notificationMessage,
-            sessionName: sessionName,
-            desktopProjectName: desktopProjectName,
-            workspaceFile: workspaceFile,
-            source: source,
-            endedAt: endedAt,
-            disconnectedAt: disconnectedAt,
-            activeSubagents: activeSubagents,
-            isSubagentSession: isSubagentSession,
-            hidden: hidden,
-            createdByHookVersion: createdByHookVersion,
-            lastWrittenByHookVersion: lastWrittenByHookVersion
-        )
+        var copy = self
+        copy.sessionId = newId
+        if let branch { copy.branch = branch }
+        if let terminal { copy.terminal = terminal }
+        return copy
     }
 
     /// Look for a `.code-workspace` file in the given directory.

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -46,6 +46,14 @@ extension JSONDecoder {
     }()
 }
 
+/// Bundle identifiers of the desktop apps that host coding sessions in-app.
+/// Single source of truth for both targets: the hook trusts these IDs when
+/// classifying desktop-hosted sessions, and the app maps them to `HostApp` cases.
+enum HostAppBundleID {
+    static let claudeDesktop = "com.anthropic.claudefordesktop"
+    static let codexDesktop = "com.openai.codex"
+}
+
 struct TerminalInfo: Codable, Equatable {
     let program: String
     let sessionId: String?

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -336,32 +336,24 @@ struct Session: Codable, Identifiable, Equatable {
     }
 
     /// Convenience init for creating new sessions (used by cctop-hook).
+    /// Delegates to the memberwise init so fields added to `Session` later pick up
+    /// their memberwise defaults here instead of needing a second hand-synced list.
     init(sessionId: String, projectPath: String, branch: String, terminal: TerminalInfo) {
-        self.sessionId = sessionId
-        self.projectPath = projectPath
-        self.projectName = Self.extractProjectName(projectPath)
-        self.branch = branch
-        self.status = .idle
-        self.lastPrompt = nil
-        self.lastActivity = Date()
-        self.startedAt = Date()
-        self.terminal = terminal
-        self.pid = nil
-        self.pidStartTime = nil
-        self.lastTool = nil
-        self.lastToolDetail = nil
-        self.notificationMessage = nil
-        self.sessionName = nil
-        self.desktopProjectName = nil
-        self.workspaceFile = nil
-        self.source = nil
-        self.endedAt = nil
-        self.disconnectedAt = nil
-        self.activeSubagents = nil
-        self.isSubagentSession = false
-        self.hidden = false
-        self.createdByHookVersion = nil
-        self.lastWrittenByHookVersion = nil
+        self.init(
+            sessionId: sessionId,
+            projectPath: projectPath,
+            projectName: Self.extractProjectName(projectPath),
+            branch: branch,
+            status: .idle,
+            lastPrompt: nil,
+            lastActivity: Date(),
+            startedAt: Date(),
+            terminal: terminal,
+            pid: nil,
+            lastTool: nil,
+            lastToolDetail: nil,
+            notificationMessage: nil
+        )
     }
 
     mutating func markWrittenByHook(version: String, isNewSessionFile: Bool) {

--- a/menubar/CctopMenubar/Models/StatusColors.swift
+++ b/menubar/CctopMenubar/Models/StatusColors.swift
@@ -20,6 +20,16 @@ enum StatusColors {
     /// Accent — used to tint icons when sessions need attention.
     static var accent: RGBColor { permission }
 
+    /// Resolve the current theme color for a semantic segment kind.
+    static func color(for kind: StatusCounts.SegmentKind) -> RGBColor {
+        switch kind {
+        case .permission: return permission
+        case .attention: return attention
+        case .working: return working
+        case .idle: return idle
+        }
+    }
+
     struct RGBColor: Hashable {
         let red: Double
         let green: Double

--- a/menubar/CctopMenubar/Models/StatusCounts.swift
+++ b/menubar/CctopMenubar/Models/StatusCounts.swift
@@ -1,6 +1,14 @@
 /// Aggregated session status counts used by the menubar icon, notch pill, and accessibility labels.
-@MainActor
 struct StatusCounts: Equatable {
+    /// Semantic identity of a status-bar segment. Renderers resolve the
+    /// theme color for a kind at render time (see `StatusColors.color(for:)`).
+    enum SegmentKind: Equatable {
+        case permission, attention, working, idle
+
+        /// Whether this segment represents sessions needing user action.
+        var needsAction: Bool { self == .permission || self == .attention }
+    }
+
     let permission: Int
     let attention: Int
     let working: Int
@@ -37,35 +45,32 @@ struct StatusCounts: Equatable {
     var total: Int { permission + attention + working + idle }
     var needsAction: Int { permission + attention }
 
-    /// Proportional bar segments: (fraction of total, color).
+    /// Proportional bar segments: (fraction of total, semantic kind).
     /// Used by both MenubarIconRenderer (AppKit) and NotchStatusView (SwiftUI).
-    var barSegments: [(proportion: Double, color: StatusColors.RGBColor)] {
+    var barSegments: [(proportion: Double, kind: SegmentKind)] {
         guard total > 0 else { return [] }
-        var segs: [(Double, StatusColors.RGBColor)] = []
+        var segs: [(Double, SegmentKind)] = []
         if permission > 0 {
-            segs.append((Double(permission) / Double(total), StatusColors.permission))
+            segs.append((Double(permission) / Double(total), .permission))
         }
         if attention > 0 {
-            segs.append((Double(attention) / Double(total), StatusColors.attention))
+            segs.append((Double(attention) / Double(total), .attention))
         }
         if working > 0 {
-            segs.append((Double(working) / Double(total), StatusColors.working))
+            segs.append((Double(working) / Double(total), .working))
         }
         if idle > 0 {
-            segs.append((Double(idle) / Double(total), StatusColors.idle))
+            segs.append((Double(idle) / Double(total), .idle))
         }
         return segs
     }
 
     /// Minimum width in points for action-needing segments (permission, attention).
     private static let minActionWidth: Double = 5
-    private static var actionColors: Set<StatusColors.RGBColor> {
-        [StatusColors.permission, StatusColors.attention]
-    }
 
     /// Bar segments with minimum width enforcement for action-needing segments.
     /// Steals space proportionally from non-action segments (working, idle).
-    func barSegments(forWidth barWidth: Double) -> [(proportion: Double, color: StatusColors.RGBColor)] {
+    func barSegments(forWidth barWidth: Double) -> [(proportion: Double, kind: SegmentKind)] {
         let raw = barSegments
         guard !raw.isEmpty, barWidth > 0 else { return raw }
 
@@ -75,7 +80,7 @@ struct StatusCounts: Equatable {
         var nonActionTotal = 0.0
         var totalActionClamped = 0.0
         for seg in raw {
-            if Self.actionColors.contains(seg.color) {
+            if seg.kind.needsAction {
                 totalActionClamped += max(seg.proportion, minProportion)
                 if seg.proportion < minProportion {
                     deficit += minProportion - seg.proportion
@@ -91,11 +96,11 @@ struct StatusCounts: Equatable {
         guard totalActionClamped <= 0.8 else { return raw }
 
         var result = raw.map { seg in
-            if Self.actionColors.contains(seg.color) && seg.proportion < minProportion {
-                return (minProportion, seg.color)
-            } else if !Self.actionColors.contains(seg.color) {
+            if seg.kind.needsAction && seg.proportion < minProportion {
+                return (minProportion, seg.kind)
+            } else if !seg.kind.needsAction {
                 let shrink = deficit * (seg.proportion / nonActionTotal)
-                return (max(seg.proportion - shrink, 0), seg.color)
+                return (max(seg.proportion - shrink, 0), seg.kind)
             }
             return seg
         }

--- a/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/ClaudeDesktopSessionArchiveLookup.swift
@@ -1,5 +1,14 @@
 import Foundation
 
+/// Read-side seam over Claude Desktop's session metadata store. The live implementation scans
+/// `~/Library/Application Support/Claude/claude-code-sessions`; tests substitute stubs so
+/// archive/orphan filtering can run without metadata files on disk. `nil` keeps the lookup's
+/// contract: the store exists but a matching read was uncertain.
+protocol ClaudeDesktopSessionStateProviding {
+    func archivedSessionIDs(matching sessionIDs: Set<String>) -> Set<String>?
+    func metadataSnapshot(matching sessionIDs: Set<String>) -> ClaudeDesktopSessionMetadataSnapshot?
+}
+
 struct ClaudeDesktopSessionArchiveLookup {
     let sessionsDirectory: String
 
@@ -166,6 +175,8 @@ struct ClaudeDesktopSessionArchiveLookup {
         return nonEmpty((normalized as NSString).lastPathComponent)
     }
 }
+
+extension ClaudeDesktopSessionArchiveLookup: ClaudeDesktopSessionStateProviding {}
 
 struct ClaudeDesktopSessionMetadataSnapshot: Equatable {
     let matchedSessionIDs: Set<String>

--- a/menubar/CctopMenubar/Services/CodexIntegrationManager.swift
+++ b/menubar/CctopMenubar/Services/CodexIntegrationManager.swift
@@ -47,6 +47,10 @@ struct CodexIntegrationObservation: Equatable {
     let needsUpdate: Bool
     let configText: String?
     let legacyConfigKey: Bool
+    /// Absolute path of the observed hooks.json. Codex keys its trust
+    /// records by this path, so it is part of the observation instead of
+    /// being read from the installer at derivation time.
+    let hooksJsonPath: String
 }
 
 enum CodexIntegrationManager {
@@ -55,7 +59,8 @@ enum CodexIntegrationManager {
             installed: observation.hookFilesInstalled,
             featureEnabled: observation.featureEnabled,
             needsUpdate: observation.needsUpdate,
-            configText: observation.configText
+            configText: observation.configText,
+            hooksJsonPath: observation.hooksJsonPath
         )
         // Derive the published update flag from the status so every UI
         // surface agrees with the status-driven Settings row.
@@ -74,7 +79,8 @@ enum CodexIntegrationManager {
         installed: Bool,
         featureEnabled: Bool,
         needsUpdate: Bool,
-        configText: String?
+        configText: String?,
+        hooksJsonPath: String
     ) -> CodexHookStatus {
         guard installed else {
             return featureEnabled ? .notInstalled : .hooksDisabled
@@ -86,9 +92,7 @@ enum CodexIntegrationManager {
             return .needsUpdate
         }
         if let configText,
-           hasTrustedCctopHookState(
-               in: configText, hooksPath: CodexPluginInstaller.hooksJsonPath.path
-           ) {
+           hasTrustedCctopHookState(in: configText, hooksPath: hooksJsonPath) {
             return .trusted
         }
         return .installedUntrusted

--- a/menubar/CctopMenubar/Services/CodexIntegrationManager.swift
+++ b/menubar/CctopMenubar/Services/CodexIntegrationManager.swift
@@ -100,12 +100,24 @@ enum CodexIntegrationManager {
 
     // MARK: - Codex trust records
 
-    /// Snake-case event keys Codex uses for `[hooks.state]` trust entries.
-    /// These are empirical observations of Codex's format that mirror
-    /// `CodexPluginInstaller.registeredEvents` — keep both lists in sync.
-    static let trustStateEventKeys: [String] = [
-        "session_start", "user_prompt_submit", "pre_tool_use", "post_tool_use", "stop"
-    ]
+    /// Snake-case event keys Codex uses for `[hooks.state]` trust entries
+    /// (an empirical observation of Codex's format), derived from
+    /// `CodexPluginInstaller.registeredEvents` so the two lists cannot drift.
+    static let trustStateEventKeys: [String] =
+        CodexPluginInstaller.registeredEvents.map(snakeCased)
+
+    /// PascalCase -> snake_case as Codex writes its trust-record keys:
+    /// SessionStart -> session_start, PreToolUse -> pre_tool_use.
+    private static func snakeCased(_ pascal: String) -> String {
+        var result = ""
+        for character in pascal {
+            if character.isUppercase && !result.isEmpty {
+                result.append("_")
+            }
+            result.append(character.lowercased())
+        }
+        return result
+    }
 
     /// Codex records reviewed command hooks under `[hooks.state]` in
     /// config.toml. Reading them is a conservative UI signal only: cctop

--- a/menubar/CctopMenubar/Services/CodexPluginInstaller.swift
+++ b/menubar/CctopMenubar/Services/CodexPluginInstaller.swift
@@ -14,8 +14,11 @@ private let logger = Logger(subsystem: "com.st0012.CctopMenubar", category: "Cod
 /// so reinstall is idempotent and uninstall never touches entries it did not create.
 enum CodexPluginInstaller {
 
-    /// Mirrors `CodexIntegrationManager.trustStateEventKeys` (the snake_case
-    /// keys Codex uses for trust records) — keep both lists in sync.
+    /// The one Swift source for the events cctop registers with Codex.
+    /// `CodexIntegrationManager.trustStateEventKeys` derives its snake_case
+    /// trust-record keys from this list, and validate-hook-contract.py
+    /// checks it against the hook-input schema — keep the literal
+    /// `[String] = [...]` shape the validator scrapes.
     static let registeredEvents: [String] = [
         "SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop"
     ]

--- a/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
@@ -1,6 +1,17 @@
 import Foundation
 import SQLite3
 
+/// Read-side seam over Codex's local thread state. `CodexThreadArchiveLookup` is the live
+/// SQLite-backed implementation; tests substitute in-memory stubs so visibility and archive
+/// logic can run without a database on disk. All methods share the lookup's nil contract:
+/// `nil` means "the store exists but could not be read" (callers fail safe or open per site).
+protocol CodexThreadStateProviding {
+    func archivedThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
+    func subagentThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
+    func execHelperThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
+    func projectNames(matching threadIDs: Set<String>) -> [String: String]?
+}
+
 struct CodexThreadArchiveLookup {
     let stateDatabasePath: String
 
@@ -254,5 +265,7 @@ struct CodexThreadArchiveLookup {
         return true
     }
 }
+
+extension CodexThreadArchiveLookup: CodexThreadStateProviding {}
 
 private let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -34,7 +34,7 @@ func resolveFocusStrategy(session: Session) -> FocusStrategy {
     // Prefer trusted bundle_id (from __CFBundleIdentifier) over program name: it
     // identifies VS Code forks that all set TERM_PROGRAM=vscode. Explicit non-desktop
     // harnesses ignore leaked AI desktop bundle IDs before this fallback.
-    let hostApp = SessionIdentityPolicy.trustedHostApp(for: session)
+    let hostApp = session.trustedHostApp
         ?? HostApp.from(editorName: terminal.program)
     let target = session.workspaceFile ?? session.projectPath
 

--- a/menubar/CctopMenubar/Services/NavigateController.swift
+++ b/menubar/CctopMenubar/Services/NavigateController.swift
@@ -1,5 +1,5 @@
-import AppKit
 import Combine
+import Foundation
 
 class NavigateController: ObservableObject {
     @Published var isActive = false
@@ -9,14 +9,7 @@ class NavigateController: ObservableObject {
     /// Sorted session snapshot captured when navigate activates.
     /// Prevents reordering while badges are visible.
     private(set) var frozenSessions: [Session] = []
-    private(set) var previousApp: NSRunningApplication?
-    private(set) var panelWasClosedBeforeNavigate = false
     private var timeoutWork: DispatchWorkItem?
-
-    struct DeactivationState {
-        let previousApp: NSRunningApplication?
-        let panelWasClosed: Bool
-    }
 
     func activate(sessions: [Session]) {
         frozenSessions = Session.sorted(sessions)
@@ -24,25 +17,11 @@ class NavigateController: ObservableObject {
         didActivateSubject.send()
     }
 
-    func activate(sessions: [Session], previousApp: NSRunningApplication?, panelWasClosed: Bool) {
-        self.previousApp = previousApp
-        self.panelWasClosedBeforeNavigate = panelWasClosed
-        activate(sessions: sessions)
-    }
-
-    /// Resets all navigate state and returns the state needed for teardown.
-    @discardableResult
-    func deactivate() -> DeactivationState {
-        let state = DeactivationState(
-            previousApp: previousApp,
-            panelWasClosed: panelWasClosedBeforeNavigate
-        )
+    /// Resets all navigate state.
+    func deactivate() {
         isActive = false
         frozenSessions = []
-        previousApp = nil
-        panelWasClosedBeforeNavigate = false
         cancelTimeout()
-        return state
     }
 
     func startTimeout(duration: TimeInterval = 5, onTimeout: @escaping () -> Void) {

--- a/menubar/CctopMenubar/Services/NotchStatusController.swift
+++ b/menubar/CctopMenubar/Services/NotchStatusController.swift
@@ -13,11 +13,19 @@ class NotchStatusController {
     private var panel: NotchStatusPanel?
     private var hostingView: NSHostingView<NotchStatusView>?
 
+    /// Provides the current theme identifier; injected so tests and previews
+    /// don't have to go through the ThemeManager singleton.
+    private let themeId: @MainActor () -> String
+
     /// Called when the notch pill is clicked.
     var onPillClicked: (() -> Void)?
 
     /// Last counts received, used when creating or updating the panel.
     private(set) var lastCounts = StatusCounts.zero
+
+    init(themeId: @escaping @MainActor () -> String = { ThemeManager.shared.themeId }) {
+        self.themeId = themeId
+    }
 
     /// The pill's current frame in screen coordinates, if visible.
     var pillFrame: NSRect? {
@@ -36,9 +44,7 @@ class NotchStatusController {
 
         if let panel {
             if counts != lastCounts {
-                hostingView?.rootView = NotchStatusView(
-                    counts: counts, themeId: ThemeManager.shared.themeId
-                )
+                hostingView?.rootView = NotchStatusView(counts: counts, themeId: themeId())
                 lastCounts = counts
             }
             panel.setFrame(frame, display: true)
@@ -46,7 +52,7 @@ class NotchStatusController {
             return
         }
 
-        let statusView = NotchStatusView(counts: counts, themeId: ThemeManager.shared.themeId)
+        let statusView = NotchStatusView(counts: counts, themeId: themeId())
         let hosting = NSHostingView(rootView: statusView)
         hosting.autoresizingMask = [.width, .height]
 
@@ -68,7 +74,7 @@ class NotchStatusController {
     func update(counts: StatusCounts) {
         lastCounts = counts
         guard let hostingView else { return }
-        hostingView.rootView = NotchStatusView(counts: counts, themeId: ThemeManager.shared.themeId)
+        hostingView.rootView = NotchStatusView(counts: counts, themeId: themeId())
     }
 
     /// Remove the notch panel. Hide first, then release views.

--- a/menubar/CctopMenubar/Services/NotchStatusController.swift
+++ b/menubar/CctopMenubar/Services/NotchStatusController.swift
@@ -13,6 +13,9 @@ class NotchStatusController {
     private var panel: NotchStatusPanel?
     private var hostingView: NSHostingView<NotchStatusView>?
 
+    /// Called when the notch pill is clicked.
+    var onPillClicked: (() -> Void)?
+
     /// Last counts received, used when creating or updating the panel.
     private(set) var lastCounts = StatusCounts.zero
 
@@ -51,6 +54,7 @@ class NotchStatusController {
             contentRect: .zero, styleMask: [],
             backing: .buffered, defer: false
         )
+        newPanel.onPillClick = { [weak self] in self?.onPillClicked?() }
         newPanel.contentView = hosting
         newPanel.setFrame(frame, display: true)
         newPanel.orderFrontRegardless()

--- a/menubar/CctopMenubar/Services/PluginManager.swift
+++ b/menubar/CctopMenubar/Services/PluginManager.swift
@@ -66,7 +66,8 @@ class PluginManager: ObservableObject {
             featureEnabled: codexConfigText.map(CodexPluginInstaller.isFeatureFlagEnabled) ?? true,
             needsUpdate: codexHookFilesInstalled && (Self.codexShimStale() || codexLegacyKey),
             configText: codexConfigText,
-            legacyConfigKey: codexLegacyKey
+            legacyConfigKey: codexLegacyKey,
+            hooksJsonPath: CodexPluginInstaller.hooksJsonPath.path
         ))
         codexConfigExists = codexSnapshot.configExists
         codexNeedsUpdate = codexSnapshot.needsUpdate

--- a/menubar/CctopMenubar/Services/PluginManager.swift
+++ b/menubar/CctopMenubar/Services/PluginManager.swift
@@ -27,11 +27,13 @@ class PluginManager: ObservableObject {
     static let ccOrphanedMarker = ".orphaned_at"
     static let ccPluginManifestPath = ".claude-plugin/plugin.json"
 
-    /// `homeDirectory` controls where plugin detection looks, so tests and
-    /// previews can stage a directory (or point at a nonexistent one) instead
-    /// of reading the developer's real home. `refreshOnInit: false` yields an
-    /// inert manager whose published flags all start false — preview and
-    /// snapshot setups override exactly the flags they mean to show.
+    /// `homeDirectory` controls where Claude Code, opencode, and pi detection
+    /// looks, so tests and previews can stage a directory (or point at a
+    /// nonexistent one) instead of reading the developer's real home. Codex
+    /// detection and install/remove still go through `CodexPluginInstaller`'s
+    /// real-home paths and are NOT redirected by this seam. `refreshOnInit:
+    /// false` yields an inert manager whose published flags all start false —
+    /// preview and snapshot setups override exactly the flags they mean to show.
     init(
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
         refreshOnInit: Bool = true

--- a/menubar/CctopMenubar/Services/PluginManager.swift
+++ b/menubar/CctopMenubar/Services/PluginManager.swift
@@ -20,37 +20,50 @@ class PluginManager: ObservableObject {
     static let ccInstallCommand =
         "claude plugin marketplace add st0012/cctop && claude plugin install cctop"
 
-    private static let home = FileManager.default.homeDirectoryForCurrentUser
-    private static let ocPluginPath = home.appendingPathComponent(
-        ".config/opencode/plugins/cctop.js"
-    )
-    private static let piPluginPath = home.appendingPathComponent(
-        ".pi/agent/extensions/cctop.ts"
-    )
-    private static let ccPluginCacheDir = home.appendingPathComponent(
-        ".claude/plugins/cache/cctop/cctop"
-    )
+    private let homeDirectory: URL
+    private let ocPluginPath: URL
+    private let piPluginPath: URL
+    private let ccPluginCacheDir: URL
     static let ccOrphanedMarker = ".orphaned_at"
     static let ccPluginManifestPath = ".claude-plugin/plugin.json"
 
-    init() {
-        refresh()
+    /// `homeDirectory` controls where plugin detection looks, so tests and
+    /// previews can stage a directory (or point at a nonexistent one) instead
+    /// of reading the developer's real home. `refreshOnInit: false` yields an
+    /// inert manager whose published flags all start false — preview and
+    /// snapshot setups override exactly the flags they mean to show.
+    init(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        refreshOnInit: Bool = true
+    ) {
+        self.homeDirectory = homeDirectory
+        self.ocPluginPath = homeDirectory.appendingPathComponent(
+            ".config/opencode/plugins/cctop.js"
+        )
+        self.piPluginPath = homeDirectory.appendingPathComponent(
+            ".pi/agent/extensions/cctop.ts"
+        )
+        self.ccPluginCacheDir = homeDirectory.appendingPathComponent(
+            ".claude/plugins/cache/cctop/cctop"
+        )
+        if refreshOnInit {
+            refresh()
+        }
     }
 
     func refresh() {
         let fm = FileManager.default
-        let home = Self.home
 
-        ccInstalled = Self.hasActiveClaudeCodePluginVersion(in: Self.ccPluginCacheDir)
+        ccInstalled = Self.hasActiveClaudeCodePluginVersion(in: ccPluginCacheDir)
 
-        let ocConfigDir = home.appendingPathComponent(".config/opencode")
+        let ocConfigDir = homeDirectory.appendingPathComponent(".config/opencode")
         ocConfigExists = fm.fileExists(atPath: ocConfigDir.path)
-        ocInstalled = fm.fileExists(atPath: Self.ocPluginPath.path)
-        ocNeedsUpdate = ocInstalled && Self.installedPluginOutdated()
+        ocInstalled = fm.fileExists(atPath: ocPluginPath.path)
+        ocNeedsUpdate = ocInstalled && Self.installedPluginOutdated(at: ocPluginPath)
 
-        let piConfigDir = home.appendingPathComponent(".pi")
+        let piConfigDir = homeDirectory.appendingPathComponent(".pi")
         piConfigExists = fm.fileExists(atPath: piConfigDir.path)
-        piInstalled = fm.fileExists(atPath: Self.piPluginPath.path)
+        piInstalled = fm.fileExists(atPath: piPluginPath.path)
 
         let codexDirExists = CodexPluginInstaller.codexConfigExists()
         let codexConfigText: String? = codexDirExists
@@ -92,7 +105,7 @@ class PluginManager: ObservableObject {
         }
     }
 
-    private static func installedPluginOutdated() -> Bool {
+    private static func installedPluginOutdated(at ocPluginPath: URL) -> Bool {
         guard let bundledData = loadBundledResource(name: "opencode-plugin", ext: "js"),
               let installedData = try? Data(contentsOf: ocPluginPath) else {
             return false
@@ -146,23 +159,23 @@ class PluginManager: ObservableObject {
     func installOpenCodePlugin() -> Bool {
         installBundledPlugin(
             resource: "opencode-plugin", ext: "js",
-            destination: Self.ocPluginPath, name: "opencode"
+            destination: ocPluginPath, name: "opencode"
         )
     }
 
     func removeOpenCodePlugin() -> Bool {
-        removeBundledPlugin(path: Self.ocPluginPath, name: "opencode")
+        removeBundledPlugin(path: ocPluginPath, name: "opencode")
     }
 
     func installPiPlugin() -> Bool {
         installBundledPlugin(
             resource: "pi-plugin", ext: "ts",
-            destination: Self.piPluginPath, name: "pi"
+            destination: piPluginPath, name: "pi"
         )
     }
 
     func removePiPlugin() -> Bool {
-        removeBundledPlugin(path: Self.piPluginPath, name: "pi")
+        removeBundledPlugin(path: piPluginPath, name: "pi")
     }
 
     // MARK: - Private

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -33,15 +33,6 @@ enum SessionIdentityPolicy {
         return session.pid.map { String($0) } ?? session.sessionId
     }
 
-    /// Durable file identity. Codex uses session_id to avoid shared-PID collisions and to avoid
-    /// legacy UUID-file cleanup; other sources remain PID-keyed.
-    static func fileName(harnessName: String?, pid: UInt32, safeSessionId: String) -> String {
-        if harnessName == Session.codexSource {
-            return "codex-\(safeSessionId).json"
-        }
-        return "\(pid).json"
-    }
-
     /// Stable grouping key shared by dedup and notification transition guards.
     static func stableKey(for session: Session) -> String {
         if session.isCodex {

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -4,28 +4,6 @@ enum SessionIdentityPolicy {
     static let notificationSessionIDKey = "sessionID"
     static let notificationSessionPIDKey = "sessionPID"
 
-    /// GUI environments can leak `__CFBundleIdentifier` into child tools; an explicit
-    /// non-desktop harness must not become "Codex Desktop" or "Claude Desktop" because
-    /// of inherited env. Other sources keep the previous bundle-first behavior, including
-    /// nil-source legacy desktop records.
-    static func trustedHostApp(for session: Session) -> HostApp? {
-        guard let app = HostApp.from(bundleIdentifier: session.terminal?.bundleId) else { return nil }
-        if app.isDesktopApp && Session.isExplicitNonDesktopHarness(session.source) {
-            return nil
-        }
-        return app
-    }
-
-    /// File-local host classification. Deliberately strict: source alone never classifies desktop
-    /// vs CLI because both integrations share source strings with their desktop counterparts.
-    static func hostClass(for session: Session) -> SessionHostClass {
-        if let app = trustedHostApp(for: session) {
-            return app.isDesktopApp ? .desktop : .terminal
-        }
-        if session.terminal?.multiplexer != nil { return .terminal }
-        return .ambiguous
-    }
-
     /// UI identity. Codex multiplexes many conversations onto one host process, so its PID is
     /// not unique per conversation; every other source keeps the existing PID identity.
     static func displayID(for session: Session) -> String {
@@ -38,7 +16,7 @@ enum SessionIdentityPolicy {
         if session.isCodex {
             return "codex:\(session.sessionId)"
         }
-        if hostClass(for: session) == .desktop {
+        if session.hostClass == .desktop {
             return "desktop:\(session.sessionId)"
         }
         return "active:\(displayID(for: session))"

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -23,27 +23,38 @@ struct SessionVisibilitySnapshot {
 }
 
 extension SessionManager {
-    nonisolated static func visibilitySnapshot(in candidates: [DedupCandidate]) -> SessionVisibilitySnapshot {
+    nonisolated static func visibilitySnapshot(
+        in candidates: [DedupCandidate],
+        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup(),
+        claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup()
+    ) -> SessionVisibilitySnapshot {
         let sessions = candidates.map(\.session)
-        let claudeMetadata = claudeDesktopMetadataSnapshot(in: sessions)
-        return visibilitySnapshot(in: candidates, sessions: sessions, claudeMetadata: claudeMetadata)
+        let claudeMetadata = claudeDesktopMetadataSnapshot(in: sessions, claudeDesktopSessions: claudeDesktopSessions)
+        return visibilitySnapshot(in: candidates, sessions: sessions, claudeMetadata: claudeMetadata, codexThreads: codexThreads)
     }
 
     nonisolated static func visibilitySnapshot(
         in candidates: [DedupCandidate],
-        claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?
+        claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?,
+        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup()
     ) -> SessionVisibilitySnapshot {
-        visibilitySnapshot(in: candidates, sessions: candidates.map(\.session), claudeMetadata: claudeMetadata)
+        visibilitySnapshot(
+            in: candidates,
+            sessions: candidates.map(\.session),
+            claudeMetadata: claudeMetadata,
+            codexThreads: codexThreads
+        )
     }
 
     private nonisolated static func visibilitySnapshot(
         in candidates: [DedupCandidate],
         sessions: [Session],
-        claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?
+        claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?,
+        codexThreads: any CodexThreadStateProviding
     ) -> SessionVisibilitySnapshot {
-        let archivedCodexThreadIDs = archivedCodexDesktopThreadIDs(in: sessions)
-        let codexSubagentThreadIDs = codexSubagentThreadIDs(in: sessions)
-        let codexExecHelperThreadIDs = codexExecHelperThreadIDs(in: sessions)
+        let archivedCodexThreadIDs = archivedCodexDesktopThreadIDs(in: sessions, codexThreads: codexThreads)
+        let codexSubagentThreadIDs = codexSubagentThreadIDs(in: sessions, codexThreads: codexThreads)
+        let codexExecHelperThreadIDs = codexExecHelperThreadIDs(in: sessions, codexThreads: codexThreads)
         let archivedClaudeSessionIDs = claudeMetadata?.archivedSessionIDs ?? []
         let codexSubagentCandidates = candidates.filter {
             isCodexSubagentSession($0.session, subagentThreadIDs: codexSubagentThreadIDs)
@@ -67,13 +78,16 @@ extension SessionManager {
 
     /// Batch snapshot for the display path. This never deletes files, so unreadable external state
     /// fails OPEN: at worst an archived session shows for one pass.
-    nonisolated static func archivedCodexDesktopThreadIDs(in sessions: [Session]) -> Set<String> {
+    nonisolated static func archivedCodexDesktopThreadIDs(
+        in sessions: [Session],
+        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup()
+    ) -> Set<String> {
         let threadIDs = Set(
             sessions
                 .filter(\.isCodexDesktopHost)
                 .map(\.sessionId)
         )
-        return CodexThreadArchiveLookup().archivedThreadIDs(matching: threadIDs) ?? []
+        return codexThreads.archivedThreadIDs(matching: threadIDs) ?? []
     }
 
     nonisolated static func isArchivedCodexDesktopSession(
@@ -85,13 +99,16 @@ extension SessionManager {
 
     /// Codex records whether a thread is user-owned or subagent-owned in its local thread
     /// database. That signal applies across Codex hosts: Desktop and terminal Codex CLI.
-    nonisolated static func codexSubagentThreadIDs(in sessions: [Session]) -> Set<String> {
+    nonisolated static func codexSubagentThreadIDs(
+        in sessions: [Session],
+        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup()
+    ) -> Set<String> {
         let threadIDs = Set(
             sessions
                 .filter { $0.isCodex || $0.isCodexDesktopHost }
                 .map(\.sessionId)
         )
-        return CodexThreadArchiveLookup().subagentThreadIDs(matching: threadIDs) ?? []
+        return codexThreads.subagentThreadIDs(matching: threadIDs) ?? []
     }
 
     nonisolated static func isCodexSubagentSession(
@@ -103,13 +120,16 @@ extension SessionManager {
 
     /// Codex Desktop can launch short-lived `codex exec` helper threads. They are useful as
     /// rollout artifacts but should not appear as user-visible cctop sessions.
-    nonisolated static func codexExecHelperThreadIDs(in sessions: [Session]) -> Set<String> {
+    nonisolated static func codexExecHelperThreadIDs(
+        in sessions: [Session],
+        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup()
+    ) -> Set<String> {
         let threadIDs = Set(
             sessions
                 .filter { $0.isCodex || $0.isCodexDesktopHost }
                 .map(\.sessionId)
         )
-        return CodexThreadArchiveLookup().execHelperThreadIDs(matching: threadIDs) ?? []
+        return codexThreads.execHelperThreadIDs(matching: threadIDs) ?? []
     }
 
     nonisolated static func isCodexExecHelperSession(
@@ -122,11 +142,14 @@ extension SessionManager {
     /// Fresh single-session check used before persisting a hidden flag for a Codex subagent
     /// thread. Lookup uncertainty fails OPEN: if we cannot prove it is a subagent, leave it
     /// visible rather than permanently hiding the file.
-    nonisolated static func codexSubagentHiddenSessionSnapshot(path: String) throws -> Session? {
+    nonisolated static func codexSubagentHiddenSessionSnapshot(
+        path: String,
+        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup()
+    ) throws -> Session? {
         guard FileManager.default.fileExists(atPath: path) else { return nil }
         var latest = try Session.fromFile(path: path)
         guard !latest.hidden, latest.isCodex || latest.isCodexDesktopHost else { return nil }
-        guard let subagentIDs = CodexThreadArchiveLookup().subagentThreadIDs(matching: [latest.sessionId]),
+        guard let subagentIDs = codexThreads.subagentThreadIDs(matching: [latest.sessionId]),
               subagentIDs.contains(latest.sessionId) else {
             return nil
         }
@@ -166,17 +189,23 @@ extension SessionManager {
 
     /// Batch snapshot for the display path. This mirrors the Codex behavior: archive metadata read
     /// uncertainty fails OPEN because this path never deletes files.
-    nonisolated static func archivedClaudeDesktopSessionIDs(in sessions: [Session]) -> Set<String> {
-        claudeDesktopMetadataSnapshot(in: sessions)?.archivedSessionIDs ?? []
+    nonisolated static func archivedClaudeDesktopSessionIDs(
+        in sessions: [Session],
+        claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup()
+    ) -> Set<String> {
+        claudeDesktopMetadataSnapshot(in: sessions, claudeDesktopSessions: claudeDesktopSessions)?.archivedSessionIDs ?? []
     }
 
-    nonisolated static func claudeDesktopMetadataSnapshot(in sessions: [Session]) -> ClaudeDesktopSessionMetadataSnapshot? {
+    nonisolated static func claudeDesktopMetadataSnapshot(
+        in sessions: [Session],
+        claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup()
+    ) -> ClaudeDesktopSessionMetadataSnapshot? {
         let sessionIDs = Set(
             sessions
                 .filter(\.isClaudeDesktopHost)
                 .map(\.sessionId)
         )
-        return ClaudeDesktopSessionArchiveLookup().metadataSnapshot(matching: sessionIDs)
+        return claudeDesktopSessions.metadataSnapshot(matching: sessionIDs)
     }
 
     nonisolated static func isArchivedClaudeDesktopSession(
@@ -202,9 +231,12 @@ extension SessionManager {
     /// `loadSessions` uses, this re-reads Codex's SQLite state at call time, so a thread archived
     /// after the GC directory scan is never deleted out from under a pending unarchive. When the
     /// database exists but cannot be read, the lookup returns nil and we fail SAFE.
-    nonisolated static func isCodexDesktopThreadArchived(_ session: Session) -> Bool {
+    nonisolated static func isCodexDesktopThreadArchived(
+        _ session: Session,
+        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup()
+    ) -> Bool {
         guard session.isCodexDesktopHost else { return false }
-        guard let archived = CodexThreadArchiveLookup().archivedThreadIDs(matching: [session.sessionId]) else {
+        guard let archived = codexThreads.archivedThreadIDs(matching: [session.sessionId]) else {
             return true
         }
         return archived.contains(session.sessionId)
@@ -213,16 +245,24 @@ extension SessionManager {
     /// Fresh single-session archive check for Claude Desktop's GC deletion decision. Missing
     /// metadata means "not archived"; unreadable matching metadata means "unknown" and keeps the
     /// file.
-    nonisolated static func isClaudeDesktopSessionArchived(_ session: Session) -> Bool {
+    nonisolated static func isClaudeDesktopSessionArchived(
+        _ session: Session,
+        claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup()
+    ) -> Bool {
         guard session.isClaudeDesktopHost else { return false }
-        guard let archived = ClaudeDesktopSessionArchiveLookup().archivedSessionIDs(matching: [session.sessionId]) else {
+        guard let archived = claudeDesktopSessions.archivedSessionIDs(matching: [session.sessionId]) else {
             return true
         }
         return archived.contains(session.sessionId)
     }
 
-    nonisolated static func isArchivedDesktopSession(_ session: Session) -> Bool {
-        isCodexDesktopThreadArchived(session) || isClaudeDesktopSessionArchived(session)
+    nonisolated static func isArchivedDesktopSession(
+        _ session: Session,
+        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup(),
+        claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup()
+    ) -> Bool {
+        isCodexDesktopThreadArchived(session, codexThreads: codexThreads)
+            || isClaudeDesktopSessionArchived(session, claudeDesktopSessions: claudeDesktopSessions)
     }
 
     /// Decode each session file, derive its lifecycle, and capture mtime — the inputs the dedup
@@ -231,11 +271,14 @@ extension SessionManager {
         _ sessionFiles: [(url: URL, session: Session)],
         now: Date,
         desktopAppConnectionLookup: DesktopAppConnectionLookup = .live,
-        claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?
+        claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?,
+        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup(),
+        processAlive: (Session) -> Bool = { $0.isAlive }
     ) -> [DedupCandidate] {
         let projectNames = desktopProjectNamesBySessionID(
             in: sessionFiles.map(\.session),
-            claudeMetadata: claudeMetadata
+            claudeMetadata: claudeMetadata,
+            codexThreads: codexThreads
         )
         var candidates: [DedupCandidate] = []
         for (url, var session) in sessionFiles {
@@ -243,7 +286,7 @@ extension SessionManager {
                 session.desktopProjectName = projectName
             }
             session.lifecycle = SessionLifecyclePolicy.lifecycle(
-                for: session, hostClass: session.hostClass, processAlive: session.isAlive,
+                for: session, hostClass: session.hostClass, processAlive: processAlive(session),
                 now: now, windows: lifecycleWindows,
                 desktopAppRunning: desktopAppRunning(for: session, lookup: desktopAppConnectionLookup)
             )
@@ -258,7 +301,10 @@ extension SessionManager {
     nonisolated static func buildCandidates(
         _ jsonFiles: [URL],
         now: Date,
-        desktopAppConnectionLookup: DesktopAppConnectionLookup = .live
+        desktopAppConnectionLookup: DesktopAppConnectionLookup = .live,
+        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup(),
+        claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup(),
+        processAlive: (Session) -> Bool = { $0.isAlive }
     ) -> [DedupCandidate] {
         let sessionFiles: [(url: URL, session: Session)] = jsonFiles.compactMap { url in
             guard let data = try? Data(contentsOf: url) else {
@@ -272,24 +318,34 @@ extension SessionManager {
             return (url, session)
         }
 
-        let claudeMetadata = claudeDesktopMetadataSnapshot(in: sessionFiles.map(\.session))
+        let claudeMetadata = claudeDesktopMetadataSnapshot(
+            in: sessionFiles.map(\.session),
+            claudeDesktopSessions: claudeDesktopSessions
+        )
         return buildCandidates(
             sessionFiles,
             now: now,
             desktopAppConnectionLookup: desktopAppConnectionLookup,
-            claudeMetadata: claudeMetadata
+            claudeMetadata: claudeMetadata,
+            codexThreads: codexThreads,
+            processAlive: processAlive
         )
-    }
-
-    nonisolated static func desktopProjectNamesBySessionID(in sessions: [Session]) -> [String: String] {
-        let claudeSessionIDs = Set(sessions.filter(\.isClaudeDesktopHost).map(\.sessionId))
-        let claudeMetadata = ClaudeDesktopSessionArchiveLookup().metadataSnapshot(matching: claudeSessionIDs)
-        return desktopProjectNamesBySessionID(in: sessions, claudeMetadata: claudeMetadata)
     }
 
     nonisolated static func desktopProjectNamesBySessionID(
         in sessions: [Session],
-        claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?
+        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup(),
+        claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup()
+    ) -> [String: String] {
+        let claudeSessionIDs = Set(sessions.filter(\.isClaudeDesktopHost).map(\.sessionId))
+        let claudeMetadata = claudeDesktopSessions.metadataSnapshot(matching: claudeSessionIDs)
+        return desktopProjectNamesBySessionID(in: sessions, claudeMetadata: claudeMetadata, codexThreads: codexThreads)
+    }
+
+    nonisolated static func desktopProjectNamesBySessionID(
+        in sessions: [Session],
+        claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?,
+        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup()
     ) -> [String: String] {
         var projectNames: [String: String] = [:]
 
@@ -298,7 +354,7 @@ extension SessionManager {
         }
 
         let codexThreadIDs = Set(sessions.filter(\.isCodexDesktopHost).map(\.sessionId))
-        if let codexProjectNames = CodexThreadArchiveLookup().projectNames(matching: codexThreadIDs) {
+        if let codexProjectNames = codexThreads.projectNames(matching: codexThreadIDs) {
             projectNames.merge(codexProjectNames) { current, _ in current }
         }
 

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -13,6 +13,35 @@ struct DesktopAppConnectionLookup {
     }
 }
 
+/// Every external input SessionManager consults while deriving session state: the sessions
+/// directory, the Codex/Claude Desktop archive stores, desktop-app liveness, process liveness,
+/// the notification preference, and the clock. Production uses `.live()`; tests override
+/// individual fields to run the full pipeline against temp directories, stub lookups, and a
+/// deterministic clock.
+struct SessionDataSources {
+    var sessionsDir: URL
+    var codexThreads: any CodexThreadStateProviding
+    var claudeDesktopSessions: any ClaudeDesktopSessionStateProviding
+    var desktopAppConnection: DesktopAppConnectionLookup
+    var processAlive: (Session) -> Bool
+    var notificationsEnabled: () -> Bool
+    var now: () -> Date
+
+    /// A function rather than a stored constant so `Config.sessionsDir()` (and the lookup
+    /// paths behind the live stores) are resolved when the caller constructs its sources.
+    static func live() -> SessionDataSources {
+        SessionDataSources(
+            sessionsDir: URL(fileURLWithPath: Config.sessionsDir()),
+            codexThreads: CodexThreadArchiveLookup(),
+            claudeDesktopSessions: ClaudeDesktopSessionArchiveLookup(),
+            desktopAppConnection: .live,
+            processAlive: { $0.isAlive },
+            notificationsEnabled: { UserDefaults.standard.bool(forKey: "notificationsEnabled") },
+            now: Date.init
+        )
+    }
+}
+
 struct SessionVisibilitySnapshot {
     let archivedCodexThreadIDs: Set<String>
     let codexSubagentThreadIDs: Set<String>
@@ -173,7 +202,10 @@ extension SessionManager {
             )
             do {
                 try withSessionLock(sessionPath: candidate.path) {
-                    guard let hiddenSession = try Self.codexSubagentHiddenSessionSnapshot(path: candidate.path) else {
+                    guard let hiddenSession = try Self.codexSubagentHiddenSessionSnapshot(
+                        path: candidate.path,
+                        codexThreads: dataSources.codexThreads
+                    ) else {
                         return
                     }
                     try hiddenSession.writeToFile(path: candidate.path)

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -13,11 +13,12 @@ struct DesktopAppConnectionLookup {
     }
 }
 
-/// Every external input SessionManager consults while deriving session state: the sessions
+/// The external inputs SessionManager consults while deriving session state: the sessions
 /// directory, the Codex/Claude Desktop archive stores, desktop-app liveness, process liveness,
 /// the notification preference, and the clock. Production uses `.live()`; tests override
 /// individual fields to run the full pipeline against temp directories, stub lookups, and a
-/// deterministic clock.
+/// deterministic clock. One state-deriving input remains outside this seam:
+/// `adjustPermissionStatus` probes the live process tree (`proc_listchildpids`) directly.
 struct SessionDataSources {
     var sessionsDir: URL
     var codexThreads: any CodexThreadStateProviding
@@ -29,6 +30,8 @@ struct SessionDataSources {
 
     /// A function rather than a stored constant so `Config.sessionsDir()` (and the lookup
     /// paths behind the live stores) are resolved when the caller constructs its sources.
+    /// The store paths are then FROZEN for this value's lifetime — env-var overrides
+    /// (e.g. in tests) must be in place before `live()` is called, not after.
     static func live() -> SessionDataSources {
         SessionDataSources(
             sessionsDir: URL(fileURLWithPath: Config.sessionsDir()),

--- a/menubar/CctopMenubar/Services/SessionManager+Loading.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Loading.swift
@@ -9,6 +9,44 @@ struct SessionLoadSummary {
 }
 
 extension SessionManager {
+    func decodedSessions(from jsonFiles: [URL]) -> [(url: URL, session: Session)] {
+        jsonFiles.compactMap { url in
+            guard let data = try? Data(contentsOf: url) else {
+                sessionManagerLogger.warning("loadSessions: could not read \(url.lastPathComponent, privacy: .public)")
+                return nil
+            }
+            do {
+                let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: data)
+                return (url, session)
+            } catch {
+                sessionManagerLogger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public): \(error, privacy: .public)")
+                return nil
+            }
+        }
+    }
+
+    /// Derives lifecycle-stamped candidates and the visibility classification for one load pass,
+    /// reading desktop archive state and process liveness through the injected data sources.
+    func deriveVisibility(from visibleDecoded: [(url: URL, session: Session)]) -> SessionVisibilitySnapshot {
+        let claudeMetadata = Self.claudeDesktopMetadataSnapshot(
+            in: visibleDecoded.map(\.session),
+            claudeDesktopSessions: dataSources.claudeDesktopSessions
+        )
+        let candidates = Self.buildCandidates(
+            visibleDecoded,
+            now: dataSources.now(),
+            desktopAppConnectionLookup: dataSources.desktopAppConnection,
+            claudeMetadata: claudeMetadata,
+            codexThreads: dataSources.codexThreads,
+            processAlive: dataSources.processAlive
+        )
+        return Self.visibilitySnapshot(
+            in: candidates,
+            claudeMetadata: claudeMetadata,
+            codexThreads: dataSources.codexThreads
+        )
+    }
+
     func currentStatusesByStableKey() -> [String: SessionStatus] {
         Dictionary(
             sessions.map { (SessionIdentityPolicy.stableKey(for: $0), $0.status) },

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -298,7 +298,7 @@ class SessionManager: ObservableObject {
 
     /// If a session has been in `waitingInput` for over 60 minutes, treat it as
     /// `idle` for display. The user likely walked away.
-    static func adjustIdleTimeout(_ session: Session, now: Date) -> Session {
+    nonisolated static func adjustIdleTimeout(_ session: Session, now: Date) -> Session {
         guard session.status == .waitingInput,
               now.timeIntervalSince(session.lastActivity) > Self.idleTimeoutSeconds else {
             return session

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -5,7 +5,6 @@ import UserNotifications
 import os.log
 
 let sessionManagerLogger = Logger(subsystem: "com.st0012.CctopMenubar", category: "SessionManager")
-private typealias SessionFile = (url: URL, session: Session)
 
 @MainActor
 // swiftlint:disable:next type_body_length
@@ -13,9 +12,9 @@ class SessionManager: ObservableObject {
     @Published var sessions: [Session] = []
 
     let historyManager: HistoryManager
+    let dataSources: SessionDataSources
 
     private let sessionsDir: URL
-    private let desktopAppConnectionLookup: DesktopAppConnectionLookup
     private var source: DispatchSourceFileSystemObject?
     private var debounceTask: DispatchWorkItem?
     private var livenessTimer: Timer?
@@ -25,14 +24,18 @@ class SessionManager: ObservableObject {
     /// fallback recency threshold and `retention` controls dormant desktop cleanup.
     nonisolated static let lifecycleWindows = LifecycleWindows(active: 600, retention: 1_209_600)
 
+    /// `startMonitoring: false` skips the directory watcher and the periodic timers so tests can
+    /// drive `loadSessions()`/`garbageCollectFinished()` explicitly without background reloads.
     init(
         historyManager: HistoryManager,
-        desktopAppConnectionLookup: DesktopAppConnectionLookup = .live
+        dataSources: SessionDataSources = .live(),
+        startMonitoring: Bool = true
     ) {
         self.historyManager = historyManager
-        self.desktopAppConnectionLookup = desktopAppConnectionLookup
-        self.sessionsDir = URL(fileURLWithPath: Config.sessionsDir())
+        self.dataSources = dataSources
+        self.sessionsDir = dataSources.sessionsDir
         loadSessions()
+        guard startMonitoring else { return }
         startWatching()
         // Pass 1 (fast): read, derive lifecycle, dedup, publish.
         livenessTimer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { [weak self] _ in
@@ -42,6 +45,15 @@ class SessionManager: ObservableObject {
         gcTimer = Timer.scheduledTimer(withTimeInterval: 45, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.garbageCollectFinished() }
         }
+    }
+
+    convenience init(
+        historyManager: HistoryManager,
+        desktopAppConnectionLookup: DesktopAppConnectionLookup
+    ) {
+        var dataSources = SessionDataSources.live()
+        dataSources.desktopAppConnection = desktopAppConnectionLookup
+        self.init(historyManager: historyManager, dataSources: dataSources)
     }
 
     func loadSessions() {
@@ -63,15 +75,7 @@ class SessionManager: ObservableObject {
         let hidden = allDecoded.filter { $0.session.hidden }
         let autoHidden = allDecoded.filter { !$0.session.hidden && $0.session.shouldAutoHide }
         let visibleDecoded = allDecoded.filter { !$0.session.hidden && !$0.session.shouldAutoHide }
-        let visibleSessions = visibleDecoded.map(\.session)
-        let claudeMetadata = Self.claudeDesktopMetadataSnapshot(in: visibleSessions)
-        let candidates = Self.buildCandidates(
-            visibleDecoded,
-            now: Date(),
-            desktopAppConnectionLookup: desktopAppConnectionLookup,
-            claudeMetadata: claudeMetadata
-        )
-        let visibility = Self.visibilitySnapshot(in: candidates, claudeMetadata: claudeMetadata)
+        let visibility = deriveVisibility(from: visibleDecoded)
         let liveCandidates = visibility.liveCandidates
         let summary = SessionLoadSummary(
             files: jsonFiles.count,
@@ -99,8 +103,8 @@ class SessionManager: ObservableObject {
 
         hideAutoHiddenSessions(autoHidden)
         hideCodexSubagentSessions(visibility.codexSubagentCandidates)
-        clearReconnectedDesktopSessions(liveCandidates, now: Date())
-        stampDisconnectedDesktopSessions(liveCandidates, now: Date())
+        clearReconnectedDesktopSessions(liveCandidates, now: dataSources.now())
+        stampDisconnectedDesktopSessions(liveCandidates, now: dataSources.now())
 
         // Non-desktop finished sessions keep today's behavior: archive to Recent Projects and
         // remove now (no Recent-Projects lag). Desktop files are retained while dormant and reaped
@@ -111,28 +115,12 @@ class SessionManager: ObservableObject {
 
     private func sendTransitionNotifications(for newSessions: [Session], oldStatuses: [String: SessionStatus]) {
         // Notifications: only a LIVE (active) session that NEWLY needs attention. Dormant never notifies.
-        guard UserDefaults.standard.bool(forKey: "notificationsEnabled") else { return }
+        guard dataSources.notificationsEnabled() else { return }
         for session in newSessions where session.lifecycle == .active {
             guard session.status.needsAttention,
                   let oldStatus = oldStatuses[SessionIdentityPolicy.stableKey(for: session)],
                   !oldStatus.needsAttention else { continue }
             sendNotification(for: session)
-        }
-    }
-
-    private func decodedSessions(from jsonFiles: [URL]) -> [SessionFile] {
-        jsonFiles.compactMap { url in
-            guard let data = try? Data(contentsOf: url) else {
-                sessionManagerLogger.warning("loadSessions: could not read \(url.lastPathComponent, privacy: .public)")
-                return nil
-            }
-            do {
-                let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: data)
-                return (url, session)
-            } catch {
-                sessionManagerLogger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public): \(error, privacy: .public)")
-                return nil
-            }
         }
     }
 
@@ -206,10 +194,10 @@ class SessionManager: ObservableObject {
                 let lifecycle = SessionLifecyclePolicy.lifecycle(
                     for: session,
                     hostClass: SessionHostClass.desktop,
-                    processAlive: session.isAlive,
+                    processAlive: dataSources.processAlive(session),
                     now: now,
                     windows: Self.lifecycleWindows,
-                    desktopAppRunning: Self.desktopAppRunning(for: session, lookup: desktopAppConnectionLookup)
+                    desktopAppRunning: Self.desktopAppRunning(for: session, lookup: dataSources.desktopAppConnection)
                 )
                 guard lifecycle == .active else { return }
                 session.disconnectedAt = nil
@@ -232,10 +220,10 @@ class SessionManager: ObservableObject {
                 let lifecycle = SessionLifecyclePolicy.lifecycle(
                     for: session,
                     hostClass: SessionHostClass.desktop,
-                    processAlive: session.isAlive,
+                    processAlive: dataSources.processAlive(session),
                     now: now,
                     windows: Self.lifecycleWindows,
-                    desktopAppRunning: Self.desktopAppRunning(for: session, lookup: desktopAppConnectionLookup)
+                    desktopAppRunning: Self.desktopAppRunning(for: session, lookup: dataSources.desktopAppConnection)
                 )
                 guard lifecycle == .dormant else { return }
                 session.disconnectedAt = now
@@ -250,7 +238,7 @@ class SessionManager: ObservableObject {
     func garbageCollectFinished() {
         let fm = FileManager.default
         guard let files = try? fm.contentsOfDirectory(at: sessionsDir, includingPropertiesForKeys: nil) else { return }
-        let now = Date()
+        let now = dataSources.now()
         let jsonFiles = files.filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasSuffix(".tmp") }
         var removedAny = false
         for url in jsonFiles {
@@ -269,15 +257,19 @@ class SessionManager: ObservableObject {
                 let life = SessionLifecyclePolicy.lifecycle(
                     for: session,
                     hostClass: hostClass,
-                    processAlive: session.isAlive,
+                    processAlive: dataSources.processAlive(session),
                     now: now,
                     windows: Self.lifecycleWindows,
-                    desktopAppRunning: Self.desktopAppRunning(for: session, lookup: desktopAppConnectionLookup)
+                    desktopAppRunning: Self.desktopAppRunning(for: session, lookup: dataSources.desktopAppConnection)
                 )
                 guard life == .finished else { return }
                 // Re-read external desktop archive state under the lock, right before deleting. A session
                 // archived after the directory scan must keep its .json so a later unarchive can restore it.
-                guard !Self.isArchivedDesktopSession(session) else { return }
+                guard !Self.isArchivedDesktopSession(
+                    session,
+                    codexThreads: dataSources.codexThreads,
+                    claudeDesktopSessions: dataSources.claudeDesktopSessions
+                ) else { return }
                 try? fm.removeItem(at: url)   // .json ONLY — never the .lock
                 removedAny = true
             }
@@ -298,7 +290,7 @@ class SessionManager: ObservableObject {
             return result
         }
         var result = adjustPermissionStatus(session)
-        result = Self.adjustIdleTimeout(result)
+        result = Self.adjustIdleTimeout(result, now: dataSources.now())
         return result
     }
 
@@ -306,9 +298,9 @@ class SessionManager: ObservableObject {
 
     /// If a session has been in `waitingInput` for over 60 minutes, treat it as
     /// `idle` for display. The user likely walked away.
-    private static func adjustIdleTimeout(_ session: Session) -> Session {
+    static func adjustIdleTimeout(_ session: Session, now: Date) -> Session {
         guard session.status == .waitingInput,
-              -session.lastActivity.timeIntervalSinceNow > Self.idleTimeoutSeconds else {
+              now.timeIntervalSince(session.lastActivity) > Self.idleTimeoutSeconds else {
             return session
         }
         var adjusted = session

--- a/menubar/CctopMenubar/Views/CodexPluginRowView.swift
+++ b/menubar/CctopMenubar/Views/CodexPluginRowView.swift
@@ -272,7 +272,7 @@ struct HooksReadyBadge: View {
 // MARK: - Previews
 
 @MainActor private func previewCodexPM(status: CodexHookStatus) -> PluginManager {
-    let pm = PluginManager()
+    let pm = PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
     pm.codexConfigExists = true
     pm.codexHookStatus = status
     pm.codexInstalled = status.isInstalled

--- a/menubar/CctopMenubar/Views/EmptyStateView.swift
+++ b/menubar/CctopMenubar/Views/EmptyStateView.swift
@@ -358,7 +358,7 @@ private func previewPluginManager(
     codex: Bool = false, codexConfig: Bool = false,
     codexHookStatus: CodexHookStatus = .notInstalled
 ) -> PluginManager {
-    let pm = PluginManager()
+    let pm = PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
     pm.ccInstalled = cc
     pm.ocInstalled = oc
     pm.ocConfigExists = ocConfig

--- a/menubar/CctopMenubar/Views/MenubarIconRenderer.swift
+++ b/menubar/CctopMenubar/Views/MenubarIconRenderer.swift
@@ -61,7 +61,7 @@ enum MenubarIconRenderer {
             let segWidth = index == segments.count - 1
                 ? max(0, barRect.maxX - xPos)
                 : barRect.width * seg.proportion
-            seg.color.nsColor.setFill()
+            StatusColors.color(for: seg.kind).nsColor.setFill()
             NSRect(
                 x: xPos, y: barRect.minY,
                 width: segWidth, height: barRect.height

--- a/menubar/CctopMenubar/Views/NotchStatusPanel.swift
+++ b/menubar/CctopMenubar/Views/NotchStatusPanel.swift
@@ -1,8 +1,11 @@
 import AppKit
 
 /// A borderless, non-activating panel for displaying status in the notch area.
-/// Clicking the pill posts a notification that AppDelegate uses to toggle the main panel.
+/// Clicking the pill invokes `onPillClick`, which the owner uses to toggle the main panel.
 class NotchStatusPanel: NSPanel {
+    /// Called when the pill is clicked.
+    var onPillClick: (() -> Void)?
+
     override init(
         contentRect: NSRect,
         styleMask: NSWindow.StyleMask,
@@ -32,10 +35,6 @@ class NotchStatusPanel: NSPanel {
     override var canBecomeMain: Bool { false }
 
     override func mouseDown(with event: NSEvent) {
-        NotificationCenter.default.post(name: .notchPillClicked, object: nil)
+        onPillClick?()
     }
-}
-
-extension Notification.Name {
-    static let notchPillClicked = Notification.Name("notchPillClicked")
 }

--- a/menubar/CctopMenubar/Views/NotchStatusView.swift
+++ b/menubar/CctopMenubar/Views/NotchStatusView.swift
@@ -64,9 +64,9 @@ private struct StatusBar: View {
                 ) { index, seg in
                     if index == segments.count - 1 {
                         // Last segment fills remaining space to avoid float rounding gaps
-                        seg.color.color
+                        StatusColors.color(for: seg.kind).color
                     } else {
-                        seg.color.color.frame(width: geo.size.width * seg.proportion)
+                        StatusColors.color(for: seg.kind).color.frame(width: geo.size.width * seg.proportion)
                     }
                 }
             }

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -2,10 +2,6 @@ import Combine
 import KeyboardShortcuts
 import SwiftUI
 
-extension Notification.Name {
-    static let layoutChanged = Notification.Name("layoutChanged")
-}
-
 enum PopupTab {
     case active, recent
 }
@@ -21,6 +17,8 @@ struct PopupView: View {
     var navigate: NavigateController?
     @ObservedObject var overlayController: OverlayController = OverlayController()
     var initialTab: PopupTab = .active
+    /// Called (async on main) whenever content layout changes so the host can resize the panel.
+    var onLayoutChanged: () -> Void = {}
     @State private var selectedTab: PopupTab = .active
     @State private var selectedIndex: Int?
     @State private var gearHovered = false
@@ -345,7 +343,7 @@ extension PopupView {
     }
 
     private func notifyLayoutChanged() {
-        DispatchQueue.main.async { NotificationCenter.default.post(name: .layoutChanged, object: nil) }
+        DispatchQueue.main.async { onLayoutChanged() }
     }
     private func openInFinder(path: String) { NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: path) }
     private func copyPath(_ path: String) {

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -17,7 +17,7 @@ struct PopupView: View {
     let sessions: [Session]
     var recentProjects: [RecentProject] = []
     @ObservedObject var updater: UpdaterBase
-    var pluginManager: PluginManager?
+    let pluginManager: PluginManager
     var navigate: NavigateController?
     @ObservedObject var overlayController: OverlayController = OverlayController()
     var initialTab: PopupTab = .active
@@ -33,10 +33,10 @@ struct PopupView: View {
     @AppStorage("piBannerDismissed") private var piBannerDismissed = false
 
     private var showOcBanner: Bool {
-        pluginManager.map { $0.ocConfigExists && !$0.ocInstalled && !ocBannerDismissed } ?? false
+        pluginManager.ocConfigExists && !pluginManager.ocInstalled && !ocBannerDismissed
     }
     private var showPiBanner: Bool {
-        pluginManager.map { $0.piConfigExists && !$0.piInstalled && !piBannerDismissed } ?? false
+        pluginManager.piConfigExists && !pluginManager.piInstalled && !piBannerDismissed
     }
 
     private var showTabs: Bool { !recentProjects.isEmpty }
@@ -63,10 +63,7 @@ struct PopupView: View {
                     overlayPanel {
                         switch overlay {
                         case .settings:
-                            SettingsSection(
-                                updater: updater,
-                                pluginManager: pluginManager ?? PluginManager()
-                            )
+                            SettingsSection(updater: updater, pluginManager: pluginManager)
                         case .about:
                             AboutView()
                         }
@@ -115,21 +112,19 @@ struct PopupView: View {
     private var activeContent: some View {
         Group {
             if sessions.isEmpty {
-                if let pluginManager {
-                    EmptyStateView(pluginManager: pluginManager)
-                }
+                EmptyStateView(pluginManager: pluginManager)
             } else {
                 VStack(spacing: 0) {
                 if showOcBanner {
                     ToolInstallBanner(
                         toolName: "opencode", iconLabel: ">_", iconColor: .blue,
-                        installAction: { pluginManager?.installOpenCodePlugin() ?? false },
+                        installAction: { pluginManager.installOpenCodePlugin() },
                         installed: $ocBannerInstalled, dismissed: $ocBannerDismissed)
                 }
                 if showPiBanner {
                     ToolInstallBanner(
                         toolName: "pi", iconLabel: "\u{03C0}", iconColor: .green,
-                        installAction: { pluginManager?.installPiPlugin() ?? false },
+                        installAction: { pluginManager.installPiPlugin() },
                         installed: $piBannerInstalled, dismissed: $piBannerDismissed)
                 }
                 ScrollViewReader { proxy in

--- a/menubar/CctopMenubar/Views/PopupViewHelpers.swift
+++ b/menubar/CctopMenubar/Views/PopupViewHelpers.swift
@@ -118,35 +118,48 @@ struct PanelContentView: View {
 
 // MARK: - PopupView Previews
 
+/// Inert manager for previews: no home-dir IO, every flag starts false.
+@MainActor private func previewPluginManager() -> PluginManager {
+    PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
+}
+
 #Preview("With sessions") {
-    PopupView(sessions: Session.mockSessions, updater: DisabledUpdater()).frame(width: 320)
+    PopupView(
+        sessions: Session.mockSessions, updater: DisabledUpdater(), pluginManager: previewPluginManager()
+    ).frame(width: 320)
 }
 #Preview("Mixed sources") {
-    PopupView(sessions: Session.qaShowcase, updater: DisabledUpdater()).frame(width: 320)
+    PopupView(
+        sessions: Session.qaShowcase, updater: DisabledUpdater(), pluginManager: previewPluginManager()
+    ).frame(width: 320)
 }
 #Preview("Empty") {
-    PopupView(sessions: [], updater: DisabledUpdater(), pluginManager: PluginManager()).frame(width: 320)
+    PopupView(
+        sessions: [], updater: DisabledUpdater(), pluginManager: previewPluginManager()
+    ).frame(width: 320)
 }
 #Preview("With Tabs") {
     PopupView(
-        sessions: Session.mockSessions, recentProjects: RecentProject.mockRecents, updater: DisabledUpdater()
+        sessions: Session.mockSessions, recentProjects: RecentProject.mockRecents,
+        updater: DisabledUpdater(), pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("Only Recents") {
     PopupView(
         sessions: [], recentProjects: RecentProject.mockRecents,
-        updater: DisabledUpdater(), pluginManager: PluginManager()
+        updater: DisabledUpdater(), pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("Empty Recents Tab") {
     PopupView(
-        sessions: Session.mockSessions, recentProjects: [RecentProject.mock()], updater: DisabledUpdater()
+        sessions: Session.mockSessions, recentProjects: [RecentProject.mock()],
+        updater: DisabledUpdater(), pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("Navigate") {
     let rc = NavigateController(); rc.isActive = true
     return PopupView(
         sessions: Session.qaShowcase, recentProjects: RecentProject.mockRecents,
-        updater: DisabledUpdater(), navigate: rc
+        updater: DisabledUpdater(), pluginManager: previewPluginManager(), navigate: rc
     ).frame(width: 320)
 }

--- a/menubar/CctopMenubar/Views/PopupViewHelpers.swift
+++ b/menubar/CctopMenubar/Views/PopupViewHelpers.swift
@@ -97,6 +97,8 @@ struct PanelContentView: View {
     @ObservedObject var updater: UpdaterBase
     @ObservedObject var pluginManager: PluginManager
     @ObservedObject var navigate: NavigateController
+    /// Called (async on main) whenever content layout changes so the host can resize the panel.
+    var onLayoutChanged: () -> Void = {}
     @ObservedObject private var themeManager = ThemeManager.shared
     @StateObject private var overlayController = OverlayController()
 
@@ -107,7 +109,8 @@ struct PanelContentView: View {
             updater: updater,
             pluginManager: pluginManager,
             navigate: navigate,
-            overlayController: overlayController
+            overlayController: overlayController,
+            onLayoutChanged: onLayoutChanged
         )
         .frame(width: 320)
         .background(Color.panelBackground)

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -441,9 +441,14 @@ struct ConnectedBadge: View {
 }
 // MARK: - Previews
 @MainActor private func previewCCRow(installed: Bool) -> PluginManager {
-    let pm = PluginManager()
+    let pm = previewBasePM()
     pm.ccInstalled = installed
     return pm
+}
+
+/// Inert manager for previews: no home-dir IO, every flag starts false.
+@MainActor private func previewBasePM() -> PluginManager {
+    PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
 }
 
 #Preview("CC row - Not installed") {
@@ -457,7 +462,7 @@ struct ConnectedBadge: View {
 
 @MainActor private class MockUpdater: UpdaterBase { override var canCheckForUpdates: Bool { true } }
 @MainActor private func previewPM() -> PluginManager {
-    let pm = PluginManager(); pm.ccInstalled = true; pm.ocInstalled = true
+    let pm = previewBasePM(); pm.ccInstalled = true; pm.ocInstalled = true
     pm.ocConfigExists = true; pm.piInstalled = true; pm.piConfigExists = true
     pm.codexInstalled = true; pm.codexConfigExists = true
     pm.codexHookStatus = .trusted
@@ -468,7 +473,7 @@ struct ConnectedBadge: View {
     pm.codexHookStatus = .installedUntrusted
     return pm
 }
-#Preview("Default") { SettingsSection(updater: DisabledUpdater(), pluginManager: PluginManager()).frame(width: 320).padding() }
+#Preview("Default") { SettingsSection(updater: DisabledUpdater(), pluginManager: previewBasePM()).frame(width: 320).padding() }
 #Preview("All connected") { SettingsSection(updater: DisabledUpdater(), pluginManager: previewPM()).frame(width: 320).padding() }
 #Preview("Codex trust needed") {
     SettingsSection(updater: DisabledUpdater(), pluginManager: previewPendingCodexTrustPM()).frame(width: 320).padding()

--- a/menubar/CctopMenubarTests/CodexIntegrationManagerTests.swift
+++ b/menubar/CctopMenubarTests/CodexIntegrationManagerTests.swift
@@ -126,6 +126,16 @@ final class CodexIntegrationManagerTests: XCTestCase {
 
     // MARK: - Trust-record parsing
 
+    func testTrustStateEventKeysPinCodexTrustRecordFormat() {
+        // Derived from CodexPluginInstaller.registeredEvents; pin the exact
+        // snake_case output so the derivation can never silently mangle a
+        // key Codex writes into [hooks.state].
+        XCTAssertEqual(
+            CodexIntegrationManager.trustStateEventKeys,
+            ["session_start", "user_prompt_submit", "pre_tool_use", "post_tool_use", "stop"]
+        )
+    }
+
     func testHasTrustedCctopHookStateRequiresAllRegisteredEvents() {
         let config = trustStateConfig(
             hooksPath: hooksPath, events: CodexIntegrationManager.trustStateEventKeys

--- a/menubar/CctopMenubarTests/CodexIntegrationManagerTests.swift
+++ b/menubar/CctopMenubarTests/CodexIntegrationManagerTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import CctopMenubar
 
 final class CodexIntegrationManagerTests: XCTestCase {
+    private let hooksPath = "/Users/tester/.codex/hooks.json"
+
     func testSnapshotReportsUntrustedHooksAsInstalledButNeedingTrust() {
         let snapshot = CodexIntegrationManager.snapshot(CodexIntegrationObservation(
             configExists: true,
@@ -9,7 +11,8 @@ final class CodexIntegrationManagerTests: XCTestCase {
             featureEnabled: true,
             needsUpdate: false,
             configText: makeTrustedConfig(events: CodexIntegrationManager.trustStateEventKeys.dropLast()),
-            legacyConfigKey: false
+            legacyConfigKey: false,
+            hooksJsonPath: hooksPath
         ))
 
         XCTAssertEqual(snapshot.hookStatus, .installedUntrusted)
@@ -25,13 +28,34 @@ final class CodexIntegrationManagerTests: XCTestCase {
             featureEnabled: true,
             needsUpdate: false,
             configText: makeTrustedConfig(events: CodexIntegrationManager.trustStateEventKeys),
-            legacyConfigKey: false
+            legacyConfigKey: false,
+            hooksJsonPath: hooksPath
         ))
 
         XCTAssertEqual(snapshot.hookStatus, .trusted)
         XCTAssertFalse(snapshot.hookStatus.needsTrust)
         XCTAssertTrue(snapshot.installed)
         XCTAssertFalse(snapshot.needsUpdate)
+    }
+
+    func testSnapshotTreatsTrustForDifferentHooksPathAsUntrusted() {
+        // Fully-trusted records keyed to another hooks.json file must not
+        // count for the observed install — trust is per hooks-file path.
+        let snapshot = CodexIntegrationManager.snapshot(CodexIntegrationObservation(
+            configExists: true,
+            hookFilesInstalled: true,
+            featureEnabled: true,
+            needsUpdate: false,
+            configText: trustStateConfig(
+                hooksPath: "/Users/tester/elsewhere/.codex/hooks.json",
+                events: CodexIntegrationManager.trustStateEventKeys
+            ),
+            legacyConfigKey: false,
+            hooksJsonPath: hooksPath
+        ))
+
+        XCTAssertEqual(snapshot.hookStatus, .installedUntrusted)
+        XCTAssertTrue(snapshot.hookStatus.needsTrust)
     }
 
     func testSnapshotTreatsStaleInstallAsNeedsUpdate() {
@@ -41,7 +65,8 @@ final class CodexIntegrationManagerTests: XCTestCase {
             featureEnabled: true,
             needsUpdate: true,
             configText: makeTrustedConfig(events: CodexIntegrationManager.trustStateEventKeys),
-            legacyConfigKey: false
+            legacyConfigKey: false,
+            hooksJsonPath: hooksPath
         ))
 
         XCTAssertEqual(snapshot.hookStatus, .needsUpdate)
@@ -59,7 +84,8 @@ final class CodexIntegrationManagerTests: XCTestCase {
             featureEnabled: false,
             needsUpdate: true,
             configText: nil,
-            legacyConfigKey: false
+            legacyConfigKey: false,
+            hooksJsonPath: hooksPath
         ))
 
         XCTAssertEqual(snapshot.hookStatus, .hooksDisabled)
@@ -76,7 +102,8 @@ final class CodexIntegrationManagerTests: XCTestCase {
             featureEnabled: true,
             needsUpdate: false,
             configText: makeTrustedConfig(events: CodexIntegrationManager.trustStateEventKeys),
-            legacyConfigKey: false
+            legacyConfigKey: false,
+            hooksJsonPath: hooksPath
         ))
 
         XCTAssertEqual(snapshot.hookStatus, .notInstalled)
@@ -90,15 +117,14 @@ final class CodexIntegrationManagerTests: XCTestCase {
             featureEnabled: true,
             needsUpdate: false,
             configText: nil,
-            legacyConfigKey: true
+            legacyConfigKey: true,
+            hooksJsonPath: hooksPath
         ))
 
         XCTAssertTrue(snapshot.legacyConfigKey)
     }
 
     // MARK: - Trust-record parsing
-
-    private let hooksPath = "/Users/tester/.codex/hooks.json"
 
     func testHasTrustedCctopHookStateRequiresAllRegisteredEvents() {
         let config = trustStateConfig(
@@ -216,49 +242,57 @@ final class CodexIntegrationManagerTests: XCTestCase {
 
         XCTAssertEqual(
             CodexIntegrationManager.hookStatus(
-                installed: false, featureEnabled: true, needsUpdate: false, configText: nil
+                installed: false, featureEnabled: true, needsUpdate: false,
+                configText: nil, hooksJsonPath: hooksPath
             ),
             .notInstalled
         )
         XCTAssertEqual(
             CodexIntegrationManager.hookStatus(
-                installed: false, featureEnabled: false, needsUpdate: false, configText: nil
+                installed: false, featureEnabled: false, needsUpdate: false,
+                configText: nil, hooksJsonPath: hooksPath
             ),
             .hooksDisabled
         )
         XCTAssertEqual(
             CodexIntegrationManager.hookStatus(
-                installed: true, featureEnabled: true, needsUpdate: true, configText: trustedConfig
+                installed: true, featureEnabled: true, needsUpdate: true,
+                configText: trustedConfig, hooksJsonPath: hooksPath
             ),
             .needsUpdate
         )
         XCTAssertEqual(
             CodexIntegrationManager.hookStatus(
-                installed: true, featureEnabled: false, needsUpdate: false, configText: trustedConfig
+                installed: true, featureEnabled: false, needsUpdate: false,
+                configText: trustedConfig, hooksJsonPath: hooksPath
             ),
             .hooksDisabled
         )
         XCTAssertEqual(
             CodexIntegrationManager.hookStatus(
-                installed: true, featureEnabled: false, needsUpdate: true, configText: trustedConfig
+                installed: true, featureEnabled: false, needsUpdate: true,
+                configText: trustedConfig, hooksJsonPath: hooksPath
             ),
             .hooksDisabled
         )
         XCTAssertEqual(
             CodexIntegrationManager.hookStatus(
-                installed: true, featureEnabled: true, needsUpdate: false, configText: partialConfig
+                installed: true, featureEnabled: true, needsUpdate: false,
+                configText: partialConfig, hooksJsonPath: hooksPath
             ),
             .installedUntrusted
         )
         XCTAssertEqual(
             CodexIntegrationManager.hookStatus(
-                installed: true, featureEnabled: true, needsUpdate: false, configText: nil
+                installed: true, featureEnabled: true, needsUpdate: false,
+                configText: nil, hooksJsonPath: hooksPath
             ),
             .installedUntrusted
         )
         XCTAssertEqual(
             CodexIntegrationManager.hookStatus(
-                installed: true, featureEnabled: true, needsUpdate: false, configText: trustedConfig
+                installed: true, featureEnabled: true, needsUpdate: false,
+                configText: trustedConfig, hooksJsonPath: hooksPath
             ),
             .trusted
         )
@@ -274,10 +308,10 @@ final class CodexIntegrationManagerTests: XCTestCase {
 
     // MARK: - Test helpers
 
-    /// Builds config.toml trust entries for the path `hookStatus` checks at
-    /// runtime (`CodexPluginInstaller.hooksJsonPath`).
+    /// Builds config.toml trust entries keyed to the same fixed `hooksPath`
+    /// the tests pass as the observed hooks.json path.
     private func makeTrustedConfig(events: some Sequence<String>) -> String {
-        trustStateConfig(hooksPath: CodexPluginInstaller.hooksJsonPath.path, events: events)
+        trustStateConfig(hooksPath: hooksPath, events: events)
     }
 
     private func trustStateConfig(hooksPath: String, events: some Sequence<String>) -> String {

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -4,22 +4,70 @@ import XCTest
 final class HookHandlerTests: XCTestCase {
 
     private var sessionsDir: String!
+    private var logsDir: String!
 
     override func setUp() {
         super.setUp()
         sessionsDir = NSTemporaryDirectory() + "cctop-test-\(UUID().uuidString)"
+        logsDir = NSTemporaryDirectory() + "cctop-test-logs-\(UUID().uuidString)"
         try? FileManager.default.createDirectory(
             atPath: sessionsDir, withIntermediateDirectories: true
         )
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
     }
 
     override func tearDown() {
-        unsetenv("CCTOP_SESSIONS_DIR")
         try? FileManager.default.removeItem(atPath: sessionsDir)
-        HookLogger.cleanupSessionLog(sessionId: "test-session-001")
+        try? FileManager.default.removeItem(atPath: logsDir)
         super.tearDown()
     }
+
+    // MARK: - Injected dependencies
+
+    /// Scripted process prober: a fixed parent PID (4242 by default, so session
+    /// files land at a deterministic "4242.json"), a scripted start time, and a
+    /// scripted liveness answer — no getppid/sysctl/kill against the test runner.
+    private struct FakeProcessProber: ProcessProbing {
+        var pid: UInt32 = 4242
+        var start: TimeInterval? = 1000
+        var alive: Bool = true
+        var tty: String?
+
+        func parentPID() -> UInt32 { pid }
+        func startTime(pid: UInt32) -> TimeInterval? { start }
+        func isAlive(pid: UInt32) -> Bool { alive }
+        func controllingTTY() -> String? { tty }
+    }
+
+    /// Name resolver that answers from fixed values (all nil by default), so tests
+    /// never scan the real transcript/index/session-store locations.
+    private struct StubNameResolver: SessionNameResolving {
+        var codexName: String?
+        var desktopTitle: String?
+        var transcriptName: String?
+
+        func codexThreadName(sessionId: String) -> String? { codexName }
+        func claudeDesktopTitle(cliSessionId: String) -> String? { desktopTitle }
+        func transcriptSessionName(transcriptPath: String?, sessionId: String) -> String? { transcriptName }
+    }
+
+    private func makeDeps(
+        pid: UInt32 = 4242,
+        startTime: TimeInterval? = 1000,
+        env: [String: String] = [:],
+        branch: String = "main",
+        names: any SessionNameResolving = StubNameResolver()
+    ) -> HookDependencies {
+        HookDependencies(
+            sessionsDir: { self.sessionsDir },
+            environment: { env },
+            currentBranch: { _ in branch },
+            process: FakeProcessProber(pid: pid, start: startTime),
+            names: names,
+            logger: HookLogger(logsDir: logsDir)
+        )
+    }
+
+    // MARK: - Helpers
 
     private func loadFixture(_ name: String) throws -> Data {
         let projectDir = ProcessInfo.processInfo.environment["PROJECT_DIR"]
@@ -32,29 +80,34 @@ final class HookHandlerTests: XCTestCase {
         return try Data(contentsOf: URL(fileURLWithPath: path))
     }
 
-    private func handleFixture(_ name: String, hookName: String? = nil) throws {
+    private func handleFixture(_ name: String, hookName: String? = nil, deps: HookDependencies? = nil) throws {
         let data = try loadFixture(name)
         let input = try JSONDecoder().decode(HookInput.self, from: data)
-        try HookHandler.handleHook(hookName: hookName ?? input.hookEventName, input: input)
+        try HookHandler.handleHook(hookName: hookName ?? input.hookEventName, input: input, deps: deps ?? makeDeps())
     }
 
-    private func loadSession() throws -> Session {
-        try Session.fromFile(path: sessionFilePath())
+    private func handleHook(_ json: String, hookName: String, deps: HookDependencies? = nil) throws {
+        let input = try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
+        try HookHandler.handleHook(hookName: hookName, input: input, deps: deps ?? makeDeps())
     }
 
-    private func sessionFilePath() throws -> String {
-        let entries = try FileManager.default.contentsOfDirectory(atPath: sessionsDir)
-        let jsonFiles = entries.filter { $0.hasSuffix(".json") }
-        XCTAssertEqual(
-            jsonFiles.count, 1,
-            "Expected exactly 1 session file, found \(jsonFiles.count): \(jsonFiles)"
-        )
-        return (sessionsDir as NSString).appendingPathComponent(jsonFiles[0])
+    /// PID-keyed sessions land at "4242.json" (FakeProcessProber's fixed parent PID);
+    /// Codex sessions are keyed by session id instead.
+    private func sessionFilePath(_ fileName: String = "4242.json") -> String {
+        (sessionsDir as NSString).appendingPathComponent(fileName)
     }
 
-    private func sessionFileExists() -> Bool {
-        let entries = (try? FileManager.default.contentsOfDirectory(atPath: sessionsDir)) ?? []
-        return entries.contains { $0.hasSuffix(".json") }
+    private func loadSession(_ fileName: String = "4242.json") throws -> Session {
+        try Session.fromFile(path: sessionFilePath(fileName))
+    }
+
+    private func sessionFileExists(_ fileName: String = "4242.json") -> Bool {
+        FileManager.default.fileExists(atPath: sessionFilePath(fileName))
+    }
+
+    private func jsonString(_ value: String) throws -> String {
+        let data = try JSONEncoder().encode(value)
+        return String(decoding: data, as: UTF8.self)
     }
 
     // MARK: - Shared host app bundle IDs
@@ -73,7 +126,7 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertEqual(session.sessionId, "test-session-001")
         XCTAssertEqual(session.projectPath, "/tmp/test-project")
         XCTAssertEqual(session.projectName, "test-project")
-        XCTAssertNotNil(session.pid)
+        XCTAssertEqual(session.pid, 4242)
         XCTAssertEqual(session.activeSubagents?.count, 0)
     }
 
@@ -88,7 +141,7 @@ final class HookHandlerTests: XCTestCase {
     func testCurrentHookUpdateDoesNotBackfillLegacyCreatedByVersion() throws {
         try handleFixture("SessionStart")
 
-        let path = try sessionFilePath()
+        let path = sessionFilePath()
         var legacy = try Session.fromFile(path: path)
         legacy.createdByHookVersion = nil
         legacy.lastWrittenByHookVersion = nil
@@ -104,7 +157,7 @@ final class HookHandlerTests: XCTestCase {
     func testSessionEndRefreshesLastWrittenByHookVersion() throws {
         try handleFixture("SessionStart")
 
-        let path = try sessionFilePath()
+        let path = sessionFilePath()
         var session = try Session.fromFile(path: path)
         session.lastWrittenByHookVersion = "0.16.0-dev"
         try session.writeToFile(path: path)
@@ -275,13 +328,12 @@ final class HookHandlerTests: XCTestCase {
     }
 
     func testDesktopSessionEndStampsDisconnectedAt() throws {
-        setenv("__CFBundleIdentifier", HostAppBundleID.claudeDesktop, 1)
-        defer { unsetenv("__CFBundleIdentifier") }
+        let deps = makeDeps(env: ["__CFBundleIdentifier": HostAppBundleID.claudeDesktop])
 
-        try handleFixture("SessionStart")
+        try handleFixture("SessionStart", deps: deps)
         XCTAssertNil(try loadSession().disconnectedAt)
 
-        try handleFixture("SessionEnd")
+        try handleFixture("SessionEnd", deps: deps)
 
         let session = try loadSession()
         XCTAssertNotNil(session.endedAt)
@@ -289,16 +341,15 @@ final class HookHandlerTests: XCTestCase {
     }
 
     func testOpencodeSessionEndIgnoresLeakedCodexDesktopBundle() throws {
-        setenv("__CFBundleIdentifier", HostAppBundleID.codexDesktop, 1)
-        defer { unsetenv("__CFBundleIdentifier") }
+        let deps = makeDeps(env: ["__CFBundleIdentifier": HostAppBundleID.codexDesktop])
 
-        try handleFixture("SessionStart-opencode")
+        try handleFixture("SessionStart-opencode", deps: deps)
         XCTAssertEqual(try loadSession().source, "opencode")
         XCTAssertNil(try loadSession().disconnectedAt)
 
         try handleHook("""
         {"session_id":"opencode-12345","cwd":"/tmp/test-project","hook_event_name":"SessionEnd","harness_name":"opencode"}
-        """, hookName: "SessionEnd")
+        """, hookName: "SessionEnd", deps: deps)
 
         let session = try loadSession()
         XCTAssertNotNil(session.endedAt)
@@ -306,15 +357,14 @@ final class HookHandlerTests: XCTestCase {
     }
 
     func testSessionStartClearsEndedAndDisconnectedAt() throws {
-        setenv("__CFBundleIdentifier", HostAppBundleID.claudeDesktop, 1)
-        defer { unsetenv("__CFBundleIdentifier") }
+        let deps = makeDeps(env: ["__CFBundleIdentifier": HostAppBundleID.claudeDesktop])
 
-        try handleFixture("SessionStart")
-        try handleFixture("SessionEnd")
+        try handleFixture("SessionStart", deps: deps)
+        try handleFixture("SessionEnd", deps: deps)
         XCTAssertNotNil(try loadSession().endedAt)
         XCTAssertNotNil(try loadSession().disconnectedAt)
 
-        try handleFixture("SessionStart")
+        try handleFixture("SessionStart", deps: deps)
 
         let session = try loadSession()
         XCTAssertNil(session.endedAt)
@@ -322,45 +372,43 @@ final class HookHandlerTests: XCTestCase {
     }
 
     func testNoOpHooksPreserveEndedAndDisconnectedAt() throws {
-        setenv("__CFBundleIdentifier", HostAppBundleID.claudeDesktop, 1)
-        defer { unsetenv("__CFBundleIdentifier") }
+        let deps = makeDeps(env: ["__CFBundleIdentifier": HostAppBundleID.claudeDesktop])
 
-        try handleFixture("SessionStart")
-        try handleFixture("SessionEnd")
+        try handleFixture("SessionStart", deps: deps)
+        try handleFixture("SessionEnd", deps: deps)
         let endedAt = try XCTUnwrap(try loadSession().endedAt)
         let disconnectedAt = try XCTUnwrap(try loadSession().disconnectedAt)
 
-        try handleFixture("Notification-permission", hookName: "Notification")
+        try handleFixture("Notification-permission", hookName: "Notification", deps: deps)
         XCTAssertEqual(try loadSession().endedAt, endedAt)
         XCTAssertEqual(try loadSession().disconnectedAt, disconnectedAt)
 
         try handleHook("""
         {"session_id":"test-session-001","cwd":"/tmp/test-project","hook_event_name":"Notification","notification_type":"future_type"}
-        """, hookName: "Notification")
+        """, hookName: "Notification", deps: deps)
         XCTAssertEqual(try loadSession().endedAt, endedAt)
         XCTAssertEqual(try loadSession().disconnectedAt, disconnectedAt)
 
-        try handleFixture("SessionStart", hookName: "FutureHook")
+        try handleFixture("SessionStart", hookName: "FutureHook", deps: deps)
         XCTAssertEqual(try loadSession().endedAt, endedAt)
         XCTAssertEqual(try loadSession().disconnectedAt, disconnectedAt)
     }
 
     func testSubagentHooksPreserveEndedAndDisconnectedAt() throws {
-        setenv("__CFBundleIdentifier", HostAppBundleID.claudeDesktop, 1)
-        defer { unsetenv("__CFBundleIdentifier") }
+        let deps = makeDeps(env: ["__CFBundleIdentifier": HostAppBundleID.claudeDesktop])
 
-        try handleFixture("SessionStart")
-        try handleFixture("SessionEnd")
+        try handleFixture("SessionStart", deps: deps)
+        try handleFixture("SessionEnd", deps: deps)
         let endedAt = try XCTUnwrap(try loadSession().endedAt)
         let disconnectedAt = try XCTUnwrap(try loadSession().disconnectedAt)
 
-        try handleFixture("SubagentStart")
+        try handleFixture("SubagentStart", deps: deps)
         var session = try loadSession()
         XCTAssertEqual(session.endedAt, endedAt)
         XCTAssertEqual(session.disconnectedAt, disconnectedAt)
         XCTAssertEqual(session.activeSubagents?.count, 1)
 
-        try handleFixture("SubagentStop")
+        try handleFixture("SubagentStop", deps: deps)
         session = try loadSession()
         XCTAssertEqual(session.endedAt, endedAt)
         XCTAssertEqual(session.disconnectedAt, disconnectedAt)
@@ -402,8 +450,8 @@ final class HookHandlerTests: XCTestCase {
         try handleFixture("SessionStart-opencode")  // sets sessionName = "Fix login bug"
         XCTAssertEqual(try loadSession().sessionName, "Fix login bug")
 
-        // Same session_id, UserPromptSubmit with no `session_name` field and no
-        // transcript_path. Lookup will return nil. sessionName should be preserved.
+        // Same session_id, UserPromptSubmit with no `session_name` field and a
+        // name resolver that returns nil. sessionName should be preserved.
         try handleFixture("UserPromptSubmit-opencode")
         XCTAssertEqual(try loadSession().sessionName, "Fix login bug",
                        "sessionName should be preserved when lookup returns nil within the same session")
@@ -421,8 +469,8 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertEqual(first.sessionName, "Fix login bug")
         XCTAssertEqual(first.projectName, "test-project")
 
-        // Same PID (test runner), different session_id. Simulates Codex Desktop
-        // spawning a new conversation inside the same OS process.
+        // Same PID (FakeProcessProber's 4242), different session_id. Simulates Codex
+        // Desktop spawning a new conversation inside the same OS process.
         try handleFixture("SessionStart")
         let second = try loadSession()
         XCTAssertEqual(second.sessionId, "test-session-001",
@@ -433,6 +481,41 @@ final class HookHandlerTests: XCTestCase {
                        "PID liveness metadata should carry over")
         XCTAssertEqual(second.pidStartTime, first.pidStartTime,
                        "pidStartTime should carry over for the process-alive check")
+    }
+
+    // MARK: - PID reuse detection
+
+    /// Same PID, same process start time: the same process is still running, so a
+    /// repeated SessionStart must keep the existing session state.
+    func testSessionStart_samePIDSameStartTime_keepsSessionState() throws {
+        try handleFixture("SessionStart-opencode")
+        try handleFixture("UserPromptSubmit-opencode")
+        XCTAssertEqual(try loadSession().lastPrompt, "Help me debug this")
+
+        try handleFixture("SessionStart-opencode")
+        XCTAssertEqual(try loadSession().lastPrompt, "Help me debug this")
+    }
+
+    /// Same PID but a different process start time: the OS reused the PID for a new
+    /// process, so SessionStart must start fresh instead of inheriting the previous
+    /// process's conversation state.
+    func testSessionStart_samePIDDifferentStartTime_dropsPreviousSessionState() throws {
+        try handleFixture("SessionStart-opencode", deps: makeDeps(startTime: 1000))
+        try handleFixture("UserPromptSubmit-opencode", deps: makeDeps(startTime: 1000))
+        XCTAssertEqual(try loadSession().lastPrompt, "Help me debug this")
+
+        try handleFixture("SessionStart-opencode", deps: makeDeps(startTime: 2000))
+
+        let session = try loadSession()
+        XCTAssertNil(session.lastPrompt, "conversation state must not leak across PID reuse")
+        XCTAssertEqual(session.pidStartTime, 2000)
+    }
+
+    // MARK: - Git branch capture
+
+    func testBranchFromDepsLandsInSession() throws {
+        try handleFixture("SessionStart", deps: makeDeps(branch: "feature-x"))
+        XCTAssertEqual(try loadSession().branch, "feature-x")
     }
 
     // MARK: - Full lifecycle sequence
@@ -470,11 +553,12 @@ final class HookHandlerTests: XCTestCase {
         """
         try content.write(toFile: ccsDir + "/local_x.json", atomically: true, encoding: .utf8)
 
-        setenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR", ccsDir, 1)
-        setenv("__CFBundleIdentifier", HostAppBundleID.claudeDesktop, 1)
-        defer { unsetenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR"); unsetenv("__CFBundleIdentifier") }
+        let deps = makeDeps(
+            env: ["__CFBundleIdentifier": HostAppBundleID.claudeDesktop],
+            names: LiveSessionNameResolver(claudeSessionsDir: ccsDir)
+        )
 
-        try handleFixture("SessionStart")  // session_id test-session-001, no session_name
+        try handleFixture("SessionStart", deps: deps)  // session_id test-session-001, no session_name
         XCTAssertEqual(try loadSession().sessionName, "Investigate RBS RDoc plugin")
     }
 
@@ -486,12 +570,13 @@ final class HookHandlerTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: ccsDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(atPath: ccsDir) }
 
-        setenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR", ccsDir, 1)
-        setenv("__CFBundleIdentifier", HostAppBundleID.claudeDesktop, 1)
-        defer { unsetenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR"); unsetenv("__CFBundleIdentifier") }
+        let deps = makeDeps(
+            env: ["__CFBundleIdentifier": HostAppBundleID.claudeDesktop],
+            names: LiveSessionNameResolver(claudeSessionsDir: ccsDir)
+        )
 
         // No title file yet → name stays nil at SessionStart.
-        try handleFixture("SessionStart")
+        try handleFixture("SessionStart", deps: deps)
         XCTAssertNil(try loadSession().sessionName)
 
         // Claude Desktop writes the auto title after the first turn.
@@ -501,7 +586,7 @@ final class HookHandlerTests: XCTestCase {
         try content.write(toFile: ccsDir + "/local_x.json", atomically: true, encoding: .utf8)
 
         // Stop re-runs the lookup and picks it up.
-        try handleFixture("Stop")
+        try handleFixture("Stop", deps: deps)
         XCTAssertEqual(try loadSession().sessionName, "Auto title")
     }
 
@@ -511,20 +596,14 @@ final class HookHandlerTests: XCTestCase {
     func testCodex_fillsNameOnToolEventWhileNil() throws {
         let idx = NSTemporaryDirectory() + "cctop-codex-\(UUID().uuidString).jsonl"
         defer { try? FileManager.default.removeItem(atPath: idx) }
-        setenv("CCTOP_CODEX_SESSION_INDEX", idx, 1)
-        defer { unsetenv("CCTOP_CODEX_SESSION_INDEX") }
-
-        func handle(_ json: String, _ hook: String) throws {
-            let input = try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
-            try HookHandler.handleHook(hookName: hook, input: input)
-        }
+        let deps = makeDeps(names: LiveSessionNameResolver(codexIndexPath: idx))
 
         // SessionStart before Codex has titled the thread → name stays nil.
         let startJSON = """
         {"session_id":"codex-1","cwd":"/tmp/p","hook_event_name":"SessionStart","harness_name":"codex"}
         """
-        try handle(startJSON, "SessionStart")
-        XCTAssertNil(try loadSession().sessionName)
+        try handleHook(startJSON, hookName: "SessionStart", deps: deps)
+        XCTAssertNil(try loadSession("codex-codex-1.json").sessionName)
 
         // Codex writes the thread name to its index mid-turn.
         try """
@@ -535,24 +614,18 @@ final class HookHandlerTests: XCTestCase {
         let toolJSON = """
         {"session_id":"codex-1","cwd":"/tmp/p","hook_event_name":"PreToolUse","harness_name":"codex","tool_name":"Bash"}
         """
-        try handle(toolJSON, "PreToolUse")
-        XCTAssertEqual(try loadSession().sessionName, "Investigate session name capture")
+        try handleHook(toolJSON, hookName: "PreToolUse", deps: deps)
+        XCTAssertEqual(try loadSession("codex-codex-1.json").sessionName, "Investigate session name capture")
     }
 
     func testCodexDesktopTitleGenerationPromptWritesHiddenSession() throws {
-        setenv("__CFBundleIdentifier", HostAppBundleID.codexDesktop, 1)
-        defer { unsetenv("__CFBundleIdentifier") }
-
-        func handle(_ json: String, _ hook: String) throws {
-            let input = try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
-            try HookHandler.handleHook(hookName: hook, input: input)
-        }
+        let deps = makeDeps(env: ["__CFBundleIdentifier": HostAppBundleID.codexDesktop])
 
         let startJSON = """
         {"session_id":"title-helper","cwd":"/tmp/cctop","hook_event_name":"SessionStart","harness_name":"codex"}
         """
-        try handle(startJSON, "SessionStart")
-        XCTAssertFalse(try loadSession().hidden)
+        try handleHook(startJSON, hookName: "SessionStart", deps: deps)
+        XCTAssertFalse(try loadSession("codex-title-helper.json").hidden)
 
         let titlePrompt = """
         You are a helpful assistant. You will be presented with a user prompt, and your job is to provide a short title for a task that will be created from that prompt.
@@ -566,12 +639,12 @@ final class HookHandlerTests: XCTestCase {
         let promptJSON = """
         {"session_id":"title-helper","cwd":"/tmp/cctop","hook_event_name":"UserPromptSubmit","harness_name":"codex","prompt":\(try jsonString(titlePrompt))}
         """
-        try handle(promptJSON, "UserPromptSubmit")
-        XCTAssertTrue(try loadSession().hidden)
+        try handleHook(promptJSON, hookName: "UserPromptSubmit", deps: deps)
+        XCTAssertTrue(try loadSession("codex-title-helper.json").hidden)
     }
 
     func testHookInputMarkedSubagentWritesHiddenSession() throws {
-        let json = """
+        try handleHook("""
         {
           "session_id": "delegated-agent-session",
           "cwd": "/tmp/p",
@@ -579,16 +652,16 @@ final class HookHandlerTests: XCTestCase {
           "harness_name": "opencode",
           "is_subagent": true
         }
-        """
-        let input = try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
-        try HookHandler.handleHook(hookName: "SessionStart", input: input)
+        """, hookName: "SessionStart")
 
         XCTAssertTrue(try loadSession().hidden)
     }
 
+    // MARK: - Project cleanup (stale-PID GC)
+
     func testProjectCleanupPreservesHookMarkedSubagentSession() throws {
         let project = "/tmp/cctop-subagent-cleanup-\(UUID().uuidString)"
-        let json = """
+        try handleHook("""
         {
           "session_id": "delegated-agent-session",
           "cwd": "\(project)",
@@ -596,28 +669,20 @@ final class HookHandlerTests: XCTestCase {
           "harness_name": "opencode",
           "is_subagent": true
         }
-        """
-        let input = try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
-        try HookHandler.handleHook(hookName: "SessionStart", input: input)
+        """, hookName: "SessionStart")
 
-        let path = try sessionFilePath()
-        var session = try Session.fromFile(path: path)
-        session.pid = 999_999
-        try session.writeToFile(path: path)
-
+        // Even with the owning PID dead, hidden subagent sessions must be preserved.
         HookHandler.cleanupSessionsForProject(
-            sessionsDir: sessionsDir,
-            projectPath: project,
-            currentPid: UInt32(getpid())
+            sessionsDir: sessionsDir, projectPath: project, currentPid: 1,
+            process: FakeProcessProber(alive: false), logger: HookLogger(logsDir: logsDir)
         )
 
-        XCTAssertTrue(FileManager.default.fileExists(atPath: path))
+        XCTAssertTrue(sessionFileExists())
     }
 
     func testProjectCleanupRemovesStaleOpencodeWithLeakedCodexDesktopBundle() throws {
         let project = "/tmp/cctop-opencode-cleanup-\(UUID().uuidString)"
-        setenv("__CFBundleIdentifier", HostAppBundleID.codexDesktop, 1)
-        defer { unsetenv("__CFBundleIdentifier") }
+        let deps = makeDeps(env: ["__CFBundleIdentifier": HostAppBundleID.codexDesktop])
 
         try handleHook("""
         {
@@ -626,38 +691,74 @@ final class HookHandlerTests: XCTestCase {
           "hook_event_name": "SessionStart",
           "harness_name": "opencode"
         }
-        """, hookName: "SessionStart")
+        """, hookName: "SessionStart", deps: deps)
 
-        let path = try sessionFilePath()
-        var session = try Session.fromFile(path: path)
-        session.pid = 999_999
-        try session.writeToFile(path: path)
-
+        // The leaked desktop bundle id must not shield an explicit opencode session
+        // from PID-staleness GC.
         HookHandler.cleanupSessionsForProject(
-            sessionsDir: sessionsDir,
-            projectPath: project,
-            currentPid: UInt32(getpid())
+            sessionsDir: sessionsDir, projectPath: project, currentPid: 1,
+            process: FakeProcessProber(alive: false), logger: HookLogger(logsDir: logsDir)
         )
 
-        XCTAssertFalse(FileManager.default.fileExists(atPath: path))
+        XCTAssertFalse(sessionFileExists())
+    }
+
+    func testProjectCleanupRemovesSessionWhosePIDIsDead() throws {
+        let project = "/tmp/cctop-stale-cleanup-\(UUID().uuidString)"
+        try handleHook("""
+        {"session_id":"stale-cc","cwd":"\(project)","hook_event_name":"SessionStart"}
+        """, hookName: "SessionStart")
+        XCTAssertTrue(sessionFileExists())
+
+        HookHandler.cleanupSessionsForProject(
+            sessionsDir: sessionsDir, projectPath: project, currentPid: 1,
+            process: FakeProcessProber(alive: false), logger: HookLogger(logsDir: logsDir)
+        )
+
+        XCTAssertFalse(sessionFileExists())
+    }
+
+    func testProjectCleanupKeepsSessionWhosePIDIsAlive() throws {
+        let project = "/tmp/cctop-alive-cleanup-\(UUID().uuidString)"
+        try handleHook("""
+        {"session_id":"alive-cc","cwd":"\(project)","hook_event_name":"SessionStart"}
+        """, hookName: "SessionStart")
+
+        HookHandler.cleanupSessionsForProject(
+            sessionsDir: sessionsDir, projectPath: project, currentPid: 1,
+            process: FakeProcessProber(start: 1000, alive: true), logger: HookLogger(logsDir: logsDir)
+        )
+
+        XCTAssertTrue(sessionFileExists())
+    }
+
+    func testProjectCleanupRemovesSessionWhosePIDWasReused() throws {
+        let project = "/tmp/cctop-reuse-cleanup-\(UUID().uuidString)"
+        try handleHook("""
+        {"session_id":"reused-cc","cwd":"\(project)","hook_event_name":"SessionStart"}
+        """, hookName: "SessionStart")  // stored pidStartTime = 1000
+
+        // PID is alive but now belongs to a different process (start time moved).
+        HookHandler.cleanupSessionsForProject(
+            sessionsDir: sessionsDir, projectPath: project, currentPid: 1,
+            process: FakeProcessProber(start: 2000, alive: true), logger: HookLogger(logsDir: logsDir)
+        )
+
+        XCTAssertFalse(sessionFileExists())
     }
 
     /// Codex Desktop fires every conversation's hooks from one shared host process, so
     /// PID keying collapses them into a single file. Keyed by session_id, two concurrent
-    /// Codex conversations (same host PID — here the test runner's PID) get two files.
+    /// Codex conversations (same host PID) get two files.
     func testCodex_keepsSeparateFilePerSessionId() throws {
-        func handle(_ json: String, _ hook: String) throws {
-            let input = try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
-            try HookHandler.handleHook(hookName: hook, input: input)
-        }
         let convoA = """
         {"session_id":"019e0000-aaaa-7000-8000-000000000001","cwd":"/tmp/p","hook_event_name":"SessionStart","harness_name":"codex"}
         """
         let convoB = """
         {"session_id":"019e0000-bbbb-7000-8000-000000000002","cwd":"/tmp/p","hook_event_name":"SessionStart","harness_name":"codex"}
         """
-        try handle(convoA, "SessionStart")
-        try handle(convoB, "SessionStart")
+        try handleHook(convoA, hookName: "SessionStart")
+        try handleHook(convoB, hookName: "SessionStart")
 
         let files = try FileManager.default.contentsOfDirectory(atPath: sessionsDir)
             .filter { $0.hasSuffix(".json") }.sorted()
@@ -665,15 +766,5 @@ final class HookHandlerTests: XCTestCase {
             "codex-019e0000-aaaa-7000-8000-000000000001.json",
             "codex-019e0000-bbbb-7000-8000-000000000002.json"
         ])
-    }
-
-    private func jsonString(_ value: String) throws -> String {
-        let data = try JSONEncoder().encode(value)
-        return String(decoding: data, as: UTF8.self)
-    }
-
-    private func handleHook(_ json: String, hookName: String) throws {
-        let input = try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
-        try HookHandler.handleHook(hookName: hookName, input: input)
     }
 }

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -767,4 +767,28 @@ final class HookHandlerTests: XCTestCase {
             "codex-019e0000-bbbb-7000-8000-000000000002.json"
         ])
     }
+
+    // MARK: - Session file naming contract
+
+    /// Pins the writer-side naming rule directly: Codex files are keyed by session id
+    /// (one host PID serves many conversations), everything else by PID. The codex-
+    /// prefix must also keep matching what SessionManager.isLegacyUUIDFilename skips.
+    func testSessionFileNameKeysCodexBySessionIdAndOthersByPID() throws {
+        func input(_ json: String) throws -> HookInput {
+            try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
+        }
+        let codex = try input("""
+        {"session_id":"thread-1","cwd":"/tmp/p","hook_event_name":"SessionStart","harness_name":"codex"}
+        """)
+        let claude = try input("""
+        {"session_id":"thread-1","cwd":"/tmp/p","hook_event_name":"SessionStart","harness_name":"cc"}
+        """)
+        let legacy = try input("""
+        {"session_id":"thread-1","cwd":"/tmp/p","hook_event_name":"SessionStart"}
+        """)
+
+        XCTAssertEqual(sessionFileName(input: codex, pid: 4242, safeSessionId: "thread-1"), "codex-thread-1.json")
+        XCTAssertEqual(sessionFileName(input: claude, pid: 4242, safeSessionId: "thread-1"), "4242.json")
+        XCTAssertEqual(sessionFileName(input: legacy, pid: 4242, safeSessionId: "thread-1"), "4242.json")
+    }
 }

--- a/menubar/CctopMenubarTests/NavigateControllerTests.swift
+++ b/menubar/CctopMenubarTests/NavigateControllerTests.swift
@@ -19,8 +19,6 @@ final class NavigateControllerTests: XCTestCase {
     func testInitialState() {
         XCTAssertFalse(sut.isActive)
         XCTAssertTrue(sut.frozenSessions.isEmpty)
-        XCTAssertNil(sut.previousApp)
-        XCTAssertFalse(sut.panelWasClosedBeforeNavigate)
     }
 
     // MARK: - Activate
@@ -166,17 +164,6 @@ final class NavigateControllerTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
     }
 
-    // MARK: - Panel state tracking
-
-    func testPanelWasClosedBeforeNavigateDefaultsFalse() {
-        XCTAssertFalse(sut.panelWasClosedBeforeNavigate)
-    }
-
-    func testPanelWasClosedBeforeNavigateTracksState() {
-        sut.activate(sessions: [], previousApp: nil, panelWasClosed: true)
-        XCTAssertTrue(sut.panelWasClosedBeforeNavigate)
-    }
-
     // MARK: - Activate → Deactivate cycle
 
     func testFullActivateDeactivateCycle() {
@@ -186,22 +173,16 @@ final class NavigateControllerTests: XCTestCase {
         ]
 
         // Activate
-        sut.activate(sessions: sessions, previousApp: nil, panelWasClosed: true)
+        sut.activate(sessions: sessions)
 
         XCTAssertTrue(sut.isActive)
         XCTAssertEqual(sut.frozenSessions.count, 2)
-        XCTAssertTrue(sut.panelWasClosedBeforeNavigate)
 
         // Deactivate resets all state
-        let state = sut.deactivate()
+        sut.deactivate()
 
         XCTAssertFalse(sut.isActive)
         XCTAssertTrue(sut.frozenSessions.isEmpty)
-        XCTAssertFalse(sut.panelWasClosedBeforeNavigate)
-        XCTAssertNil(sut.previousApp)
-        // Returned state preserves pre-deactivation values
-        XCTAssertTrue(state.panelWasClosed)
-        XCTAssertNil(state.previousApp)
     }
 
     func testMultipleActivateDeactivateCycles() {

--- a/menubar/CctopMenubarTests/PanelLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/PanelLifecycleTests.swift
@@ -1,29 +1,31 @@
 import XCTest
 @testable import CctopMenubar
 
-// MARK: - Lifecycle simulation
+// MARK: - In-memory store
 
-/// Simulates AppDelegate's panel position state management for lifecycle testing.
+/// Test stand-in for UserDefaultsPanelPositionStore.
+private final class InMemoryPanelPositionStore: PanelPositionStoring {
+    var positionsDict: [String: [String: CGFloat]] = [:]
+}
+
+// MARK: - Lifecycle driver
+
+/// Drives the real PanelGeometryModel through AppDelegate-shaped lifecycle
+/// sequences (show/drag/dismiss/screenChange/resize/reset).
 ///
-/// Models the interaction between savedPositions (UserDefaults), focusLocation
-/// (transient per-toggle), and panelFrame across show/drag/dismiss/screenChange
-/// operations. Each method mirrors a real AppDelegate code path.
-///
-/// **What this does NOT model** (potential gap for the real bug):
-/// - Async timing between `.positionPanel` and `.showPanel` actions
-/// - NSEvent.mouseLocation behavior on multi-monitor setups
-/// - macOS notifications firing at unexpected times
-/// - `resizePanel` interactions with `hasCustomPanelPosition`
-private struct PanelLifecycle {
-    var savedPositions: [String: (originX: CGFloat, topY: CGFloat)]
+/// Every geometry and persistence decision is a model call; this struct only
+/// gathers inputs the way AppDelegate does (click/panel screen keys) and keeps
+/// the frame/visibility bookkeeping AppDelegate keeps in the panel itself.
+private struct PanelLifecycleDriver {
+    let model: PanelGeometryModel
     var panelFrame: NSRect?
     var isVisible: Bool = false
 
-    let screens: [ScreenLayout]
+    var screens: [ScreenLayout]
     let anchorRect: NSRect
     let panelSize: NSSize
 
-    var hasCustomPosition: Bool { !savedPositions.isEmpty }
+    var savedPositions: [String: (originX: CGFloat, topY: CGFloat)] { model.savedPositions() }
 
     init(
         savedPositions: [String: (originX: CGFloat, topY: CGFloat)] = [:],
@@ -31,9 +33,13 @@ private struct PanelLifecycle {
         isVisible: Bool = false,
         screens: [ScreenLayout],
         anchorRect: NSRect,
-        panelSize: NSSize
+        panelSize: NSSize,
+        store: PanelPositionStoring = InMemoryPanelPositionStore()
     ) {
-        self.savedPositions = savedPositions
+        self.model = PanelGeometryModel(store: store)
+        for (key, position) in savedPositions {
+            model.saveCustomPosition(originX: position.originX, topY: position.topY, forScreenKey: key)
+        }
         self.panelFrame = panelFrame
         self.isVisible = isVisible
         self.screens = screens
@@ -41,7 +47,7 @@ private struct PanelLifecycle {
         self.panelSize = panelSize
     }
 
-    /// Find the screen key for a point.
+    /// Find the screen key for a point (mirrors AppDelegate.screenKey(at:)).
     private func screenKey(for point: NSPoint) -> String? {
         guard let idx = PanelPositioning.screenIndex(containing: point, in: screens) else {
             return nil
@@ -49,23 +55,19 @@ private struct PanelLifecycle {
         return screens[idx].key
     }
 
-    /// The screen key the panel is currently on (based on midpoint).
+    /// The screen key the panel is currently on (mirrors AppDelegate.panelScreenKey()).
     private var panelScreenKey: String? {
         guard let frame = panelFrame else { return nil }
         return screenKey(for: NSPoint(x: frame.midX, y: frame.midY))
     }
 
-    /// Simulate togglePanel() when hidden → show.
-    /// Models: captureApps → positionPanel → showPanel → activateApp.
-    /// See AppDelegate.togglePanel() + PanelCoordinator (.hidden, .menubarIconClicked).
+    /// togglePanel() when hidden → show.
+    /// Mirrors: captureApps → positionPanel → showPanel → activateApp.
     mutating func show(clickAt clickLocation: NSPoint) {
         precondition(!isVisible, "Panel must be hidden to show")
 
-        let clickKey = screenKey(for: clickLocation)
-
-        if let frame = PanelPositioning.resolveShowPosition(
-            savedPositions: savedPositions,
-            clickScreenKey: clickKey,
+        if let frame = model.showFrame(
+            clickScreenKey: screenKey(for: clickLocation),
             clickLocation: clickLocation,
             anchorRect: anchorRect,
             panelSize: panelSize,
@@ -77,18 +79,14 @@ private struct PanelLifecycle {
         // focusLocation cleared after show (AppDelegate .showPanel async block)
     }
 
-    /// Simulate the OLD navigate shortcut bug (no focusLocation set).
+    /// The OLD navigate shortcut bug (no focusLocation set).
     /// Before the fix, navigate shortcut didn't set focusLocation,
     /// so positionPanel() fell back to panelScreenKey().
     mutating func showViaNavigateWithoutMouseLocation() {
         precondition(!isVisible, "Panel must be hidden to show via navigate")
 
-        // Falls back to panel's last screen key (or nil if no panel frame)
-        let clickKey = panelScreenKey
-
-        if let frame = PanelPositioning.resolveShowPosition(
-            savedPositions: savedPositions,
-            clickScreenKey: clickKey,
+        if let frame = model.showFrame(
+            clickScreenKey: panelScreenKey,
             clickLocation: nil,
             anchorRect: anchorRect,
             panelSize: panelSize,
@@ -99,8 +97,8 @@ private struct PanelLifecycle {
         isVisible = true
     }
 
-    /// Simulate header drag to a new position.
-    /// Models: FloatingPanel.handleHeaderDrag → .panelDragEnded → saveCustomPanelPosition.
+    /// Header drag to a new position.
+    /// Mirrors: FloatingPanel.handleHeaderDrag → AppDelegate.panelDidDrag.
     mutating func drag(toOriginX originX: CGFloat, topY: CGFloat) {
         precondition(isVisible, "Panel must be visible to drag")
         panelFrame = NSRect(
@@ -109,29 +107,26 @@ private struct PanelLifecycle {
         )
         // Save under the screen key the panel is now on
         if let key = panelScreenKey {
-            savedPositions[key] = (originX: originX, topY: topY)
+            model.saveCustomPosition(originX: originX, topY: topY, forScreenKey: key)
         }
     }
 
-    /// Simulate togglePanel() when visible → dismiss.
-    /// Models: PanelCoordinator (.normal, .menubarIconClicked) → .dismissPanel.
+    /// togglePanel() when visible → dismiss.
+    /// Mirrors: PanelCoordinator (.normal, .menubarIconClicked) → .dismissPanel.
     mutating func dismiss() {
         precondition(isVisible, "Panel must be visible to dismiss")
         isVisible = false
         // focusLocation cleared in .dismissPanel action
     }
 
-    /// Simulate handleScreenChange while panel is visible.
-    /// Models: AppDelegate.handleScreenChange → positionPanel(focusLocation: nil) + save if custom.
+    /// Screen-parameter change while panel is visible.
+    /// Mirrors: AppDelegate.handleScreenChange → positionPanel + resave if custom.
     mutating func handleScreenChange() {
         guard isVisible else { return }
 
-        let currentKey = panelScreenKey
-
         // positionPanel with focusLocation = nil (always cleared by this point)
-        if let frame = PanelPositioning.resolveShowPosition(
-            savedPositions: savedPositions,
-            clickScreenKey: currentKey,
+        if let frame = model.showFrame(
+            clickScreenKey: panelScreenKey,
             clickLocation: nil,
             anchorRect: anchorRect,
             panelSize: panelSize,
@@ -140,56 +135,37 @@ private struct PanelLifecycle {
             panelFrame = frame
         }
 
-        // AppDelegate overwrites saved position for current screen with current frame
-        if let key = currentKey, savedPositions[key] != nil, let frame = panelFrame {
-            savedPositions[key] = (originX: frame.origin.x, topY: frame.maxY)
+        // Overwrite the saved position with the possibly clamped frame, if one exists
+        if let frame = panelFrame {
+            model.resaveAfterScreenChange(panelScreenKey: panelScreenKey, panelFrame: frame)
         }
     }
 
-    /// Simulate handleScreenChange with a new screen layout.
-    /// Models: monitors reconfigured (e.g., resolution change, monitor disconnected).
-    mutating func handleScreenChange(newScreens: [ScreenLayout]) -> PanelLifecycle {
-        var updated = PanelLifecycle(
-            savedPositions: savedPositions,
-            panelFrame: panelFrame,
-            isVisible: isVisible,
-            screens: newScreens,
-            anchorRect: anchorRect,
-            panelSize: panelSize
-        )
+    /// Screen-parameter change with a new screen layout.
+    /// Mirrors: monitors reconfigured (e.g., resolution change, monitor disconnected).
+    mutating func handleScreenChange(newScreens: [ScreenLayout]) -> PanelLifecycleDriver {
+        var updated = self // shares the reference-typed store
+        updated.screens = newScreens
         updated.handleScreenChange()
         return updated
     }
 
-    /// Simulate resizePanel triggered by session count change.
-    /// Models: AppDelegate.resizePanel with per-screen hasCustomPanelPosition check.
+    /// Content resize triggered by session count change.
+    /// Mirrors: AppDelegate.resizePanel.
     mutating func resize(newHeight: CGFloat) {
         guard isVisible, let oldFrame = panelFrame else { return }
         let newSize = NSSize(width: panelSize.width, height: newHeight)
-        let hasPositionOnCurrentScreen = panelScreenKey.map { savedPositions[$0] != nil } ?? false
-        if hasPositionOnCurrentScreen {
-            // Keep top-left corner stable
-            panelFrame = NSRect(
-                x: oldFrame.origin.x, y: oldFrame.maxY - newSize.height,
-                width: newSize.width, height: newSize.height
-            )
-        } else {
-            // Keep midX centered, top edge stable
-            panelFrame = NSRect(
-                x: oldFrame.midX - newSize.width / 2, y: oldFrame.maxY - newSize.height,
-                width: newSize.width, height: newSize.height
-            )
-        }
+        panelFrame = model.resizedFrame(from: oldFrame, to: newSize, panelScreenKey: panelScreenKey)
     }
 
-    /// Simulate double-click reset.
-    /// Models: .resetPanelPosition → clearCustomPanelPosition for current screen only.
+    /// Double-click reset.
+    /// Mirrors: AppDelegate.panelDidRequestReset → resetPanelToCurrentScreen.
     mutating func resetPosition() {
         precondition(isVisible, "Panel must be visible to reset")
 
         // Clear only the current screen's saved position
         if let key = panelScreenKey {
-            savedPositions.removeValue(forKey: key)
+            model.clearCustomPosition(forScreenKey: key)
         }
 
         let panelIdx = panelFrame.flatMap { frame in
@@ -198,7 +174,7 @@ private struct PanelLifecycle {
             )
         }
 
-        if let frame = PanelPositioning.resolveResetPosition(
+        if let frame = model.resetFrame(
             anchorRect: anchorRect,
             panelScreenIndex: panelIdx,
             panelSize: panelSize,
@@ -231,8 +207,8 @@ final class PanelLifecycleTests: XCTestCase {
     let clickOnPrimary = NSPoint(x: 1890, y: 1060)
     let clickOnSecondary = NSPoint(x: 2500, y: 1060)
 
-    private func makeLifecycle() -> PanelLifecycle {
-        PanelLifecycle(
+    private func makeLifecycle() -> PanelLifecycleDriver {
+        PanelLifecycleDriver(
             screens: screens,
             anchorRect: anchorOnPrimary,
             panelSize: panelSize
@@ -294,6 +270,13 @@ final class PanelLifecycleTests: XCTestCase {
 
     // MARK: - Screen change while on different screen
 
+    /// The deleted hand-written simulation asserted the primary position
+    /// survived this scenario, but it computed the resave key BEFORE
+    /// repositioning. Production AppDelegate reads the panel's screen AFTER
+    /// positionPanel: with no custom position on secondary, the screen change
+    /// snaps the panel back to the anchor on primary and the clamp-resave then
+    /// overwrites primary's saved entry with the anchor frame. This now pins
+    /// the real behavior the simulation drifted from.
     func testScreenChangeWhileOnSecondaryPreservesPrimaryPosition() {
         var lc = makeLifecycle()
 
@@ -308,13 +291,28 @@ final class PanelLifecycleTests: XCTestCase {
         // Screen change fires while panel is on secondary
         lc.handleScreenChange()
 
+        // No custom position on secondary → the panel snaps back to the anchor
+        // on primary, and the resave overwrites primary's entry with that frame
+        XCTAssertLessThan(
+            lc.panelFrame!.maxX, primary.frame.maxX,
+            "Panel should snap back to the anchor screen"
+        )
+        XCTAssertEqual(
+            lc.savedPositions["primary"]!.originX, lc.panelFrame!.origin.x, accuracy: 0.5,
+            "Resave overwrites primary's entry with the panel's new frame"
+        )
+        XCTAssertEqual(
+            lc.savedPositions["primary"]!.topY, lc.panelFrame!.maxY, accuracy: 0.5,
+            "Resave overwrites primary's entry with the panel's new frame"
+        )
+
         lc.dismiss()
 
-        // Show on primary — custom position should survive
+        // Show on primary — the dragged position was overwritten by the resave
         lc.show(clickAt: clickOnPrimary)
-        XCTAssertEqual(
-            lc.panelFrame!.origin.x, 200, accuracy: 1,
-            "Custom position should survive screen change on different screen"
+        XCTAssertNotEqual(
+            lc.panelFrame!.origin.x, 200,
+            "The dragged position does not survive a screen change that snaps the panel home"
         )
     }
 
@@ -495,8 +493,8 @@ final class PanelLifecycleTests: XCTestCase {
     // MARK: - Stale saved position on wrong screen
 
     func testStalePositionOnWrongScreenIsIgnored() {
-        // Simulate stale data: savedPositions["primary"] has coordinates on secondary screen
-        var lc = PanelLifecycle(
+        // Stale data: savedPositions["primary"] has coordinates on secondary screen
+        var lc = PanelLifecycleDriver(
             savedPositions: ["primary": (originX: 2500, topY: 800)],
             screens: screens,
             anchorRect: anchorOnPrimary,
@@ -524,7 +522,7 @@ final class PanelLifecycleTests: XCTestCase {
             visibleFrame: NSRect(x: 0, y: 0, width: 1920, height: 1055),
             key: "primary"
         )
-        var lc = PanelLifecycle(
+        var lc = PanelLifecycleDriver(
             screens: [screen],
             anchorRect: anchorOnPrimary,
             panelSize: panelSize
@@ -584,5 +582,94 @@ final class PanelLifecycleTests: XCTestCase {
             "Without mouse location, falls back to panel's last screen position"
         )
         // This is the broken behavior — panel opens on primary even if user is on secondary
+    }
+
+    // MARK: - Resize x custom position interaction (real resizedFrame branch)
+
+    func testResizeWithCustomPositionKeepsTopLeftStable() {
+        var lc = makeLifecycle()
+
+        lc.show(clickAt: clickOnPrimary)
+        lc.drag(toOriginX: 200, topY: 700)
+
+        lc.resize(newHeight: 550)
+
+        XCTAssertEqual(
+            lc.panelFrame!.origin.x, 200, accuracy: 0.5,
+            "With a custom position, resize must keep the left edge stable"
+        )
+        XCTAssertEqual(
+            lc.panelFrame!.maxY, 700, accuracy: 0.5,
+            "With a custom position, resize must keep the top edge stable"
+        )
+        XCTAssertEqual(lc.panelFrame!.height, 550, accuracy: 0.5)
+    }
+
+    func testResizeWithoutCustomPositionKeepsMidXCentered() {
+        var lc = makeLifecycle()
+
+        lc.show(clickAt: clickOnPrimary)
+        let before = lc.panelFrame!
+
+        lc.resize(newHeight: 550)
+
+        XCTAssertEqual(
+            lc.panelFrame!.midX, before.midX, accuracy: 0.5,
+            "Without a custom position, resize must keep midX centered"
+        )
+        XCTAssertEqual(
+            lc.panelFrame!.maxY, before.maxY, accuracy: 0.5,
+            "Without a custom position, resize must keep the top edge stable"
+        )
+        XCTAssertEqual(lc.panelFrame!.height, 550, accuracy: 0.5)
+    }
+
+    // MARK: - Screen change clamp-resave (what actually lands in the store)
+
+    func testScreenChangeResaveWritesClampedPositionToStore() {
+        let store = InMemoryPanelPositionStore()
+        var lc = PanelLifecycleDriver(
+            screens: [primary],
+            anchorRect: anchorOnPrimary,
+            panelSize: panelSize,
+            store: store
+        )
+
+        lc.show(clickAt: clickOnPrimary)
+        lc.drag(toOriginX: 1200, topY: 700)
+
+        // Screen shrinks — panel (x=1200, w=320) overflows the new right edge
+        let smaller = ScreenLayout(
+            frame: NSRect(x: 0, y: 0, width: 1440, height: 900),
+            visibleFrame: NSRect(x: 0, y: 0, width: 1440, height: 875),
+            key: "primary"
+        )
+        lc = lc.handleScreenChange(newScreens: [smaller])
+
+        let expectedX = smaller.visibleFrame.maxX - panelSize.width - PanelPositioning.margin
+        XCTAssertEqual(
+            store.positionsDict,
+            ["primary": ["originX": expectedX, "topY": 700]],
+            "Screen change must resave the clamped position in the persisted format"
+        )
+    }
+
+    func testScreenChangeDoesNotCreatePositionForScreenWithoutOne() {
+        let store = InMemoryPanelPositionStore()
+        var lc = PanelLifecycleDriver(
+            screens: screens,
+            anchorRect: anchorOnPrimary,
+            panelSize: panelSize,
+            store: store
+        )
+
+        // No custom position anywhere; panel shown on secondary
+        lc.show(clickAt: clickOnSecondary)
+        lc.handleScreenChange()
+
+        XCTAssertEqual(
+            store.positionsDict, [:],
+            "Resave must not invent a position for a screen that never had one"
+        )
     }
 }

--- a/menubar/CctopMenubarTests/PanelPositioningTests.swift
+++ b/menubar/CctopMenubarTests/PanelPositioningTests.swift
@@ -251,31 +251,6 @@ final class PanelPositioningTests: XCTestCase {
 
     // MARK: - Persisted panelPositions format (UserDefaults compatibility)
 
-    /// Pins the exact dictionary shape persisted under the "panelPositions"
-    /// UserDefaults key: `[screenKey: ["originX": x, "topY": y]]`. Existing
-    /// installs have this on disk, so any refactor of the persistence path
-    /// must keep reading and writing this exact format.
-    func testPanelPositionsPersistedFormatRoundTrip() throws {
-        let suiteName = "PanelPositioningTests.\(UUID().uuidString)"
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
-        defer {
-            UserDefaults.standard.removeSuite(named: suiteName)
-            defaults.removePersistentDomain(forName: suiteName)
-        }
-
-        let persisted: [String: [String: CGFloat]] = [
-            "primary": ["originX": 200, "topY": 700],
-            "secondary": ["originX": 2200.5, "topY": 901.25]
-        ]
-        defaults.set(persisted, forKey: "panelPositions")
-
-        let readBack = defaults.dictionary(forKey: "panelPositions") as? [String: [String: CGFloat]]
-        XCTAssertEqual(
-            readBack, persisted,
-            "panelPositions must round-trip through UserDefaults in the established format"
-        )
-    }
-
     /// The UserDefaults-backed store must read positions persisted by previous
     /// app versions and write back the identical raw format.
     func testUserDefaultsStoreReadsAndWritesEstablishedFormat() throws {

--- a/menubar/CctopMenubarTests/PanelPositioningTests.swift
+++ b/menubar/CctopMenubarTests/PanelPositioningTests.swift
@@ -276,6 +276,49 @@ final class PanelPositioningTests: XCTestCase {
         )
     }
 
+    /// The UserDefaults-backed store must read positions persisted by previous
+    /// app versions and write back the identical raw format.
+    func testUserDefaultsStoreReadsAndWritesEstablishedFormat() throws {
+        let suiteName = "PanelPositioningTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer {
+            UserDefaults.standard.removeSuite(named: suiteName)
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        // Seed pre-existing data exactly as older app versions persisted it.
+        let preExisting: [String: [String: CGFloat]] = [
+            "primary": ["originX": 200, "topY": 700]
+        ]
+        defaults.set(preExisting, forKey: "panelPositions")
+
+        let store = UserDefaultsPanelPositionStore(defaults: defaults)
+        XCTAssertEqual(store.positionsDict, preExisting, "Store must read positions written by older versions")
+
+        let model = PanelGeometryModel(store: store)
+        XCTAssertEqual(model.savedPositions()["primary"]?.originX, 200)
+        XCTAssertEqual(model.savedPositions()["primary"]?.topY, 700)
+        XCTAssertTrue(model.hasCustomPosition(forScreenKey: "primary"))
+        XCTAssertFalse(model.hasCustomPosition(forScreenKey: "secondary"))
+
+        model.saveCustomPosition(originX: 2200.5, topY: 901.25, forScreenKey: "secondary")
+        XCTAssertEqual(
+            defaults.dictionary(forKey: "panelPositions") as? [String: [String: CGFloat]],
+            [
+                "primary": ["originX": 200, "topY": 700],
+                "secondary": ["originX": 2200.5, "topY": 901.25]
+            ],
+            "Saving must write the identical raw UserDefaults format"
+        )
+
+        model.clearCustomPosition(forScreenKey: "primary")
+        XCTAssertEqual(
+            defaults.dictionary(forKey: "panelPositions") as? [String: [String: CGFloat]],
+            ["secondary": ["originX": 2200.5, "topY": 901.25]],
+            "Clearing must remove only the given screen's entry, preserving the format"
+        )
+    }
+
     // MARK: - Edge cases
 
     func testSingleScreen() {

--- a/menubar/CctopMenubarTests/PanelPositioningTests.swift
+++ b/menubar/CctopMenubarTests/PanelPositioningTests.swift
@@ -249,6 +249,33 @@ final class PanelPositioningTests: XCTestCase {
         XCTAssertNotNil(result)
     }
 
+    // MARK: - Persisted panelPositions format (UserDefaults compatibility)
+
+    /// Pins the exact dictionary shape persisted under the "panelPositions"
+    /// UserDefaults key: `[screenKey: ["originX": x, "topY": y]]`. Existing
+    /// installs have this on disk, so any refactor of the persistence path
+    /// must keep reading and writing this exact format.
+    func testPanelPositionsPersistedFormatRoundTrip() throws {
+        let suiteName = "PanelPositioningTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer {
+            UserDefaults.standard.removeSuite(named: suiteName)
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let persisted: [String: [String: CGFloat]] = [
+            "primary": ["originX": 200, "topY": 700],
+            "secondary": ["originX": 2200.5, "topY": 901.25]
+        ]
+        defaults.set(persisted, forKey: "panelPositions")
+
+        let readBack = defaults.dictionary(forKey: "panelPositions") as? [String: [String: CGFloat]]
+        XCTAssertEqual(
+            readBack, persisted,
+            "panelPositions must round-trip through UserDefaults in the established format"
+        )
+    }
+
     // MARK: - Edge cases
 
     func testSingleScreen() {

--- a/menubar/CctopMenubarTests/PluginManagerCcDetectionTests.swift
+++ b/menubar/CctopMenubarTests/PluginManagerCcDetectionTests.swift
@@ -72,3 +72,82 @@ final class PluginManagerCcDetectionTests: XCTestCase {
         }
     }
 }
+
+/// Integration coverage for `refresh()` against a staged home directory.
+/// Only the oc/pi/cc flags are asserted: Codex detection reads `~/.codex`
+/// through `CodexPluginInstaller`, which is not derived from the injected
+/// home directory.
+@MainActor
+final class PluginManagerRefreshTests: XCTestCase {
+
+    func testRefreshDetectsPluginsInStagedHomeDirectory() throws {
+        let home = makeTempHome()
+        try stage(home, file: ".config/opencode/plugins/cctop.js", contents: "// plugin")
+        try stage(home, file: ".pi/agent/extensions/cctop.ts", contents: "// extension")
+        try stage(
+            home,
+            file: ".claude/plugins/cache/cctop/cctop/0.15.3/\(PluginManager.ccPluginManifestPath)",
+            contents: "{}"
+        )
+
+        let manager = PluginManager(homeDirectory: home)
+
+        XCTAssertTrue(manager.ccInstalled)
+        XCTAssertTrue(manager.ocConfigExists)
+        XCTAssertTrue(manager.ocInstalled)
+        XCTAssertTrue(manager.piConfigExists)
+        XCTAssertTrue(manager.piInstalled)
+    }
+
+    func testRefreshAgainstEmptyHomeReportsNothingInstalled() {
+        let manager = PluginManager(homeDirectory: makeTempHome())
+
+        XCTAssertFalse(manager.ccInstalled)
+        XCTAssertFalse(manager.ocConfigExists)
+        XCTAssertFalse(manager.ocInstalled)
+        XCTAssertFalse(manager.ocNeedsUpdate)
+        XCTAssertFalse(manager.piConfigExists)
+        XCTAssertFalse(manager.piInstalled)
+    }
+
+    func testInertManagerStartsWithAllFlagsFalse() {
+        // The preview/snapshot construction: no refresh, no home-dir IO, so
+        // every published flag starts deterministically false regardless of
+        // what is installed on the machine running the tests.
+        let manager = PluginManager(
+            homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false
+        )
+
+        XCTAssertFalse(manager.ccInstalled)
+        XCTAssertFalse(manager.ocInstalled)
+        XCTAssertFalse(manager.ocNeedsUpdate)
+        XCTAssertFalse(manager.ocConfigExists)
+        XCTAssertFalse(manager.piInstalled)
+        XCTAssertFalse(manager.piConfigExists)
+        XCTAssertFalse(manager.codexInstalled)
+        XCTAssertFalse(manager.codexNeedsUpdate)
+        XCTAssertFalse(manager.codexConfigExists)
+        XCTAssertFalse(manager.codexLegacyConfigKey)
+        XCTAssertEqual(manager.codexHookStatus, .notInstalled)
+    }
+
+    // MARK: - Helpers
+
+    private func makeTempHome() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-home-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+
+    private func stage(_ home: URL, file relativePath: String, contents: String) throws {
+        let url = home.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+}

--- a/menubar/CctopMenubarTests/QASnapshotTests.swift
+++ b/menubar/CctopMenubarTests/QASnapshotTests.swift
@@ -135,11 +135,17 @@ final class QASnapshotTests: XCTestCase {
     }
 
     private func popupView(for sessions: [Session]) -> some View {
-        PopupView(sessions: sessions, updater: DisabledUpdater())
+        PopupView(sessions: sessions, updater: DisabledUpdater(), pluginManager: inertPluginManager())
             .frame(width: 320)
             .background(Color(NSColor.windowBackgroundColor))
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .environment(\.colorScheme, .light)
+    }
+
+    /// Inert manager: no home-dir IO, every flag starts deterministically
+    /// false, so snapshots never carry the developer's machine state.
+    private func inertPluginManager() -> PluginManager {
+        PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
     }
 
     // MARK: - Rendering
@@ -149,7 +155,7 @@ final class QASnapshotTests: XCTestCase {
         name: String,
         colorScheme: ColorScheme = .light
     ) throws {
-        let view = PopupView(sessions: sessions, updater: DisabledUpdater())
+        let view = PopupView(sessions: sessions, updater: DisabledUpdater(), pluginManager: inertPluginManager())
             .frame(width: 320)
             .background(Color(NSColor.windowBackgroundColor))
             .clipShape(RoundedRectangle(cornerRadius: 10))
@@ -180,10 +186,7 @@ final class QASnapshotTests: XCTestCase {
         name: String,
         colorScheme: ColorScheme = .light
     ) throws {
-        let view = SettingsSection(
-            updater: updater,
-            pluginManager: PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
-        )
+        let view = SettingsSection(updater: updater, pluginManager: inertPluginManager())
             .frame(width: 320)
             .padding()
             .background(Color(NSColor.windowBackgroundColor))

--- a/menubar/CctopMenubarTests/QASnapshotTests.swift
+++ b/menubar/CctopMenubarTests/QASnapshotTests.swift
@@ -180,7 +180,10 @@ final class QASnapshotTests: XCTestCase {
         name: String,
         colorScheme: ColorScheme = .light
     ) throws {
-        let view = SettingsSection(updater: updater, pluginManager: PluginManager())
+        let view = SettingsSection(
+            updater: updater,
+            pluginManager: PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
+        )
             .frame(width: 320)
             .padding()
             .background(Color(NSColor.windowBackgroundColor))

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -1854,6 +1854,129 @@ final class SessionFileFormatTests: XCTestCase {
         // Recent activity means active even with a dead/irrelevant PID.
         XCTAssertEqual(life(recent, .desktop, alive: false), .active)
     }
+
+    // MARK: - Visibility filtering with stub providers (no SQLite or metadata files on disk)
+
+    func testVisibilitySnapshotFiltersArchivedSubagentExecHelperAndOrphanedSessions() {
+        let archived = candidate(sessionId: "archived-thread", pid: 1, bundleId: HostAppBundleID.codexDesktop,
+                                 lifecycleRank: 0, source: Session.codexSource, path: "/archived.json")
+        let subagent = candidate(sessionId: "subagent-thread", pid: 2, bundleId: HostAppBundleID.codexDesktop,
+                                 lifecycleRank: 0, source: Session.codexSource, path: "/subagent.json")
+        let execHelper = candidate(sessionId: "exec-helper-thread", pid: 3, bundleId: HostAppBundleID.codexDesktop,
+                                   lifecycleRank: 0, source: Session.codexSource, path: "/exec.json")
+        let archivedClaude = candidate(sessionId: "archived-claude", pid: 4, bundleId: HostAppBundleID.claudeDesktop,
+                                       lifecycleRank: 0, source: "cc", path: "/claude-archived.json")
+        // Ended, with authoritative metadata that does not know the session → orphaned, filtered.
+        let orphanClaude = candidate(sessionId: "orphan-claude", pid: 5, bundleId: HostAppBundleID.claudeDesktop,
+                                     lifecycleRank: 0, source: "cc",
+                                     endedAt: Date(timeIntervalSince1970: 2000), path: "/claude-orphan.json")
+        let visibleCodex = candidate(sessionId: "visible-thread", pid: 6, bundleId: HostAppBundleID.codexDesktop,
+                                     lifecycleRank: 0, source: Session.codexSource, path: "/visible.json")
+        let visibleClaude = candidate(sessionId: "visible-claude", pid: 7, bundleId: HostAppBundleID.claudeDesktop,
+                                      lifecycleRank: 0, source: "cc", path: "/claude-visible.json")
+
+        let codexThreads = StubCodexThreadState(
+            archived: ["archived-thread"],
+            subagents: ["subagent-thread"],
+            execHelpers: ["exec-helper-thread"]
+        )
+        let claudeMetadata = ClaudeDesktopSessionMetadataSnapshot(
+            matchedSessionIDs: ["archived-claude", "visible-claude"],
+            archivedSessionIDs: ["archived-claude"],
+            isAuthoritative: true
+        )
+
+        let visibility = SessionManager.visibilitySnapshot(
+            in: [archived, subagent, execHelper, archivedClaude, orphanClaude, visibleCodex, visibleClaude],
+            claudeMetadata: claudeMetadata,
+            codexThreads: codexThreads
+        )
+
+        XCTAssertEqual(
+            visibility.liveCandidates.map(\.session.sessionId).sorted(),
+            ["visible-claude", "visible-thread"]
+        )
+        XCTAssertEqual(visibility.codexSubagentCandidates.map(\.session.sessionId), ["subagent-thread"])
+        XCTAssertEqual(visibility.archivedCodexThreadIDs, ["archived-thread"])
+        XCTAssertEqual(visibility.codexSubagentThreadIDs, ["subagent-thread"])
+        XCTAssertEqual(visibility.codexExecHelperThreadIDs, ["exec-helper-thread"])
+        XCTAssertEqual(visibility.archivedClaudeSessionIDs, ["archived-claude"])
+    }
+
+    // The display path never deletes files, so unreadable external stores must fail OPEN: the
+    // sessions stay visible for the pass rather than vanishing on lookup uncertainty.
+    func testVisibilitySnapshotFailsOpenWhenExternalStoresAreUnreadable() {
+        let codexThread = candidate(sessionId: "maybe-archived", pid: 1, bundleId: HostAppBundleID.codexDesktop,
+                                    lifecycleRank: 0, source: Session.codexSource, path: "/maybe.json")
+        let claudeSession = candidate(sessionId: "maybe-orphaned", pid: 2, bundleId: HostAppBundleID.claudeDesktop,
+                                      lifecycleRank: 0, source: "cc",
+                                      endedAt: Date(timeIntervalSince1970: 2000), path: "/claude-maybe.json")
+
+        let visibility = SessionManager.visibilitySnapshot(
+            in: [codexThread, claudeSession],
+            codexThreads: StubCodexThreadState(archived: nil, subagents: nil, execHelpers: nil),
+            claudeDesktopSessions: StubClaudeDesktopState(snapshot: nil)
+        )
+
+        XCTAssertEqual(
+            visibility.liveCandidates.map(\.session.sessionId).sorted(),
+            ["maybe-archived", "maybe-orphaned"]
+        )
+        XCTAssertEqual(visibility.codexSubagentCandidates.map(\.session.sessionId), [])
+    }
+
+    // MARK: - Lifecycle derivation via injected process liveness
+
+    // Lifecycle used to be testable only by fabricating PIDs that could not exist; with liveness
+    // injected, the same session flips between finished and active purely by the injected answer.
+    func testBuildCandidatesDerivesLifecycleFromInjectedProcessAlive() {
+        var session = Session(
+            sessionId: "terminal-session", projectPath: "/tmp/p", branch: "main",
+            terminal: TerminalInfo(program: "zsh", bundleId: "com.googlecode.iterm2")
+        )
+        session.source = "cc"
+        session.pid = 12345
+        session.lastActivity = Self.lifeNow.addingTimeInterval(-60)
+        let files = [(url: URL(fileURLWithPath: "/nonexistent/12345.json"), session: session)]
+        let noDesktopApps = DesktopAppConnectionLookup { _ in false }
+
+        let dead = SessionManager.buildCandidates(
+            files, now: Self.lifeNow,
+            desktopAppConnectionLookup: noDesktopApps,
+            claudeMetadata: nil,
+            codexThreads: StubCodexThreadState(),
+            processAlive: { _ in false }
+        )
+        XCTAssertEqual(dead.map(\.session.lifecycle), [.finished])
+
+        let alive = SessionManager.buildCandidates(
+            files, now: Self.lifeNow,
+            desktopAppConnectionLookup: noDesktopApps,
+            claudeMetadata: nil,
+            codexThreads: StubCodexThreadState(),
+            processAlive: { _ in true }
+        )
+        XCTAssertEqual(alive.map(\.session.lifecycle), [.active])
+    }
+
+    // MARK: - Idle timeout with an injected clock
+
+    func testAdjustIdleTimeoutUsesInjectedNow() {
+        var session = Session(sessionId: "s", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        session.status = .waitingInput
+        session.lastActivity = Date(timeIntervalSince1970: 1_000_000)
+
+        let justUnderTimeout = session.lastActivity.addingTimeInterval(3_599)
+        XCTAssertEqual(SessionManager.adjustIdleTimeout(session, now: justUnderTimeout).status, .waitingInput)
+
+        let pastTimeout = session.lastActivity.addingTimeInterval(3_601)
+        XCTAssertEqual(SessionManager.adjustIdleTimeout(session, now: pastTimeout).status, .idle)
+
+        // Only waitingInput times out; other statuses pass through untouched.
+        var working = session
+        working.status = .working
+        XCTAssertEqual(SessionManager.adjustIdleTimeout(working, now: pastTimeout).status, .working)
+    }
 }
 
 /// In-memory stand-in for Codex's thread state database, so visibility and archive logic can be

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -191,6 +191,26 @@ final class SessionFileFormatTests: XCTestCase {
         """
     }
 
+    /// Constructs a SessionManager against a temp sessions directory with injected data sources
+    /// and no background monitoring, replacing the old setenv(CCTOP_SESSIONS_DIR) ceremony.
+    @MainActor
+    private func makeManager(
+        sessionsDir: String,
+        historyDir: String,
+        desktopAppConnection: DesktopAppConnectionLookup? = nil
+    ) -> SessionManager {
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
+        if let desktopAppConnection {
+            sources.desktopAppConnection = desktopAppConnection
+        }
+        return SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            dataSources: sources,
+            startMonitoring: false
+        )
+    }
+
     func testLegacyUUIDFilenameClassification() {
         // Pre-PID files were keyed by a bare session UUID → should be removed.
         XCTAssertTrue(SessionManager.isLegacyUUIDFilename("019e4b0c-9473-7a33-a4b9-749fd2c83a9e"))
@@ -335,10 +355,8 @@ final class SessionFileFormatTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
         setenv("CCTOP_CODEX_MEMORIES_DIR", memoriesDir, 1)
         defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
             unsetenv("CCTOP_CODEX_MEMORIES_DIR")
             try? FileManager.default.removeItem(atPath: root)
         }
@@ -348,18 +366,14 @@ final class SessionFileFormatTests: XCTestCase {
         try memorySession.writeToFile(path: memoryPath)
         FileManager.default.createFile(atPath: memoryPath + ".lock", contents: nil)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
-        )
-        manager?.loadSessions()
+        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions, [])
+        XCTAssertEqual(manager.sessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: memoryPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: memoryPath + ".lock"))
         XCTAssertTrue(try Session.fromFile(path: memoryPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
-
-        manager = nil
     }
 
     @MainActor
@@ -370,11 +384,7 @@ final class SessionFileFormatTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
-        defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
-            try? FileManager.default.removeItem(atPath: root)
-        }
+        defer { try? FileManager.default.removeItem(atPath: root) }
 
         var titleGeneration = codexDesktopSession(
             sessionId: "title-helper",
@@ -385,18 +395,14 @@ final class SessionFileFormatTests: XCTestCase {
         try titleGeneration.writeToFile(path: titleHelperPath)
         FileManager.default.createFile(atPath: titleHelperPath + ".lock", contents: nil)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
-        )
-        manager?.loadSessions()
+        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions, [])
+        XCTAssertEqual(manager.sessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: titleHelperPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: titleHelperPath + ".lock"))
         XCTAssertTrue(try Session.fromFile(path: titleHelperPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
-
-        manager = nil
     }
 
     func testAutoHiddenSessionSnapshotPreservesLatestFileFields() throws {
@@ -457,11 +463,7 @@ final class SessionFileFormatTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
-        defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
-            try? FileManager.default.removeItem(atPath: root)
-        }
+        defer { try? FileManager.default.removeItem(atPath: root) }
 
         var hidden = Session(
             sessionId: "hidden-review",
@@ -474,16 +476,12 @@ final class SessionFileFormatTests: XCTestCase {
         let hiddenPath = (sessionsDir as NSString).appendingPathComponent("999999.json")
         try hidden.writeToFile(path: hiddenPath)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
-        )
-        manager?.loadSessions()
+        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions, [])
+        XCTAssertEqual(manager.sessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: hiddenPath))
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
-
-        manager = nil
     }
 
     @MainActor
@@ -494,11 +492,7 @@ final class SessionFileFormatTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
-        defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
-            try? FileManager.default.removeItem(atPath: root)
-        }
+        defer { try? FileManager.default.removeItem(atPath: root) }
 
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("12345.json")
         let now = ISO8601DateFormatter().string(from: Date())
@@ -520,18 +514,14 @@ final class SessionFileFormatTests: XCTestCase {
         try json.write(toFile: sessionPath, atomically: true, encoding: .utf8)
         FileManager.default.createFile(atPath: sessionPath + ".lock", contents: nil)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
-        )
-        manager?.loadSessions()
+        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions, [])
+        XCTAssertEqual(manager.sessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath + ".lock"))
         XCTAssertTrue(try Session.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
-
-        manager = nil
     }
 
     @MainActor
@@ -548,10 +538,8 @@ final class SessionFileFormatTests: XCTestCase {
             subagentThreads: ["codex-cli-subagent", "codex-desktop-subagent"]
         )
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
         setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
         defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
             unsetenv("CCTOP_CODEX_STATE_DB")
             try? FileManager.default.removeItem(atPath: root)
         }
@@ -569,12 +557,10 @@ final class SessionFileFormatTests: XCTestCase {
         FileManager.default.createFile(atPath: cliPath + ".lock", contents: nil)
         FileManager.default.createFile(atPath: desktopPath + ".lock", contents: nil)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
-        )
-        manager?.loadSessions()
+        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions, [])
+        XCTAssertEqual(manager.sessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: cliPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: desktopPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: cliPath + ".lock"))
@@ -582,8 +568,6 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertTrue(try Session.fromFile(path: cliPath).hidden)
         XCTAssertTrue(try Session.fromFile(path: desktopPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
-
-        manager = nil
     }
 
     @MainActor
@@ -600,10 +584,8 @@ final class SessionFileFormatTests: XCTestCase {
             execHelperThreads: ["codex-exec-helper"]
         )
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
         setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
         defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
             unsetenv("CCTOP_CODEX_STATE_DB")
             try? FileManager.default.removeItem(atPath: root)
         }
@@ -615,19 +597,18 @@ final class SessionFileFormatTests: XCTestCase {
         ).writeToFile(path: sessionPath)
         FileManager.default.createFile(atPath: sessionPath + ".lock", contents: nil)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
-            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true }
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            desktopAppConnection: DesktopAppConnectionLookup { _ in true }
         )
-        manager?.loadSessions()
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions, [])
+        XCTAssertEqual(manager.sessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath + ".lock"))
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
-
-        manager = nil
     }
 
     @MainActor
@@ -644,10 +625,8 @@ final class SessionFileFormatTests: XCTestCase {
             userExecThreads: ["codex-user-exec"]
         )
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
         setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
         defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
             unsetenv("CCTOP_CODEX_STATE_DB")
             try? FileManager.default.removeItem(atPath: root)
         }
@@ -658,16 +637,15 @@ final class SessionFileFormatTests: XCTestCase {
             projectPath: (root as NSString).appendingPathComponent("projects/cctop")
         ).writeToFile(path: sessionPath)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
-            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true }
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            desktopAppConnection: DesktopAppConnectionLookup { _ in true }
         )
-        manager?.loadSessions()
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions.map(\.sessionId), ["codex-user-exec"])
+        XCTAssertEqual(manager.sessions.map(\.sessionId), ["codex-user-exec"])
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
-
-        manager = nil
     }
 
     @MainActor
@@ -684,10 +662,8 @@ final class SessionFileFormatTests: XCTestCase {
             execThreadsWithFirstUserMessage: ["codex-exec-first-message": "Review this diff"]
         )
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
         setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
         defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
             unsetenv("CCTOP_CODEX_STATE_DB")
             try? FileManager.default.removeItem(atPath: root)
         }
@@ -698,16 +674,15 @@ final class SessionFileFormatTests: XCTestCase {
             projectPath: (root as NSString).appendingPathComponent("projects/cctop")
         ).writeToFile(path: sessionPath)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
-            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true }
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            desktopAppConnection: DesktopAppConnectionLookup { _ in true }
         )
-        manager?.loadSessions()
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions.map(\.sessionId), ["codex-exec-first-message"])
+        XCTAssertEqual(manager.sessions.map(\.sessionId), ["codex-exec-first-message"])
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
-
-        manager = nil
     }
 
     @MainActor
@@ -720,10 +695,8 @@ final class SessionFileFormatTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [])
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
         setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
         defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
             unsetenv("CCTOP_CODEX_STATE_DB")
             try? FileManager.default.removeItem(atPath: root)
         }
@@ -738,16 +711,15 @@ final class SessionFileFormatTests: XCTestCase {
         ]
         try session.writeToFile(path: sessionPath)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
-            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true }
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            desktopAppConnection: DesktopAppConnectionLookup { _ in true }
         )
-        manager?.loadSessions()
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions.map(\.sessionId), ["parent-thread"])
+        XCTAssertEqual(manager.sessions.map(\.sessionId), ["parent-thread"])
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
-
-        manager = nil
     }
 
     // MARK: - Desktop dedup by session_id (Phase 1, total order)
@@ -872,11 +844,7 @@ final class SessionFileFormatTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
-        defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
-            try? FileManager.default.removeItem(atPath: root)
-        }
+        defer { try? FileManager.default.removeItem(atPath: root) }
 
         var oldPidKeyed = Session(
             sessionId: "conv-a", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo()
@@ -896,17 +864,13 @@ final class SessionFileFormatTests: XCTestCase {
         let desktopPath = (sessionsDir as NSString).appendingPathComponent("codex-conv-a.json")
         try desktopKeyed.writeToFile(path: desktopPath)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
-        )
-        manager?.loadSessions()
+        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        manager.loadSessions()
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: oldPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: desktopPath))
-        XCTAssertEqual(manager?.sessions.map(\.sessionId), ["conv-a"])
+        XCTAssertEqual(manager.sessions.map(\.sessionId), ["conv-a"])
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
-
-        manager = nil
     }
 
     @MainActor
@@ -919,10 +883,8 @@ final class SessionFileFormatTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
         try writeCodexStateDatabase(path: stateDB, archivedThreads: ["archived-thread"])
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
         setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
         defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
             unsetenv("CCTOP_CODEX_STATE_DB")
             try? FileManager.default.removeItem(atPath: root)
         }
@@ -932,23 +894,19 @@ final class SessionFileFormatTests: XCTestCase {
         session.lastActivity = Date()
         try session.writeToFile(path: sessionPath)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
-        )
-        manager?.loadSessions()
+        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions.map(\.sessionId), [])
+        XCTAssertEqual(manager.sessions.map(\.sessionId), [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
 
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [])
-        manager?.loadSessions()
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions.map(\.sessionId), ["archived-thread"])
+        XCTAssertEqual(manager.sessions.map(\.sessionId), ["archived-thread"])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
-
-        manager = nil
     }
 
     @MainActor
@@ -961,10 +919,8 @@ final class SessionFileFormatTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
         try writeCodexStateDatabase(path: stateDB, archivedThreads: ["archived-without-source"])
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
         setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
         defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
             unsetenv("CCTOP_CODEX_STATE_DB")
             try? FileManager.default.removeItem(atPath: root)
         }
@@ -975,23 +931,19 @@ final class SessionFileFormatTests: XCTestCase {
         session.lastActivity = Date()
         try session.writeToFile(path: sessionPath)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
-        )
-        manager?.loadSessions()
+        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions.map(\.sessionId), [])
+        XCTAssertEqual(manager.sessions.map(\.sessionId), [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
 
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [])
-        manager?.loadSessions()
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions.map(\.sessionId), ["archived-without-source"])
+        XCTAssertEqual(manager.sessions.map(\.sessionId), ["archived-without-source"])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
-
-        manager = nil
     }
 
     @MainActor
@@ -1008,10 +960,8 @@ final class SessionFileFormatTests: XCTestCase {
             isArchived: true
         )
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
         setenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR", claudeDir, 1)
         defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
             unsetenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR")
             try? FileManager.default.removeItem(atPath: root)
         }
@@ -1021,12 +971,10 @@ final class SessionFileFormatTests: XCTestCase {
         session.lastActivity = Date()
         try session.writeToFile(path: sessionPath)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
-        )
-        manager?.loadSessions()
+        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions.map(\.sessionId), [])
+        XCTAssertEqual(manager.sessions.map(\.sessionId), [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
@@ -1037,12 +985,10 @@ final class SessionFileFormatTests: XCTestCase {
             cliSessionId: "archived-claude-session",
             isArchived: false
         )
-        manager?.loadSessions()
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions.map(\.sessionId), ["archived-claude-session"])
+        XCTAssertEqual(manager.sessions.map(\.sessionId), ["archived-claude-session"])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
-
-        manager = nil
     }
 
     @MainActor
@@ -1059,10 +1005,8 @@ final class SessionFileFormatTests: XCTestCase {
             isArchived: true
         )
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
         setenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR", claudeDir, 1)
         defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
             unsetenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR")
             try? FileManager.default.removeItem(atPath: root)
         }
@@ -1073,17 +1017,13 @@ final class SessionFileFormatTests: XCTestCase {
         session.lastActivity = Date()
         try session.writeToFile(path: sessionPath)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
-        )
-        manager?.loadSessions()
+        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions.map(\.sessionId), [])
+        XCTAssertEqual(manager.sessions.map(\.sessionId), [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
-
-        manager = nil
     }
 
     @MainActor
@@ -1100,10 +1040,8 @@ final class SessionFileFormatTests: XCTestCase {
             isArchived: false
         )
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
         setenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR", claudeDir, 1)
         defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
             unsetenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR")
             try? FileManager.default.removeItem(atPath: root)
         }
@@ -1117,17 +1055,13 @@ final class SessionFileFormatTests: XCTestCase {
         session.disconnectedAt = ended
         try session.writeToFile(path: sessionPath)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
-        )
-        manager?.loadSessions()
+        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        manager.loadSessions()
 
-        XCTAssertEqual(manager?.sessions.map(\.sessionId), [])
+        XCTAssertEqual(manager.sessions.map(\.sessionId), [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
-
-        manager = nil
     }
 
     // The GC deletion decision must read live Codex archive state on every call, not a snapshot,
@@ -1228,10 +1162,8 @@ final class SessionFileFormatTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
         setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
         defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
             unsetenv("CCTOP_CODEX_STATE_DB")
             try? FileManager.default.removeItem(atPath: root)
         }
@@ -1244,20 +1176,19 @@ final class SessionFileFormatTests: XCTestCase {
         session.disconnectedAt = old
         try session.writeToFile(path: sessionPath)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
-            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in false }
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            desktopAppConnection: DesktopAppConnectionLookup { _ in false }
         )
 
         try writeCodexStateDatabase(path: stateDB, archivedThreads: ["finished-thread"])
-        manager?.garbageCollectFinished()
+        manager.garbageCollectFinished()
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
 
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [])
-        manager?.garbageCollectFinished()
+        manager.garbageCollectFinished()
         XCTAssertFalse(FileManager.default.fileExists(atPath: sessionPath))
-
-        manager = nil
     }
 
     // GC keeps a finished Claude Desktop file while its session metadata is archived, then reaps
@@ -1271,10 +1202,8 @@ final class SessionFileFormatTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
         setenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR", claudeDir, 1)
         defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
             unsetenv("CCTOP_CLAUDE_CODE_SESSIONS_DIR")
             try? FileManager.default.removeItem(atPath: root)
         }
@@ -1286,9 +1215,10 @@ final class SessionFileFormatTests: XCTestCase {
         session.disconnectedAt = old
         try session.writeToFile(path: sessionPath)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
-            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in false }
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            desktopAppConnection: DesktopAppConnectionLookup { _ in false }
         )
 
         try writeClaudeDesktopSessionMetadata(
@@ -1296,7 +1226,7 @@ final class SessionFileFormatTests: XCTestCase {
             cliSessionId: "finished-claude-session",
             isArchived: true
         )
-        manager?.garbageCollectFinished()
+        manager.garbageCollectFinished()
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
 
         try FileManager.default.removeItem(atPath: claudeDir)
@@ -1305,10 +1235,8 @@ final class SessionFileFormatTests: XCTestCase {
             cliSessionId: "finished-claude-session",
             isArchived: false
         )
-        manager?.garbageCollectFinished()
+        manager.garbageCollectFinished()
         XCTAssertFalse(FileManager.default.fileExists(atPath: sessionPath))
-
-        manager = nil
     }
 
     // A missing DB means "no Codex state ⇒ nothing archived" → empty set (deletable). A DB that
@@ -1589,10 +1517,8 @@ final class SessionFileFormatTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
         setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
         defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
             unsetenv("CCTOP_CODEX_STATE_DB")
             try? FileManager.default.removeItem(atPath: root)
         }
@@ -1607,21 +1533,20 @@ final class SessionFileFormatTests: XCTestCase {
 
         // DB present but unparseable → lookup returns nil → GC fails safe and keeps the file.
         try Data("not a database".utf8).write(to: URL(fileURLWithPath: stateDB))
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
-            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in false }
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            desktopAppConnection: DesktopAppConnectionLookup { _ in false }
         )
-        manager?.garbageCollectFinished()
+        manager.garbageCollectFinished()
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
 
         // Once the DB is readable and shows the thread is not archived, GC reaps it. (Remove the
         // corrupt bytes first — sqlite3 cannot DROP/CREATE over a non-database file.)
         try FileManager.default.removeItem(atPath: stateDB)
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [])
-        manager?.garbageCollectFinished()
+        manager.garbageCollectFinished()
         XCTAssertFalse(FileManager.default.fileExists(atPath: sessionPath))
-
-        manager = nil
     }
 
     // Distinct conversations never collapse.
@@ -1710,11 +1635,7 @@ final class SessionFileFormatTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
-        defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
-            try? FileManager.default.removeItem(atPath: root)
-        }
+        defer { try? FileManager.default.removeItem(atPath: root) }
 
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-reconnected.json")
         var session = lifeSession(source: Session.codexSource, agoSeconds: 10_000, disconnectedAgoSeconds: 10_000)
@@ -1722,17 +1643,16 @@ final class SessionFileFormatTests: XCTestCase {
         session.pid = nil
         try session.writeToFile(path: sessionPath)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
-            desktopAppConnectionLookup: DesktopAppConnectionLookup { bundleID in
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            desktopAppConnection: DesktopAppConnectionLookup { bundleID in
                 bundleID == HostAppBundleID.codexDesktop
             }
         )
 
-        XCTAssertEqual(manager?.sessions.map(\.lifecycle), [.active])
+        XCTAssertEqual(manager.sessions.map(\.lifecycle), [.active])
         XCTAssertNil(try Session.fromFile(path: sessionPath).disconnectedAt)
-
-        manager = nil
     }
 
     @MainActor
@@ -1743,11 +1663,7 @@ final class SessionFileFormatTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
 
-        setenv("CCTOP_SESSIONS_DIR", sessionsDir, 1)
-        defer {
-            unsetenv("CCTOP_SESSIONS_DIR")
-            try? FileManager.default.removeItem(atPath: root)
-        }
+        defer { try? FileManager.default.removeItem(atPath: root) }
 
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-ended.json")
         var session = lifeSession(source: Session.codexSource, agoSeconds: 10_000, disconnectedAgoSeconds: 10_000)
@@ -1758,17 +1674,16 @@ final class SessionFileFormatTests: XCTestCase {
         session.disconnectedAt = disconnectedAt
         try session.writeToFile(path: sessionPath)
 
-        var manager: SessionManager? = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
-            desktopAppConnectionLookup: DesktopAppConnectionLookup { bundleID in
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            desktopAppConnection: DesktopAppConnectionLookup { bundleID in
                 bundleID == HostAppBundleID.codexDesktop
             }
         )
 
-        XCTAssertEqual(manager?.sessions.map(\.lifecycle), [.dormant])
+        XCTAssertEqual(manager.sessions.map(\.lifecycle), [.dormant])
         XCTAssertEqual(try Session.fromFile(path: sessionPath).disconnectedAt, disconnectedAt)
-
-        manager = nil
     }
 
     func testIdentityPolicyNamesStableGroupingRules() {
@@ -1938,5 +1853,44 @@ final class SessionFileFormatTests: XCTestCase {
         recent.terminal = TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
         // Recent activity means active even with a dead/irrelevant PID.
         XCTAssertEqual(life(recent, .desktop, alive: false), .active)
+    }
+}
+
+/// In-memory stand-in for Codex's thread state database, so visibility and archive logic can be
+/// exercised without SQLite fixtures on disk. Set a field to `nil` to simulate an unreadable store.
+private struct StubCodexThreadState: CodexThreadStateProviding {
+    var archived: Set<String>? = []
+    var subagents: Set<String>? = []
+    var execHelpers: Set<String>? = []
+    var projectNamesByThreadID: [String: String]? = [:]
+
+    func archivedThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        archived.map { $0.intersection(threadIDs) }
+    }
+
+    func subagentThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        subagents.map { $0.intersection(threadIDs) }
+    }
+
+    func execHelperThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        execHelpers.map { $0.intersection(threadIDs) }
+    }
+
+    func projectNames(matching threadIDs: Set<String>) -> [String: String]? {
+        projectNamesByThreadID.map { $0.filter { threadIDs.contains($0.key) } }
+    }
+}
+
+/// In-memory stand-in for Claude Desktop's session metadata store. `nil` simulates an
+/// unreadable store.
+private struct StubClaudeDesktopState: ClaudeDesktopSessionStateProviding {
+    var snapshot: ClaudeDesktopSessionMetadataSnapshot?
+
+    func archivedSessionIDs(matching sessionIDs: Set<String>) -> Set<String>? {
+        snapshot?.archivedSessionIDs
+    }
+
+    func metadataSnapshot(matching sessionIDs: Set<String>) -> ClaudeDesktopSessionMetadataSnapshot? {
+        snapshot
     }
 }

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -668,4 +668,104 @@ final class SessionTests: XCTestCase {
         XCTAssertNotEqual(base, dormant)
         XCTAssertEqual(base.lifecycle, .active)
     }
+
+    // MARK: - Schema tripwire
+
+    /// A `Session` with every optional field populated, both Bools true, and distinct values
+    /// per field. Dates carry whole milliseconds so the sessionEncoder's fractional-second
+    /// ISO 8601 format round-trips them exactly. `lifecycle` is deliberately left at `.active`
+    /// because it is transient and never persisted.
+    private func makeFullyPopulatedSession() -> Session {
+        Session(
+            sessionId: "full-fixture-1",
+            projectPath: "/Users/test/projects/full-fixture",
+            projectName: "full-fixture",
+            branch: "feature/full-coverage",
+            status: .working,
+            lastPrompt: "Wire every field through",
+            lastActivity: isoDate("2026-02-08T12:00:00.123Z"),
+            startedAt: isoDate("2026-02-08T11:00:00.456Z"),
+            terminal: TerminalInfo(
+                program: "iTerm.app",
+                sessionId: "w0t0p0:1A2B3C4D",
+                tty: "/dev/ttys003",
+                bundleId: "com.googlecode.iterm2",
+                socket: "/tmp/kitty-socket",
+                multiplexer: .tmux(socket: "/tmp/tmux-501/default", paneId: "%1", binaryPath: "/opt/homebrew/bin/tmux"),
+                binaryPaths: ["tmux": "/opt/homebrew/bin/tmux"]
+            ),
+            pid: 4242,
+            pidStartTime: 1707400000.5,
+            lastTool: "Bash",
+            lastToolDetail: "npm test",
+            notificationMessage: "Permission needed",
+            sessionName: "full fixture session",
+            desktopProjectName: "full-fixture-desktop",
+            workspaceFile: "/Users/test/projects/full-fixture/full-fixture.code-workspace",
+            source: "codex",
+            endedAt: isoDate("2026-02-08T13:00:00.789Z"),
+            disconnectedAt: isoDate("2026-02-08T12:30:00.012Z"),
+            activeSubagents: [
+                SubagentInfo(agentId: "agent-1", agentType: "explore", startedAt: isoDate("2026-02-08T12:10:00.345Z"))
+            ],
+            isSubagentSession: true,
+            hidden: true,
+            createdByHookVersion: "0.16.0",
+            lastWrittenByHookVersion: "0.17.2"
+        )
+    }
+
+    private func isoDate(_ string: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: string)!
+    }
+
+    private func encodeToDictionary(_ session: Session) throws -> [String: Any] {
+        let data = try JSONEncoder.sessionEncoder.encode(session)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    // 25 persisted fields + the transient `lifecycle`. If this fails, a stored property was
+    // added or removed: wire it through CodingKeys, init(from:), the memberwise init, and
+    // makeFullyPopulatedSession() above, then update this count.
+    func testStoredPropertyCountTripwire() {
+        XCTAssertEqual(Mirror(reflecting: makeFullyPopulatedSession()).children.count, 26)
+    }
+
+    // Catches asymmetry between CodingKeys, init(from:), and the synthesized encode: a field
+    // that encodes but doesn't decode (or vice versa) breaks equality after a round-trip.
+    func testFullyPopulatedSessionRoundTripsThroughSessionCoders() throws {
+        let session = makeFullyPopulatedSession()
+        let data = try JSONEncoder.sessionEncoder.encode(session)
+        let decoded = try JSONDecoder.sessionDecoder.decode(Session.self, from: data)
+        XCTAssertEqual(decoded, session)
+    }
+
+    // Session-id rotation must be lossless: the rotated copy's persisted JSON differs from the
+    // original in session_id only, so a future field forgotten in withSessionId fails loudly
+    // instead of silently resetting on every Claude Code resume.
+    func testWithSessionIdPreservesEveryPersistedField() throws {
+        let session = makeFullyPopulatedSession()
+        let rotated = session.withSessionId("rotated-id")
+
+        var original = try encodeToDictionary(session)
+        var copy = try encodeToDictionary(rotated)
+        XCTAssertEqual(original["session_id"] as? String, "full-fixture-1")
+        XCTAssertEqual(copy["session_id"] as? String, "rotated-id")
+        original.removeValue(forKey: "session_id")
+        copy.removeValue(forKey: "session_id")
+        XCTAssertEqual(original as NSDictionary, copy as NSDictionary)
+    }
+
+    func testWithSessionIdAppliesBranchAndTerminalOverrides() {
+        let session = makeFullyPopulatedSession()
+        let newTerminal = TerminalInfo(program: "WezTerm", bundleId: "com.github.wez.wezterm")
+
+        let rotated = session.withSessionId("rotated-id", branch: "hotfix/rotation", terminal: newTerminal)
+
+        XCTAssertEqual(rotated.sessionId, "rotated-id")
+        XCTAssertEqual(rotated.branch, "hotfix/rotation")
+        XCTAssertEqual(rotated.terminal, newTerminal)
+    }
 }

--- a/menubar/CctopMenubarTests/SnapshotTests.swift
+++ b/menubar/CctopMenubarTests/SnapshotTests.swift
@@ -35,7 +35,7 @@ final class SnapshotTests: XCTestCase {
     ///     -only-testing:CctopMenubarTests/SnapshotTests/testGenerateEmptyStateScreenshot \
     ///     -derivedDataPath menubar/build/ CODE_SIGN_IDENTITY="-"
     func testGenerateEmptyStateScreenshot() throws {
-        let pm = PluginManager()
+        let pm = PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
         pm.ccInstalled = false
         pm.ocInstalled = false
         pm.ocConfigExists = true
@@ -51,7 +51,7 @@ final class SnapshotTests: XCTestCase {
     }
 
     func testGenerateOnboardingSettingsScreenshot() throws {
-        let pm = PluginManager()
+        let pm = PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
         pm.ccInstalled = false
         pm.ocInstalled = false
         pm.ocConfigExists = true

--- a/menubar/CctopMenubarTests/SnapshotTests.swift
+++ b/menubar/CctopMenubarTests/SnapshotTests.swift
@@ -11,7 +11,9 @@ final class SnapshotTests: XCTestCase {
     ///     -only-testing:CctopMenubarTests/SnapshotTests/testGenerateMenubarScreenshot \
     ///     -derivedDataPath menubar/build/ CODE_SIGN_IDENTITY="-"
     func testGenerateMenubarScreenshot() throws {
-        let view = PopupView(sessions: Session.qaShowcase, updater: DisabledUpdater())
+        let view = PopupView(
+            sessions: Session.qaShowcase, updater: DisabledUpdater(), pluginManager: inertPluginManager()
+        )
         try renderScreenshot(view: view, colorScheme: .light, filename: "menubar-light.png")
         try renderScreenshot(view: view, colorScheme: .dark, filename: "menubar-dark.png")
     }
@@ -20,7 +22,8 @@ final class SnapshotTests: XCTestCase {
         let rc = NavigateController()
         rc.isActive = true
         let view = PopupView(
-            sessions: Session.qaShowcase, updater: DisabledUpdater(), navigate: rc
+            sessions: Session.qaShowcase, updater: DisabledUpdater(),
+            pluginManager: inertPluginManager(), navigate: rc
         )
         try renderScreenshot(view: view, colorScheme: .dark, filename: "menubar-navigate.png")
     }
@@ -35,7 +38,7 @@ final class SnapshotTests: XCTestCase {
     ///     -only-testing:CctopMenubarTests/SnapshotTests/testGenerateEmptyStateScreenshot \
     ///     -derivedDataPath menubar/build/ CODE_SIGN_IDENTITY="-"
     func testGenerateEmptyStateScreenshot() throws {
-        let pm = PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
+        let pm = inertPluginManager()
         pm.ccInstalled = false
         pm.ocInstalled = false
         pm.ocConfigExists = true
@@ -51,7 +54,7 @@ final class SnapshotTests: XCTestCase {
     }
 
     func testGenerateOnboardingSettingsScreenshot() throws {
-        let pm = PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
+        let pm = inertPluginManager()
         pm.ccInstalled = false
         pm.ocInstalled = false
         pm.ocConfigExists = true
@@ -95,7 +98,7 @@ final class SnapshotTests: XCTestCase {
     func testGenerateRecentProjectsScreenshot() throws {
         let view = PopupView(
             sessions: Session.qaShowcase, recentProjects: RecentProject.mockRecents,
-            updater: DisabledUpdater(), initialTab: .recent
+            updater: DisabledUpdater(), pluginManager: inertPluginManager(), initialTab: .recent
         )
         try renderScreenshot(view: view, colorScheme: .dark, filename: "menubar-recent.png")
     }
@@ -109,12 +112,20 @@ final class SnapshotTests: XCTestCase {
     func testGenerateThemeScreenshots() throws {
         for theme in AppTheme.allCases {
             ThemeManager.shared.setTheme(theme)
-            let view = PopupView(sessions: Session.qaShowcase, updater: DisabledUpdater())
+            let view = PopupView(
+                sessions: Session.qaShowcase, updater: DisabledUpdater(), pluginManager: inertPluginManager()
+            )
             try renderScreenshot(view: view, colorScheme: .dark, filename: "theme-\(theme.rawValue)-dark.png")
             try renderScreenshot(view: view, colorScheme: .light, filename: "theme-\(theme.rawValue)-light.png")
         }
         // Restore default
         ThemeManager.shared.setTheme(.claude)
+    }
+
+    /// Inert manager: no home-dir IO, every flag starts deterministically
+    /// false, so screenshots are reproducible across machines.
+    private func inertPluginManager() -> PluginManager {
+        PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
     }
 
     private func renderScreenshot(

--- a/menubar/CctopMenubarTests/StatusCountsSessionInitTests.swift
+++ b/menubar/CctopMenubarTests/StatusCountsSessionInitTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import CctopMenubar
 
-@MainActor
 final class StatusCountsSessionInitTests: XCTestCase {
     func testEmptyArray_returnsZero() {
         let counts = StatusCounts(sessions: [])

--- a/menubar/CctopMenubarTests/StatusCountsTests.swift
+++ b/menubar/CctopMenubarTests/StatusCountsTests.swift
@@ -239,4 +239,19 @@ final class StatusCountsTests: XCTestCase {
             XCTAssertGreaterThanOrEqual(sum, 1.0 - 1e-9, "Sum below 1.0 at \(barWidth)pt")
         }
     }
+
+    // MARK: - Segment kind to rendered color
+
+    /// Pins the kind-to-color resolution both renderers rely on. The four
+    /// theme colors are distinct in every theme, so a transposed case in
+    /// `StatusColors.color(for:)` fails here instead of shipping wrong
+    /// menubar/notch colors.
+    @MainActor
+    func testStatusColorsResolveEachSegmentKind() {
+        XCTAssertEqual(StatusColors.color(for: .permission), StatusColors.permission)
+        XCTAssertEqual(StatusColors.color(for: .attention), StatusColors.attention)
+        XCTAssertEqual(StatusColors.color(for: .working), StatusColors.working)
+        XCTAssertEqual(StatusColors.color(for: .idle), StatusColors.idle)
+        XCTAssertNotEqual(StatusColors.permission, StatusColors.attention)
+    }
 }

--- a/menubar/CctopMenubarTests/StatusCountsTests.swift
+++ b/menubar/CctopMenubarTests/StatusCountsTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import CctopMenubar
 
-@MainActor
 final class StatusCountsTests: XCTestCase {
     func testTotal() {
         let counts = StatusCounts(permission: 1, attention: 2, working: 3, idle: 4)
@@ -75,16 +74,16 @@ final class StatusCountsTests: XCTestCase {
     func testBarSegments_permissionAndAttentionSeparate() {
         let counts = StatusCounts(permission: 1, attention: 1, working: 0, idle: 0)
         XCTAssertEqual(counts.barSegments.count, 2)
-        XCTAssertEqual(counts.barSegments[0].color, StatusColors.permission)
+        XCTAssertEqual(counts.barSegments[0].kind, .permission)
         XCTAssertEqual(counts.barSegments[0].proportion, 0.5, accuracy: 0.001)
-        XCTAssertEqual(counts.barSegments[1].color, StatusColors.attention)
+        XCTAssertEqual(counts.barSegments[1].kind, .attention)
         XCTAssertEqual(counts.barSegments[1].proportion, 0.5, accuracy: 0.001)
     }
 
-    func testBarSegments_attentionOnlyUsesAttentionColor() {
+    func testBarSegments_attentionOnlyUsesAttentionKind() {
         let counts = StatusCounts(permission: 0, attention: 2, working: 0, idle: 0)
         XCTAssertEqual(counts.barSegments.count, 1)
-        XCTAssertEqual(counts.barSegments[0].color, StatusColors.attention)
+        XCTAssertEqual(counts.barSegments[0].kind, .attention)
         XCTAssertEqual(counts.barSegments[0].proportion, 1.0, accuracy: 0.001)
     }
 
@@ -98,25 +97,25 @@ final class StatusCountsTests: XCTestCase {
     func testBarSegments_order_permissionAttentionWorkingIdle() {
         let counts = StatusCounts(permission: 1, attention: 1, working: 1, idle: 1)
         XCTAssertEqual(counts.barSegments.count, 4)
-        XCTAssertEqual(counts.barSegments[0].color, StatusColors.permission)
-        XCTAssertEqual(counts.barSegments[1].color, StatusColors.attention)
-        XCTAssertEqual(counts.barSegments[2].color, StatusColors.working)
-        XCTAssertEqual(counts.barSegments[3].color, StatusColors.idle)
+        XCTAssertEqual(counts.barSegments[0].kind, .permission)
+        XCTAssertEqual(counts.barSegments[1].kind, .attention)
+        XCTAssertEqual(counts.barSegments[2].kind, .working)
+        XCTAssertEqual(counts.barSegments[3].kind, .idle)
     }
 
     func testBarSegments_attentionFirstWhenNoPermission() {
         let counts = StatusCounts(permission: 0, attention: 1, working: 2, idle: 1)
         XCTAssertEqual(counts.barSegments.count, 3)
-        XCTAssertEqual(counts.barSegments[0].color, StatusColors.attention)
-        XCTAssertEqual(counts.barSegments[1].color, StatusColors.working)
-        XCTAssertEqual(counts.barSegments[2].color, StatusColors.idle)
+        XCTAssertEqual(counts.barSegments[0].kind, .attention)
+        XCTAssertEqual(counts.barSegments[1].kind, .working)
+        XCTAssertEqual(counts.barSegments[2].kind, .idle)
     }
 
     func testBarSegments_allAttention_singleSegment() {
         let counts = StatusCounts(permission: 0, attention: 5, working: 0, idle: 0)
         XCTAssertEqual(counts.barSegments.count, 1)
         XCTAssertEqual(counts.barSegments[0].proportion, 1.0, accuracy: 0.001)
-        XCTAssertEqual(counts.barSegments[0].color, StatusColors.attention)
+        XCTAssertEqual(counts.barSegments[0].kind, .attention)
     }
 
     func testBarSegments_proportionsSumToOne() {
@@ -142,7 +141,7 @@ final class StatusCountsTests: XCTestCase {
         // 1 attention out of 10 = 10% of 22pt = 2.2pt, below 5pt minimum
         let counts = StatusCounts(permission: 0, attention: 1, working: 5, idle: 4)
         let segs = counts.barSegments(forWidth: 22)
-        let attentionSeg = segs.first { $0.color == StatusColors.attention }!
+        let attentionSeg = segs.first { $0.kind == .attention }!
         XCTAssertEqual(attentionSeg.proportion, 5.0 / 22.0, accuracy: 0.001)
     }
 
@@ -187,8 +186,8 @@ final class StatusCountsTests: XCTestCase {
         // 1 permission + 1 attention + 18 working = both action at 5% of 22pt = 1.1pt
         let counts = StatusCounts(permission: 1, attention: 1, working: 18, idle: 0)
         let segs = counts.barSegments(forWidth: 22)
-        let permSeg = segs.first { $0.color == StatusColors.permission }!
-        let attnSeg = segs.first { $0.color == StatusColors.attention }!
+        let permSeg = segs.first { $0.kind == .permission }!
+        let attnSeg = segs.first { $0.kind == .attention }!
         XCTAssertEqual(permSeg.proportion, 5.0 / 22.0, accuracy: 0.001)
         XCTAssertEqual(attnSeg.proportion, 5.0 / 22.0, accuracy: 0.001)
         let sum = segs.map(\.proportion).reduce(0, +)
@@ -207,7 +206,7 @@ final class StatusCountsTests: XCTestCase {
         // 1 permission + 99 working at 100pt bar
         let counts = StatusCounts(permission: 1, attention: 0, working: 99, idle: 0)
         let segs = counts.barSegments(forWidth: 100)
-        let permSeg = segs.first { $0.color == StatusColors.permission }!
+        let permSeg = segs.first { $0.kind == .permission }!
         XCTAssertEqual(permSeg.proportion, 5.0 / 100.0, accuracy: 0.001)
         let sum = segs.map(\.proportion).reduce(0, +)
         XCTAssertEqual(sum, 1.0, accuracy: 0.001)

--- a/scripts/validate-hook-contract.py
+++ b/scripts/validate-hook-contract.py
@@ -2,8 +2,9 @@
 """Validate cctop hook contract drift across schema, fixtures, Swift, and plugins.
 
 The JSON Schema remains the source of truth. This script intentionally stays
-narrow: it checks that consumers agree with schema-owned event and harness
-metadata, while validate-fixtures.sh handles full fixture schema validation.
+narrow: it checks that consumers agree with schema-owned event, harness, and
+cctop-hook binary-location metadata, while validate-fixtures.sh handles full
+fixture schema validation.
 """
 
 from __future__ import annotations
@@ -60,16 +61,16 @@ def quoted_strings(text: str) -> set[str]:
     return set(re.findall(r'"([^"]+)"', text))
 
 
-def schema_contract(errors: list[str]) -> tuple[set[str], set[str], dict[str, set[str]]]:
+def schema_contract(errors: list[str]) -> tuple[set[str], set[str], dict[str, set[str]], list[str]]:
     schema = load_json(SCHEMA)
     if not isinstance(schema, dict):
         errors.append("hook-input.schema.json must be a JSON object")
-        return set(), set(), {}
+        return set(), set(), {}, []
 
     properties = schema.get("properties", {})
     if not isinstance(properties, dict):
         errors.append("schema properties must be an object")
-        return set(), set(), {}
+        return set(), set(), {}, []
 
     event_schema = properties.get("hook_event_name", {})
     events = set(event_schema.get("enum", [])) if isinstance(event_schema, dict) else set()
@@ -96,10 +97,26 @@ def schema_contract(errors: list[str]) -> tuple[set[str], set[str], dict[str, se
     metadata = schema.get("x-cctop")
     expect(isinstance(metadata, dict), "schema must define x-cctop contract metadata", errors)
     if not isinstance(metadata, dict):
-        return events, harnesses, {}
+        return events, harnesses, {}, []
 
     metadata_harnesses = set(metadata.get("harnesses", []))
     compare_sets("x-cctop harnesses", harnesses, metadata_harnesses, errors)
+
+    raw_binary_locations = metadata.get("binary_locations")
+    expect(
+        isinstance(raw_binary_locations, list) and bool(raw_binary_locations),
+        "x-cctop binary_locations must be a non-empty array",
+        errors,
+    )
+    binary_locations: list[str] = []
+    if isinstance(raw_binary_locations, list):
+        for location in raw_binary_locations:
+            if isinstance(location, str) and (location.startswith("~/") or location.startswith("/")):
+                binary_locations.append(location)
+            else:
+                errors.append(
+                    f"x-cctop binary_locations entry {location!r} must be a string starting with ~/ or /"
+                )
 
     raw_harness_events = metadata.get("events_by_harness", {})
     expect(isinstance(raw_harness_events, dict), "x-cctop events_by_harness must be an object", errors)
@@ -116,7 +133,7 @@ def schema_contract(errors: list[str]) -> tuple[set[str], set[str], dict[str, se
                 errors,
             )
 
-    return events, harnesses, harness_events
+    return events, harnesses, harness_events, binary_locations
 
 
 def fixture_contract(
@@ -251,6 +268,30 @@ def plugin_contract(harnesses: set[str], harness_events: dict[str, set[str]], er
         )
 
 
+def binary_location_contract(binary_locations: list[str], errors: list[str]) -> None:
+    """Require every client to look for cctop-hook at the schema-owned discovery locations.
+
+    Home-relative (~/) locations must appear anchored to the home directory ($HOME/ in
+    shell, homedir() in JS/TS) so the bare /Applications entry cannot satisfy the
+    ~/Applications check. Absolute locations must appear verbatim and not as the tail of
+    a $HOME-prefixed path, so the ~/Applications entry cannot satisfy the bare one either.
+    """
+    clients = [CC_SHIM, CODEX_SHIM, OPENCODE_PLUGIN, PI_PLUGIN]
+    for client in clients:
+        text = read_text(client)
+        for location in binary_locations:
+            if location.startswith("~/"):
+                suffix = re.escape(location[2:])
+                pattern = r'(\$HOME/|homedir\(\), ?")' + suffix
+            else:
+                pattern = r"(?<!\$HOME)" + re.escape(location)
+            expect(
+                re.search(pattern, text) is not None,
+                f"{client.relative_to(ROOT)} does not look for cctop-hook at {location}",
+                errors,
+            )
+
+
 def main() -> int:
     mode = sys.argv[1] if len(sys.argv) > 1 else "all"
     if mode not in {"all", "fixtures", "hooks"}:
@@ -258,13 +299,14 @@ def main() -> int:
         return 2
 
     errors: list[str] = []
-    schema_events, harnesses, harness_events = schema_contract(errors)
+    schema_events, harnesses, harness_events, binary_locations = schema_contract(errors)
     if mode in {"all", "fixtures"}:
         fixture_contract(schema_events, harnesses, harness_events, errors)
     if mode in {"all", "hooks"}:
         swift_events(schema_events, errors)
         swift_harnesses(harnesses, errors)
         plugin_contract(harnesses, harness_events, errors)
+        binary_location_contract(binary_locations, errors)
 
     if errors:
         for error in errors:


### PR DESCRIPTION
## Problem

The app's stateful components hard-wire their dependencies, which shows up three ways:

- **Tests fight the architecture.** `HookHandlerTests` needed ~24 process-global `setenv()` mutations, directory globbing to find PID-named files, and post-hoc PID rewriting; `HookLogger` wrote into the real `~/.cctop/logs` from unit tests; `PanelLifecycleTests` maintained a hand-written simulation of AppDelegate's panel-position code paths — which had silently drifted from real production behavior (one retained test now pins the actual behavior the simulation got wrong).
- **Single facts live in several places.** `Session.swift` spelled its schema in five hand-synchronized field lists, and a field missed in `withSessionId` was silently dropped on rewrite; desktop bundle IDs existed in three copies (one inside `Hook/HookHandler.swift`); Codex trust-record keys were kept in sync with `registeredEvents` only by comments; the `cctop-hook` discovery list was hardcoded in four client shims with nothing checking agreement.
- **Dependencies point the wrong way.** Models called into Services for host classification; `SessionManager` and `HostApp` referenced symbols defined inside `Hook/HookHandler.swift`; views and the app shell communicated through stringly-typed `NotificationCenter` names; the SQLite-backed archive lookups were constructed inline at nine call sites, so a single display pass opened the Codex state DB three times.

## Solution

Behavior-preserving throughout: no session-JSON schema change, no hook CLI argv/stdin change, and the opencode/pi/Claude/Codex plugin runtime files are untouched. Each seam is a protocol or closure-struct with a `.live` production default, so production wiring is unchanged while tests inject fakes.

- **`HookDependencies`** (new file, compiled into both targets) bundles the hook CLI's external inputs — process probing, paths, environment, git-branch capture, session-name lookups, logging, and the session file lock — threaded through `HookHandler` with a `.live` default. App code no longer references symbols defined in `HookHandler.swift`.
- **`SessionDataSources`** injects SessionManager's external inputs (sessions dir, Codex/Claude Desktop archive stores, desktop-app liveness, process liveness, notification preference, clock). Archive lookups are constructed once per manager instead of nine times inline.
- **Session schema**: `withSessionId` is now copy-mutation, structurally eliminating the fifth hand-synced field list; a Mirror-based field-count tripwire plus an encode/decode round-trip test guard the remaining ones. Desktop bundle-ID constants are consolidated into `Session.swift`.
- **Host classification** (`hostClass`, `trustedHostApp`) moved from `Services/SessionIdentityPolicy` onto `Session` in Models, removing the Models→Services dependency cycle. `HostApp` is `CaseIterable` and derives its bundle-ID table from `allCases`, closing the forget-an-entry silent-failure trap.
- **Panel geometry** (saved positions, screen-change clamping, resize decisions) moved from AppDelegate into `PanelGeometryModel` behind a position-store protocol; `PanelLifecycleTests` exercises the real model and the hand-written simulation is deleted. The persisted `panelPositions` UserDefaults format is pinned by test.
- **Shell edges**: the `.layoutChanged` / `.notchPillClicked` NotificationCenter channels are replaced with closures injected at construction; dead navigate-mode state (`previousApp`, `DeactivationState`, an unused `activate` overload) is deleted.
- **Status bar segments** carry a semantic `SegmentKind` resolved to a theme color at render time, instead of encoding meaning as RGB equality against the theme singleton; the kind-to-color resolution is pinned by test.
- **PluginManager** takes an injected home directory for Claude Code/opencode/pi detection plus an inert mode for previews/snapshots; PopupView requires its PluginManager instead of constructing one inside `body`. Codex trust derivation is pure over its observation input, and trust-record keys are derived from `registeredEvents` with a pinning test.
- **Contract enforcement**: `validate-hook-contract.py` (via `make contract`) now also checks the `cctop-hook` discovery locations agree across `run-hook.sh`, `plugin.js`, `cctop.ts`, and `cctop-shim.sh` against `x-cctop.binary_locations` in `hook-input.schema.json`.

## Verification

- `make all` green: swiftlint `--strict` (0 violations in 63 files), hook contract validation, both targets build, full test suite — **666 tests, 0 failures** (the suite was fully green on master before the branch; net new coverage includes previously untestable branches: PID-reuse detection, stale-PID garbage collection, git-branch capture, and segment kind-to-color resolution).
- Hook CLI smoke-tested end to end: `SessionStart` JSON on stdin produces a PID-keyed session file with unchanged schema; `--version` works.
- Every commit builds green individually for bisectability.
- App relaunched locally against live sessions after the change; hook reinstalled via `make install`.


## Documentation

- `AGENTS.md`: corrected the architecture tree — the Hook/ directory comment claimed "cctop-hook CLI target only", but only `HookMain.swift` is CLI-exclusive (verified against both PBXSourcesBuildPhase lists); added the new `HookDependencies.swift` to the tree.
- `CONTRIBUTING.md`: same target-membership correction in the Code Organization list.
- All other docs verified against the diff: `docs/session-lifecycle.md`'s claim that `SessionIdentityPolicy` owns the dedup rule still holds (only host classification moved), and `DESIGN.md`'s `Session.agentBadge` location claim is unchanged.
