### PR TITLE
Add idle sessions tab

### DIFF
--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -97,10 +97,12 @@
 		NSV000010000000000000001 /* NotchStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = NSV000020000000000000001 /* NotchStatusView.swift */; };
 		NSC000010000000000000001 /* NotchStatusController.swift in Sources */ = {isa = PBXBuildFile; fileRef = NSC000020000000000000001 /* NotchStatusController.swift */; };
 		STC000010000000000000001 /* StatusColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = STC000020000000000000001 /* StatusColors.swift */; };
+		SDP000010000000000000001 /* SessionDisplayPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDP000020000000000000001 /* SessionDisplayPolicy.swift */; };
 		SCN000010000000000000001 /* StatusCounts.swift in Sources */ = {isa = PBXBuildFile; fileRef = SCN000020000000000000001 /* StatusCounts.swift */; };
 		MRT000010000000000000001 /* MenubarIconRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MRT000020000000000000001 /* MenubarIconRendererTests.swift */; };
 		SCT000010000000000000001 /* StatusCountsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SCT000020000000000000001 /* StatusCountsTests.swift */; };
 		HVT000010000000000000001 /* StatusCountsSessionInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = HVT000020000000000000001 /* StatusCountsSessionInitTests.swift */; };
+		SDPT00010000000000000001 /* SessionDisplayPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDPT00020000000000000001 /* SessionDisplayPolicyTests.swift */; };
 		NVT000010000000000000001 /* NotchVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = NVT000020000000000000001 /* NotchVisibilityTests.swift */; };
 		PPO000010000000000000001 /* PanelPositioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = PPO000020000000000000001 /* PanelPositioning.swift */; };
 		PLT000010000000000000001 /* PanelLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PLT000020000000000000001 /* PanelLifecycleTests.swift */; };
@@ -216,10 +218,12 @@
 		NSV000020000000000000001 /* NotchStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchStatusView.swift; sourceTree = "<group>"; };
 		NSC000020000000000000001 /* NotchStatusController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchStatusController.swift; sourceTree = "<group>"; };
 		STC000020000000000000001 /* StatusColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusColors.swift; sourceTree = "<group>"; };
+		SDP000020000000000000001 /* SessionDisplayPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDisplayPolicy.swift; sourceTree = "<group>"; };
 		SCN000020000000000000001 /* StatusCounts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusCounts.swift; sourceTree = "<group>"; };
 		MRT000020000000000000001 /* MenubarIconRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarIconRendererTests.swift; sourceTree = "<group>"; };
 		SCT000020000000000000001 /* StatusCountsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusCountsTests.swift; sourceTree = "<group>"; };
 		HVT000020000000000000001 /* StatusCountsSessionInitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusCountsSessionInitTests.swift; sourceTree = "<group>"; };
+		SDPT00020000000000000001 /* SessionDisplayPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDisplayPolicyTests.swift; sourceTree = "<group>"; };
 		NVT000020000000000000001 /* NotchVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchVisibilityTests.swift; sourceTree = "<group>"; };
 		PPO000020000000000000001 /* PanelPositioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelPositioning.swift; sourceTree = "<group>"; };
 		PLT000020000000000000001 /* PanelLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelLifecycleTests.swift; sourceTree = "<group>"; };
@@ -342,6 +346,7 @@
 				RPM000020000000000000001 /* RecentProject+Mock.swift */,
 				EK0000020000000000000001 /* HostApp.swift */,
 				STC000020000000000000001 /* StatusColors.swift */,
+				SDP000020000000000000001 /* SessionDisplayPolicy.swift */,
 				SCN000020000000000000001 /* StatusCounts.swift */,
 				PPO000020000000000000001 /* PanelPositioning.swift */,
 			);
@@ -415,6 +420,7 @@
 				MRT000020000000000000001 /* MenubarIconRendererTests.swift */,
 				SCT000020000000000000001 /* StatusCountsTests.swift */,
 				HVT000020000000000000001 /* StatusCountsSessionInitTests.swift */,
+				SDPT00020000000000000001 /* SessionDisplayPolicyTests.swift */,
 				NVT000020000000000000001 /* NotchVisibilityTests.swift */,
 				PLT000020000000000000001 /* PanelLifecycleTests.swift */,
 				PPT000020000000000000001 /* PanelPositioningTests.swift */,
