### PR TITLE
Support exact cmux surface focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ When you click a session card (or jump via Navigate mode), cctop focuses the hos
 |-----|-------------|
 | VS Code, Cursor, Windsurf, Zed | Opens the project (workspace file if present) |
 | iTerm2 | Targets the specific window, tab, and pane |
+| cmux | Targets the specific workspace surface, including already-running sessions when live cmux metadata is available |
 | Kitty | Targets the specific window via remote control |
 | Ghostty | Targets a terminal whose working directory matches the project (best-effort) |
 | Terminal | Targets the specific tab by tty |
@@ -76,6 +77,12 @@ When you click a session card (or jump via Navigate mode), cctop focuses the hos
 > Kitty requires `allow_remote_control socket-only` and `listen_on` in your `kitty.conf`.
 > Without remote control enabled, Kitty falls back to app activation (same as Warp).
 >
+> cmux exposes workspace and surface IDs inside each terminal. cctop stores
+> those IDs when hooks run, and can recover them from a live cmux process when
+> an already-running session file is missing multiplexer metadata. It opens a
+> `cmux://` navigation URL for exact surface focus, with a CLI `focus-surface`
+> fallback for cmux reference IDs.
+>
 > Ghostty requires version 1.3.0+ for AppleScript support. Because Ghostty does not
 > yet expose a per-surface env var inside the shell, cctop matches by working
 > directory — ambiguous when multiple Ghostty splits share the same cwd.
@@ -86,11 +93,12 @@ When you click a session card (or jump via Navigate mode), cctop focuses the hos
 
 ### Terminal Multiplexers
 
-When running inside a multiplexer, cctop additionally focuses the specific pane.
+When running inside a multiplexer, cctop additionally focuses the specific pane or surface.
 This composes with any terminal emulator above.
 
 | Multiplexer | How it focuses |
 |-------------|----------------|
+| cmux | `cmux://workspace/.../surface/...` or `cmux focus-surface` — targets the exact workspace surface from stored or live cmux metadata |
 | Zellij | `zellij --session <name> action focus-pane-id <paneId>` — targets the exact pane |
 | tmux | `tmux select-window` + `select-pane` — targets the exact window and pane |
 

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -4,6 +4,54 @@ cctop stores live session state as JSON files in `~/.cctop/sessions/`. The menub
 
 Session files are intentionally local and inspectable. Missing optional fields must be treated as their default values so older files continue to load.
 
+## Terminal Focus Metadata
+
+### `terminal.multiplexer`
+
+Type: `object`
+
+Default: `null` when omitted.
+
+When present, `terminal.multiplexer` records pane or surface metadata for a
+terminal multiplexer that hosts the session. cctop uses this to jump directly
+to the right multiplexer target after focusing the host app.
+
+Supported shapes:
+
+```json
+{
+  "name": "cmux",
+  "socket": "/Users/me/.local/state/cmux/cmux.sock",
+  "workspace_id": "B48DBE7E-B98F-48E7-9914-17D7F119BEAA",
+  "surface_id": "0BEEE68A-A07D-4225-ACF6-8C973615AA91",
+  "binary_path": "/Applications/cmux.app/Contents/Resources/bin/cmux"
+}
+```
+
+```json
+{
+  "name": "zellij",
+  "session_name": "dev",
+  "pane_id": "terminal_3",
+  "binary_path": "/opt/homebrew/bin/zellij"
+}
+```
+
+```json
+{
+  "name": "tmux",
+  "socket": "/tmp/tmux-501/default",
+  "pane_id": "%3",
+  "binary_path": "/opt/homebrew/bin/tmux"
+}
+```
+
+All multiplexer fields are optional except the values needed for the specific
+jump strategy. Older live cmux session files may not have
+`terminal.multiplexer`; when the session process is still running and exposes
+`CMUX_*` environment variables, the app can recover the cmux workspace and
+surface at jump time without rewriting the session file.
+
 ## Visibility
 
 ### `hidden`

--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		PVH000010000000000000001 /* PopupViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = PVH000020000000000000001 /* PopupViewHelpers.swift */; };
 		D10000090000000000000001 /* QuitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000000A000000000000001 /* QuitButton.swift */; };
 		E10000010000000000000001 /* FocusTerminal.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000020000000000000001 /* FocusTerminal.swift */; };
+		ECMUX001000000000000001 /* FocusTerminal+Cmux.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECMUX002000000000000001 /* FocusTerminal+Cmux.swift */; };
+		EMUX0010000000000000001 /* FocusTerminal+Multiplexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EMUX0020000000000000001 /* FocusTerminal+Multiplexer.swift */; };
 		EK0000010000000000000001 /* HostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EK0000020000000000000001 /* HostApp.swift */; };
 		F10000010000000000000001 /* Session+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000020000000000000001 /* Session+Mock.swift */; };
 		FK0000010000000000000001 /* ForkSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FK0000020000000000000001 /* ForkSessionTests.swift */; };
@@ -160,6 +162,8 @@
 		D10000080000000000000001 /* PopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupView.swift; sourceTree = "<group>"; };
 		PVH000020000000000000001 /* PopupViewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupViewHelpers.swift; sourceTree = "<group>"; };
 		E10000020000000000000001 /* FocusTerminal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusTerminal.swift; sourceTree = "<group>"; };
+		ECMUX002000000000000001 /* FocusTerminal+Cmux.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FocusTerminal+Cmux.swift"; sourceTree = "<group>"; };
+		EMUX0020000000000000001 /* FocusTerminal+Multiplexer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FocusTerminal+Multiplexer.swift"; sourceTree = "<group>"; };
 		EK0000020000000000000001 /* HostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostApp.swift; sourceTree = "<group>"; };
 		F10000020000000000000001 /* Session+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Session+Mock.swift"; sourceTree = "<group>"; };
 		FK0000020000000000000001 /* ForkSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForkSessionTests.swift; sourceTree = "<group>"; };
@@ -296,6 +300,8 @@
 				SML000020000000000000001 /* SessionManager+Loading.swift */,
 				HM0000020000000000000001 /* HistoryManager.swift */,
 				E10000020000000000000001 /* FocusTerminal.swift */,
+				ECMUX002000000000000001 /* FocusTerminal+Cmux.swift */,
+				EMUX0020000000000000001 /* FocusTerminal+Multiplexer.swift */,
 				SP0000020000000000000001 /* SparkleUpdater.swift */,
 				PM0000020000000000000001 /* PluginManager.swift */,
 				CIM000020000000000000001 /* CodexIntegrationManager.swift */,
@@ -591,6 +597,8 @@
 				PVH000010000000000000001 /* PopupViewHelpers.swift in Sources */,
 				D10000090000000000000001 /* QuitButton.swift in Sources */,
 				E10000010000000000000001 /* FocusTerminal.swift in Sources */,
