### PR TITLE
Restore minimized app windows on focus

### DIFF
--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		PVH000010000000000000001 /* PopupViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = PVH000020000000000000001 /* PopupViewHelpers.swift */; };
 		D10000090000000000000001 /* QuitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000000A000000000000001 /* QuitButton.swift */; };
 		E10000010000000000000001 /* FocusTerminal.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000020000000000000001 /* FocusTerminal.swift */; };
+		EAPPRESTORE0010000000001 /* FocusTerminal+AppRestore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAPPRESTORE0020000000001 /* FocusTerminal+AppRestore.swift */; };
 		ECMUX001000000000000001 /* FocusTerminal+Cmux.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECMUX002000000000000001 /* FocusTerminal+Cmux.swift */; };
 		EMUX0010000000000000001 /* FocusTerminal+Multiplexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EMUX0020000000000000001 /* FocusTerminal+Multiplexer.swift */; };
 		EK0000010000000000000001 /* HostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EK0000020000000000000001 /* HostApp.swift */; };
@@ -162,6 +163,7 @@
 		D10000080000000000000001 /* PopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupView.swift; sourceTree = "<group>"; };
 		PVH000020000000000000001 /* PopupViewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupViewHelpers.swift; sourceTree = "<group>"; };
 		E10000020000000000000001 /* FocusTerminal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusTerminal.swift; sourceTree = "<group>"; };
+		EAPPRESTORE0020000000001 /* FocusTerminal+AppRestore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FocusTerminal+AppRestore.swift"; sourceTree = "<group>"; };
 		ECMUX002000000000000001 /* FocusTerminal+Cmux.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FocusTerminal+Cmux.swift"; sourceTree = "<group>"; };
 		EMUX0020000000000000001 /* FocusTerminal+Multiplexer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FocusTerminal+Multiplexer.swift"; sourceTree = "<group>"; };
 		EK0000020000000000000001 /* HostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostApp.swift; sourceTree = "<group>"; };
@@ -300,6 +302,7 @@
 				SML000020000000000000001 /* SessionManager+Loading.swift */,
 				HM0000020000000000000001 /* HistoryManager.swift */,
 				E10000020000000000000001 /* FocusTerminal.swift */,
+				EAPPRESTORE0020000000001 /* FocusTerminal+AppRestore.swift */,
 				ECMUX002000000000000001 /* FocusTerminal+Cmux.swift */,
 				EMUX0020000000000000001 /* FocusTerminal+Multiplexer.swift */,
 				SP0000020000000000000001 /* SparkleUpdater.swift */,
@@ -597,6 +600,7 @@
 				PVH000010000000000000001 /* PopupViewHelpers.swift in Sources */,
 				D10000090000000000000001 /* QuitButton.swift in Sources */,
 				E10000010000000000000001 /* FocusTerminal.swift in Sources */,
+				EAPPRESTORE0010000000001 /* FocusTerminal+AppRestore.swift in Sources */,
 				ECMUX001000000000000001 /* FocusTerminal+Cmux.swift in Sources */,
 				EMUX0010000000000000001 /* FocusTerminal+Multiplexer.swift in Sources */,
 				F10000010000000000000001 /* Session+Mock.swift in Sources */,

