### PR TITLE
Fix notification permission toggle state

### DIFF
--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -126,6 +126,9 @@
 		CDRP00010000000000000001 /* CodexDesktopRuntimeProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDRP00020000000000000001 /* CodexDesktopRuntimeProbe.swift */; };
 		SMA000010000000000000001 /* SessionManager+Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = SMA000020000000000000001 /* SessionManager+Archive.swift */; };
 		SML000010000000000000001 /* SessionManager+Loading.swift in Sources */ = {isa = PBXBuildFile; fileRef = SML000020000000000000001 /* SessionManager+Loading.swift */; };
+		NPC000010000000000000001 /* NotificationPermissionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = NPC000020000000000000001 /* NotificationPermissionController.swift */; };
+		SCTRL0010000000000000001 /* SettingsControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = SCTRL0020000000000000001 /* SettingsControls.swift */; };
+		NROW00010000000000000001 /* NotificationSettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = NROW00020000000000000001 /* NotificationSettingsRow.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -155,6 +158,7 @@
 		CDRP00020000000000000001 /* CodexDesktopRuntimeProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexDesktopRuntimeProbe.swift; sourceTree = "<group>"; };
 		SMA000020000000000000001 /* SessionManager+Archive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionManager+Archive.swift"; sourceTree = "<group>"; };
 		SML000020000000000000001 /* SessionManager+Loading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionManager+Loading.swift"; sourceTree = "<group>"; };
+		NPC000020000000000000001 /* NotificationPermissionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPermissionController.swift; sourceTree = "<group>"; };
 		D1000000A000000000000001 /* QuitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitButton.swift; sourceTree = "<group>"; };
 		D10000020000000000000001 /* StatusChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusChip.swift; sourceTree = "<group>"; };
 		D10000040000000000000001 /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
@@ -237,6 +241,8 @@
 		STC000020000000000000001 /* StatusColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusColors.swift; sourceTree = "<group>"; };
 		SDP000020000000000000001 /* SessionDisplayPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDisplayPolicy.swift; sourceTree = "<group>"; };
 		SCN000020000000000000001 /* StatusCounts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusCounts.swift; sourceTree = "<group>"; };
+		SCTRL0020000000000000001 /* SettingsControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsControls.swift; sourceTree = "<group>"; };
+		NROW00020000000000000001 /* NotificationSettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsRow.swift; sourceTree = "<group>"; };
 		MRT000020000000000000001 /* MenubarIconRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarIconRendererTests.swift; sourceTree = "<group>"; };
 		SCT000020000000000000001 /* StatusCountsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusCountsTests.swift; sourceTree = "<group>"; };
 		HVT000020000000000000001 /* StatusCountsSessionInitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusCountsSessionInitTests.swift; sourceTree = "<group>"; };
@@ -300,6 +306,7 @@
 				CDRP00020000000000000001 /* CodexDesktopRuntimeProbe.swift */,
 				SMA000020000000000000001 /* SessionManager+Archive.swift */,
 				SML000020000000000000001 /* SessionManager+Loading.swift */,
+				NPC000020000000000000001 /* NotificationPermissionController.swift */,
 				HM0000020000000000000001 /* HistoryManager.swift */,
 				E10000020000000000000001 /* FocusTerminal.swift */,
 				EAPPRESTORE0020000000001 /* FocusTerminal+AppRestore.swift */,
@@ -390,6 +397,8 @@
 				PVH000020000000000000001 /* PopupViewHelpers.swift */,
 				D1000000A000000000000001 /* QuitButton.swift */,
 				J10000020000000000000001 /* SettingsSection.swift */,
+				SCTRL0020000000000000001 /* SettingsControls.swift */,
+				NROW00020000000000000001 /* NotificationSettingsRow.swift */,
 				JSPREV020000000000000001 /* SettingsSection+Preview.swift */,
 				CDXROW020000000000000001 /* CodexPluginRowView.swift */,
 				L10000020000000000000001 /* EmptyStateView.swift */,
@@ -592,6 +601,7 @@
 				CDRP00010000000000000001 /* CodexDesktopRuntimeProbe.swift in Sources */,
 				SMA000010000000000000001 /* SessionManager+Archive.swift in Sources */,
 				SML000010000000000000001 /* SessionManager+Loading.swift in Sources */,
+				NPC000010000000000000001 /* NotificationPermissionController.swift in Sources */,
 				D10000010000000000000001 /* StatusChip.swift in Sources */,
 				D10000030000000000000001 /* HeaderView.swift in Sources */,
 				D10000050000000000000001 /* SessionCardView.swift in Sources */,
@@ -647,6 +657,8 @@
 				STC000010000000000000001 /* StatusColors.swift in Sources */,
 				SDP000010000000000000001 /* SessionDisplayPolicy.swift in Sources */,
 				SCN000010000000000000001 /* StatusCounts.swift in Sources */,
