### PR TITLE
Remove dead code: unused archive helpers, preview mock, and convenience init

### DIFF
--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -316,15 +316,6 @@ extension SessionManager {
         }
     }
 
-    /// Batch snapshot for the display path. This mirrors the Codex behavior: archive metadata read
-    /// uncertainty fails OPEN because this path never deletes files.
-    nonisolated static func archivedClaudeDesktopSessionIDs(
-        in sessions: [Session],
-        claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup()
-    ) -> Set<String> {
-        claudeDesktopMetadataSnapshot(in: sessions, claudeDesktopSessions: claudeDesktopSessions)?.archivedSessionIDs ?? []
-    }
-
     nonisolated static func claudeDesktopMetadataSnapshot(
         in sessions: [Session],
         claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup()
@@ -464,16 +455,6 @@ extension SessionManager {
             codexThreads: codexThreads,
             processAlive: processAlive
         )
-    }
-
-    nonisolated static func desktopProjectNamesBySessionID(
-        in sessions: [Session],
-        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup(),
-        claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup()
-    ) -> [String: String] {
-        let claudeSessionIDs = Set(sessions.filter(\.isClaudeDesktopHost).map(\.sessionId))
-        let claudeMetadata = claudeDesktopSessions.metadataSnapshot(matching: claudeSessionIDs)
-        return desktopProjectNamesBySessionID(in: sessions, claudeMetadata: claudeMetadata, codexThreads: codexThreads)
     }
 
     nonisolated static func desktopProjectNamesBySessionID(

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -50,15 +50,6 @@ class SessionManager: ObservableObject {
         }
     }
 
-    convenience init(
-        historyManager: HistoryManager,
-        desktopAppConnectionLookup: DesktopAppConnectionLookup
-    ) {
-        var dataSources = SessionDataSources.live()
-        dataSources.desktopAppConnection = desktopAppConnectionLookup
-        self.init(historyManager: historyManager, dataSources: dataSources)
-    }
-
     func loadSessions() {
         guard let files = try? FileManager.default.contentsOfDirectory(
             at: sessionsDir,

--- a/menubar/CctopMenubar/Views/SettingsSection+Preview.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection+Preview.swift
@@ -8,11 +8,6 @@ private func previewBasePM() -> PluginManager {
 }
 
 @MainActor
-private class MockUpdater: UpdaterBase {
-    override var canCheckForUpdates: Bool { true }
-}
-
-@MainActor
 private func previewPM() -> PluginManager {
     let pm = previewBasePM()
     pm.ccInstalled = true


### PR DESCRIPTION
## Problem

The menubar app still carried a few declarations that looked like live extension points but were not part of the active session-loading, archive, or preview paths. That extra surface made the code harder to scan because some names paralleled the real implementations used by production and tests.

## Solution

- Remove the extra Claude Desktop archive wrapper and desktop-project-name overload so archive and project-name lookup stay on the snapshot-aware paths used by candidate building.
- Remove the preview-only updater subclass now that the settings previews construct the disabled updater directly.
- Remove the convenience `SessionManager` initializer that duplicated the existing data-source injection path used by tests and production setup.