@@ -601,6 +607,7 @@
 				NSV000010000000000000001 /* NotchStatusView.swift in Sources */,
 				NSC000010000000000000001 /* NotchStatusController.swift in Sources */,
 				STC000010000000000000001 /* StatusColors.swift in Sources */,
+				SDP000010000000000000001 /* SessionDisplayPolicy.swift in Sources */,
 				SCN000010000000000000001 /* StatusCounts.swift in Sources */,
 				PPO000010000000000000001 /* PanelPositioning.swift in Sources */,
 			);
@@ -653,6 +660,7 @@
 				MRT000010000000000000001 /* MenubarIconRendererTests.swift in Sources */,
 				SCT000010000000000000001 /* StatusCountsTests.swift in Sources */,
 				HVT000010000000000000001 /* StatusCountsSessionInitTests.swift in Sources */,
+				SDPT00010000000000000001 /* SessionDisplayPolicyTests.swift in Sources */,
 				NVT000010000000000000001 /* NotchVisibilityTests.swift in Sources */,
 				PLT000010000000000000001 /* PanelLifecycleTests.swift in Sources */,
 				PPT000010000000000000001 /* PanelPositioningTests.swift in Sources */,

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -481,7 +481,7 @@ extension AppDelegate {
                     lastExternalApp = prev
                 }
             case .startNavigateMode:
-                navigateController.activate(sessions: sessionManager.sessions)
+                navigateController.activate(sessions: SessionDisplayPolicy.activeSessions(from: sessionManager.sessions))
                 navigateController.startTimeout { [weak self] in
                     self?.handleEvent(.navigateTimedOut)
                 }

--- a/menubar/CctopMenubar/Models/SessionDisplayPolicy.swift
+++ b/menubar/CctopMenubar/Models/SessionDisplayPolicy.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Presentation-only grouping for visible retained sessions.
+/// This does not change lifecycle or cleanup semantics.
+enum SessionDisplayPolicy {
+    struct Signature: Equatable {
+        let activeIDs: [String]
+        let idleIDs: [String]
+
+        static let empty = Signature(activeIDs: [], idleIDs: [])
+    }
+
+    static let staleIdleInterval: TimeInterval = 172_800 // 48 hours
+
+    static func activeSessions(from sessions: [Session], now: Date = Date()) -> [Session] {
+        sessions.filter { session in
+            session.lifecycle == .active && !isStaleActiveIdle(session, now: now)
+        }
+    }
+
+    static func idleSessions(from sessions: [Session], now: Date = Date()) -> [Session] {
+        sessions.filter { session in
+            session.lifecycle == .dormant || isStaleActiveIdle(session, now: now)
+        }
+    }
+
+    static func signature(for sessions: [Session], now: Date = Date()) -> Signature {
+        Signature(
+            activeIDs: activeSessions(from: sessions, now: now).map(\.id),
+            idleIDs: idleSessions(from: sessions, now: now).map(\.id)
+        )
+    }
+
+    private static func isStaleActiveIdle(_ session: Session, now: Date) -> Bool {
+        guard session.lifecycle == .active, session.status == .idle else { return false }
+        return now.timeIntervalSince(session.lastActivity) > staleIdleInterval
+    }
+}

