### PR TITLE
Remove unused positionPanelAtAnchor from AppDelegate

### DIFF
--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -372,18 +372,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         }
     }
 
-    @MainActor private func positionPanelAtAnchor(animate: Bool = false) {
-        guard let size = panelFittingSize() else { return }
-        if let frame = PanelPositioning.resolveAnchorPosition(
-            anchorRect: anchorRect(),
-            clickLocation: focusLocation,
-            panelSize: size,
-            screens: screenLayouts
-        ) {
-            setPanelFrame(frame, animate: animate)
-        }
-    }
-
     @MainActor private func handleScreenChange() {
         screenChangeWork?.cancel()
         suppressResize = true


### PR DESCRIPTION
Deletes the private method `positionPanelAtAnchor(animate:)` from `AppDelegate`. It has no callers — `git grep positionPanelAtAnchor` finds only the definition, on this branch and on `master` alike. Panel placement goes through `positionPanel(animate:)` and `resetPanelToCurrentScreen(animate:)` instead.

`PanelPositioning.resolveAnchorPosition` is intentionally kept: it is still called by `resolveShowPosition` and `resolveResetPosition` in `PanelPositioning.swift` and is covered by `PanelPositioningTests`.

No behavior change. `make lint` (SwiftLint strict), `make build` (CctopMenubar and cctop-hook targets), and the app test suite all pass.