### PR TITLE
Reopen panel on active Space

### DIFF
--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -86,8 +86,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     @MainActor private func registerShortcuts() {
         KeyboardShortcuts.onKeyUp(for: .togglePanel) { [weak self] in self?.togglePanel() }
         KeyboardShortcuts.onKeyUp(for: .navigate) { [weak self] in
-            self?.focusLocation = NSEvent.mouseLocation
-            self?.handleEvent(.navigateShortcut)
+            guard let self else { return }
+            self.focusLocation = NSEvent.mouseLocation
+            self.handleEvent(.navigateShortcut(panelVisibleInActiveSpace: self.panelVisibleInActiveSpace))
         }
         navigateController.didConfirmSubject
             .receive(on: RunLoop.main)
@@ -188,7 +189,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             return clickKey != currentKey
         }()
 
-        handleEvent(.menubarIconClicked(appIsActive: NSApp.isActive, onDifferentScreen: onDifferentScreen))
+        handleEvent(.menubarIconClicked(
+            appIsActive: NSApp.isActive,
+            onDifferentScreen: onDifferentScreen,
+            panelVisibleInActiveSpace: panelVisibleInActiveSpace
+        ))
+    }
+
+    @MainActor private var panelVisibleInActiveSpace: Bool {
+        panel.isVisible && panel.isOnActiveSpace
     }
 
     /// Whether the status item is hidden behind the notch.