--- a/menubar/CctopMenubar/Models/StatusCounts.swift
+++ b/menubar/CctopMenubar/Models/StatusCounts.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Aggregated session status counts used by the menubar icon, notch pill, and accessibility labels.
 struct StatusCounts: Equatable {
     /// Semantic identity of a status-bar segment. Renderers resolve the
@@ -24,11 +26,11 @@ struct StatusCounts: Equatable {
     }
 
     /// Create counts by aggregating session statuses.
-    init(sessions: [Session]) {
+    init(sessions: [Session], now: Date = Date()) {
         var perm = 0, attn = 0, work = 0, idleCount = 0
-        // Only live (active) sessions drive the menubar badge. Dormant cards are reachable
-        // history, not live work, so they never inflate counts or trigger the attention pill.
-        for session in sessions where session.lifecycle == .active {
+        // Only presentation-active sessions drive the menubar badge. Dormant and stale-idle
+        // cards are retained for reachability, not live work, so they never inflate counts.
+        for session in SessionDisplayPolicy.activeSessions(from: sessions, now: now) {
             switch session.status {
             case .idle: idleCount += 1
             case .working, .compacting: work += 1

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -19,6 +19,7 @@ class SessionManager: ObservableObject {
     private var debounceTask: DispatchWorkItem?
     private var livenessTimer: Timer?
     private var gcTimer: Timer?
+    private var lastDisplaySignature = SessionDisplayPolicy.Signature.empty
 
     /// Lifecycle windows: desktop app liveness decides connection when available; `active` is the
     /// fallback recency threshold and `retention` controls dormant desktop cleanup.
@@ -62,6 +63,7 @@ class SessionManager: ObservableObject {
             includingPropertiesForKeys: [.contentModificationDateKey]
         ) else {
             sessionManagerLogger.warning("loadSessions: could not read directory")
+            lastDisplaySignature = .empty
             sessions = []
             return
         }
@@ -88,23 +90,27 @@ class SessionManager: ObservableObject {
 
         // Publish active + dormant; finished are hidden (swept below / by GC).
         let winners = SessionIdentityPolicy.dedupedCandidatesByStableKey(liveCandidates)
+        let now = dataSources.now()
         let newSessions = winners
             .filter { $0.session.lifecycle != .finished }
             .map { adjustDisplayStatus($0.session) }
+        let displaySignature = SessionDisplayPolicy.signature(for: newSessions, now: now)
 
         sendTransitionNotifications(for: newSessions, oldStatuses: oldStatuses)
-        // Only publish when data actually changed to avoid unnecessary SwiftUI re-renders.
-        if newSessions != sessions {
+        // Only publish when data actually changed, or when the presentation bucket changed
+        // because an active idle session crossed the stale-idle threshold.
+        if newSessions != sessions || displaySignature != lastDisplaySignature {
             if newSessions.count != sessions.count {
                 sessionManagerLogger.info("loadSessions: session count \(self.sessions.count) -> \(newSessions.count)")
             }
+            lastDisplaySignature = displaySignature
             sessions = newSessions
         }
 
         hideAutoHiddenSessions(autoHidden)
         hideCodexSubagentSessions(visibility.codexSubagentCandidates)
-        clearReconnectedDesktopSessions(liveCandidates, now: dataSources.now())
-        stampDisconnectedDesktopSessions(liveCandidates, now: dataSources.now())
+        clearReconnectedDesktopSessions(liveCandidates, now: now)
+        stampDisconnectedDesktopSessions(liveCandidates, now: now)
 
         // Non-desktop finished sessions keep today's behavior: archive to Recent Projects and
         // remove now (no Recent-Projects lag). Desktop files are retained while dormant and reaped

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -3,7 +3,7 @@ import KeyboardShortcuts
 import SwiftUI
 
 enum PopupTab {
-    case active, recent
+    case active, idle, recent
 }
 
 private let overlayAnimationDuration: TimeInterval = 0.2
@@ -37,7 +37,7 @@ struct PopupView: View {
         pluginManager.piConfigExists && !pluginManager.piInstalled && !piBannerDismissed
     }
 
-    private var showTabs: Bool { !recentProjects.isEmpty }
+    private var showTabs: Bool { availableTabs.count > 1 }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -51,6 +51,7 @@ struct PopupView: View {
                 Group {
                     switch selectedTab {
                     case .active: activeContent
+                    case .idle: idleContent
                     case .recent: recentContent
                     }
                 }
@@ -76,7 +77,7 @@ struct PopupView: View {
         }
         .onReceive(navigate?.didActivateSubject.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
             selectedIndex = nil
-            if selectedTab == .recent { selectedTab = .active }
+            if selectedTab != .active { selectedTab = .active }
             if overlayController.active != nil { closeOverlay(animated: false) }
         }
         .onReceive(navigate?.navActionSubject.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { action in
@@ -84,15 +85,24 @@ struct PopupView: View {
             handleNavAction(action)
         }
         .onChange(of: selectedTab) { _ in selectedIndex = nil }
-        .onAppear { selectedTab = initialTab }
+        .onChange(of: sessions) { _ in ensureSelectedTabAvailable() }
+        .onChange(of: recentProjects.map(\.id)) { _ in ensureSelectedTabAvailable() }
+        .onAppear {
+            selectedTab = availableTabs.contains(initialTab) ? initialTab : .active
+        }
     }
 
     // MARK: - Tab picker
 
     private var tabPicker: some View {
         HStack(spacing: 6) {
-            tabButton("Active", count: sessions.count, tab: .active)
-            tabButton("Recent", count: recentProjects.count, tab: .recent)
+            tabButton("Active", count: sortedActiveSessions.count, tab: .active)
+            if !sortedIdleSessions.isEmpty {
+                tabButton("Idle", count: sortedIdleSessions.count, tab: .idle)
+            }
+            if !recentProjects.isEmpty {
+                tabButton("Recent", count: recentProjects.count, tab: .recent)
+            }
             Spacer()
         }
         .padding(.horizontal, 12)
@@ -111,80 +121,41 @@ struct PopupView: View {
         Group {
             if sessions.isEmpty {
                 EmptyStateView(pluginManager: pluginManager)
+            } else if sortedActiveSessions.isEmpty {
+                noActiveSessionsContent
             } else {
                 VStack(spacing: 0) {
-                if showOcBanner {
-                    ToolInstallBanner(
-                        toolName: "opencode", iconLabel: ">_", iconColor: .blue,
-                        installAction: { pluginManager.installOpenCodePlugin() },
-                        installed: $ocBannerInstalled, dismissed: $ocBannerDismissed)
-                }
-                if showPiBanner {
-                    ToolInstallBanner(
-                        toolName: "pi", iconLabel: "\u{03C0}", iconColor: .green,
-                        installAction: { pluginManager.installPiPlugin() },
-                        installed: $piBannerInstalled, dismissed: $piBannerDismissed)
-                }
-                ScrollViewReader { proxy in
-                    ScrollView(showsIndicators: false) {
-                        LazyVStack(spacing: 0) {
-                            ForEach(Array(sortedSessions.enumerated()), id: \.element.id) { index, session in
-                                if index > 0 && selectedIndex != index && selectedIndex != index - 1 {
-                                    Divider()
-                                        .padding(.horizontal, 16)
-                                }
-                                SessionCardView(
-                                    session: session,
-                                    navigateIndex: isNavigateActive ? index + 1 : nil,
-                                    showSourceBadge: hasMultipleSources,
-                                    isSelected: selectedIndex == index
-                                )
-                                .id(session.id)
-                                .onTapGesture { focusSession(session) }
-                                .contextMenu {
-                                    Button { focusSession(session) } label: {
-                                        Label("Jump to Terminal", systemImage: "terminal")
-                                    }
-                                    Button { openInFinder(path: session.projectPath) } label: {
-                                        Label("Open in Finder", systemImage: "folder")
-                                    }
-                                    Button { copyPath(session.projectPath) } label: {
-                                        Label("Copy Project Path", systemImage: "doc.on.doc")
-                                    }
-                                }
-                                .help("Click to jump to session")
-                            }
-                        }
-                        .padding(.vertical, 4)
+                    if showOcBanner {
+                        ToolInstallBanner(
+                            toolName: "opencode", iconLabel: ">_", iconColor: .blue,
+                            installAction: { pluginManager.installOpenCodePlugin() },
+                            installed: $ocBannerInstalled, dismissed: $ocBannerDismissed)
                     }
-                    .frame(maxHeight: popupContentHeight)
-                    .onChange(of: selectedIndex) { newIndex in
-                        guard selectedTab == .active,
-                              let idx = newIndex, idx < sortedSessions.count else { return }
-                        withAnimation(.easeOut(duration: 0.15)) {
-                            proxy.scrollTo(sortedSessions[idx].id, anchor: .center)
-                        }
+                    if showPiBanner {
+                        ToolInstallBanner(
+                            toolName: "pi", iconLabel: "\u{03C0}", iconColor: .green,
+                            installAction: { pluginManager.installPiPlugin() },
+                            installed: $piBannerInstalled, dismissed: $piBannerDismissed)
                     }
-                }
+                    sessionList(sortedActiveSessions, tab: .active, showNavigateNumbers: true)
                 }
             }
+        }
+    }
+    // MARK: - Idle tab
+    @ViewBuilder
+    private var idleContent: some View {
+        if sortedIdleSessions.isEmpty {
+            noIdleSessionsContent
+        } else {
+            sessionList(sortedIdleSessions, tab: .idle)
         }
     }
     // MARK: - Recent tab
     @ViewBuilder
     private var recentContent: some View {
         if recentProjects.isEmpty {
-            VStack(spacing: 8) {
-                Image(systemName: "clock")
-                    .font(.system(size: 20))
-                    .foregroundStyle(Color.textMuted)
-                Text("Recent projects will appear here\nafter sessions end")
-                    .font(.system(size: 12))
-                    .foregroundStyle(Color.textMuted)
-                    .multilineTextAlignment(.center)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 24)
+            emptyPlaceholder(systemImage: "clock", title: "Recent projects will appear here\nafter sessions end")
         } else {
             ScrollViewReader { proxy in
                 ScrollView(showsIndicators: false) {
@@ -227,6 +198,72 @@ struct PopupView: View {
                 }
             }
             .help("Click to open in \(project.lastEditor ?? "editor")")
+    }
+
+    private func sessionList(_ list: [Session], tab: PopupTab, showNavigateNumbers: Bool = false) -> some View {
+        ScrollViewReader { proxy in
+            ScrollView(showsIndicators: false) {
+                LazyVStack(spacing: 0) {
+                    ForEach(Array(list.enumerated()), id: \.element.id) { index, session in
+                        if index > 0 && selectedIndex != index && selectedIndex != index - 1 {
+                            Divider()
+                                .padding(.horizontal, 16)
+                        }
+                        SessionCardView(
+                            session: session,
+                            navigateIndex: showNavigateNumbers && isNavigateActive ? index + 1 : nil,
+                            showSourceBadge: hasMultipleSources,
+                            isSelected: selectedIndex == index
+                        )
+                        .id(session.id)
+                        .onTapGesture { focusSession(session) }
+                        .contextMenu {
+                            Button { focusSession(session) } label: {
+                                Label("Jump to Terminal", systemImage: "terminal")
+                            }
+                            Button { openInFinder(path: session.projectPath) } label: {
+                                Label("Open in Finder", systemImage: "folder")
+                            }
+                            Button { copyPath(session.projectPath) } label: {
+                                Label("Copy Project Path", systemImage: "doc.on.doc")
+                            }
+                        }
+                        .help("Click to jump to session")
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .frame(maxHeight: popupContentHeight)
+            .onChange(of: selectedIndex) { newIndex in
+                guard selectedTab == tab,
+                      let idx = newIndex, idx < list.count else { return }
+                withAnimation(.easeOut(duration: 0.15)) {
+                    proxy.scrollTo(list[idx].id, anchor: .center)
+                }
+            }
+        }
+    }
+
+    private var noActiveSessionsContent: some View {
+        emptyPlaceholder(systemImage: "circle.dotted", title: "No active sessions")
+    }
+
+    private var noIdleSessionsContent: some View {
+        emptyPlaceholder(systemImage: "moon", title: "No idle sessions")
+    }
+
+    private func emptyPlaceholder(systemImage: String, title: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: systemImage)
+                .font(.system(size: 20))
+                .foregroundStyle(Color.textMuted)
+            Text(title)
+                .font(.system(size: 12))
+                .foregroundStyle(Color.textMuted)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 24)
     }
 
 }
@@ -312,11 +349,20 @@ extension PopupView {
     }
     private var isNavigateActive: Bool { navigate?.isActive ?? false }
     private var hasMultipleSources: Bool { Set(sessions.map(\.agentBadge)).count > 1 }
-    private var sortedSessions: [Session] {
+    private var sortedActiveSessions: [Session] {
         if isNavigateActive, let frozen = navigate?.frozenSessions, !frozen.isEmpty {
             return frozen
         }
-        return Session.sorted(sessions)
+        return Session.sorted(SessionDisplayPolicy.activeSessions(from: sessions))
+    }
+    private var sortedIdleSessions: [Session] {
+        Session.sorted(SessionDisplayPolicy.idleSessions(from: sessions))
+    }
+    private var availableTabs: [PopupTab] {
+        var tabs: [PopupTab] = [.active]
+        if !sortedIdleSessions.isEmpty { tabs.append(.idle) }
+        if !recentProjects.isEmpty { tabs.append(.recent) }
+        return tabs
     }
 
     private func focusSession(_ session: Session) {
@@ -362,7 +408,12 @@ extension PopupView {
     }
 
     private func moveSelection(by delta: Int) {
-        let count = selectedTab == .active ? sortedSessions.count : recentProjects.count
+        let count: Int
+        switch selectedTab {
+        case .active: count = sortedActiveSessions.count
+        case .idle: count = sortedIdleSessions.count
+        case .recent: count = recentProjects.count
+        }
         guard count > 0 else { return }
         selectedIndex = selectedIndex.map { ($0 + delta + count) % count } ?? (delta > 0 ? 0 : count - 1)
     }
@@ -371,8 +422,11 @@ extension PopupView {
         guard let index = selectedIndex else { return }
         switch selectedTab {
         case .active:
-            guard index < sortedSessions.count else { return }
-            focusSession(sortedSessions[index])
+            guard index < sortedActiveSessions.count else { return }
+            focusSession(sortedActiveSessions[index])
+        case .idle:
+            guard index < sortedIdleSessions.count else { return }
+            focusSession(sortedIdleSessions[index])
         case .recent:
             guard index < recentProjects.count else { return }
             openInEditor(project: recentProjects[index])
@@ -385,11 +439,31 @@ extension PopupView {
 
     private func switchTab(to action: PanelNavAction) {
         guard showTabs else { return }
-        let newTab: PopupTab = action == .previousTab ? .active : action == .nextTab ? .recent
-            : (selectedTab == .active ? .recent : .active)
+        let tabs = availableTabs
+        guard let currentIndex = tabs.firstIndex(of: selectedTab) else {
+            selectedTab = .active
+            return
+        }
+        let newIndex: Int
+        switch action {
+        case .previousTab:
+            newIndex = (currentIndex - 1 + tabs.count) % tabs.count
+        case .nextTab, .toggleTab:
+            newIndex = (currentIndex + 1) % tabs.count
+        default:
+            return
+        }
+        let newTab = tabs[newIndex]
         guard newTab != selectedTab else { return }
         if overlayController.active != nil { closeOverlay(animated: true) }
         withAnimation(.easeInOut(duration: 0.15)) { selectedTab = newTab }
         notifyLayoutChanged()
+    }
+
+    private func ensureSelectedTabAvailable() {
+        guard availableTabs.contains(selectedTab) else {
+            selectedTab = .active
+            return
+        }
     }
 }

--- a/menubar/CctopMenubarTests/SessionDisplayPolicyTests.swift
+++ b/menubar/CctopMenubarTests/SessionDisplayPolicyTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import CctopMenubar
+
+final class SessionDisplayPolicyTests: XCTestCase {
+    func testActiveSessionsExcludesDormantAndStaleActiveIdle() {
+        let now = Date()
+        let sessions = [
+            activeIdle(id: "fresh", lastActivity: now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval + 60)),
+            activeIdle(id: "stale", lastActivity: now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 60)),
+            dormant(id: "dormant"),
+            activeWaiting(id: "waiting", lastActivity: now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 60)),
+        ]
+
+        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: sessions, now: now).map(\.id), ["fresh", "waiting"])
+    }
+
+    func testIdleSessionsIncludesDormantAndStaleActiveIdleOnly() {
+        let now = Date()
+        let sessions = [
+            activeIdle(id: "fresh", lastActivity: now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval + 60)),
+            activeIdle(id: "stale", lastActivity: now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 60)),
+            dormant(id: "dormant"),
+            activeWaiting(id: "waiting", lastActivity: now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 60)),
+        ]
+
+        XCTAssertEqual(SessionDisplayPolicy.idleSessions(from: sessions, now: now).map(\.id), ["stale", "dormant"])
+    }
+
+    func testSignatureTracksDisplayBuckets() {
+        let now = Date()
+        let sessions = [
+            activeIdle(id: "fresh", lastActivity: now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval + 60)),
+            activeIdle(id: "stale", lastActivity: now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 60)),
+            dormant(id: "dormant"),
+        ]
+
+        XCTAssertEqual(
+            SessionDisplayPolicy.signature(for: sessions, now: now),
+            .init(activeIDs: ["fresh"], idleIDs: ["stale", "dormant"])
+        )
+    }
+
+    private func activeIdle(id: String, lastActivity: Date) -> Session {
+        var session = Session.mock(id: id, status: .idle)
+        session.lifecycle = .active
+        session.lastActivity = lastActivity
+        return session
+    }
+
+    private func activeWaiting(id: String, lastActivity: Date) -> Session {
+        var session = Session.mock(id: id, status: .waitingInput)
+        session.lifecycle = .active
+        session.lastActivity = lastActivity
+        return session
+    }
+
+    private func dormant(id: String) -> Session {
+        var session = Session.mock(id: id, status: .idle)
+        session.lifecycle = .dormant
+        return session
+    }
+}

--- a/menubar/CctopMenubarTests/StatusCountsSessionInitTests.swift
+++ b/menubar/CctopMenubarTests/StatusCountsSessionInitTests.swift
@@ -14,6 +14,40 @@ final class StatusCountsSessionInitTests: XCTestCase {
         XCTAssertEqual(counts.working, 0)
     }
 
+    func testFreshActiveIdle_countsAsIdle() {
+        let now = Date()
+        var session = Session.mock(status: .idle)
+        session.lifecycle = .active
+        session.lastActivity = now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval + 60)
+
+        let counts = StatusCounts(sessions: [session], now: now)
+
+        XCTAssertEqual(counts.idle, 1)
+        XCTAssertEqual(counts.total, 1)
+    }
+
+    func testStaleActiveIdle_isExcludedFromCounts() {
+        let now = Date()
+        var session = Session.mock(status: .idle)
+        session.lifecycle = .active
+        session.lastActivity = now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 60)
+
+        let counts = StatusCounts(sessions: [session], now: now)
+
+        XCTAssertEqual(counts.idle, 0)
+        XCTAssertEqual(counts.total, 0)
+    }
+
+    func testDormantSession_isExcludedFromCounts() {
+        var session = Session.mock(status: .waitingPermission)
+        session.lifecycle = .dormant
+
+        let counts = StatusCounts(sessions: [session])
+
+        XCTAssertEqual(counts.permission, 0)
+        XCTAssertEqual(counts.total, 0)
+    }
+
     func testWorking_countsAsWorking() {
         let sessions = [Session.mock(status: .working)]
         let counts = StatusCounts(sessions: sessions)


### PR DESCRIPTION
## Problem

The session loader publishes retained active and dormant sessions to the panel while finished sessions are hidden, so dormant retained sessions can occupy the same top-level view as live work after dormant support ([source](https://github.com/st0012/cctop/blob/codex/idle-sessions-tab/menubar/CctopMenubar/Services/SessionManager.swift#L91-L97)). The header and menubar status proportions derive from `StatusCounts(sessions:)`, so the count source also needs to match the visible Active bucket ([source](https://github.com/st0012/cctop/blob/codex/idle-sessions-tab/menubar/CctopMenubar/Models/StatusCounts.swift#L28-L33)).

## Solution

- Add `SessionDisplayPolicy` as a presentation-only grouping layer: Active is lifecycle-active except stale idle sessions, Idle is dormant sessions plus active idle sessions older than 48 hours, and the policy does not change lifecycle or cleanup semantics ([source](https://github.com/st0012/cctop/blob/codex/idle-sessions-tab/menubar/CctopMenubar/Models/SessionDisplayPolicy.swift#L3-L37)).
- Add an Idle top-level tab and feed Active and Idle tab counts/lists from the display policy; both tabs share the same session-card jump/context-menu rendering path ([source](https://github.com/st0012/cctop/blob/codex/idle-sessions-tab/menubar/CctopMenubar/Views/PopupView.swift#L97-L152), [source](https://github.com/st0012/cctop/blob/codex/idle-sessions-tab/menubar/CctopMenubar/Views/PopupView.swift#L203-L244)).
- Exclude Idle-bucket sessions from status proportions and navigate-mode shortcuts by using `SessionDisplayPolicy.activeSessions` in both paths ([source](https://github.com/st0012/cctop/blob/codex/idle-sessions-tab/menubar/CctopMenubar/Models/StatusCounts.swift#L28-L45), [source](https://github.com/st0012/cctop/blob/codex/idle-sessions-tab/menubar/CctopMenubar/AppDelegate.swift#L483-L485)).
- Republish when the display bucket signature changes, so active idle sessions can move tabs after crossing the threshold even when persisted session data has not otherwise changed ([source](https://github.com/st0012/cctop/blob/codex/idle-sessions-tab/menubar/CctopMenubar/Services/SessionManager.swift#L97-L107)).
- Cover the display split and status-count behavior with targeted tests ([source](https://github.com/st0012/cctop/blob/codex/idle-sessions-tab/menubar/CctopMenubarTests/SessionDisplayPolicyTests.swift#L4-L62), [source](https://github.com/st0012/cctop/blob/codex/idle-sessions-tab/menubar/CctopMenubarTests/StatusCountsSessionInitTests.swift#L17-L49)).

## Verification

Local verification run before opening this PR:

```sh
git diff --cached --check
make lint
xcodebuild build-for-testing -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -configuration Debug -derivedDataPath menubar/build CODE_SIGN_IDENTITY="-"
```