### PR TITLE
Hide Codex Desktop sessions missing from state

### DIFF
--- a/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
@@ -3,9 +3,10 @@ import SQLite3
 
 /// Read-side seam over Codex's local thread state. `CodexThreadArchiveLookup` is the live
 /// SQLite-backed implementation; tests substitute in-memory stubs so visibility and archive
-/// logic can run without a database on disk. All methods share the lookup's nil contract:
-/// `nil` means "the store exists but could not be read" (callers fail safe or open per site).
+/// logic can run without a database on disk. `nil` means the lookup could not prove an answer,
+/// either because the store was unreadable or because absence is intentionally treated as unknown.
 protocol CodexThreadStateProviding {
+    func existingThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
     func archivedThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
     func subagentThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
     func execHelperThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
@@ -17,6 +18,13 @@ struct CodexThreadArchiveLookup {
 
     init(stateDatabasePath: String = Config.codexStateDatabasePath()) {
         self.stateDatabasePath = stateDatabasePath
+    }
+
+    /// Returns the subset of `threadIDs` present in Codex's thread state. Unlike archive
+    /// lookups, a missing database is unknown rather than proof of absence, so callers
+    /// should fail OPEN when this returns `nil`.
+    func existingThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        matchingThreadIDs(matching: threadIDs, whereClause: "1 = 1", missingDatabaseResult: nil)
     }
 
     /// Returns the subset of `threadIDs` that Codex has archived, or `nil` when the database
@@ -145,9 +153,13 @@ struct CodexThreadArchiveLookup {
         }
     }
 