+				ECMUX001000000000000001 /* FocusTerminal+Cmux.swift in Sources */,
+				EMUX0010000000000000001 /* FocusTerminal+Multiplexer.swift in Sources */,
 				F10000010000000000000001 /* Session+Mock.swift in Sources */,
 				G10000010000000000000001 /* FloatingPanel.swift in Sources */,
 				G10000030000000000000001 /* AppDelegate.swift in Sources */,

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -301,8 +301,32 @@ enum HookHandler {
         )
     }
 
-    /// Detect zellij or tmux from env vars. Checks zellij first, then tmux.
+    /// Detect cmux, zellij, or tmux from env vars. Checks outer GUI multiplexers first.
     private static func captureMultiplexerInfo(env: [String: String]) -> MultiplexerInfo? {
+        // cmux: CMUX_SOCKET_PATH + CMUX_WORKSPACE_ID + CMUX_SURFACE_ID.
+        // CMUX_PANE_ID is accepted for same-session deep links when available, but
+        // current cmux builds expose CMUX_SURFACE_ID as the documented focus target.
+        let cmuxSurfaceId = sanitizeTerminalSessionId(env["CMUX_SURFACE_ID"])
+        if let socket = env["CMUX_SOCKET_PATH"], !socket.isEmpty,
+           let workspaceId = sanitizeTerminalSessionId(env["CMUX_WORKSPACE_ID"]),
+           let surfaceId = cmuxSurfaceId {
+            let paneId = sanitizeTerminalSessionId(env["CMUX_PANE_ID"])
+            let path = resolveBinaryPath(env: env, name: "cmux")
+            return .cmux(
+                socket: socket, workspaceId: workspaceId,
+                surfaceId: surfaceId, paneId: paneId, binaryPath: path
+            )
+        }
+        // Older or experimental cmux contexts may expose a pane id without a surface id.
+        if let socket = env["CMUX_SOCKET_PATH"], !socket.isEmpty,
+           let workspaceId = sanitizeTerminalSessionId(env["CMUX_WORKSPACE_ID"]),
+           let paneId = sanitizeTerminalSessionId(env["CMUX_PANE_ID"]) {
+            let path = resolveBinaryPath(env: env, name: "cmux")
+            return .cmux(
+                socket: socket, workspaceId: workspaceId,
+                surfaceId: nil, paneId: paneId, binaryPath: path
+            )
+        }
         // zellij: ZELLIJ_SESSION_NAME + ZELLIJ_PANE_ID
         if let sessionName = sanitizeTerminalSessionId(env["ZELLIJ_SESSION_NAME"]),
            let paneId = sanitizeTerminalSessionId(env["ZELLIJ_PANE_ID"]) {
@@ -321,7 +345,8 @@ enum HookHandler {
     }
 
     /// Validate terminal session IDs to prevent injection via env vars.
-    /// Only allows alphanumeric, hyphens, colons, periods, at-signs, underscores, and percent (covers iTerm2, Kitty, and tmux formats).
+    /// Only allows alphanumeric, hyphens, colons, periods, at-signs, underscores, and percent
+    /// (covers iTerm2, Kitty, cmux, zellij, and tmux formats).
     private static func sanitizeTerminalSessionId(_ value: String?) -> String? {
         guard let value, !value.isEmpty,
               value.range(of: #"^[0-9a-zA-Z:.@_%-]+$"#, options: .regularExpression) != nil

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -12,6 +12,7 @@ enum HostApp: CaseIterable {
     case terminal
     case ghostty
     case kitty
+    case cmux
     /// Claude Desktop runs sessions inside the app itself — no terminal, no editor.
     case claudeDesktop
     /// Codex Desktop runs sessions inside the app itself — no terminal, no editor.
@@ -22,6 +23,9 @@ enum HostApp: CaseIterable {
     /// because `__CFBundleIdentifier` unambiguously identifies VS Code forks.
     static func from(bundleIdentifier: String?) -> HostApp? {
         guard let id = bundleIdentifier, !id.isEmpty else { return nil }
+        if id == "com.cmuxterm.app" || id.hasPrefix("com.cmuxterm.app.") {
+            return .cmux
+        }
         return allByBundleID[id]
     }
 
@@ -39,6 +43,7 @@ enum HostApp: CaseIterable {
         if lower.contains("warp") { return .warp }
         if lower.contains("ghostty") { return .ghostty }
         if lower.contains("kitty") { return .kitty }
+        if lower.contains("cmux") { return .cmux }
         if lower.contains("terminal") { return .terminal }
         return .unknown
     }
@@ -54,6 +59,7 @@ enum HostApp: CaseIterable {
         case .terminal: return "com.apple.Terminal"
         case .ghostty: return "com.mitchellh.ghostty"
         case .kitty: return "net.kovidgoyal.kitty"
+        case .cmux: return "com.cmuxterm.app"
         case .claudeDesktop: return HostAppBundleID.claudeDesktop
         case .codexDesktop: return HostAppBundleID.codexDesktop
         case .unknown: return nil
@@ -73,6 +79,7 @@ enum HostApp: CaseIterable {
         case .terminal: return "terminal"
         case .ghostty: return "ghostty"
         case .kitty: return "kitty"
+        case .cmux: return "cmux"
         case .claudeDesktop, .codexDesktop, .unknown: return nil
         }
     }
@@ -81,7 +88,7 @@ enum HostApp: CaseIterable {
         switch self {
         case .vscode, .cursor, .windsurf, .zed:
             return "chevron.left.forwardslash.chevron.right"
-        case .iterm2, .warp, .terminal, .ghostty, .kitty, .unknown:
+        case .iterm2, .warp, .terminal, .ghostty, .kitty, .cmux, .unknown:
             return "terminal"
         case .claudeDesktop, .codexDesktop:
             return "sparkles"
@@ -92,7 +99,7 @@ enum HostApp: CaseIterable {
     var usesWorkspaceFile: Bool {
         switch self {
         case .vscode, .cursor, .windsurf, .zed: return true
-        case .iterm2, .warp, .terminal, .ghostty, .kitty,
+        case .iterm2, .warp, .terminal, .ghostty, .kitty, .cmux,
              .claudeDesktop, .codexDesktop, .unknown: return false
         }
     }
@@ -175,7 +182,7 @@ extension Session {
     /// Phase-1 host classification from file-local signals only.
     /// Precedence: a recognized bundle id (`__CFBundleIdentifier`, the same trusted signal
     /// `isHostedByDesktopApp` uses) classifies desktop vs terminal. Failing that, a terminal
-    /// multiplexer (tmux/zellij) is hard terminal evidence — desktop is already returned
+    /// multiplexer (cmux/tmux/zellij) is hard terminal evidence — desktop is already returned
     /// above, so a leaked `TMUX` env can't misclassify a desktop session here. Everything
     /// else (no/unknown bundle id, only env-copyable `tty` or program name) → ambiguous.
     var hostClass: SessionHostClass {

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -90,9 +90,11 @@ struct TerminalInfo: Codable, Equatable {
     }
 }
 
-/// Identifies a terminal multiplexer (zellij, tmux) hosting the session.
+/// Identifies a terminal multiplexer (cmux, zellij, tmux) hosting the session.
 /// Each variant carries exactly the fields needed for its focus command.
 enum MultiplexerInfo: Codable, Equatable {
+    /// cmux focus-surface --workspace $workspaceId --surface $surfaceId
+    case cmux(socket: String, workspaceId: String, surfaceId: String?, paneId: String?, binaryPath: String?)
     /// zellij --session $sessionName action focus-pane-id $paneId
     case zellij(sessionName: String, paneId: String, binaryPath: String?)
     /// tmux -S $socket select-window -t $paneId && tmux -S $socket select-pane -t $paneId
@@ -101,6 +103,8 @@ enum MultiplexerInfo: Codable, Equatable {
     private enum CodingKeys: String, CodingKey {
         case name
         case sessionName = "session_name"
+        case workspaceId = "workspace_id"
+        case surfaceId = "surface_id"
         case paneId = "pane_id"
         case socket
         case binaryPath = "binary_path"
@@ -111,6 +115,14 @@ enum MultiplexerInfo: Codable, Equatable {
         let name = try container.decode(String.self, forKey: .name)
         let binaryPath = try container.decodeIfPresent(String.self, forKey: .binaryPath)
         switch name {
+        case "cmux":
+            self = .cmux(
+                socket: try container.decode(String.self, forKey: .socket),
+                workspaceId: try container.decode(String.self, forKey: .workspaceId),
+                surfaceId: try container.decodeIfPresent(String.self, forKey: .surfaceId),
+                paneId: try container.decodeIfPresent(String.self, forKey: .paneId),
+                binaryPath: binaryPath
+            )
         case "zellij":
             self = .zellij(
                 sessionName: try container.decode(String.self, forKey: .sessionName),
@@ -134,6 +146,13 @@ enum MultiplexerInfo: Codable, Equatable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
+        case .cmux(let socket, let workspaceId, let surfaceId, let paneId, let binaryPath):
+            try container.encode("cmux", forKey: .name)
+            try container.encode(socket, forKey: .socket)
+            try container.encode(workspaceId, forKey: .workspaceId)
+            try container.encodeIfPresent(surfaceId, forKey: .surfaceId)
+            try container.encodeIfPresent(paneId, forKey: .paneId)
+            try container.encodeIfPresent(binaryPath, forKey: .binaryPath)
         case .zellij(let sessionName, let paneId, let binaryPath):
             try container.encode("zellij", forKey: .name)
             try container.encode(sessionName, forKey: .sessionName)
@@ -145,6 +164,13 @@ enum MultiplexerInfo: Codable, Equatable {
             try container.encode(paneId, forKey: .paneId)
             try container.encodeIfPresent(binaryPath, forKey: .binaryPath)
         }
+    }
+}
+
+extension MultiplexerInfo {
+    var isCmux: Bool {
+        if case .cmux = self { return true }
+        return false
     }
 }
 

--- a/menubar/CctopMenubar/Services/FocusTerminal+Cmux.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal+Cmux.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+private let cmuxEnvironmentKeys = [
+    "CMUX_SOCKET_PATH",
+    "CMUX_WORKSPACE_ID",
+    "CMUX_TAB_ID",
+    "CMUX_SURFACE_ID",
+    "CMUX_PANEL_ID",
+    "CMUX_PANE_ID",
+    "CMUX_CLAUDE_HOOK_CMUX_BIN",
+    "CMUX_BUNDLED_CLI_PATH",
+    "PATH"
+]
+
+/// cmux handles cmux://workspace/<workspace>/surface/<surface> by locating the
+/// owning window, focusing it, then focusing the requested surface.
+/// Source: https://github.com/manaflow-ai/cmux/blob/main/Sources/CmuxSSHURLRequest.swift
+func cmuxNavigationURL(multiplexer: MultiplexerInfo?) -> URL? {
+    guard case .cmux(_, let workspaceId, let surfaceId, let paneId, _) = multiplexer else {
+        return nil
+    }
+    return cmuxNavigationURL(workspaceId: workspaceId, surfaceId: surfaceId, paneId: paneId)
+}
+
+func cmuxNavigationURL(workspaceId: String, surfaceId: String?, paneId: String?) -> URL? {
+    guard let workspaceUUID = UUID(uuidString: workspaceId) else { return nil }
+    if let surfaceUUID = surfaceId.flatMap(UUID.init(uuidString:)) {
+        return URL(string: "cmux://workspace/\(workspaceUUID.uuidString)/surface/\(surfaceUUID.uuidString)")
+    }
+    if let paneUUID = paneId.flatMap(UUID.init(uuidString:)) {
+        return URL(string: "cmux://workspace/\(workspaceUUID.uuidString)/pane/\(paneUUID.uuidString)")
+    }
+    return nil
+}
+
+// https://cmux.com/docs/api
+func cmuxFocusArguments(socket: String, workspaceId: String, surfaceId: String?, paneId: String?) -> [String]? {
+    guard let surfaceId else { return nil }
+    return ["--socket", socket, "focus-surface", "--workspace", workspaceId, "--surface", surfaceId]
+}
+
+func resolveCmuxLiveMultiplexer(session: Session) -> MultiplexerInfo? {
+    resolveCmuxLiveMultiplexer(session: session, environmentLookup: cmuxEnvironmentForProcess(pid:))
+}
+
+func resolveCmuxLiveMultiplexer(
+    session: Session,
+    environmentLookup: (UInt32) -> [String: String]?
+) -> MultiplexerInfo? {
+    guard session.terminal?.multiplexer == nil,
+          session.trustedHostApp == .cmux,
+          let pid = session.pid,
+          let env = environmentLookup(pid)
+    else { return nil }
+    return cmuxMultiplexerInfo(env: env)
+}
+
+func cmuxMultiplexerInfo(env: [String: String]) -> MultiplexerInfo? {
+    guard let socket = env["CMUX_SOCKET_PATH"], !socket.isEmpty,
+          let workspaceId = sanitizeCmuxIdentifier(env["CMUX_WORKSPACE_ID"] ?? env["CMUX_TAB_ID"])
+    else { return nil }
+
+    let surfaceId = sanitizeCmuxIdentifier(env["CMUX_SURFACE_ID"] ?? env["CMUX_PANEL_ID"])
+    let paneId = sanitizeCmuxIdentifier(env["CMUX_PANE_ID"])
+    guard surfaceId != nil || paneId != nil else { return nil }
+
+    return .cmux(
+        socket: socket,
+        workspaceId: workspaceId,
+        surfaceId: surfaceId,
+        paneId: paneId,
+        binaryPath: cmuxBinaryPath(env: env)
+    )
+}
+
+func cmuxEnvironmentForProcess(pid: UInt32) -> [String: String]? {
+    guard let environmentText = cmuxProcessEnvironmentText(pid: pid) else { return nil }
+    let env = extractCmuxEnvironment(from: environmentText)
+    return env.isEmpty ? nil : env
+}
+
+func extractCmuxEnvironment(from text: String) -> [String: String] {
+    var env: [String: String] = [:]
+    for key in cmuxEnvironmentKeys {
+        let escapedKey = NSRegularExpression.escapedPattern(for: key)
+        let pattern = #"(^|\s)"# + escapedKey + #"=([^\s]+)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+              let valueRange = Range(match.range(at: 2), in: text)
+        else { continue }
+        let value = String(text[valueRange])
+        if !value.isEmpty {
+            env[key] = value
+        }
+    }
+    return env
+}
+
+private func cmuxProcessEnvironmentText(pid: UInt32) -> String? {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/ps")
+    process.arguments = ["eww", "-p", String(pid)]
+    let output = Pipe()
+    process.standardOutput = output
+    process.standardError = FileHandle.nullDevice
+
+    do {
+        try process.run()
+        process.waitUntilExit()
+    } catch {
+        return nil
+    }
+
+    guard process.terminationStatus == 0 else { return nil }
+    let data = output.fileHandleForReading.readDataToEndOfFile()
+    return String(data: data, encoding: .utf8)
+}
+
+private func cmuxBinaryPath(env: [String: String]) -> String? {
+    for key in ["CMUX_CLAUDE_HOOK_CMUX_BIN", "CMUX_BUNDLED_CLI_PATH"] {
+        if let path = executablePath(env[key]) {
+            return path
+        }
+    }
+    guard let pathEnv = env["PATH"] else { return nil }
+    for dir in pathEnv.split(separator: ":") {
+        let fullPath = URL(fileURLWithPath: String(dir)).appendingPathComponent("cmux").path
+        if let path = executablePath(fullPath) {
+            return path
+        }
+    }
+    return nil
+}
+
+private func executablePath(_ path: String?) -> String? {
+    guard let path, path.hasPrefix("/"), FileManager.default.isExecutableFile(atPath: path) else {
+        return nil
+    }
+    return path
+}
+
+private func sanitizeCmuxIdentifier(_ value: String?) -> String? {
+    guard let value, !value.isEmpty,
+          value.range(of: #"^[0-9a-zA-Z:.@_%-]+$"#, options: .regularExpression) != nil
+    else { return nil }
+    return value
+}
+
+func executeCmuxFocus(
+    binaryPath: String,
+    socket: String,
+    workspaceId: String,
+    surfaceId: String?,
+    paneId: String?
+) {
+    guard let arguments = cmuxFocusArguments(
+        socket: socket,
+        workspaceId: workspaceId,
+        surfaceId: surfaceId,
+        paneId: paneId
+    ) else { return }
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: binaryPath)
+    process.arguments = arguments
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    do {
+        try process.run()
+        process.waitUntilExit()
+    } catch {}
+}

--- a/menubar/CctopMenubar/Services/FocusTerminal+Multiplexer.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal+Multiplexer.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Describes how to focus a specific pane inside a terminal multiplexer.
+enum MultiplexerFocusStrategy: Equatable {
+    /// cmux --socket $socket focus-surface --workspace $workspaceId --surface $surfaceId
+    case cmux(socket: String, workspaceId: String, surfaceId: String?, paneId: String?, binaryPath: String)
+    /// zellij --session $sessionName action focus-pane-id $paneId
+    case zellij(sessionName: String, paneId: String, binaryPath: String)
+    /// tmux -S $socket select-window -t $paneId && tmux -S $socket select-pane -t $paneId
+    case tmux(socket: String, paneId: String, binaryPath: String)
+}
+
+/// Resolve multiplexer focus from session info. Returns nil when no multiplexer is present.
+/// Pure function — no side effects, fully testable.
+func resolveMultiplexerFocus(session: Session) -> MultiplexerFocusStrategy? {
+    resolveMultiplexerFocus(session: session, multiplexerOverride: nil)
+}
+
+/// Resolve multiplexer focus from persisted or freshly resolved multiplexer info.
+func resolveMultiplexerFocus(session: Session, multiplexerOverride: MultiplexerInfo?) -> MultiplexerFocusStrategy? {
+    guard let mux = multiplexerOverride ?? session.terminal?.multiplexer else { return nil }
+    switch mux {
+    case .cmux(let socket, let workspaceId, let surfaceId, let paneId, let binaryPath):
+        if cmuxNavigationURL(workspaceId: workspaceId, surfaceId: surfaceId, paneId: paneId) != nil {
+            return nil
+        }
+        guard let binaryPath,
+              cmuxFocusArguments(socket: socket, workspaceId: workspaceId, surfaceId: surfaceId, paneId: paneId) != nil
+        else { return nil }
+        return .cmux(
+            socket: socket,
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            paneId: paneId,
+            binaryPath: binaryPath
+        )
+    case .zellij(let sessionName, let paneId, let binaryPath):
+        guard let binaryPath else { return nil }
+        return .zellij(sessionName: sessionName, paneId: paneId, binaryPath: binaryPath)
+    case .tmux(let socket, let paneId, let binaryPath):
+        guard let binaryPath else { return nil }
+        return .tmux(socket: socket, paneId: paneId, binaryPath: binaryPath)
+    }
+}
+
+// Failures are silently ignored — the emulator was already focused,
+// which is better than nothing.
+func executeMultiplexerFocus(_ strategy: MultiplexerFocusStrategy) {
+    switch strategy {
+    case .cmux(let socket, let workspaceId, let surfaceId, let paneId, let binaryPath):
+        executeCmuxFocus(
+            binaryPath: binaryPath, socket: socket, workspaceId: workspaceId,
+            surfaceId: surfaceId, paneId: paneId
+        )
+    case .zellij(let sessionName, let paneId, let binaryPath):
+        executeZellijFocus(binaryPath: binaryPath, sessionName: sessionName, paneId: paneId)
+    case .tmux(let socket, let paneId, let binaryPath):
+        executeTmuxFocus(binaryPath: binaryPath, socket: socket, paneId: paneId)
+    }
+}
+
+// https://zellij.dev/documentation/controlling-zellij-through-cli
+private func executeZellijFocus(binaryPath: String, sessionName: String, paneId: String) {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: binaryPath)
+    process.arguments = ["--session", sessionName, "action", "focus-pane-id", paneId]
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    do {
+        try process.run()
+        process.waitUntilExit()
+    } catch {}
+}
+
+// https://man.openbsd.org/tmux.1
+// select-window switches to the window containing the pane;
+// select-pane then activates the specific pane within that window.
+private func executeTmuxFocus(binaryPath: String, socket: String, paneId: String) {
+    for cmd in [["select-window", "-t", paneId], ["select-pane", "-t", paneId]] {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binaryPath)
+        process.arguments = ["-S", socket] + cmd
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {}
+    }
+}

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -27,16 +27,29 @@ enum FocusStrategy: Equatable {
 /// Resolve which strategy to use for jumping to a session.
 /// Pure function — no AppKit side effects, fully testable.
 func resolveFocusStrategy(session: Session) -> FocusStrategy {
+    resolveFocusStrategy(session: session, multiplexerOverride: nil)
+}
+
+/// Resolve which strategy to use for jumping to a session, optionally using
+/// freshly resolved multiplexer metadata for legacy live sessions.
+/// Pure function — no AppKit side effects, fully testable.
+func resolveFocusStrategy(session: Session, multiplexerOverride: MultiplexerInfo?) -> FocusStrategy {
     guard let terminal = session.terminal else {
         return .openInFinder(session.projectPath)
     }
+    let multiplexer = multiplexerOverride ?? terminal.multiplexer
 
     // Prefer trusted bundle_id (from __CFBundleIdentifier) over program name: it
     // identifies VS Code forks that all set TERM_PROGRAM=vscode. Explicit non-desktop
     // harnesses ignore leaked AI desktop bundle IDs before this fallback.
     let hostApp = session.trustedHostApp
-        ?? HostApp.from(editorName: terminal.program)
+        ?? (multiplexer?.isCmux == true ? .cmux : HostApp.from(editorName: terminal.program))
     let target = session.workspaceFile ?? session.projectPath
+
+    if hostApp == .cmux,
+       let url = cmuxNavigationURL(multiplexer: multiplexer) {
+        return .openURL(url)
+    }
 
     // Falls through to bundle-ID activation below if the session ID isn't a
     // valid UUID, so the user still gets the app focused.
@@ -92,35 +105,12 @@ func resolveFocusStrategy(session: Session) -> FocusStrategy {
     return .openInFinder(session.projectPath)
 }
 
-// MARK: - Multiplexer focus (independent of emulator focus)
-
-/// Describes how to focus a specific pane inside a terminal multiplexer.
-enum MultiplexerFocusStrategy: Equatable {
-    /// zellij --session $sessionName action focus-pane-id $paneId
-    case zellij(sessionName: String, paneId: String, binaryPath: String)
-    /// tmux -S $socket select-window -t $paneId && tmux -S $socket select-pane -t $paneId
-    case tmux(socket: String, paneId: String, binaryPath: String)
-}
-
-/// Resolve multiplexer focus from session info. Returns nil when no multiplexer is present.
-/// Pure function — no side effects, fully testable.
-func resolveMultiplexerFocus(session: Session) -> MultiplexerFocusStrategy? {
-    guard let mux = session.terminal?.multiplexer else { return nil }
-    switch mux {
-    case .zellij(let sessionName, let paneId, let binaryPath):
-        guard let binaryPath else { return nil }
-        return .zellij(sessionName: sessionName, paneId: paneId, binaryPath: binaryPath)
-    case .tmux(let socket, let paneId, let binaryPath):
-        guard let binaryPath else { return nil }
-        return .tmux(socket: socket, paneId: paneId, binaryPath: binaryPath)
-    }
-}
-
 // MARK: - Execution (AppKit side effects)
 
 func focusTerminal(session: Session) {
-    let strategy = resolveFocusStrategy(session: session)
-    let muxStrategy = resolveMultiplexerFocus(session: session)
+    let multiplexerOverride = resolveCmuxLiveMultiplexer(session: session)
+    let strategy = resolveFocusStrategy(session: session, multiplexerOverride: multiplexerOverride)
+    let muxStrategy = resolveMultiplexerFocus(session: session, multiplexerOverride: multiplexerOverride)
     if case .ghostty(let cwd) = strategy, let tty = session.terminal?.tty {
         primeGhosttyCWD(tty: tty, workingDirectory: cwd)
     }
@@ -414,47 +404,4 @@ private func activateAppByName(_ program: String) -> Bool {
     }
     app.activate()
     return true
-}
-
-// MARK: - Multiplexer focus execution
-// Failures are silently ignored — the emulator was already focused,
-// which is better than nothing.
-
-private func executeMultiplexerFocus(_ strategy: MultiplexerFocusStrategy) {
-    switch strategy {
-    case .zellij(let sessionName, let paneId, let binaryPath):
-        executeZellijFocus(binaryPath: binaryPath, sessionName: sessionName, paneId: paneId)
-    case .tmux(let socket, let paneId, let binaryPath):
-        executeTmuxFocus(binaryPath: binaryPath, socket: socket, paneId: paneId)
-    }
-}
-
-// https://zellij.dev/documentation/controlling-zellij-through-cli
-private func executeZellijFocus(binaryPath: String, sessionName: String, paneId: String) {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: binaryPath)
-    process.arguments = ["--session", sessionName, "action", "focus-pane-id", paneId]
-    process.standardOutput = FileHandle.nullDevice
-    process.standardError = FileHandle.nullDevice
-    do {
-        try process.run()
-        process.waitUntilExit()
-    } catch {}
-}
-
-// https://man.openbsd.org/tmux.1
-// select-window switches to the window containing the pane;
-// select-pane then activates the specific pane within that window.
-private func executeTmuxFocus(binaryPath: String, socket: String, paneId: String) {
-    for cmd in [["select-window", "-t", paneId], ["select-pane", "-t", paneId]] {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: binaryPath)
-        process.arguments = ["-S", socket] + cmd
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        do {
-            try process.run()
-            process.waitUntilExit()
-        } catch {}
-    }
 }

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -112,6 +112,15 @@ final class HookHandlerTests: XCTestCase {
         return String(decoding: data, as: UTF8.self)
     }
 
+    private func makeExecutable(named name: String) throws -> String {
+        let directory = (logsDir as NSString).appendingPathComponent("bin-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+        let path = (directory as NSString).appendingPathComponent(name)
+        try "#!/bin/sh\nexit 0\n".write(toFile: path, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
+        return path
+    }
+
     // MARK: - Shared host app bundle IDs
 
     func testDesktopBundleIDsAreSharedWithHostApp() {
@@ -138,6 +147,51 @@ final class HookHandlerTests: XCTestCase {
 
         XCTAssertEqual(session.createdByHookVersion, Config.hookVersion)
         XCTAssertEqual(session.lastWrittenByHookVersion, Config.hookVersion)
+    }
+
+    func testSessionStartCapturesCmuxMultiplexerContext() throws {
+        let cmuxPath = try makeExecutable(named: "cmux")
+        let env = [
+            "TERM_PROGRAM": "ghostty",
+            "__CFBundleIdentifier": "com.cmuxterm.app",
+            "CMUX_SOCKET_PATH": "/tmp/cmux.sock",
+            "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+            "CMUX_SURFACE_ID": "22222222-2222-2222-2222-222222222222",
+            "CMUX_PANE_ID": "pane:3",
+            "PATH": (cmuxPath as NSString).deletingLastPathComponent
+        ]
+
+        try handleFixture("SessionStart", deps: makeDeps(env: env))
+        let session = try loadSession()
+
+        XCTAssertEqual(session.terminal?.program, "ghostty")
+        XCTAssertEqual(session.terminal?.bundleId, "com.cmuxterm.app")
+        XCTAssertEqual(
+            session.terminal?.multiplexer,
+            .cmux(
+                socket: "/tmp/cmux.sock",
+                workspaceId: "11111111-1111-1111-1111-111111111111",
+                surfaceId: "22222222-2222-2222-2222-222222222222",
+                paneId: "pane:3",
+                binaryPath: cmuxPath
+            )
+        )
+    }
+
+    func testSessionStartDoesNotTreatCmuxPanelIdAsSurfaceId() throws {
+        let cmuxPath = try makeExecutable(named: "cmux")
+        let env = [
+            "CMUX_SOCKET_PATH": "/tmp/cmux.sock",
+            "CMUX_WORKSPACE_ID": "workspace:1",
+            "CMUX_SURFACE_ID": "",
+            "CMUX_PANEL_ID": "surface:2",
+            "PATH": (cmuxPath as NSString).deletingLastPathComponent
+        ]
+
+        try handleFixture("SessionStart", deps: makeDeps(env: env))
+        let session = try loadSession()
+
+        XCTAssertNil(session.terminal?.multiplexer)
     }
 
     func testCurrentHookUpdateDoesNotBackfillLegacyCreatedByVersion() throws {

--- a/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
+++ b/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
@@ -3,7 +3,146 @@ import XCTest
 
 final class MultiplexerFocusTests: XCTestCase {
 
+    private let workspaceUUID = "11111111-1111-1111-1111-111111111111"
+    private let surfaceUUID = "22222222-2222-2222-2222-222222222222"
+    private let paneUUID = "33333333-3333-3333-3333-333333333333"
+
     // MARK: - resolveMultiplexerFocus
+
+    func testCmuxUUIDSurfaceUsesNavigationURL() {
+        let session = Session.mock(
+            terminal: TerminalInfo(
+                program: "ghostty",
+                multiplexer: .cmux(
+                    socket: "/tmp/cmux.sock",
+                    workspaceId: workspaceUUID,
+                    surfaceId: surfaceUUID,
+                    paneId: nil,
+                    binaryPath: "/usr/local/bin/cmux"
+                )
+            )
+        )
+        let expectedURL = URL(string: "cmux://workspace/\(workspaceUUID)/surface/\(surfaceUUID)")!
+
+        XCTAssertEqual(
+            cmuxNavigationURL(multiplexer: session.terminal?.multiplexer),
+            expectedURL
+        )
+        XCTAssertEqual(resolveFocusStrategy(session: session), .openURL(expectedURL))
+        XCTAssertNil(resolveMultiplexerFocus(session: session))
+    }
+
+    func testCmuxUUIDPaneUsesNavigationURL() {
+        let session = Session.mock(
+            terminal: TerminalInfo(
+                program: "ghostty",
+                multiplexer: .cmux(
+                    socket: "/tmp/cmux.sock",
+                    workspaceId: workspaceUUID,
+                    surfaceId: nil,
+                    paneId: paneUUID,
+                    binaryPath: "/usr/local/bin/cmux"
+                )
+            )
+        )
+        let expectedURL = URL(string: "cmux://workspace/\(workspaceUUID)/pane/\(paneUUID)")!
+
+        XCTAssertEqual(
+            cmuxNavigationURL(multiplexer: session.terminal?.multiplexer),
+            expectedURL
+        )
+        XCTAssertEqual(resolveFocusStrategy(session: session), .openURL(expectedURL))
+        XCTAssertNil(resolveMultiplexerFocus(session: session))
+    }
+
+    func testCmuxReturnsSurfaceCliFallbackForReferenceIds() {
+        let session = Session.mock(
+            terminal: TerminalInfo(
+                program: "ghostty",
+                multiplexer: .cmux(
+                    socket: "/tmp/cmux.sock",
+                    workspaceId: "workspace:1",
+                    surfaceId: "surface:2",
+                    paneId: nil,
+                    binaryPath: "/usr/local/bin/cmux"
+                )
+            )
+        )
+
+        XCTAssertNil(cmuxNavigationURL(multiplexer: session.terminal?.multiplexer))
+        XCTAssertEqual(
+            resolveMultiplexerFocus(session: session),
+            .cmux(
+                socket: "/tmp/cmux.sock",
+                workspaceId: "workspace:1",
+                surfaceId: "surface:2",
+                paneId: nil,
+                binaryPath: "/usr/local/bin/cmux"
+            )
+        )
+    }
+
+    func testCmuxReferencePaneWithoutSurfaceReturnsNil() {
+        let session = Session.mock(
+            terminal: TerminalInfo(
+                program: "ghostty",
+                multiplexer: .cmux(
+                    socket: "/tmp/cmux.sock",
+                    workspaceId: "workspace:1",
+                    surfaceId: nil,
+                    paneId: "pane:2",
+                    binaryPath: "/usr/local/bin/cmux"
+                )
+            )
+        )
+        XCTAssertNil(cmuxNavigationURL(multiplexer: session.terminal?.multiplexer))
+        XCTAssertNil(resolveMultiplexerFocus(session: session))
+    }
+
+    func testLegacyCmuxSessionUsesLiveProcessEnvironmentForNavigationURL() {
+        let session = Session.mock(
+            project: "irb",
+            pid: 5079,
+            terminal: TerminalInfo(
+                program: "ghostty",
+                tty: "/dev/ttys010",
+                bundleId: "com.cmuxterm.app"
+            )
+        )
+        let env = [
+            "CMUX_SOCKET_PATH": "/Users/test/.local/state/cmux/cmux.sock",
+            "CMUX_WORKSPACE_ID": workspaceUUID,
+            "CMUX_SURFACE_ID": surfaceUUID,
+            "CMUX_BUNDLED_CLI_PATH": "/bin/echo"
+        ]
+        let multiplexer = resolveCmuxLiveMultiplexer(session: session) { pid in
+            XCTAssertEqual(pid, 5079)
+            return env
+        }
+        let expectedURL = URL(string: "cmux://workspace/\(workspaceUUID)/surface/\(surfaceUUID)")!
+
+        XCTAssertEqual(cmuxNavigationURL(multiplexer: multiplexer), expectedURL)
+        XCTAssertEqual(
+            resolveFocusStrategy(session: session, multiplexerOverride: multiplexer),
+            .openURL(expectedURL)
+        )
+        XCTAssertNil(resolveMultiplexerFocus(session: session, multiplexerOverride: multiplexer))
+    }
+
+    func testCmuxEnvironmentExtractionParsesProcessEnvironment() {
+        let psOutput = """
+        PID TT STAT COMMAND
+        5079 s010 S+ claude CMUX_SOCKET_PATH=/Users/test/.local/state/cmux/cmux.sock \
+        CMUX_WORKSPACE_ID=\(workspaceUUID) CMUX_SURFACE_ID=\(surfaceUUID) \
+        CMUX_BUNDLED_CLI_PATH=/Applications/cmux.app/Contents/Resources/bin/cmux GIT_EDITOR=code --wait
+        """
+        let env = extractCmuxEnvironment(from: psOutput)
+
+        XCTAssertEqual(env["CMUX_SOCKET_PATH"], "/Users/test/.local/state/cmux/cmux.sock")
+        XCTAssertEqual(env["CMUX_WORKSPACE_ID"], workspaceUUID)
+        XCTAssertEqual(env["CMUX_SURFACE_ID"], surfaceUUID)
+        XCTAssertEqual(env["CMUX_BUNDLED_CLI_PATH"], "/Applications/cmux.app/Contents/Resources/bin/cmux")
+    }
 
     func testZellijReturnsStrategy() {
         let session = Session.mock(
@@ -41,6 +180,23 @@ final class MultiplexerFocusTests: XCTestCase {
         XCTAssertNil(strategy)
     }
 
+    func testCmuxWithoutSurfaceOrPaneReturnsNil() {
+        let session = Session.mock(
+            terminal: TerminalInfo(
+                program: "ghostty",
+                multiplexer: .cmux(
+                    socket: "/tmp/cmux.sock",
+                    workspaceId: "workspace:1",
+                    surfaceId: nil,
+                    paneId: nil,
+                    binaryPath: "/usr/local/bin/cmux"
+                )
+            )
+        )
+        let strategy = resolveMultiplexerFocus(session: session)
+        XCTAssertNil(strategy)
+    }
+
     func testNoMultiplexerReturnsNil() {
         let session = Session.mock(
             terminal: TerminalInfo(program: "Ghostty")
@@ -55,7 +211,50 @@ final class MultiplexerFocusTests: XCTestCase {
         XCTAssertNil(strategy)
     }
 
+    // MARK: - cmux CLI fallback arguments
+
+    func testCmuxFocusArgumentsUseDocumentedSurfaceCommand() {
+        XCTAssertEqual(
+            cmuxFocusArguments(
+                socket: "/tmp/cmux.sock",
+                workspaceId: "workspace:1",
+                surfaceId: "surface:2",
+                paneId: nil
+            ),
+            [
+                "--socket", "/tmp/cmux.sock",
+                "focus-surface",
+                "--workspace", "workspace:1",
+                "--surface", "surface:2"
+            ]
+        )
+    }
+
+    func testCmuxFocusArgumentsRequireSurfaceId() {
+        XCTAssertNil(
+            cmuxFocusArguments(
+                socket: "/tmp/cmux.sock",
+                workspaceId: "workspace:1",
+                surfaceId: nil,
+                paneId: "pane:2"
+            )
+        )
+    }
+
     // MARK: - MultiplexerInfo Codable round-trip
+
+    func testCmuxCodableRoundTrip() throws {
+        let info = MultiplexerInfo.cmux(
+            socket: "/tmp/cmux.sock",
+            workspaceId: "workspace:1",
+            surfaceId: "surface:2",
+            paneId: "pane:3",
+            binaryPath: "/usr/local/bin/cmux"
+        )
+        let data = try JSONEncoder().encode(info)
+        let decoded = try JSONDecoder().decode(MultiplexerInfo.self, from: data)
+        XCTAssertEqual(decoded, info)
+    }
 
     func testZellijCodableRoundTrip() throws {
         let info = MultiplexerInfo.zellij(sessionName: "amzn", paneId: "42", binaryPath: "/usr/bin/zellij")
@@ -72,10 +271,35 @@ final class MultiplexerFocusTests: XCTestCase {
     }
 
     func testNilBinaryPathCodableRoundTrip() throws {
-        let info = MultiplexerInfo.zellij(sessionName: "dev", paneId: "1", binaryPath: nil)
+        let info = MultiplexerInfo.cmux(
+            socket: "/tmp/cmux.sock",
+            workspaceId: "workspace:1",
+            surfaceId: "surface:2",
+            paneId: nil,
+            binaryPath: nil
+        )
         let data = try JSONEncoder().encode(info)
         let decoded = try JSONDecoder().decode(MultiplexerInfo.self, from: data)
         XCTAssertEqual(decoded, info)
+    }
+
+    func testCmuxJSONShape() throws {
+        let info = MultiplexerInfo.cmux(
+            socket: "/tmp/cmux.sock",
+            workspaceId: "workspace:1",
+            surfaceId: "surface:2",
+            paneId: "pane:3",
+            binaryPath: "/usr/local/bin/cmux"
+        )
+        let data = try JSONEncoder().encode(info)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: String]
+        XCTAssertEqual(json?["name"], "cmux")
+        XCTAssertEqual(json?["socket"], "/tmp/cmux.sock")
+        XCTAssertEqual(json?["workspace_id"], "workspace:1")
+        XCTAssertEqual(json?["surface_id"], "surface:2")
+        XCTAssertEqual(json?["pane_id"], "pane:3")
+        XCTAssertEqual(json?["binary_path"], "/usr/local/bin/cmux")
+        XCTAssertNil(json?["session_name"])
     }
 
     func testZellijJSONShape() throws {
@@ -122,5 +346,24 @@ final class MultiplexerFocusTests: XCTestCase {
 
         let muxStrategy = resolveMultiplexerFocus(session: session)
         XCTAssertEqual(muxStrategy, .zellij(sessionName: "dev", paneId: "terminal_1", binaryPath: "/usr/bin/zellij"))
+    }
+
+    func testCmuxMultiplexerResolvesCmuxHostDespiteGhosttyProgram() {
+        let session = Session.mock(
+            terminal: TerminalInfo(
+                program: "ghostty",
+                multiplexer: .cmux(
+                    socket: "/tmp/cmux.sock",
+                    workspaceId: "workspace:1",
+                    surfaceId: "surface:2",
+                    paneId: nil,
+                    binaryPath: "/usr/local/bin/cmux"
+                )
+            )
+        )
+
+        let emulatorStrategy = resolveFocusStrategy(session: session)
+
+        XCTAssertEqual(emulatorStrategy, .activateByName("cmux"))
     }
 }

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -749,6 +749,24 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(Session.mock(terminal: term).hostClass, .terminal)
     }
 
+    func testHostClassCmuxWithoutBundleIdIsTerminal() {
+        let term = TerminalInfo(
+            multiplexer: .cmux(
+                socket: "/tmp/cmux.sock",
+                workspaceId: "workspace:1",
+                surfaceId: "surface:2",
+                paneId: nil,
+                binaryPath: nil
+            )
+        )
+        XCTAssertEqual(Session.mock(terminal: term).hostClass, .terminal)
+    }
+
+    func testHostClassCmuxBundleIdIsTerminal() {
+        let term = TerminalInfo(bundleId: "com.cmuxterm.app")
+        XCTAssertEqual(Session.mock(terminal: term).hostClass, .terminal)
+    }
+
     // tty alone is NOT hard evidence — it can be env-copied (env["TTY"]) and inherited by GUI children.
     func testHostClassTtyOnlyIsAmbiguous() {
         let term = TerminalInfo(tty: "/dev/ttys003")

--- a/site/index.html
+++ b/site/index.html
@@ -542,6 +542,7 @@
         </div>
         <div class="chips">
           <span class="chip">iTerm2</span>
+          <span class="chip">cmux<sup>&sect;</sup></span>
           <span class="chip">Kitty<sup>*</sup></span>
           <span class="chip">Ghostty<sup>&dagger;</sup></span>
           <span class="chip">Terminal<sup>&Dagger;</sup></span>
@@ -574,6 +575,8 @@
       </div>
       <p class="tier-footnote" style="font-size:.85rem;color:var(--c-muted);margin-top:8px">
         *&thinsp;Kitty targets the exact window when <a href="https://sw.kovidgoyal.net/kitty/remote-control/" target="_blank" rel="noopener noreferrer"><code>remote control</code></a> is enabled in kitty.conf. Without it, falls back to app activation.
+        <br>
+        &sect;&thinsp;cmux targets the exact workspace surface using <a href="https://cmux.com/docs/api" target="_blank" rel="noopener noreferrer">workspace and surface IDs</a> from stored session data or the live cmux process, so already-running sessions can jump correctly without restart.
         <br>
         &dagger;&thinsp;Ghostty 1.3.0+ targets a terminal by working directory via AppleScript. Ambiguous if multiple Ghostty splits share the same cwd; falls back to app activation otherwise.
         <br>


### PR DESCRIPTION
## Problem

- cmux exposes socket/workspace/surface context and supports focusing surfaces, but cctop's multiplexer model and focus resolver only handled Zellij and tmux, so a cmux-hosted session could fall back to app or Ghostty activation instead of selecting the requested cmux surface. Sources: [cmux socket API](https://manaflow-ai-cmux.mintlify.app/automation/socket-api), [cmux navigation URL parser](https://github.com/manaflow-ai/cmux/blob/main/Sources/CmuxSSHURLRequest.swift#L2961-L3129), [previous cctop multiplexer resolver](https://github.com/st0012/cctop/blob/ceb6da90e1efa48cd5bc75f78a09b656716255e3/menubar/CctopMenubar/Services/FocusTerminal.swift#L95-L117).
- Already-running cmux sessions can have `CMUX_*` metadata in the live process even when their persisted session JSON lacks `terminal.multiplexer`, so relying only on persisted multiplexer metadata leaves those sessions without an exact surface target. Sources: [cmux `CMUX_SOCKET_PATH` docs](https://manaflow-ai-cmux.mintlify.app/automation/socket-api#socket-path), [new live metadata fallback](https://github.com/st0012/cctop/blob/7abc2425f0e63964c4098d3609dffb48403f78ad/menubar/CctopMenubar/Services/FocusTerminal%2BCmux.swift#L42-L80).

## Solution

- Add a `cmux` multiplexer shape and capture `CMUX_SOCKET_PATH`, `CMUX_WORKSPACE_ID`, `CMUX_SURFACE_ID`, and optional pane/binary metadata in hook-written terminal state. Sources: [MultiplexerInfo cmux schema](https://github.com/st0012/cctop/blob/7abc2425f0e63964c4098d3609dffb48403f78ad/menubar/CctopMenubar/Models/Session.swift#L93-L175), [hook capture](https://github.com/st0012/cctop/blob/7abc2425f0e63964c4098d3609dffb48403f78ad/menubar/CctopMenubar/Hook/HookHandler.swift#L304-L330), [cmux socket API](https://manaflow-ai-cmux.mintlify.app/automation/socket-api#socket-path).
- Focus cmux sessions with a `cmux://workspace/.../surface/...` or `cmux://workspace/.../pane/...` URL when UUID IDs are available, and keep the CLI `focus-surface` fallback for reference-style IDs. Sources: [cmux URL support](https://github.com/manaflow-ai/cmux/blob/main/Sources/CmuxSSHURLRequest.swift#L2961-L3129), [cctop cmux URL and CLI focus code](https://github.com/st0012/cctop/blob/7abc2425f0e63964c4098d3609dffb48403f78ad/menubar/CctopMenubar/Services/FocusTerminal%2BCmux.swift#L15-L40).
- Recover cmux workspace/surface metadata from the live process only when persisted `terminal.multiplexer` is missing, preserving the normal stored-metadata path for newly written sessions. Sources: [live fallback guard](https://github.com/st0012/cctop/blob/7abc2425f0e63964c4098d3609dffb48403f78ad/menubar/CctopMenubar/Services/FocusTerminal%2BCmux.swift#L42-L80), [multiplexer focus resolver](https://github.com/st0012/cctop/blob/7abc2425f0e63964c4098d3609dffb48403f78ad/menubar/CctopMenubar/Services/FocusTerminal%2BMultiplexer.swift#L13-L60).
- Document cmux focus behavior in the README, official site, and session-file schema docs. Sources: [README support table](https://github.com/st0012/cctop/blob/7abc2425f0e63964c4098d3609dffb48403f78ad/README.md#L58-L104), [site support copy](https://github.com/st0012/cctop/blob/7abc2425f0e63964c4098d3609dffb48403f78ad/site/index.html#L535-L585), [session-file docs](https://github.com/st0012/cctop/blob/7abc2425f0e63964c4098d3609dffb48403f78ad/docs/session-files.md#L7-L53).

## Verification

- Ran `make all`, which covers SwiftLint, hook contract validation, Debug builds for the menubar app and hook target, opencode plugin tests, and the Swift test suite. Source: [Makefile `all` target](https://github.com/st0012/cctop/blob/7abc2425f0e63964c4098d3609dffb48403f78ad/Makefile#L5-L27).