### PR TITLE
Fix per-screen panel position bugs: resave overwrite, cross-screen reset, phantom drag saves

### DIFF
--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -315,17 +315,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     /// The screen-space rect of the anchor (notch pill or menubar icon).
     @MainActor private func anchorRect() -> NSRect? {
-        if let pillFrame = notchController.pillFrame {
-            return pillFrame
-        } else if let button = statusItem.button, let buttonWindow = button.window {
-            return buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
-        }
-        return nil
+        notchController.pillFrame ?? menubarIconRect()
+    }
+
+    /// The screen-space rect of the menubar icon, even when the notch pill
+    /// is the anchor (the pill only exists on the built-in screen).
+    @MainActor private func menubarIconRect() -> NSRect? {
+        guard let button = statusItem.button, let buttonWindow = button.window else { return nil }
+        return buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
     }
 
     /// Reset panel position on double-click. If the panel is on the same screen
     /// as the anchor (menubar icon / notch pill), snap to anchor. Otherwise, snap
-    /// to the top-center of the panel's current screen so it doesn't jump across screens.
+    /// under the menubar icon's mirrored position on the panel's current screen
+    /// so it doesn't jump across screens.
     @MainActor private func resetPanelToCurrentScreen(animate: Bool = false) {
         guard let size = panelFittingSize() else { return }
         let layouts = screenLayouts
@@ -334,6 +337,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         }
         if let frame = panelGeometry.resetFrame(
             anchorRect: anchorRect(),
+            menubarIconRect: menubarIconRect(),
             panelScreenIndex: panelIdx,
             panelSize: size,
             screens: layouts
@@ -363,10 +367,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             self.hasNotch = NSScreen.builtin?.hasPhysicalNotch == true
             self.refreshStatusDisplay(counts: StatusCounts(sessions: self.sessionManager.sessions))
             guard self.panel.isVisible else { return }
+            // A click location captured before the debounce must not drive
+            // screen-change repositioning; clearing it keeps the key below
+            // and positionPanel's internal key identical.
+            self.focusLocation = nil
+            // Capture the key before repositioning: positionPanel may snap the
+            // panel home to the anchor screen, and resaving under that screen's
+            // key would overwrite a user-dragged position with the anchor frame.
+            let key = self.panelScreenKey()
             self.positionPanel(animate: false)
             // Update saved position if it was clamped to new screen bounds
             self.panelGeometry.resaveAfterScreenChange(
-                panelScreenKey: self.panelScreenKey(), panelFrame: self.panel.frame
+                panelScreenKey: key, panelFrame: self.panel.frame
             )
         }
         screenChangeWork = work