+				SCTRL0010000000000000001 /* SettingsControls.swift in Sources */,
+				NROW00010000000000000001 /* NotificationSettingsRow.swift in Sources */,
 				PPO000010000000000000001 /* PanelPositioning.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -27,6 +27,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     private var hasNotch = false
     private var focusLocation: NSPoint?
     private var cancellables: Set<AnyCancellable> = []
+    private let notificationPermissionReconciler = NotificationPermissionController()
     @AppStorage("appearanceMode") var appearanceMode: String = "system"
 
     private let panelGeometry = PanelGeometryModel(store: UserDefaultsPanelPositionStore())
@@ -39,6 +40,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         UserDefaults.standard.register(defaults: ["notificationsEnabled": true])
+        notificationPermissionReconciler.refresh()
         migrateLegacyPanelPosition()
         installHookBinaryIfNeeded()
         UNUserNotificationCenter.current().delegate = self

--- a/menubar/CctopMenubar/Services/NotificationPermissionController.swift
+++ b/menubar/CctopMenubar/Services/NotificationPermissionController.swift
@@ -31,7 +31,9 @@ enum NotificationPermissionStatus {
 
 protocol NotificationPreferenceStoring: AnyObject {
     var notificationsEnabled: Bool { get }
+    var needsSystemNotificationPermission: Bool { get }
     func setNotificationsEnabled(_ isEnabled: Bool)
+    func setNeedsSystemNotificationPermission(_ needsPermission: Bool)
 }
 
 protocol NotificationPermissionClient: AnyObject {
@@ -53,7 +55,13 @@ final class NotificationPermissionController: ObservableObject {
     ) {
         self.store = store
         self.client = client
-        state = initialState ?? (store.notificationsEnabled ? .enabling : .off)
+        if let initialState {
+            state = initialState
+        } else if store.needsSystemNotificationPermission {
+            state = .needsSystemPermission
+        } else {
+            state = store.notificationsEnabled ? .enabling : .off
+        }
     }
 
     func refresh() {
@@ -71,6 +79,7 @@ final class NotificationPermissionController: ObservableObject {
 
     func disable() {
         store.setNotificationsEnabled(false)
+        store.setNeedsSystemNotificationPermission(false)
         state = .off
     }
 
@@ -80,7 +89,11 @@ final class NotificationPermissionController: ObservableObject {
 
     private func applyRefreshStatus(_ status: NotificationPermissionStatus) {
         if status.allowsNotifications {
-            if store.notificationsEnabled || state == .needsSystemPermission || state == .enabling {
+            if store.notificationsEnabled
+                || store.needsSystemNotificationPermission
+                || state == .needsSystemPermission
+                || state == .enabling {
+                store.setNeedsSystemNotificationPermission(false)
                 store.setNotificationsEnabled(true)
                 state = .enabled
             } else {
@@ -93,8 +106,10 @@ final class NotificationPermissionController: ObservableObject {
         case .denied:
             if store.notificationsEnabled {
                 store.setNotificationsEnabled(false)
+                store.setNeedsSystemNotificationPermission(true)
                 state = .needsSystemPermission
-            } else if state == .needsSystemPermission {
+            } else if store.needsSystemNotificationPermission || state == .needsSystemPermission {
+                store.setNeedsSystemNotificationPermission(true)
                 state = .needsSystemPermission
             } else {
                 state = .off
@@ -103,11 +118,13 @@ final class NotificationPermissionController: ObservableObject {
             if store.notificationsEnabled {
                 store.setNotificationsEnabled(false)
             }
+            store.setNeedsSystemNotificationPermission(false)
             state = .off
         case .unknown:
             if store.notificationsEnabled {
                 store.setNotificationsEnabled(false)
             }
+            store.setNeedsSystemNotificationPermission(false)
             state = .failed
         case .authorized, .provisional, .ephemeral:
             break
@@ -116,6 +133,7 @@ final class NotificationPermissionController: ObservableObject {
 
     private func applyEnableStatus(_ status: NotificationPermissionStatus) {
         if status.allowsNotifications {
+            store.setNeedsSystemNotificationPermission(false)
             store.setNotificationsEnabled(true)
             state = .enabled
             return
@@ -126,10 +144,12 @@ final class NotificationPermissionController: ObservableObject {
             requestSystemPermission()
         case .denied:
             store.setNotificationsEnabled(false)
+            store.setNeedsSystemNotificationPermission(true)
             state = .needsSystemPermission
             client.openNotificationSettings()
         case .unknown:
             store.setNotificationsEnabled(false)
+            store.setNeedsSystemNotificationPermission(false)
             state = .failed
         case .authorized, .provisional, .ephemeral:
             break
@@ -141,28 +161,44 @@ final class NotificationPermissionController: ObservableObject {
             guard let self else { return }
             switch result {
             case .success(true):
+                store.setNeedsSystemNotificationPermission(false)
                 store.setNotificationsEnabled(true)
                 state = .enabled
             case .success(false):
                 store.setNotificationsEnabled(false)
+                store.setNeedsSystemNotificationPermission(true)
                 state = .needsSystemPermission
                 client.openNotificationSettings()
             case .failure(let error):
                 sessionManagerLogger.error("Notification permission error: \(error, privacy: .public)")
                 store.setNotificationsEnabled(false)
+                store.setNeedsSystemNotificationPermission(false)
                 state = .failed
             }
         }
     }
 }
 
+private enum NotificationPreferenceKeys {
+    static let notificationsEnabled = "notificationsEnabled"
+    static let needsSystemNotificationPermission = "notificationsNeedSystemPermission"
+}
+
 private final class UserDefaultsNotificationPreferenceStore: NotificationPreferenceStoring {
     var notificationsEnabled: Bool {
-        UserDefaults.standard.bool(forKey: "notificationsEnabled")
+        UserDefaults.standard.bool(forKey: NotificationPreferenceKeys.notificationsEnabled)
+    }
+
+    var needsSystemNotificationPermission: Bool {
+        UserDefaults.standard.bool(forKey: NotificationPreferenceKeys.needsSystemNotificationPermission)
     }
 
     func setNotificationsEnabled(_ isEnabled: Bool) {
-        UserDefaults.standard.set(isEnabled, forKey: "notificationsEnabled")
+        UserDefaults.standard.set(isEnabled, forKey: NotificationPreferenceKeys.notificationsEnabled)
+    }
+
+    func setNeedsSystemNotificationPermission(_ needsPermission: Bool) {
+        UserDefaults.standard.set(needsPermission, forKey: NotificationPreferenceKeys.needsSystemNotificationPermission)
     }
 }
 

--- a/menubar/CctopMenubar/Services/NotificationPermissionController.swift
+++ b/menubar/CctopMenubar/Services/NotificationPermissionController.swift
@@ -1,0 +1,232 @@
+import AppKit
+import Combine
+import Foundation
+import UserNotifications
+
+enum NotificationPreferenceState: Equatable {
+    case off
+    case enabling
+    case enabled
+    case needsSystemPermission
+    case failed
+}
+
+enum NotificationPermissionStatus {
+    case notDetermined
+    case denied
+    case authorized
+    case provisional
+    case ephemeral
+    case unknown
+
+    var allowsNotifications: Bool {
+        switch self {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .notDetermined, .denied, .unknown:
+            return false
+        }
+    }
+}
+
+protocol NotificationPreferenceStoring: AnyObject {
+    var notificationsEnabled: Bool { get }
+    func setNotificationsEnabled(_ isEnabled: Bool)
+}
+
+protocol NotificationPermissionClient: AnyObject {
+    func getAuthorizationStatus(_ completion: @escaping (NotificationPermissionStatus) -> Void)
+    func requestAuthorization(_ completion: @escaping (Result<Bool, Error>) -> Void)
+    func openNotificationSettings()
+}
+
+final class NotificationPermissionController: ObservableObject {
+    @Published private(set) var state: NotificationPreferenceState
+
+    private let store: NotificationPreferenceStoring
+    private let client: NotificationPermissionClient
+
+    init(
+        store: NotificationPreferenceStoring = UserDefaultsNotificationPreferenceStore(),
+        client: NotificationPermissionClient = UserNotificationPermissionClient(),
+        initialState: NotificationPreferenceState? = nil
+    ) {
+        self.store = store
+        self.client = client
+        state = initialState ?? (store.notificationsEnabled ? .enabling : .off)
+    }
+
+    func refresh() {
+        client.getAuthorizationStatus { [weak self] status in
+            self?.applyRefreshStatus(status)
+        }
+    }
+
+    func enable() {
+        state = .enabling
+        client.getAuthorizationStatus { [weak self] status in
+            self?.applyEnableStatus(status)
+        }
+    }
+
+    func disable() {
+        store.setNotificationsEnabled(false)
+        state = .off
+    }
+
+    func openSystemSettings() {
+        client.openNotificationSettings()
+    }
+
+    private func applyRefreshStatus(_ status: NotificationPermissionStatus) {
+        if status.allowsNotifications {
+            if store.notificationsEnabled || state == .needsSystemPermission || state == .enabling {
+                store.setNotificationsEnabled(true)
+                state = .enabled
+            } else {
+                state = .off
+            }
+            return
+        }
+
+        switch status {
+        case .denied:
+            if store.notificationsEnabled {
+                store.setNotificationsEnabled(false)
+                state = .needsSystemPermission
+            } else if state == .needsSystemPermission {
+                state = .needsSystemPermission
+            } else {
+                state = .off
+            }
+        case .notDetermined:
+            if store.notificationsEnabled {
+                store.setNotificationsEnabled(false)
+            }
+            state = .off
+        case .unknown:
+            if store.notificationsEnabled {
+                store.setNotificationsEnabled(false)
+            }
+            state = .failed
+        case .authorized, .provisional, .ephemeral:
+            break
+        }
+    }
+
+    private func applyEnableStatus(_ status: NotificationPermissionStatus) {
+        if status.allowsNotifications {
+            store.setNotificationsEnabled(true)
+            state = .enabled
+            return
+        }
+
+        switch status {
+        case .notDetermined:
+            requestSystemPermission()
+        case .denied:
+            store.setNotificationsEnabled(false)
+            state = .needsSystemPermission
+            client.openNotificationSettings()
+        case .unknown:
+            store.setNotificationsEnabled(false)
+            state = .failed
+        case .authorized, .provisional, .ephemeral:
+            break
+        }
+    }
+
+    private func requestSystemPermission() {
+        client.requestAuthorization { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(true):
+                store.setNotificationsEnabled(true)
+                state = .enabled
+            case .success(false):
+                store.setNotificationsEnabled(false)
+                state = .needsSystemPermission
+                client.openNotificationSettings()
+            case .failure(let error):
+                sessionManagerLogger.error("Notification permission error: \(error, privacy: .public)")
+                store.setNotificationsEnabled(false)
+                state = .failed
+            }
+        }
+    }
+}
+
+private final class UserDefaultsNotificationPreferenceStore: NotificationPreferenceStoring {
+    var notificationsEnabled: Bool {
+        UserDefaults.standard.bool(forKey: "notificationsEnabled")
+    }
+
+    func setNotificationsEnabled(_ isEnabled: Bool) {
+        UserDefaults.standard.set(isEnabled, forKey: "notificationsEnabled")
+    }
+}
+
+private final class UserNotificationPermissionClient: NotificationPermissionClient {
+    private let center: UNUserNotificationCenter
+
+    init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+    }
+
+    func getAuthorizationStatus(_ completion: @escaping (NotificationPermissionStatus) -> Void) {
+        center.getNotificationSettings { settings in
+            let status = NotificationPermissionStatus(settings.authorizationStatus)
+            DispatchQueue.main.async {
+                completion(status)
+            }
+        }
+    }
+
+    func requestAuthorization(_ completion: @escaping (Result<Bool, Error>) -> Void) {
+        let wasAccessory = NSApplication.shared.activationPolicy() == .accessory
+        if wasAccessory { NSApplication.shared.setActivationPolicy(.regular) }
+
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            DispatchQueue.main.async {
+                if wasAccessory { NSApplication.shared.setActivationPolicy(.accessory) }
+                if let error {
+                    completion(.failure(error))
+                } else {
+                    completion(.success(granted))
+                }
+            }
+        }
+    }
+
+    func openNotificationSettings() {
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.st0012.CctopMenubar"
+        let appSettings = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension?id=\(bundleID)")
+
+        if let appSettings, NSWorkspace.shared.open(appSettings) {
+            return
+        }
+
+        if let notifications = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings") {
+            NSWorkspace.shared.open(notifications)
+        }
+    }
+}
+
+private extension NotificationPermissionStatus {
+    init(_ status: UNAuthorizationStatus) {
+        switch status {
+        case .notDetermined:
+            self = .notDetermined
+        case .denied:
+            self = .denied
+        case .authorized:
+            self = .authorized
+        case .provisional:
+            self = .provisional
+        case .ephemeral:
+            self = .ephemeral
+        @unknown default:
+            self = .unknown
+        }
+    }
+}

--- a/menubar/CctopMenubar/Services/NotificationPermissionController.swift
+++ b/menubar/CctopMenubar/Services/NotificationPermissionController.swift
@@ -7,6 +7,7 @@ enum NotificationPreferenceState: Equatable {
     case off
     case enabling
     case enabled
+    case pendingSystemPermission
     case needsSystemPermission
     case failed
 }
@@ -92,6 +93,7 @@ final class NotificationPermissionController: ObservableObject {
             if store.notificationsEnabled
                 || store.needsSystemNotificationPermission
                 || state == .needsSystemPermission
+                || state == .pendingSystemPermission
                 || state == .enabling {
                 store.setNeedsSystemNotificationPermission(false)
                 store.setNotificationsEnabled(true)
@@ -118,7 +120,7 @@ final class NotificationPermissionController: ObservableObject {
             if store.needsSystemNotificationPermission {
                 store.setNeedsSystemNotificationPermission(false)
             }
-            state = .off
+            state = store.notificationsEnabled ? .pendingSystemPermission : .off
         case .unknown:
             if store.notificationsEnabled {
                 store.setNotificationsEnabled(false)

--- a/menubar/CctopMenubar/Services/NotificationPermissionController.swift
+++ b/menubar/CctopMenubar/Services/NotificationPermissionController.swift
@@ -115,10 +115,9 @@ final class NotificationPermissionController: ObservableObject {
                 state = .off
             }
         case .notDetermined:
-            if store.notificationsEnabled {
-                store.setNotificationsEnabled(false)
+            if store.needsSystemNotificationPermission {
+                store.setNeedsSystemNotificationPermission(false)
             }
-            store.setNeedsSystemNotificationPermission(false)
             state = .off
         case .unknown:
             if store.notificationsEnabled {

--- a/menubar/CctopMenubar/Views/NotificationSettingsRow.swift
+++ b/menubar/CctopMenubar/Views/NotificationSettingsRow.swift
@@ -31,7 +31,10 @@ struct NotificationSettingsRow: View {
 
     private var toggleBinding: Binding<Bool> {
         Binding(
-            get: { notificationPermission.state == .enabled },
+            get: {
+                notificationPermission.state == .enabled
+                    || notificationPermission.state == .pendingSystemPermission
+            },
             set: { isEnabled in
                 if isEnabled {
                     notificationPermission.enable()
@@ -48,6 +51,8 @@ struct NotificationSettingsRow: View {
             return nil
         case .enabling:
             return "Checking macOS permission"
+        case .pendingSystemPermission:
+            return "Will ask on first notification"
         case .needsSystemPermission:
             return "Enable in System Settings"
         case .failed:
@@ -76,7 +81,7 @@ struct NotificationSettingsRow: View {
             .font(.system(size: 10, weight: .semibold))
             .foregroundStyle(Color.statusAttention)
             .buttonStyle(.plain)
-        case .off, .enabling, .enabled:
+        case .off, .enabling, .enabled, .pendingSystemPermission:
             EmptyView()
         }
     }

--- a/menubar/CctopMenubar/Views/NotificationSettingsRow.swift
+++ b/menubar/CctopMenubar/Views/NotificationSettingsRow.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct NotificationSettingsRow: View {
+    @ObservedObject var notificationPermission: NotificationPermissionController
+
+    var body: some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Notifications")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Color.textPrimary)
+                    .lineLimit(1)
+                if let statusText {
+                    Text(statusText)
+                        .font(.system(size: 10))
+                        .foregroundStyle(statusColor)
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: 8)
+            action
+            Toggle("", isOn: toggleBinding)
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .labelsHidden()
+                .disabled(notificationPermission.state == .enabling)
+        }
+        .padding(.horizontal, AppChrome.settingsRowHorizontalPadding)
+        .padding(.vertical, 8)
+    }
+
+    private var toggleBinding: Binding<Bool> {
+        Binding(
+            get: { notificationPermission.state == .enabled },
+            set: { isEnabled in
+                if isEnabled {
+                    notificationPermission.enable()
+                } else {
+                    notificationPermission.disable()
+                }
+            }
+        )
+    }
+
+    private var statusText: String? {
+        switch notificationPermission.state {
+        case .off, .enabled:
+            return nil
+        case .enabling:
+            return "Checking macOS permission"
+        case .needsSystemPermission:
+            return "Enable in System Settings"
+        case .failed:
+            return "Could not enable"
+        }
+    }
+
+    private var statusColor: Color {
+        notificationPermission.state == .failed ? Color.statusAttention : Color.textMuted
+    }
+
+    @ViewBuilder
+    private var action: some View {
+        switch notificationPermission.state {
+        case .needsSystemPermission:
+            Button("Open Settings") {
+                notificationPermission.openSystemSettings()
+            }
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(Color.segmentActiveText)
+            .buttonStyle(.plain)
+        case .failed:
+            Button("Retry") {
+                notificationPermission.enable()
+            }
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(Color.statusAttention)
+            .buttonStyle(.plain)
+        case .off, .enabling, .enabled:
+            EmptyView()
+        }
+    }
+}

--- a/menubar/CctopMenubar/Views/SettingsControls.swift
+++ b/menubar/CctopMenubar/Views/SettingsControls.swift
@@ -1,0 +1,105 @@
+import KeyboardShortcuts
+import SwiftUI
+
+struct AmberSegmentedPicker<Value: Hashable>: View {
+    let options: [(value: Value, label: String)]
+    @Binding var selection: Value
+
+    var body: some View {
+        HStack(spacing: AppChrome.settingsSegmentSpacing) {
+            ForEach(options.indices, id: \.self) { index in
+                SegmentButton(
+                    label: options[index].label,
+                    isSelected: selection == options[index].value
+                ) {
+                    withAnimation(.easeOut(duration: 0.15)) { selection = options[index].value }
+                }
+            }
+        }
+        .padding(AppChrome.settingsSegmentedControlPadding)
+        .frame(height: AppChrome.settingsSegmentedControlHeight)
+        .background(Color.panelControlBackground)
+        .clipShape(RoundedRectangle(cornerRadius: AppChrome.controlCornerRadius, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: AppChrome.controlCornerRadius, style: .continuous)
+                .stroke(Color.panelControlBorder, lineWidth: 1)
+        }
+    }
+}
+
+private struct SegmentButton: View {
+    let label: String
+    let isSelected: Bool
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(.system(size: 10, weight: .medium))
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+                .allowsTightening(true)
+                .padding(.horizontal, AppChrome.settingsSegmentHorizontalPadding)
+                .frame(height: AppChrome.settingsSegmentHeight)
+                .foregroundStyle(foregroundColor)
+                .background {
+                    SelectionSurfaceChrome(
+                        isSelected: isSelected,
+                        isHovered: isHovered,
+                        cornerRadius: AppChrome.settingsSegmentSelectionCornerRadius,
+                        hoverColor: Color.panelControlBackground
+                    )
+                }
+                .overlay {
+                    if isSelected {
+                        RoundedRectangle(cornerRadius: AppChrome.settingsSegmentSelectionCornerRadius, style: .continuous)
+                            .stroke(Color.panelAccentBorder, lineWidth: 1)
+                    }
+                }
+                .contentShape(RoundedRectangle(cornerRadius: AppChrome.settingsSegmentSelectionCornerRadius, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+
+    private var foregroundColor: Color {
+        if isSelected { return Color.segmentActiveText }
+        if isHovered { return Color.segmentActiveText.opacity(0.7) }
+        return Color.segmentText
+    }
+}
+
+struct ShortcutBadge: View {
+    let name: KeyboardShortcuts.Name
+    @State private var showRecorder = false
+    @State private var isHovered = false
+
+    var body: some View {
+        Button { showRecorder.toggle() } label: {
+            if let shortcut = KeyboardShortcuts.getShortcut(for: name) {
+                Text(shortcut.description)
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundStyle(isHovered ? Color.segmentActiveText : Color.textSecondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(isHovered ? Color.panelSelectionBackground : Color.panelControlBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: AppChrome.controlCornerRadius, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: AppChrome.controlCornerRadius, style: .continuous)
+                            .stroke(Color.panelControlBorder, lineWidth: 1)
+                    }
+            } else {
+                Text("Record Shortcut")
+                    .font(.system(size: 10))
+                    .foregroundStyle(isHovered ? Color.textPrimary : Color.textMuted)
+            }
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .popover(isPresented: $showRecorder) {
+            KeyboardShortcuts.Recorder("", name: name)
+                .padding(8)
+        }
+    }
+}

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -1,117 +1,25 @@
-import KeyboardShortcuts
+import AppKit
 import ServiceManagement
 import SwiftUI
-
-struct AmberSegmentedPicker<Value: Hashable>: View {
-    let options: [(value: Value, label: String)]
-    @Binding var selection: Value
-    var body: some View {
-        HStack(spacing: AppChrome.settingsSegmentSpacing) {
-            ForEach(options.indices, id: \.self) { index in
-                SegmentButton(
-                    label: options[index].label,
-                    isSelected: selection == options[index].value
-                ) {
-                    withAnimation(.easeOut(duration: 0.15)) { selection = options[index].value }
-                }
-            }
-        }
-        .padding(AppChrome.settingsSegmentedControlPadding)
-        .frame(height: AppChrome.settingsSegmentedControlHeight)
-        .background(Color.panelControlBackground)
-        .clipShape(RoundedRectangle(cornerRadius: AppChrome.controlCornerRadius, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: AppChrome.controlCornerRadius, style: .continuous)
-                .stroke(Color.panelControlBorder, lineWidth: 1)
-        }
-    }
-}
-
-private struct SegmentButton: View {
-    let label: String
-    let isSelected: Bool
-    let action: () -> Void
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: action) {
-            Text(label)
-                .font(.system(size: 10, weight: .medium))
-                .lineLimit(1)
-                .minimumScaleFactor(0.82)
-                .allowsTightening(true)
-                .padding(.horizontal, AppChrome.settingsSegmentHorizontalPadding)
-                .frame(height: AppChrome.settingsSegmentHeight)
-                .foregroundStyle(foregroundColor)
-                .background {
-                    SelectionSurfaceChrome(
-                        isSelected: isSelected,
-                        isHovered: isHovered,
-                        cornerRadius: AppChrome.settingsSegmentSelectionCornerRadius,
-                        hoverColor: Color.panelControlBackground
-                    )
-                }
-                .overlay {
-                    if isSelected {
-                        RoundedRectangle(cornerRadius: AppChrome.settingsSegmentSelectionCornerRadius, style: .continuous)
-                            .stroke(Color.panelAccentBorder, lineWidth: 1)
-                    }
-                }
-                .contentShape(RoundedRectangle(cornerRadius: AppChrome.settingsSegmentSelectionCornerRadius, style: .continuous))
-        }
-        .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-    }
-
-    private var foregroundColor: Color {
-        if isSelected { return Color.segmentActiveText }
-        if isHovered { return Color.segmentActiveText.opacity(0.7) }
-        return Color.segmentText
-    }
-}
-
-struct ShortcutBadge: View {
-    let name: KeyboardShortcuts.Name
-    @State private var showRecorder = false
-    @State private var isHovered = false
-
-    var body: some View {
-        Button { showRecorder.toggle() } label: {
-            if let shortcut = KeyboardShortcuts.getShortcut(for: name) {
-                Text(shortcut.description)
-                    .font(.system(size: 10, weight: .medium, design: .monospaced))
-                    .foregroundStyle(isHovered ? Color.segmentActiveText : Color.textSecondary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(isHovered ? Color.panelSelectionBackground : Color.panelControlBackground)
-                    .clipShape(RoundedRectangle(cornerRadius: AppChrome.controlCornerRadius, style: .continuous))
-                    .overlay {
-                        RoundedRectangle(cornerRadius: AppChrome.controlCornerRadius, style: .continuous)
-                            .stroke(Color.panelControlBorder, lineWidth: 1)
-                    }
-            } else {
-                Text("Record Shortcut")
-                    .font(.system(size: 10))
-                    .foregroundStyle(isHovered ? Color.textPrimary : Color.textMuted)
-            }
-        }
-        .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-        .popover(isPresented: $showRecorder) {
-            KeyboardShortcuts.Recorder("", name: name)
-                .padding(8)
-        }
-    }
-}
 
 struct SettingsSection: View {
     @ObservedObject var updater: UpdaterBase
     @ObservedObject var pluginManager: PluginManager
     @ObservedObject private var themeManager = ThemeManager.shared
+    @StateObject private var notificationPermission: NotificationPermissionController
     @AppStorage("appearanceMode") private var appearanceMode = "system"
-    @AppStorage("notificationsEnabled") private var notificationsEnabled = true
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var installFailed = false
+
+    init(
+        updater: UpdaterBase,
+        pluginManager: PluginManager,
+        notificationPermission: NotificationPermissionController = NotificationPermissionController()
+    ) {
+        self.updater = updater
+        self.pluginManager = pluginManager
+        _notificationPermission = StateObject(wrappedValue: notificationPermission)
+    }
 
     var body: some View {
         ScrollView(showsIndicators: true) {
@@ -119,6 +27,10 @@ struct SettingsSection: View {
         }
         .frame(maxHeight: AppChrome.settingsScrollViewportHeight)
         .background(Color.groupedContentBackground)
+        .onAppear { notificationPermission.refresh() }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            notificationPermission.refresh()
+        }
     }
 
     private var settingsContent: some View {
@@ -169,14 +81,7 @@ struct SettingsSection: View {
                     } catch { launchAtLogin = SMAppService.mainApp.status == .enabled }
                 }
                 groupedDivider
-                settingsRow("Notifications") {
-                    Toggle("", isOn: $notificationsEnabled)
-                        .toggleStyle(.switch).controlSize(.mini)
-                        .labelsHidden()
-                }
-                .onChange(of: notificationsEnabled) { newValue in
-                    if newValue { SessionManager.requestNotificationPermission() }
-                }
+                NotificationSettingsRow(notificationPermission: notificationPermission)
             }
         }
         .padding(AppChrome.settingsContentPadding)

--- a/menubar/CctopMenubarTests/AppSettingsTests.swift
+++ b/menubar/CctopMenubarTests/AppSettingsTests.swift
@@ -140,6 +140,19 @@ final class NotificationPermissionControllerTests: XCTestCase {
         XCTAssertEqual(store.savedValues, [false])
     }
 
+    func testRefreshWithNotDeterminedPermissionKeepsPreferenceEnabledForFirstPrompt() {
+        let store = NotificationPreferenceStoreSpy(initialValue: true)
+        let client = NotificationPermissionClientSpy(statuses: [.notDetermined])
+        let controller = NotificationPermissionController(store: store, client: client)
+
+        controller.refresh()
+
+        XCTAssertEqual(controller.state, .off)
+        XCTAssertTrue(store.notificationsEnabled)
+        XCTAssertEqual(store.savedValues, [])
+        XCTAssertEqual(store.savedPermissionValues, [])
+    }
+
     func testLaunchRefreshPreservesSystemPermissionStateForLaterSettingsController() {
         let store = NotificationPreferenceStoreSpy(initialValue: true)
         let launchClient = NotificationPermissionClientSpy(statuses: [.denied])

--- a/menubar/CctopMenubarTests/AppSettingsTests.swift
+++ b/menubar/CctopMenubarTests/AppSettingsTests.swift
@@ -147,10 +147,27 @@ final class NotificationPermissionControllerTests: XCTestCase {
 
         controller.refresh()
 
-        XCTAssertEqual(controller.state, .off)
+        XCTAssertEqual(controller.state, .pendingSystemPermission)
         XCTAssertTrue(store.notificationsEnabled)
         XCTAssertEqual(store.savedValues, [])
         XCTAssertEqual(store.savedPermissionValues, [])
+    }
+
+    func testDisableClearsPendingSystemPermissionPreference() {
+        let store = NotificationPreferenceStoreSpy(initialValue: true)
+        let client = NotificationPermissionClientSpy(statuses: [.notDetermined])
+        let controller = NotificationPermissionController(
+            store: store,
+            client: client,
+            initialState: .pendingSystemPermission
+        )
+
+        controller.disable()
+
+        XCTAssertEqual(controller.state, .off)
+        XCTAssertFalse(store.notificationsEnabled)
+        XCTAssertEqual(store.savedValues, [false])
+        XCTAssertEqual(store.savedPermissionValues, [false])
     }
 
     func testLaunchRefreshPreservesSystemPermissionStateForLaterSettingsController() {

--- a/menubar/CctopMenubarTests/AppSettingsTests.swift
+++ b/menubar/CctopMenubarTests/AppSettingsTests.swift
@@ -19,3 +19,200 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(cases, [.system, .light, .dark])
     }
 }
+
+@MainActor
+final class NotificationPermissionControllerTests: XCTestCase {
+    func testEnableWithAuthorizedPermissionPersistsPreference() {
+        let store = NotificationPreferenceStoreSpy(initialValue: false)
+        let client = NotificationPermissionClientSpy(statuses: [.authorized])
+        let controller = NotificationPermissionController(store: store, client: client)
+
+        controller.enable()
+
+        XCTAssertEqual(controller.state, .enabled)
+        XCTAssertEqual(store.savedValues, [true])
+        XCTAssertFalse(client.didOpenNotificationSettings)
+    }
+
+    func testEnableWithDeniedPermissionKeepsPreferenceOffAndOpensSettings() {
+        let store = NotificationPreferenceStoreSpy(initialValue: false)
+        let client = NotificationPermissionClientSpy(statuses: [.denied])
+        let controller = NotificationPermissionController(store: store, client: client)
+
+        controller.enable()
+
+        XCTAssertEqual(controller.state, .needsSystemPermission)
+        XCTAssertEqual(store.savedValues, [false])
+        XCTAssertTrue(client.didOpenNotificationSettings)
+    }
+
+    func testEnableWithGrantedPromptPersistsAfterRequestSucceeds() {
+        let store = NotificationPreferenceStoreSpy(initialValue: false)
+        let client = NotificationPermissionClientSpy(
+            statuses: [.notDetermined],
+            requestResult: .success(true)
+        )
+        let controller = NotificationPermissionController(store: store, client: client)
+
+        controller.enable()
+
+        XCTAssertEqual(controller.state, .enabled)
+        XCTAssertEqual(store.savedValues, [true])
+        XCTAssertEqual(client.requestAuthorizationCount, 1)
+    }
+
+    func testEnableWithDeniedPromptKeepsPreferenceOffAndOpensSettings() {
+        let store = NotificationPreferenceStoreSpy(initialValue: false)
+        let client = NotificationPermissionClientSpy(
+            statuses: [.notDetermined],
+            requestResult: .success(false)
+        )
+        let controller = NotificationPermissionController(store: store, client: client)
+
+        controller.enable()
+
+        XCTAssertEqual(controller.state, .needsSystemPermission)
+        XCTAssertEqual(store.savedValues, [false])
+        XCTAssertTrue(client.didOpenNotificationSettings)
+    }
+
+    func testEnableWithRequestErrorShowsFailedAndKeepsPreferenceOff() {
+        let store = NotificationPreferenceStoreSpy(initialValue: false)
+        let client = NotificationPermissionClientSpy(
+            statuses: [.notDetermined],
+            requestResult: .failure(NSError(domain: "test", code: 1))
+        )
+        let controller = NotificationPermissionController(store: store, client: client)
+
+        controller.enable()
+
+        XCTAssertEqual(controller.state, .failed)
+        XCTAssertEqual(store.savedValues, [false])
+        XCTAssertFalse(client.didOpenNotificationSettings)
+    }
+
+    func testEnableWithUnknownStatusShowsFailedAndKeepsPreferenceOff() {
+        let store = NotificationPreferenceStoreSpy(initialValue: false)
+        let client = NotificationPermissionClientSpy(statuses: [.unknown])
+        let controller = NotificationPermissionController(store: store, client: client)
+
+        controller.enable()
+
+        XCTAssertEqual(controller.state, .failed)
+        XCTAssertEqual(store.savedValues, [false])
+    }
+
+    func testEnableDoesNotPersistWhilePermissionCheckIsPending() {
+        let store = NotificationPreferenceStoreSpy(initialValue: false)
+        let client = DeferredNotificationPermissionClientSpy()
+        let controller = NotificationPermissionController(store: store, client: client)
+
+        controller.enable()
+
+        XCTAssertEqual(controller.state, .enabling)
+        XCTAssertEqual(store.savedValues, [])
+
+        client.completeStatus(.authorized)
+
+        XCTAssertEqual(controller.state, .enabled)
+        XCTAssertEqual(store.savedValues, [true])
+    }
+
+    func testRefreshAfterSystemSettingsGrantCompletesPendingEnable() {
+        let store = NotificationPreferenceStoreSpy(initialValue: false)
+        let client = NotificationPermissionClientSpy(statuses: [.authorized])
+        let controller = NotificationPermissionController(store: store, client: client, initialState: .needsSystemPermission)
+
+        controller.refresh()
+
+        XCTAssertEqual(controller.state, .enabled)
+        XCTAssertEqual(store.savedValues, [true])
+    }
+
+    func testRefreshWithLegacyEnabledPreferenceButDeniedPermissionShowsSystemPermissionState() {
+        let store = NotificationPreferenceStoreSpy(initialValue: true)
+        let client = NotificationPermissionClientSpy(statuses: [.denied])
+        let controller = NotificationPermissionController(store: store, client: client)
+
+        controller.refresh()
+
+        XCTAssertEqual(controller.state, .needsSystemPermission)
+        XCTAssertEqual(store.savedValues, [false])
+    }
+
+    func testDisableClearsPreferenceAndState() {
+        let store = NotificationPreferenceStoreSpy(initialValue: true)
+        let client = NotificationPermissionClientSpy(statuses: [.authorized])
+        let controller = NotificationPermissionController(store: store, client: client, initialState: .enabled)
+
+        controller.disable()
+
+        XCTAssertEqual(controller.state, .off)
+        XCTAssertEqual(store.savedValues, [false])
+    }
+}
+
+private final class NotificationPreferenceStoreSpy: NotificationPreferenceStoring {
+    private var enabled: Bool
+    private(set) var savedValues: [Bool] = []
+
+    init(initialValue: Bool) {
+        enabled = initialValue
+    }
+
+    var notificationsEnabled: Bool {
+        enabled
+    }
+
+    func setNotificationsEnabled(_ isEnabled: Bool) {
+        enabled = isEnabled
+        savedValues.append(isEnabled)
+    }
+}
+
+private final class NotificationPermissionClientSpy: NotificationPermissionClient {
+    private var statuses: [NotificationPermissionStatus]
+    private let requestResult: Result<Bool, Error>
+    private(set) var requestAuthorizationCount = 0
+    private(set) var didOpenNotificationSettings = false
+
+    init(
+        statuses: [NotificationPermissionStatus],
+        requestResult: Result<Bool, Error> = .success(false)
+    ) {
+        self.statuses = statuses
+        self.requestResult = requestResult
+    }
+
+    func getAuthorizationStatus(_ completion: @escaping (NotificationPermissionStatus) -> Void) {
+        completion(statuses.isEmpty ? .unknown : statuses.removeFirst())
+    }
+
+    func requestAuthorization(_ completion: @escaping (Result<Bool, Error>) -> Void) {
+        requestAuthorizationCount += 1
+        completion(requestResult)
+    }
+
+    func openNotificationSettings() {
+        didOpenNotificationSettings = true
+    }
+}
+
+private final class DeferredNotificationPermissionClientSpy: NotificationPermissionClient {
+    private var statusCompletion: ((NotificationPermissionStatus) -> Void)?
+
+    func getAuthorizationStatus(_ completion: @escaping (NotificationPermissionStatus) -> Void) {
+        statusCompletion = completion
+    }
+
+    func requestAuthorization(_ completion: @escaping (Result<Bool, Error>) -> Void) {
+        completion(.success(false))
+    }
+
+    func openNotificationSettings() {}
+
+    func completeStatus(_ status: NotificationPermissionStatus) {
+        statusCompletion?(status)
+        statusCompletion = nil
+    }
+}

--- a/menubar/CctopMenubarTests/AppSettingsTests.swift
+++ b/menubar/CctopMenubarTests/AppSettingsTests.swift
@@ -140,6 +140,27 @@ final class NotificationPermissionControllerTests: XCTestCase {
         XCTAssertEqual(store.savedValues, [false])
     }
 
+    func testLaunchRefreshPreservesSystemPermissionStateForLaterSettingsController() {
+        let store = NotificationPreferenceStoreSpy(initialValue: true)
+        let launchClient = NotificationPermissionClientSpy(statuses: [.denied])
+        let launchController = NotificationPermissionController(store: store, client: launchClient)
+
+        launchController.refresh()
+
+        XCTAssertEqual(launchController.state, .needsSystemPermission)
+        XCTAssertEqual(store.savedValues, [false])
+        XCTAssertEqual(store.savedPermissionValues, [true])
+
+        let settingsClient = NotificationPermissionClientSpy(statuses: [.denied])
+        let settingsController = NotificationPermissionController(store: store, client: settingsClient)
+
+        XCTAssertEqual(settingsController.state, .needsSystemPermission)
+
+        settingsController.refresh()
+
+        XCTAssertEqual(settingsController.state, .needsSystemPermission)
+    }
+
     func testDisableClearsPreferenceAndState() {
         let store = NotificationPreferenceStoreSpy(initialValue: true)
         let client = NotificationPermissionClientSpy(statuses: [.authorized])
@@ -154,19 +175,31 @@ final class NotificationPermissionControllerTests: XCTestCase {
 
 private final class NotificationPreferenceStoreSpy: NotificationPreferenceStoring {
     private var enabled: Bool
+    private var needsPermission: Bool
     private(set) var savedValues: [Bool] = []
+    private(set) var savedPermissionValues: [Bool] = []
 
-    init(initialValue: Bool) {
+    init(initialValue: Bool, needsPermission: Bool = false) {
         enabled = initialValue
+        self.needsPermission = needsPermission
     }
 
     var notificationsEnabled: Bool {
         enabled
     }
 
+    var needsSystemNotificationPermission: Bool {
+        needsPermission
+    }
+
     func setNotificationsEnabled(_ isEnabled: Bool) {
         enabled = isEnabled
         savedValues.append(isEnabled)
+    }
+
+    func setNeedsSystemNotificationPermission(_ needsPermission: Bool) {
+        self.needsPermission = needsPermission
+        savedPermissionValues.append(needsPermission)
     }
 }
 


### PR DESCRIPTION
## Problem

The notification toggle in cctop could remain enabled even when macOS notifications for the app were denied or not granted. That made Settings claim notifications were active while macOS silently blocked delivery, so the feature looked broken.

## Solution

- Gate the Settings toggle through a permission controller that checks or requests macOS notification authorization before persisting the in-app preference as enabled.
- Surface denied permission as an actionable Settings row state that opens macOS Notification Settings, while keeping a failed state for unexpected permission errors.
- Reconcile stale enabled preferences at app launch and when Settings is shown or cctop becomes active again, so existing installs are corrected without periodic polling.
- Cover authorized, denied, not-determined, stale preference, and unexpected-status flows with controller tests.