--- a/menubar/CctopMenubar/Services/FocusTerminal+AppRestore.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal+AppRestore.swift
@@ -1,0 +1,28 @@
+import AppKit
+
+@discardableResult
+func restoreAndActivate(_ app: NSRunningApplication) -> Bool {
+    if let bundleID = app.bundleIdentifier {
+        restoreAppByBundleID(bundleID)
+    }
+    return app.activate(options: [.activateAllWindows])
+}
+
+private func restoreAppByBundleID(_ bundleID: String) {
+    guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else { return }
+    let configuration = NSWorkspace.OpenConfiguration()
+    configuration.activates = true
+    NSWorkspace.shared.openApplication(at: appURL, configuration: configuration)
+}
+
+func restoreAppAndOpenURL(bundleID: String, url: URL) {
+    guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else {
+        NSWorkspace.shared.open(url)
+        return
+    }
+    let configuration = NSWorkspace.OpenConfiguration()
+    configuration.activates = true
+    NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { _, _ in
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -18,8 +18,8 @@ enum FocusStrategy: Equatable {
     case activateByName(String)
     /// Activate a running app by its bundle identifier.
     case activateByBundleID(String)
-    /// Open an app-specific deep link URL (e.g. claude://resume?session=...).
-    case openURL(URL)
+    /// Open an app-specific deep link URL (e.g. codex://threads/...), optionally restoring the target app first.
+    case openURL(URL, restoreBundleID: String? = nil)
     /// Open a path in Finder.
     case openInFinder(String)
 }
@@ -60,7 +60,7 @@ func resolveFocusStrategy(session: Session, multiplexerOverride: MultiplexerInfo
     // Falls through to bundle-ID activation below if the session ID isn't a
     // valid UUID, so the user still gets the app focused.
     if let url = hostApp.sessionDeepLink(sessionId: session.sessionId) {
-        return .openURL(url)
+        return .openURL(url, restoreBundleID: hostApp.bundleID)
     }
 
     // Editors with a known bundle ID → open the project with that app.
@@ -160,8 +160,12 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
     case .activateByBundleID(let bundleID):
         activateAppByBundleID(bundleID)
 
-    case .openURL(let url):
-        NSWorkspace.shared.open(url)
+    case .openURL(let url, let restoreBundleID):
+        if let restoreBundleID {
+            restoreAppAndOpenURL(bundleID: restoreBundleID, url: url)
+        } else {
+            NSWorkspace.shared.open(url)
+        }
 
     case .openInFinder(let path):
         NSWorkspace.shared.open(URL(fileURLWithPath: path))
@@ -477,8 +481,7 @@ private func activateAppByBundleID(_ bundleID: String) -> Bool {
     }) else {
         return false
     }
-    app.activate()
-    return true
+    return restoreAndActivate(app)
 }
 
 @discardableResult
@@ -488,6 +491,5 @@ private func activateAppByName(_ program: String) -> Bool {
     }) else {
         return false
     }
-    app.activate()
-    return true
+    return restoreAndActivate(app)
 }

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -326,11 +326,12 @@ final class FocusStrategyTests: XCTestCase {
         // Codex's URL handler routes codex://threads/<uuid> to the conversation
         // and rejects anything that's not a canonical UUID — we mirror that check.
         let uuid = "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
+        let bundleID = HostApp.codexDesktop.bundleID!
         let session = makeSession(
-            program: "", bundleId: HostApp.codexDesktop.bundleID!, sessionUuid: uuid
+            program: "", bundleId: bundleID, sessionUuid: uuid
         )
         let strategy = resolveFocusStrategy(session: session)
-        XCTAssertEqual(strategy, .openURL(URL(string: "codex://threads/\(uuid)")!))
+        XCTAssertEqual(strategy, .openURL(URL(string: "codex://threads/\(uuid)")!, restoreBundleID: bundleID))
     }
 
     func testCodexDesktopFallsBackToActivateWhenSessionIdNotUUID() {

--- a/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
+++ b/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
@@ -29,6 +29,11 @@ final class MultiplexerFocusTests: XCTestCase {
             expectedURL
         )
         XCTAssertEqual(resolveFocusStrategy(session: session), .openURL(expectedURL))
+        if case .openURL(_, let restoreBundleID) = resolveFocusStrategy(session: session) {
+            XCTAssertNil(restoreBundleID)
+        } else {
+            XCTFail("Expected cmux navigation URL strategy")
+        }
         XCTAssertNil(resolveMultiplexerFocus(session: session))
     }
 


### PR DESCRIPTION
## Problem

cctop's fallback focus path could activate a desktop host app while leaving its minimized windows minimized. That made a session jump look like it did nothing even though the target app process had been activated.

Codex Desktop focus also needed to preserve the existing `codex://threads/<uuid>` route while restoring the app window first, without changing URL-only focus targets such as cmux.

## Solution

- Add a small app-restore helper that resolves an app bundle, opens it with activation enabled, and asks running apps to activate all windows.
- Extend URL focus strategies with an optional restore bundle ID so Codex Desktop can restore the app before opening the thread URL.
- Keep plain URL focus unchanged when there is no app to restore, preserving the cmux navigation path.