--- a/menubar/CctopMenubar/FloatingPanel.swift
+++ b/menubar/CctopMenubar/FloatingPanel.swift
@@ -10,6 +10,28 @@ class FloatingPanel: NSPanel {
     /// Height of the header drag zone (matches HeaderView padding + content).
     private let headerDragHeight: CGFloat = 44
 
+    enum HeaderClickAction: Equatable {
+        case resetPosition
+        case drag
+    }
+
+    /// macOS chains clickCount (1, 2, 3, …) for stationary clicks within the
+    /// double-click interval, so a click right after a double-click reset
+    /// arrives as count 3. Routing it into the drag loop would let the reset
+    /// animation's frame movement read as a user drag; re-triggering the
+    /// idempotent reset is always the intended outcome for counts ≥ 2.
+    static func headerClickAction(forClickCount count: Int) -> HeaderClickAction {
+        count >= 2 ? .resetPosition : .drag
+    }
+
+    /// The frame can move under a stationary click — reset and resize run
+    /// setFrame(animate: true) — and persisting that movement as a drag
+    /// would resurrect the saved position a reset just cleared. Only a real
+    /// mouse drag may persist.
+    static func shouldPersistDrag(sawDragEvents: Bool, originMoved: Bool) -> Bool {
+        sawDragEvents && originMoved
+    }
+
     override init(
         contentRect: NSRect,
         styleMask: NSWindow.StyleMask,
@@ -45,11 +67,12 @@ class FloatingPanel: NSPanel {
 
     override func sendEvent(_ event: NSEvent) {
         if event.type == .leftMouseDown && isInHeaderArea(event) {
-            if event.clickCount == 2 {
+            switch Self.headerClickAction(forClickCount: event.clickCount) {
+            case .resetPosition:
                 panelDelegate?.panelDidRequestReset()
-                return
+            case .drag:
+                handleHeaderDrag()
             }
-            handleHeaderDrag()
             return
         }
         super.sendEvent(event)
@@ -58,6 +81,7 @@ class FloatingPanel: NSPanel {
     private func handleHeaderDrag() {
         let startLocation = NSEvent.mouseLocation
         let startOrigin = frame.origin
+        var sawDragEvents = false
 
         // Tight event-tracking loop — runs in eventTracking mode,
         // preventing SwiftUI layout passes from interleaving.
@@ -70,6 +94,7 @@ class FloatingPanel: NSPanel {
             ) else { continue }
 
             if event.type == .leftMouseUp { break }
+            sawDragEvents = true
 
             let current = NSEvent.mouseLocation
             setFrameOrigin(NSPoint(
@@ -78,7 +103,10 @@ class FloatingPanel: NSPanel {
             ))
         }
 
-        if frame.origin != startOrigin {
+        if Self.shouldPersistDrag(
+            sawDragEvents: sawDragEvents,
+            originMoved: frame.origin != startOrigin
+        ) {
             panelDelegate?.panelDidDrag(originX: frame.origin.x, topY: frame.maxY)
         }
     }

--- a/menubar/CctopMenubar/Models/PanelPositioning.swift
+++ b/menubar/CctopMenubar/Models/PanelPositioning.swift
@@ -125,12 +125,14 @@ struct PanelGeometryModel {
     /// Resolve where the panel lands on double-click reset.
     func resetFrame(
         anchorRect: NSRect?,
+        menubarIconRect: NSRect? = nil,
         panelScreenIndex: Int?,
         panelSize: NSSize,
         screens: [ScreenLayout]
     ) -> NSRect? {
         PanelPositioning.resolveResetPosition(
             anchorRect: anchorRect,
+            menubarIconRect: menubarIconRect,
             panelScreenIndex: panelScreenIndex,
             panelSize: panelSize,
             screens: screens
@@ -139,7 +141,10 @@ struct PanelGeometryModel {
 
     /// After a screen-parameter change, overwrite the saved position for the
     /// panel's screen with the panel's current (possibly clamped) frame — but
-    /// only if a custom position already exists for that screen key.
+    /// only if a custom position already exists for that screen key. The key
+    /// must be captured before repositioning: if the change snapped the panel
+    /// to another screen, resaving under the landing screen's key would
+    /// overwrite that screen's user-dragged position with the new frame.
     func resaveAfterScreenChange(panelScreenKey: String?, panelFrame: NSRect) {
         guard let key = panelScreenKey, savedPositions()[key] != nil else { return }
         saveCustomPosition(originX: panelFrame.origin.x, topY: panelFrame.maxY, forScreenKey: key)
@@ -251,17 +256,46 @@ enum PanelPositioning {
     }
 
     /// Resolve where to position the panel on double-click reset.
-    /// Same screen as anchor → snap to anchor. Different screen → top-center.
+    /// Same screen as anchor → snap to anchor. Different screen → snap under
+    /// the menubar icon's mirrored position on the panel's screen: the menu
+    /// bar is mirrored on every display, so the icon keeps its offset from
+    /// the screen's right edge. `menubarIconRect` is the icon even when the
+    /// anchor is the notch pill (the pill only exists on the built-in screen).
     static func resolveResetPosition(
         anchorRect: NSRect?,
+        menubarIconRect: NSRect? = nil,
         panelScreenIndex: Int?,
         panelSize: NSSize,
         screens: [ScreenLayout]
     ) -> NSRect? {
         let anchorIdx = anchorRect.flatMap { screenIndex(containing: $0.origin, in: screens) }
 
-        // Center on panel's screen if it differs from the anchor screen
+        // Panel on a different screen than the anchor → stay on the panel's screen
         if let pIdx = panelScreenIndex, pIdx < screens.count, anchorIdx != pIdx {
+            let icon = menubarIconRect ?? anchorRect
+            if let icon, let iconIdx = screenIndex(containing: icon.origin, in: screens) {
+                let iconScreen = screens[iconIdx]
+                let panelScreen = screens[pIdx]
+                // Mirror against the visible-area top, not the frame top:
+                // menu bar heights differ across displays (notched vs not),
+                // and the panel must stay flush under the destination's bar
+                let mirrored = NSRect(
+                    x: panelScreen.frame.maxX - (iconScreen.frame.maxX - icon.minX),
+                    y: panelScreen.visibleFrame.maxY + (icon.minY - iconScreen.visibleFrame.maxY),
+                    width: icon.width,
+                    height: icon.height
+                )
+                if panelScreen.frame.contains(mirrored.origin) {
+                    return resolveAnchorPosition(
+                        anchorRect: mirrored,
+                        clickLocation: nil,
+                        panelSize: panelSize,
+                        screens: screens
+                    )
+                }
+            }
+            // No mirrorable icon, or the mirrored position falls outside the
+            // panel's screen (much narrower display) → top-center fallback
             let vf = screens[pIdx].visibleFrame
             let panelX = max(
                 vf.minX + margin,

--- a/menubar/CctopMenubarTests/PanelLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/PanelLifecycleTests.swift
@@ -124,9 +124,14 @@ private struct PanelLifecycleDriver {
     mutating func handleScreenChange() {
         guard isVisible else { return }
 
-        // positionPanel with focusLocation = nil (always cleared by this point)
+        // Capture the key before repositioning (mirrors AppDelegate): the
+        // resave must key off the screen the panel was on, not where it lands
+        let key = panelScreenKey
+
+        // positionPanel with focusLocation = nil (explicitly cleared at the
+        // top of AppDelegate's screen-change work item)
         if let frame = model.showFrame(
-            clickScreenKey: panelScreenKey,
+            clickScreenKey: key,
             clickLocation: nil,
             anchorRect: anchorRect,
             panelSize: panelSize,
@@ -137,7 +142,7 @@ private struct PanelLifecycleDriver {
 
         // Overwrite the saved position with the possibly clamped frame, if one exists
         if let frame = panelFrame {
-            model.resaveAfterScreenChange(panelScreenKey: panelScreenKey, panelFrame: frame)
+            model.resaveAfterScreenChange(panelScreenKey: key, panelFrame: frame)
         }
     }
 
@@ -174,6 +179,8 @@ private struct PanelLifecycleDriver {
             )
         }
 
+        // Models the no-pill case only: menubarIconRect defaults to nil and
+        // falls back to anchorRect (the pill case is covered by unit tests)
         if let frame = model.resetFrame(
             anchorRect: anchorRect,
             panelScreenIndex: panelIdx,
@@ -270,13 +277,10 @@ final class PanelLifecycleTests: XCTestCase {
 
     // MARK: - Screen change while on different screen
 
-    /// The deleted hand-written simulation asserted the primary position
-    /// survived this scenario, but it computed the resave key BEFORE
-    /// repositioning. Production AppDelegate reads the panel's screen AFTER
-    /// positionPanel: with no custom position on secondary, the screen change
-    /// snaps the panel back to the anchor on primary and the clamp-resave then
-    /// overwrites primary's saved entry with the anchor frame. This now pins
-    /// the real behavior the simulation drifted from.
+    /// The clamp-resave must key off the screen the panel was on BEFORE
+    /// repositioning. With no custom position on secondary, the screen change
+    /// snaps the panel back to the anchor on primary — but primary's
+    /// user-dragged entry must not be overwritten with the anchor frame.
     func testScreenChangeWhileOnSecondaryPreservesPrimaryPosition() {
         var lc = makeLifecycle()
 
@@ -292,27 +296,35 @@ final class PanelLifecycleTests: XCTestCase {
         lc.handleScreenChange()
 
         // No custom position on secondary → the panel snaps back to the anchor
-        // on primary, and the resave overwrites primary's entry with that frame
+        // on primary, but the resave keys off secondary and is a no-op
         XCTAssertLessThan(
             lc.panelFrame!.maxX, primary.frame.maxX,
             "Panel should snap back to the anchor screen"
         )
         XCTAssertEqual(
-            lc.savedPositions["primary"]!.originX, lc.panelFrame!.origin.x, accuracy: 0.5,
-            "Resave overwrites primary's entry with the panel's new frame"
+            lc.savedPositions["primary"]!.originX, 200, accuracy: 0.5,
+            "Dragged primary position must survive the resave"
         )
         XCTAssertEqual(
-            lc.savedPositions["primary"]!.topY, lc.panelFrame!.maxY, accuracy: 0.5,
-            "Resave overwrites primary's entry with the panel's new frame"
+            lc.savedPositions["primary"]!.topY, 700, accuracy: 0.5,
+            "Dragged primary position must survive the resave"
+        )
+        XCTAssertNil(
+            lc.savedPositions["secondary"],
+            "The no-op resave must not invent an entry for secondary"
         )
 
         lc.dismiss()
 
-        // Show on primary — the dragged position was overwritten by the resave
+        // Show on primary — the dragged position is restored
         lc.show(clickAt: clickOnPrimary)
-        XCTAssertNotEqual(
-            lc.panelFrame!.origin.x, 200,
-            "The dragged position does not survive a screen change that snaps the panel home"
+        XCTAssertEqual(
+            lc.panelFrame!.origin.x, 200, accuracy: 1,
+            "Custom position must survive a screen change fired while on secondary"
+        )
+        XCTAssertEqual(
+            lc.panelFrame!.maxY, 700, accuracy: 1,
+            "Custom position must survive a screen change fired while on secondary"
         )
     }
 
@@ -400,6 +412,31 @@ final class PanelLifecycleTests: XCTestCase {
         XCTAssertNotEqual(
             lc.panelFrame!.origin.x, 200,
             "After reset, should use anchor not custom position"
+        )
+    }
+
+    // MARK: - Double-click reset on a different screen
+
+    func testResetOnSecondarySnapsUnderMirroredIcon() {
+        var lc = makeLifecycle()
+
+        // Show on primary, drag the panel onto the secondary screen
+        lc.show(clickAt: clickOnPrimary)
+        lc.drag(toOriginX: 2200, topY: 700)
+
+        lc.resetPosition()
+
+        XCTAssertNil(lc.savedPositions["secondary"], "Reset clears the panel screen's entry")
+        // Panel stays on secondary, under the icon's mirrored position
+        // (same offset from the right edge), not centered on the screen
+        let mirroredMidX = secondary.frame.maxX - (primary.frame.maxX - anchorOnPrimary.midX)
+        let expectedX = min(
+            mirroredMidX - panelSize.width / 2,
+            secondary.visibleFrame.maxX - panelSize.width - PanelPositioning.margin
+        )
+        XCTAssertEqual(lc.panelFrame!.origin.x, expectedX, accuracy: 1)
+        XCTAssertEqual(
+            lc.panelFrame!.maxY, anchorOnPrimary.minY - PanelPositioning.margin, accuracy: 1
         )
     }
 
@@ -547,6 +584,35 @@ final class PanelLifecycleTests: XCTestCase {
             smaller.visibleFrame.maxX - panelSize.width - margin,
             "Saved position should be clamped to smaller screen"
         )
+    }
+
+    // MARK: - Header click routing and drag persistence (reset resurrection bug)
+
+    /// macOS chains clickCount (1, 2, 3, …) for stationary clicks within the
+    /// double-click interval. A chained click after a double-click reset must
+    /// re-trigger the (idempotent) reset, NOT fall into the drag loop where
+    /// the reset animation's frame movement reads as a user drag.
+    func testChainedHeaderClicksKeepResetting() {
+        XCTAssertEqual(FloatingPanel.headerClickAction(forClickCount: 1), .drag)
+        XCTAssertEqual(FloatingPanel.headerClickAction(forClickCount: 2), .resetPosition)
+        XCTAssertEqual(
+            FloatingPanel.headerClickAction(forClickCount: 3), .resetPosition,
+            "A chained third click must not enter the drag loop"
+        )
+        XCTAssertEqual(FloatingPanel.headerClickAction(forClickCount: 4), .resetPosition)
+    }
+
+    /// The panel frame can move under a stationary click (reset/resize runs
+    /// setFrame(animate: true)). Persisting that movement as a drag would
+    /// resurrect the saved position the reset just cleared.
+    func testAnimationMovementAloneDoesNotPersistAsDrag() {
+        XCTAssertFalse(
+            FloatingPanel.shouldPersistDrag(sawDragEvents: false, originMoved: true),
+            "Frame moved by animation, not the user — must not save"
+        )
+        XCTAssertTrue(FloatingPanel.shouldPersistDrag(sawDragEvents: true, originMoved: true))
+        XCTAssertFalse(FloatingPanel.shouldPersistDrag(sawDragEvents: true, originMoved: false))
+        XCTAssertFalse(FloatingPanel.shouldPersistDrag(sawDragEvents: false, originMoved: false))
     }
 
     // MARK: - Navigate shortcut opens on mouse screen (regression for #69)

--- a/menubar/CctopMenubarTests/PanelPositioningTests.swift
+++ b/menubar/CctopMenubarTests/PanelPositioningTests.swift
@@ -224,7 +224,7 @@ final class PanelPositioningTests: XCTestCase {
         XCTAssertLessThan(result!.maxX, primary.frame.maxX)
     }
 
-    func testResetOnDifferentScreenCentersOnPanelScreen() {
+    func testResetOnDifferentScreenSnapsUnderMirroredIcon() {
         let result = PanelPositioning.resolveResetPosition(
             anchorRect: anchorOnPrimary,
             panelScreenIndex: 1,
@@ -232,11 +232,75 @@ final class PanelPositioningTests: XCTestCase {
         )
         XCTAssertNotNil(result)
         XCTAssertGreaterThanOrEqual(result!.origin.x, secondary.frame.minX)
-        XCTAssertEqual(result!.midX, secondary.visibleFrame.midX, accuracy: 1)
+        // The menu bar is mirrored on every display, so the icon keeps its
+        // offset from the right edge — the panel snaps under that, not center
+        let mirroredMidX = secondary.frame.maxX - (primary.frame.maxX - anchorOnPrimary.midX)
+        let expectedX = min(
+            mirroredMidX - panelSize.width / 2,
+            secondary.visibleFrame.maxX - panelSize.width - margin
+        )
+        XCTAssertEqual(result!.origin.x, expectedX, accuracy: 1)
+        XCTAssertEqual(result!.maxY, anchorOnPrimary.minY - margin, accuracy: 1)
+        XCTAssertNotEqual(
+            result!.midX, secondary.visibleFrame.midX,
+            "Reset must snap under the mirrored icon, not center on the screen"
+        )
+    }
+
+    func testResetOnDifferentScreenMirrorsIconRectNotPillAnchor() {
+        // Notch pill anchor near the middle of the primary screen; the real
+        // menubar icon at the right edge is what's visible on other displays
+        let pillAnchor = NSRect(x: 980, y: 1056, width: 160, height: 24)
+        let result = PanelPositioning.resolveResetPosition(
+            anchorRect: pillAnchor,
+            menubarIconRect: anchorOnPrimary,
+            panelScreenIndex: 1,
+            panelSize: panelSize, screens: screens
+        )
+        XCTAssertNotNil(result)
+        let mirroredMidX = secondary.frame.maxX - (primary.frame.maxX - anchorOnPrimary.midX)
+        let expectedX = min(
+            mirroredMidX - panelSize.width / 2,
+            secondary.visibleFrame.maxX - panelSize.width - margin
+        )
         XCTAssertEqual(
-            result!.maxY,
-            secondary.visibleFrame.maxY - margin,
-            accuracy: 1
+            result!.origin.x, expectedX, accuracy: 1,
+            "Cross-screen reset must mirror the icon, not the pill"
+        )
+    }
+
+    func testResetOnDifferentScreenMirrorsIconOffsetUnclamped() {
+        // Icon far enough from the right edge that the clamp doesn't engage,
+        // asserting the mirror arithmetic itself
+        let innerIcon = NSRect(x: 1600, y: 1058, width: 40, height: 22)
+        let result = PanelPositioning.resolveResetPosition(
+            anchorRect: innerIcon,
+            panelScreenIndex: 1,
+            panelSize: panelSize, screens: screens
+        )
+        XCTAssertNotNil(result)
+        let mirroredMidX = secondary.frame.maxX - (primary.frame.maxX - innerIcon.midX)
+        XCTAssertEqual(result!.origin.x, mirroredMidX - panelSize.width / 2, accuracy: 1)
+        XCTAssertEqual(result!.maxY, innerIcon.minY - margin, accuracy: 1)
+    }
+
+    func testResetMirrorKeepsPanelBelowTallerMenubar() {
+        // Destination screen has a taller menu bar (e.g. notched display);
+        // the mirrored anchor must track the visible-area top, not frame top
+        let notched = ScreenLayout(
+            frame: NSRect(x: 1920, y: 0, width: 1920, height: 1080),
+            visibleFrame: NSRect(x: 1920, y: 0, width: 1920, height: 1042),
+            key: "notched"
+        )
+        let result = PanelPositioning.resolveResetPosition(
+            anchorRect: anchorOnPrimary,
+            panelScreenIndex: 1,
+            panelSize: panelSize, screens: [primary, notched]
+        )
+        XCTAssertNotNil(result)
+        XCTAssertLessThanOrEqual(
+            result!.maxY, notched.visibleFrame.maxY,
+            "Panel must stay below the destination screen's menu bar"
         )
     }
 


### PR DESCRIPTION
## Problem

Using the floating panel across multiple screens corrupted or ignored saved per-screen positions in three ways:

1. **Screen changes overwrote another screen's saved position.** A screen-parameter change while the panel sat on a secondary screen snapped the panel home to the anchor screen, and the clamp-resave then ran with the post-reposition screen key — overwriting the anchor screen's user-dragged position with the anchor frame.
2. **Double-click reset on a non-anchor screen centered the panel** at the top of that screen instead of snapping under the menubar icon.
3. **Reset positions didn't stick.** macOS chains `clickCount` for stationary clicks (1, 2, 3, …), so a header click right after a double-click reset arrived as count 3, failed the `== 2` check, and entered the drag-tracking loop. The reset's `setFrame(animate:)` moved the frame under the stationary click, and the loop persisted any origin change as a user drag — re-saving the position the reset had just cleared. Once a panel was dragged to a screen, its position there could effectively never be reset.

## Solution

- `handleScreenChange` captures the panel's screen key **before** `positionPanel()` and passes it to the resave, so the resave keys off the screen the panel was on, not where it landed. Stale `focusLocation` is cleared at the top of the debounced work item so the captured key and `positionPanel`'s internal key always agree.
- `resolveResetPosition` mirrors the menubar icon onto the panel's screen for cross-screen resets — the menu bar is mirrored on every display, so the icon keeps its offset from the right edge. The mirror tracks the visible-area top (menu bar heights differ between notched and external displays), uses the icon rather than the notch pill (the pill only exists on the built-in screen), and keeps top-center as the fallback when there is no mirrorable icon.
- `FloatingPanel` routes header clicks with `clickCount >= 2` to the (idempotent) reset, and persists a drag only when real `leftMouseDragged` events occurred — frame movement from an in-flight animation no longer reads as a drag.

## Verification

- Each fix was test-driven: the previously pinned buggy behaviors (`testScreenChangeWhileOnSecondaryPreservesPrimaryPosition` asserting the overwrite, `testResetOnDifferentScreenCentersOnPanelScreen` asserting the centering) were flipped to assert the intended behavior and observed failing before each fix; new tests cover icon-vs-pill mirroring, taller-menubar clamping, unclamped mirror arithmetic, chained click routing, and drag persistence.
- Full Swift suite: 672 tests, 0 failures. `make lint`: 0 violations.
- Verified manually on a two-screen setup: drag to secondary + screen change preserves the primary position; double-click reset on the secondary snaps under its menubar icon; rapid clicks after a reset no longer resurrect the old position; reopening respects the reset.