-    private func matchingThreadIDs(matching threadIDs: Set<String>, whereClause predicate: String) -> Set<String>? {
+    private func matchingThreadIDs(
+        matching threadIDs: Set<String>,
+        whereClause predicate: String,
+        missingDatabaseResult: Set<String>? = []
+    ) -> Set<String>? {
         guard !threadIDs.isEmpty else { return [] }
-        guard FileManager.default.fileExists(atPath: stateDatabasePath) else { return [] }
+        guard FileManager.default.fileExists(atPath: stateDatabasePath) else { return missingDatabaseResult }
 
         var database: OpaquePointer?
         let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -47,6 +47,7 @@ struct SessionDataSources {
 
 struct SessionVisibilitySnapshot {
     let archivedCodexThreadIDs: Set<String>
+    let missingCodexDesktopThreadIDs: Set<String>
     let codexSubagentThreadIDs: Set<String>
     let codexExecHelperThreadIDs: Set<String>
     let archivedClaudeSessionIDs: Set<String>
@@ -85,6 +86,7 @@ extension SessionManager {
         codexThreads: any CodexThreadStateProviding
     ) -> SessionVisibilitySnapshot {
         let archivedCodexThreadIDs = archivedCodexDesktopThreadIDs(in: sessions, codexThreads: codexThreads)
+        let missingCodexDesktopThreadIDs = missingCodexDesktopThreadIDs(in: sessions, codexThreads: codexThreads)
         let codexSubagentThreadIDs = codexSubagentThreadIDs(in: sessions, codexThreads: codexThreads)
         let codexExecHelperThreadIDs = codexExecHelperThreadIDs(in: sessions, codexThreads: codexThreads)
         let archivedClaudeSessionIDs = claudeMetadata?.archivedSessionIDs ?? []
@@ -93,6 +95,7 @@ extension SessionManager {
         }
         let liveCandidates = candidates.filter {
             !isArchivedCodexDesktopSession($0.session, archivedThreadIDs: archivedCodexThreadIDs)
+                && !isMissingCodexDesktopSession($0.session, missingThreadIDs: missingCodexDesktopThreadIDs)
                 && !isCodexSubagentSession($0.session, subagentThreadIDs: codexSubagentThreadIDs)
                 && !isCodexExecHelperSession($0.session, execHelperThreadIDs: codexExecHelperThreadIDs)
                 && !isArchivedClaudeDesktopSession($0.session, archivedSessionIDs: archivedClaudeSessionIDs)
@@ -100,6 +103,7 @@ extension SessionManager {
         }
         return SessionVisibilitySnapshot(
             archivedCodexThreadIDs: archivedCodexThreadIDs,
+            missingCodexDesktopThreadIDs: missingCodexDesktopThreadIDs,
             codexSubagentThreadIDs: codexSubagentThreadIDs,
             codexExecHelperThreadIDs: codexExecHelperThreadIDs,
             archivedClaudeSessionIDs: archivedClaudeSessionIDs,
@@ -127,6 +131,30 @@ extension SessionManager {
         archivedThreadIDs: Set<String>
     ) -> Bool {
         session.isCodexDesktopHost && archivedThreadIDs.contains(session.sessionId)
+    }
+
+    /// Codex Desktop sessions should correspond to a Codex thread row. If the thread store is
+    /// readable and the row is gone, the app should not publish the stale hook session.
+    nonisolated static func missingCodexDesktopThreadIDs(
+        in sessions: [Session],
+        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup()
+    ) -> Set<String> {
+        let threadIDs = Set(
+            sessions
+                .filter { $0.source == Session.codexSource && $0.isCodexDesktopHost }
+                .map(\.sessionId)
+        )
+        guard let existingThreadIDs = codexThreads.existingThreadIDs(matching: threadIDs) else { return [] }
+        return threadIDs.subtracting(existingThreadIDs)
+    }
+
+    nonisolated static func isMissingCodexDesktopSession(
+        _ session: Session,
+        missingThreadIDs: Set<String>
+    ) -> Bool {
+        session.source == Session.codexSource
+            && session.isCodexDesktopHost
+            && missingThreadIDs.contains(session.sessionId)
     }
 
     /// Codex records whether a thread is user-owned or subagent-owned in its local thread

--- a/menubar/CctopMenubar/Services/SessionManager+Loading.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Loading.swift
@@ -64,6 +64,7 @@ extension SessionManager {
             "loadSessions: \(summary.live) visible candidates, \(summary.hidden) hidden, \(summary.autoHidden) auto-hidden"
         )
         sessionManagerLogger.info("loadSessions: \(visibility.archivedCodexThreadIDs.count) codex-archived")
+        sessionManagerLogger.info("loadSessions: \(visibility.missingCodexDesktopThreadIDs.count) codex-missing-state")
         sessionManagerLogger.info("loadSessions: \(visibility.codexSubagentThreadIDs.count) codex-subagent")
         sessionManagerLogger.info("loadSessions: \(visibility.codexExecHelperThreadIDs.count) codex-exec-helper")
         sessionManagerLogger.info("loadSessions: \(visibility.archivedClaudeSessionIDs.count) claude-archived")

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -612,6 +612,51 @@ final class SessionFileFormatTests: XCTestCase {
     }
 
     @MainActor
+    func testSessionManagerFiltersCodexDesktopSessionsMissingFromReadableStateWithoutRemovingFiles() throws {
+        let root = NSTemporaryDirectory() + "cctop-codex-missing-state-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        try writeCodexStateDatabase(path: stateDB, archivedThreads: [], userExecThreads: ["visible-thread"])
+
+        setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
+        defer {
+            unsetenv("CCTOP_CODEX_STATE_DB")
+            try? FileManager.default.removeItem(atPath: root)
+        }
+
+        let missingPath = (sessionsDir as NSString).appendingPathComponent("codex-missing-thread.json")
+        let visiblePath = (sessionsDir as NSString).appendingPathComponent("codex-visible-thread.json")
+        try codexDesktopSession(
+            sessionId: "missing-thread",
+            projectPath: (root as NSString).appendingPathComponent("projects/probe")
+        ).writeToFile(path: missingPath)
+        try codexDesktopSession(
+            sessionId: "visible-thread",
+            projectPath: (root as NSString).appendingPathComponent("projects/cctop")
+        ).writeToFile(path: visiblePath)
+        FileManager.default.createFile(atPath: missingPath + ".lock", contents: nil)
+        FileManager.default.createFile(atPath: visiblePath + ".lock", contents: nil)
+
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            desktopAppConnection: DesktopAppConnectionLookup { _ in true }
+        )
+        manager.loadSessions()
+
+        XCTAssertEqual(manager.sessions.map(\.sessionId), ["visible-thread"])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: missingPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: missingPath + ".lock"))
+        XCTAssertFalse(try Session.fromFile(path: missingPath).hidden)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: visiblePath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: visiblePath + ".lock"))
+        XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
+    }
+
+    @MainActor
     func testSessionManagerKeepsUserVisibleCodexExecThreads() throws {
         let root = NSTemporaryDirectory() + "cctop-codex-user-exec-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")
@@ -693,7 +738,7 @@ final class SessionFileFormatTests: XCTestCase {
         let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
-        try writeCodexStateDatabase(path: stateDB, archivedThreads: [])
+        try writeCodexStateDatabase(path: stateDB, archivedThreads: [], userExecThreads: ["parent-thread"])
 
         setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
         defer {
@@ -841,10 +886,16 @@ final class SessionFileFormatTests: XCTestCase {
         let root = NSTemporaryDirectory() + "cctop-codex-dedup-cleanup-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")
         let historyDir = (root as NSString).appendingPathComponent("history")
+        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        try writeCodexStateDatabase(path: stateDB, archivedThreads: [], userExecThreads: ["conv-a"])
 
-        defer { try? FileManager.default.removeItem(atPath: root) }
+        setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
+        defer {
+            unsetenv("CCTOP_CODEX_STATE_DB")
+            try? FileManager.default.removeItem(atPath: root)
+        }
 
         var oldPidKeyed = Session(
             sessionId: "conv-a", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo()
@@ -902,7 +953,7 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
 
-        try writeCodexStateDatabase(path: stateDB, archivedThreads: [])
+        try writeCodexStateDatabase(path: stateDB, archivedThreads: [], userExecThreads: ["archived-thread"])
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), ["archived-thread"])
@@ -1632,10 +1683,16 @@ final class SessionFileFormatTests: XCTestCase {
         let root = NSTemporaryDirectory() + "cctop-desktop-reconnected-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")
         let historyDir = (root as NSString).appendingPathComponent("history")
+        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        try writeCodexStateDatabase(path: stateDB, archivedThreads: [], userExecThreads: ["s"])
 
-        defer { try? FileManager.default.removeItem(atPath: root) }
+        setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
+        defer {
+            unsetenv("CCTOP_CODEX_STATE_DB")
+            try? FileManager.default.removeItem(atPath: root)
+        }
 
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-reconnected.json")
         var session = lifeSession(source: Session.codexSource, agoSeconds: 10_000, disconnectedAgoSeconds: 10_000)
@@ -1663,10 +1720,16 @@ final class SessionFileFormatTests: XCTestCase {
         let root = NSTemporaryDirectory() + "cctop-ended-desktop-running-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")
         let historyDir = (root as NSString).appendingPathComponent("history")
+        let stateDB = (root as NSString).appendingPathComponent("state_5.sqlite")
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        try writeCodexStateDatabase(path: stateDB, archivedThreads: [], userExecThreads: ["s"])
 
-        defer { try? FileManager.default.removeItem(atPath: root) }
+        setenv("CCTOP_CODEX_STATE_DB", stateDB, 1)
+        defer {
+            unsetenv("CCTOP_CODEX_STATE_DB")
+            try? FileManager.default.removeItem(atPath: root)
+        }
 
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-ended.json")
         var session = lifeSession(source: Session.codexSource, agoSeconds: 10_000, disconnectedAgoSeconds: 10_000)
@@ -2091,10 +2154,15 @@ final class SessionFileFormatTests: XCTestCase {
 /// In-memory stand-in for Codex's thread state database, so visibility and archive logic can be
 /// exercised without SQLite fixtures on disk. Set a field to `nil` to simulate an unreadable store.
 private struct StubCodexThreadState: CodexThreadStateProviding {
+    var existing: Set<String>? = nil
     var archived: Set<String>? = []
     var subagents: Set<String>? = []
     var execHelpers: Set<String>? = []
     var projectNamesByThreadID: [String: String]? = [:]
+
+    func existingThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        existing.map { $0.intersection(threadIDs) }
+    }
 
     func archivedThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
         archived.map { $0.intersection(threadIDs) }


### PR DESCRIPTION
## Problem

cctop renders active work from local session files, and the session-file docs explicitly separate hiding from deletion so diagnostic state can remain on disk when it should not appear as user-facing work ([docs/session-files.md](https://github.com/st0012/cctop/blob/codex/hide-missing-codex-desktop-sessions/docs/session-files.md#L3-L19)). Codex Desktop lifecycle and visibility already depend on Codex-specific thread state keyed by thread id, while desktop hosting is identified through the trusted Codex Desktop bundle path ([docs/session-lifecycle.md](https://github.com/st0012/cctop/blob/codex/hide-missing-codex-desktop-sessions/docs/session-lifecycle.md#L117-L127), [Config.swift](https://github.com/st0012/cctop/blob/codex/hide-missing-codex-desktop-sessions/menubar/CctopMenubar/Models/Config.swift#L64-L70), [HostApp.swift](https://github.com/st0012/cctop/blob/codex/hide-missing-codex-desktop-sessions/menubar/CctopMenubar/Models/HostApp.swift#L130-L154)).

That left one narrow stale-state gap: a Codex Desktop-looking session file whose thread row is absent from a readable Codex state database could still be published as visible instead of being treated as a stale display record.

## Solution

Add a read-only `existingThreadIDs` lookup that returns matching thread rows and deliberately fails open when Codex state is missing or unreadable ([CodexThreadArchiveLookup.swift](https://github.com/st0012/cctop/blob/codex/hide-missing-codex-desktop-sessions/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift#L23-L28), [CodexThreadArchiveLookup.swift](https://github.com/st0012/cctop/blob/codex/hide-missing-codex-desktop-sessions/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift#L156-L162)).

Use that lookup only in the display visibility snapshot for sessions that are both `source == "codex"` and trusted as Codex Desktop hosts, leaving Codex CLI, legacy nil-source records, hidden flags, archive behavior, and file deletion behavior unchanged ([SessionManager+Archive.swift](https://github.com/st0012/cctop/blob/codex/hide-missing-codex-desktop-sessions/menubar/CctopMenubar/Services/SessionManager%2BArchive.swift#L88-L102), [SessionManager+Archive.swift](https://github.com/st0012/cctop/blob/codex/hide-missing-codex-desktop-sessions/menubar/CctopMenubar/Services/SessionManager%2BArchive.swift#L136-L157)).

Add regression coverage showing that a missing Codex Desktop thread row is filtered from the UI while the session JSON and lock file remain on disk and the backed thread remains visible ([SessionFileFormatTests.swift](https://github.com/st0012/cctop/blob/codex/hide-missing-codex-desktop-sessions/menubar/CctopMenubarTests/SessionFileFormatTests.swift#L614-L657)).

## Verification

- `xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -configuration Debug -derivedDataPath menubar/build -only-testing:CctopMenubarTests/SessionFileFormatTests`
- `git diff --check`