--- a/menubar/CctopMenubar/FloatingPanel.swift
+++ b/menubar/CctopMenubar/FloatingPanel.swift
@@ -9,7 +9,7 @@ class FloatingPanel: NSPanel {
     weak var panelDelegate: FloatingPanelDelegate?
     /// Height of the header drag zone (matches HeaderView padding + content).
     private let headerDragHeight: CGFloat = 44
-    static let defaultCollectionBehavior: NSWindow.CollectionBehavior = [.moveToActiveSpace]
+    static let defaultCollectionBehavior: NSWindow.CollectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
 
     enum HeaderClickAction: Equatable {
         case resetPosition

--- a/menubar/CctopMenubar/FloatingPanel.swift
+++ b/menubar/CctopMenubar/FloatingPanel.swift
@@ -9,6 +9,7 @@ class FloatingPanel: NSPanel {
     weak var panelDelegate: FloatingPanelDelegate?
     /// Height of the header drag zone (matches HeaderView padding + content).
     private let headerDragHeight: CGFloat = 44
+    static let defaultCollectionBehavior: NSWindow.CollectionBehavior = [.moveToActiveSpace]
 
     enum HeaderClickAction: Equatable {
         case resetPosition
@@ -52,6 +53,7 @@ class FloatingPanel: NSPanel {
         hidesOnDeactivate = false
         isMovableByWindowBackground = false
         animationBehavior = .utilityWindow
+        collectionBehavior = Self.defaultCollectionBehavior
     }
 
     override var canBecomeKey: Bool { true }

--- a/menubar/CctopMenubar/Services/PanelCoordinator.swift
+++ b/menubar/CctopMenubar/Services/PanelCoordinator.swift
@@ -20,10 +20,14 @@ struct PanelState: Equatable {
 // MARK: - Events & Actions
 
 enum PanelEvent {
-    case menubarIconClicked(appIsActive: Bool, onDifferentScreen: Bool = false)
+    case menubarIconClicked(
+        appIsActive: Bool,
+        onDifferentScreen: Bool = false,
+        panelVisibleInActiveSpace: Bool = true
+    )
     case escape
     case appLostFocus
-    case navigateShortcut
+    case navigateShortcut(panelVisibleInActiveSpace: Bool = true)
     case navigateConfirmed
     case navigateTimedOut
     case navKey(PanelNavAction)
@@ -87,13 +91,32 @@ struct PanelCoordinator {
 
         // MARK: normal
 
-        case (.normal, .menubarIconClicked(_, onDifferentScreen: true)):
+        case (.normal, .menubarIconClicked(
+            appIsActive: _,
+            onDifferentScreen: _,
+            panelVisibleInActiveSpace: false
+        )):
+            return Result(
+                state: PanelState(mode: .normal),
+                actions: [.captureApps, .showPanel, .activateApp, .startNavKeyMonitor,
+                          .postNavAction(.reset)]
+            )
+
+        case (.normal, .menubarIconClicked(
+            appIsActive: _,
+            onDifferentScreen: true,
+            panelVisibleInActiveSpace: true
+        )):
             return Result(
                 state: PanelState(mode: .normal),
                 actions: [.positionPanel, .activateApp]
             )
 
-        case (.normal, .menubarIconClicked(let appIsActive, onDifferentScreen: false)):
+        case (.normal, .menubarIconClicked(
+            appIsActive: let appIsActive,
+            onDifferentScreen: false,
+            panelVisibleInActiveSpace: true
+        )):
             var actions: [PanelAction] = [.dismissPanel]
             if appIsActive { actions.append(.restorePreviousApp) }
             return Result(
@@ -107,7 +130,15 @@ struct PanelCoordinator {
         case (.normal, .appLostFocus):
             return Result(state: state, actions: [])
 
-        case (.normal, .navigateShortcut):
+        case (.normal, .navigateShortcut(panelVisibleInActiveSpace: false)):
+            let mode: PanelMode = .navigate(origin: NavigateOrigin(panelWasClosed: true))
+            return Result(
+                state: PanelState(mode: mode),
+                actions: [.showPanel, .activateApp, .startNavKeyMonitor,
+                          .startNavigateMode(panelWasClosed: true)]
+            )
+
+        case (.normal, .navigateShortcut(panelVisibleInActiveSpace: true)):
             let mode: PanelMode = .navigate(origin: NavigateOrigin(panelWasClosed: false))
             return Result(
                 state: PanelState(mode: mode),
@@ -122,7 +153,11 @@ struct PanelCoordinator {
 
         // MARK: navigate
 
-        case (.navigate, .menubarIconClicked(_, onDifferentScreen: true)):
+        case (.navigate, .menubarIconClicked(
+            appIsActive: _,
+            onDifferentScreen: true,
+            panelVisibleInActiveSpace: _
+        )):
             if case .navigate(let origin) = state.mode, !origin.panelWasClosed {
                 return Result(
                     state: PanelState(mode: .normal),

--- a/menubar/CctopMenubarTests/PanelCoordinatorTests.swift
+++ b/menubar/CctopMenubarTests/PanelCoordinatorTests.swift
@@ -21,7 +21,7 @@ final class PanelCoordinatorTests: XCTestCase {
     }
 
     func testHidden_navigateShortcut() {
-        let r = handle(.navigateShortcut, mode: .hidden)
+        let r = handle(.navigateShortcut(), mode: .hidden)
         if case .navigate(let origin) = r.state.mode {
             XCTAssertTrue(origin.panelWasClosed)
         } else {
@@ -68,6 +68,23 @@ final class PanelCoordinatorTests: XCTestCase {
         XCTAssertTrue(r.actions.contains(.dismissPanel))
     }
 
+    func testNormal_menubarClickWhenPanelIsNotVisibleOnActiveSpace_showsInsteadOfDismissing() {
+        let r = handle(
+            .menubarIconClicked(
+                appIsActive: false,
+                onDifferentScreen: false,
+                panelVisibleInActiveSpace: false
+            ),
+            mode: .normal
+        )
+
+        XCTAssertEqual(r.state.mode, .normal)
+        XCTAssertTrue(r.actions.contains(.showPanel))
+        XCTAssertTrue(r.actions.contains(.activateApp))
+        XCTAssertTrue(r.actions.contains(.captureApps))
+        XCTAssertFalse(r.actions.contains(.dismissPanel))
+    }
+
     func testNormal_escape_postsEscapeAction() {
         let r = handle(.escape, mode: .normal)
         XCTAssertEqual(r.state.mode, .normal)
@@ -81,13 +98,28 @@ final class PanelCoordinatorTests: XCTestCase {
     }
 
     func testNormal_navigateShortcut() {
-        let r = handle(.navigateShortcut, mode: .normal)
+        let r = handle(.navigateShortcut(), mode: .normal)
         if case .navigate(let origin) = r.state.mode {
             XCTAssertFalse(origin.panelWasClosed)
         } else {
             XCTFail("Expected navigate mode")
         }
         XCTAssertTrue(r.actions.contains(.startNavigateMode(panelWasClosed: false)))
+    }
+
+    func testNormal_navigateShortcutWhenPanelIsNotVisibleOnActiveSpace_treatsPanelAsClosed() {
+        let r = handle(.navigateShortcut(panelVisibleInActiveSpace: false), mode: .normal)
+
+        if case .navigate(let origin) = r.state.mode {
+            XCTAssertTrue(origin.panelWasClosed)
+        } else {
+            XCTFail("Expected navigate mode")
+        }
+
+        XCTAssertTrue(r.actions.contains(.showPanel))
+        XCTAssertTrue(r.actions.contains(.activateApp))
+        XCTAssertTrue(r.actions.contains(.startNavKeyMonitor))
+        XCTAssertTrue(r.actions.contains(.startNavigateMode(panelWasClosed: true)))
     }
 
     func testNormal_navKey_forwards() {

--- a/menubar/CctopMenubarTests/PanelLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/PanelLifecycleTests.swift
@@ -615,6 +615,11 @@ final class PanelLifecycleTests: XCTestCase {
         XCTAssertFalse(FloatingPanel.shouldPersistDrag(sawDragEvents: false, originMoved: false))
     }
 
+    func testFloatingPanelMovesToActiveSpaceWhenOrderedFront() {
+        XCTAssertTrue(FloatingPanel.defaultCollectionBehavior.contains(.moveToActiveSpace))
+        XCTAssertFalse(FloatingPanel.defaultCollectionBehavior.contains(.canJoinAllSpaces))
+    }
+
     // MARK: - Navigate shortcut opens on mouse screen (regression for #69)
 
     func testNavigateShortcutOpensOnMouseScreen() {

--- a/menubar/CctopMenubarTests/PanelLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/PanelLifecycleTests.swift
@@ -617,6 +617,7 @@ final class PanelLifecycleTests: XCTestCase {
 
     func testFloatingPanelMovesToActiveSpaceWhenOrderedFront() {
         XCTAssertTrue(FloatingPanel.defaultCollectionBehavior.contains(.moveToActiveSpace))
+        XCTAssertTrue(FloatingPanel.defaultCollectionBehavior.contains(.fullScreenAuxiliary))
         XCTAssertFalse(FloatingPanel.defaultCollectionBehavior.contains(.canJoinAllSpaces))
     }
 


### PR DESCRIPTION
## Problem

cctop tracked whether the floating panel was open, but not whether that panel window was visible on the active macOS Space. That left two confusing paths:

1. **Menubar clicks could dismiss instead of reopening.** If the panel was logically open on another Space, clicking the menubar icon on the current Space could take the dismiss path rather than bringing the panel back.
2. **Navigate shortcuts could skip the show path.** The navigate shortcut could treat an off-Space panel as already visible, entering navigation without first showing the panel where the user was working.

The panel also needed to move to the active Space when shown without becoming visible on every Space.

## Solution

- Pass active-Space visibility into the panel coordinator by checking `panel.isVisible && panel.isOnActiveSpace` for both menubar clicks and navigate shortcuts.
- Treat a normal panel that is not visible on the active Space like an open request for clicks, and like a closed-panel navigate request for the shortcut.
- Set the floating panel to move to the active Space when ordered front, while avoiding the all-Spaces behavior that would make it appear everywhere.
