### PR TITLE
Improve notification content handling

### DIFF
--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		A10000010000000000000001 /* CctopApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000001 /* CctopApp.swift */; };
 		AC0000010000000000000001 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AC0000020000000000000001 /* Assets.xcassets */; };
 		B10000010000000000000001 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000020000000000000001 /* Session.swift */; };
+		SNC000010000000000000001 /* Session+NotificationContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = SNC000020000000000000001 /* Session+NotificationContent.swift */; };
 		B10000030000000000000001 /* SessionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000040000000000000001 /* SessionStatus.swift */; };
 		C10000010000000000000001 /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000020000000000000001 /* SessionManager.swift */; };
 		D10000010000000000000001 /* StatusChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000020000000000000001 /* StatusChip.swift */; };
@@ -126,6 +127,7 @@
 		CDRP00010000000000000001 /* CodexDesktopRuntimeProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDRP00020000000000000001 /* CodexDesktopRuntimeProbe.swift */; };
 		SMA000010000000000000001 /* SessionManager+Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = SMA000020000000000000001 /* SessionManager+Archive.swift */; };
 		SML000010000000000000001 /* SessionManager+Loading.swift in Sources */ = {isa = PBXBuildFile; fileRef = SML000020000000000000001 /* SessionManager+Loading.swift */; };
+		SMN000010000000000000001 /* SessionManager+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = SMN000020000000000000001 /* SessionManager+Notifications.swift */; };
 		NPC000010000000000000001 /* NotificationPermissionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = NPC000020000000000000001 /* NotificationPermissionController.swift */; };
 		SCTRL0010000000000000001 /* SettingsControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = SCTRL0020000000000000001 /* SettingsControls.swift */; };
 		NROW00010000000000000001 /* NotificationSettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = NROW00020000000000000001 /* NotificationSettingsRow.swift */; };
@@ -146,6 +148,7 @@
 		A10000030000000000000001 /* CctopMenubar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CctopMenubar.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC0000020000000000000001 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B10000020000000000000001 /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
+		SNC000020000000000000001 /* Session+NotificationContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Session+NotificationContent.swift"; sourceTree = "<group>"; };
 		B10000040000000000000001 /* SessionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStatus.swift; sourceTree = "<group>"; };
 		C10000020000000000000001 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		SLP000020000000000000001 /* SessionLifecyclePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLifecyclePolicy.swift; sourceTree = "<group>"; };
@@ -158,6 +161,7 @@
 		CDRP00020000000000000001 /* CodexDesktopRuntimeProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexDesktopRuntimeProbe.swift; sourceTree = "<group>"; };
 		SMA000020000000000000001 /* SessionManager+Archive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionManager+Archive.swift"; sourceTree = "<group>"; };
 		SML000020000000000000001 /* SessionManager+Loading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionManager+Loading.swift"; sourceTree = "<group>"; };
+		SMN000020000000000000001 /* SessionManager+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionManager+Notifications.swift"; sourceTree = "<group>"; };
 		NPC000020000000000000001 /* NotificationPermissionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPermissionController.swift; sourceTree = "<group>"; };
 		D1000000A000000000000001 /* QuitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitButton.swift; sourceTree = "<group>"; };
 		D10000020000000000000001 /* StatusChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusChip.swift; sourceTree = "<group>"; };
@@ -306,6 +310,7 @@
 				CDRP00020000000000000001 /* CodexDesktopRuntimeProbe.swift */,
 				SMA000020000000000000001 /* SessionManager+Archive.swift */,
 				SML000020000000000000001 /* SessionManager+Loading.swift */,
+				SMN000020000000000000001 /* SessionManager+Notifications.swift */,
 				NPC000020000000000000001 /* NotificationPermissionController.swift */,
 				HM0000020000000000000001 /* HistoryManager.swift */,
 				E10000020000000000000001 /* FocusTerminal.swift */,
@@ -366,6 +371,7 @@
 			isa = PBXGroup;
 			children = (
 				B10000020000000000000001 /* Session.swift */,
+				SNC000020000000000000001 /* Session+NotificationContent.swift */,
 				B10000040000000000000001 /* SessionStatus.swift */,
 				N10000040000000000000001 /* HookEvent.swift */,
 				N10000060000000000000001 /* Config.swift */,
@@ -589,6 +595,7 @@
 			files = (
 				A10000010000000000000001 /* CctopApp.swift in Sources */,
 				B10000010000000000000001 /* Session.swift in Sources */,
+				SNC000010000000000000001 /* Session+NotificationContent.swift in Sources */,
 				B10000030000000000000001 /* SessionStatus.swift in Sources */,
 				C10000010000000000000001 /* SessionManager.swift in Sources */,
 				SLP000010000000000000001 /* SessionLifecyclePolicy.swift in Sources */,
@@ -601,6 +608,7 @@
 				CDRP00010000000000000001 /* CodexDesktopRuntimeProbe.swift in Sources */,
 				SMA000010000000000000001 /* SessionManager+Archive.swift in Sources */,
 				SML000010000000000000001 /* SessionManager+Loading.swift in Sources */,
+				SMN000010000000000000001 /* SessionManager+Notifications.swift in Sources */,
 				NPC000010000000000000001 /* NotificationPermissionController.swift in Sources */,
 				D10000010000000000000001 /* StatusChip.swift in Sources */,
 				D10000030000000000000001 /* HeaderView.swift in Sources */,

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -77,10 +77,15 @@ enum HookHandler {
     }
 
     private static func clearToolState(_ session: inout Session) {
-        session.lastTool = nil
-        session.lastToolDetail = nil
+        clearRunningToolState(&session)
         session.notificationMessage = nil
     }
+
+    private static func clearRunningToolState(_ session: inout Session) {
+        session.lastTool = nil
+        session.lastToolDetail = nil
+    }
+
     private static func applySubagentEvent(event: HookEvent, session: inout Session, input: HookInput) {
         switch event {
         case .subagentStart:
@@ -188,8 +193,7 @@ enum HookHandler {
             // delayed Notification transitions to .working, the card can show what tool is running.
 
         case .notificationIdle, .notificationOther:
-            session.lastTool = nil; session.lastToolDetail = nil
-            if let msg = input.message { session.notificationMessage = msg }
+            applyNotificationEvent(event: event, session: &session, input: input)
         case .stop:
             clearToolState(&session)
         case .postToolUseFailure:
@@ -203,6 +207,15 @@ enum HookHandler {
         // notificationPermission: PermissionRequest already handles side effects; Notification fires ~6s later.
         case .notificationPermission, .postCompact, .preCompact, .postToolUse, .sessionEnd, .unknown:
             break
+        }
+    }
+
+    private static func applyNotificationEvent(event: HookEvent, session: inout Session, input: HookInput) {
+        clearRunningToolState(&session)
+        if event == .notificationIdle && input.notificationType == "idle_prompt" {
+            session.notificationMessage = nil
+        } else if let message = input.message {
+            session.notificationMessage = message
         }
     }
 

--- a/menubar/CctopMenubar/Models/Session+NotificationContent.swift
+++ b/menubar/CctopMenubar/Models/Session+NotificationContent.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+struct SessionNotificationContent: Equatable {
+    let title: String
+    let subtitle: String
+    let body: String
+}
+
+extension Session {
+    private static let notificationBodyLimit = 72
+
+    var notificationContent: SessionNotificationContent {
+        let sender = notificationSenderName
+        return SessionNotificationContent(
+            title: notificationTitle,
+            subtitle: notificationSubtitle(sender: sender),
+            body: notificationBody
+        )
+    }
+
+    private var notificationTitle: String {
+        let title = Self.cleanNotificationTitleText(displayName)
+        guard let projectContext = notificationProjectContext,
+              !Self.title(title, alreadyContainsProject: projectContext) else {
+            return title
+        }
+        return "[\(projectContext)] \(title)"
+    }
+
+    private var notificationProjectContext: String? {
+        if let desktopProjectName = Self.cleanOptionalNotificationTitleText(desktopProjectName) {
+            return desktopProjectName
+        }
+        guard sessionName != nil else { return nil }
+        return Self.cleanOptionalNotificationTitleText(projectName)
+    }
+
+    private var notificationSenderName: String {
+        let bundleId = terminal?.bundleId
+        if Self.trustsDesktopBundle(source: source, bundleId: bundleId) {
+            switch bundleId {
+            case HostAppBundleID.codexDesktop: return "Codex Desktop"
+            case HostAppBundleID.claudeDesktop: return "Claude Desktop"
+            default: break
+            }
+        }
+
+        switch source {
+        case Self.codexSource: return "Codex"
+        case Self.opencodeSource: return "opencode"
+        case Self.piSource: return "pi"
+        default: return "Claude"
+        }
+    }
+
+    private func notificationSubtitle(sender: String) -> String {
+        switch status {
+        case .waitingPermission:
+            return "\(sender) needs permission"
+        case .waitingInput:
+            return "\(sender) is waiting for input"
+        default:
+            return "\(sender) needs attention"
+        }
+    }
+
+    private var notificationBody: String {
+        let detail: String?
+        switch status {
+        case .waitingPermission:
+            detail = Self.cleanOptionalNotificationBodyText(notificationMessage) ?? "Permission needed"
+        case .waitingInput:
+            detail = Self.cleanOptionalNotificationBodyText(notificationMessage)
+                ?? Self.cleanOptionalNotificationBodyText(lastPrompt)
+                ?? "Waiting for input"
+        default:
+            detail = Self.cleanOptionalNotificationBodyText(notificationMessage) ?? "Needs attention"
+        }
+        return Self.truncateNotificationBody(detail ?? "Needs attention")
+    }
+
+    private static func title(_ title: String, alreadyContainsProject project: String) -> Bool {
+        let title = title.lowercased()
+        let project = project.lowercased()
+        return title == project || title.hasPrefix("[\(project)] ")
+    }
+
+    private static func cleanOptionalNotificationTitleText(_ text: String?) -> String? {
+        guard let text else { return nil }
+        let cleaned = cleanNotificationTitleText(text)
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
+    private static func cleanOptionalNotificationBodyText(_ text: String?) -> String? {
+        guard let text else { return nil }
+        let cleaned = cleanNotificationBodyText(text)
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
+    private static func cleanNotificationTitleText(_ text: String) -> String {
+        cleanNotificationBodyText(text)
+            .replacingOccurrences(of: "CCTOP", with: "cctop")
+    }
+
+    private static func cleanNotificationBodyText(_ text: String) -> String {
+        text.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    private static func truncateNotificationBody(_ text: String) -> String {
+        guard text.count > notificationBodyLimit else { return text }
+        let prefixLength = max(0, notificationBodyLimit - 3)
+        return String(text.prefix(prefixLength)).trimmingCharacters(in: .whitespacesAndNewlines) + "..."
+    }
+}

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -502,7 +502,6 @@ struct Session: Codable, Identifiable, Equatable {
 }
 
 extension Session {
-
     /// The best available inactive timestamp for ordering retained files.
     var effectiveEndDate: Date {
         disconnectedAt ?? endedAt ?? lastActivity
@@ -518,8 +517,10 @@ extension Session {
         case .compacting: return "Compacting context..."
         case .waitingPermission:
             return notificationMessage ?? "Permission needed"
-        case .waitingInput, .needsAttention:
+        case .waitingInput:
             return notificationMessage ?? promptSnippet
+        case .needsAttention:
+            return notificationMessage ?? promptSnippet ?? "Needs attention"
         case .working:
             if let tool = lastTool {
                 return formatToolDisplay(tool: tool, detail: lastToolDetail)

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -22,9 +22,13 @@ enum SessionIdentityPolicy {
         return "active:\(displayID(for: session))"
     }
 
+    static func notificationRequestIdentifier(for session: Session) -> String {
+        "session-\(stableKey(for: session))"
+    }
+
     static func notificationUserInfo(for session: Session) -> [AnyHashable: Any] {
         [
-            notificationSessionIDKey: displayID(for: session),
+            notificationSessionIDKey: notificationSessionID(for: session),
             notificationSessionPIDKey: session.pid.map(String.init) ?? "",
         ]
     }
@@ -34,6 +38,9 @@ enum SessionIdentityPolicy {
         in sessions: [Session]
     ) -> Session? {
         if let sessionID = nonEmptyString(userInfo[notificationSessionIDKey]) {
+            if let match = sessions.first(where: { notificationSessionID(for: $0) == sessionID }) {
+                return match
+            }
             return sessions.first { displayID(for: $0) == sessionID }
         }
 
@@ -41,6 +48,13 @@ enum SessionIdentityPolicy {
         return sessions.first {
             displayID(for: $0) == pid || $0.pid.map(String.init) == pid
         }
+    }
+
+    private static func notificationSessionID(for session: Session) -> String {
+        if session.isCodex || session.hostClass == .desktop {
+            return session.sessionId
+        }
+        return displayID(for: session)
     }
 
     private static func nonEmptyString(_ value: Any?) -> String? {

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -13,6 +13,7 @@ struct SessionDataSources {
     var desktopAppConnection: DesktopAppConnectionLookup
     var processAlive: (Session) -> Bool
     var notificationsEnabled: () -> Bool
+    var notificationClient: SessionNotificationClient = .live
     var now: () -> Date
 
     /// A function rather than a stored constant so `Config.sessionsDir()` is resolved

--- a/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
@@ -1,0 +1,131 @@
+import Foundation
+@preconcurrency import UserNotifications
+
+struct SessionNotificationClient {
+    var add: (UNNotificationRequest, @escaping (Error?) -> Void) -> Void
+    var removePending: ([String]) -> Void
+    var removeDelivered: ([String]) -> Void
+
+    static let live = SessionNotificationClient(
+        add: { request, completion in
+            UNUserNotificationCenter.current().add(request, withCompletionHandler: completion)
+        },
+        removePending: { identifiers in
+            UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: identifiers)
+        },
+        removeDelivered: { identifiers in
+            UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: identifiers)
+        }
+    )
+}
+
+enum SessionNotificationAction: Equatable {
+    case remove(identifier: String)
+    case post(session: Session)
+}
+
+@MainActor
+extension SessionManager {
+    func syncTransitionNotifications(for newSessions: [Session], oldSessions: [Session]) {
+        for action in Self.notificationActions(
+            newSessions: newSessions,
+            oldSessions: oldSessions,
+            notificationsEnabled: dataSources.notificationsEnabled()
+        ) {
+            switch action {
+            case .remove(let identifier):
+                removeNotification(identifier: identifier)
+            case .post(let session):
+                sendNotification(for: session)
+            }
+        }
+    }
+
+    nonisolated static func notificationActions(
+        newSessions: [Session],
+        oldSessions: [Session],
+        notificationsEnabled: Bool
+    ) -> [SessionNotificationAction] {
+        let newByStableKey = Dictionary(
+            newSessions.map { (SessionIdentityPolicy.stableKey(for: $0), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let oldByStableKey = Dictionary(
+            oldSessions.map { (SessionIdentityPolicy.stableKey(for: $0), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        var actions: [SessionNotificationAction] = []
+        for (key, oldSession) in oldByStableKey where oldSession.status.needsAttention {
+            guard let newSession = newByStableKey[key],
+                  newSession.lifecycle == .active,
+                  newSession.status.needsAttention else {
+                actions.append(.remove(identifier: SessionIdentityPolicy.notificationRequestIdentifier(for: oldSession)))
+                continue
+            }
+        }
+
+        guard notificationsEnabled else { return actions }
+        for (key, newSession) in newByStableKey where newSession.lifecycle == .active && newSession.status.needsAttention {
+            guard let oldSession = oldByStableKey[key],
+                  !oldSession.status.needsAttention else { continue }
+            actions.append(.post(session: newSession))
+        }
+        return actions
+    }
+
+    nonisolated static func notificationRequest(for session: Session) -> UNNotificationRequest {
+        let content = UNMutableNotificationContent()
+        let notification = session.notificationContent
+        content.title = notification.title
+        content.subtitle = notification.subtitle
+        content.body = notification.body
+        content.sound = .default
+        content.userInfo = SessionIdentityPolicy.notificationUserInfo(for: session)
+
+        return UNNotificationRequest(
+            identifier: SessionIdentityPolicy.notificationRequestIdentifier(for: session),
+            content: content,
+            trigger: nil
+        )
+    }
+
+    func postNotification(for session: Session) {
+        let client = dataSources.notificationClient
+        let request = Self.notificationRequest(for: session)
+        client.removePending([request.identifier])
+        client.removeDelivered([request.identifier])
+        client.add(request) { error in
+            if let error {
+                sessionManagerLogger.error("Failed to send notification: \(error, privacy: .public)")
+            }
+        }
+    }
+
+    private func sendNotification(for session: Session) {
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { settings in
+            switch settings.authorizationStatus {
+            case .notDetermined:
+                center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+                    if let error {
+                        sessionManagerLogger.error("Notification permission error: \(error, privacy: .public)")
+                    }
+                    if granted {
+                        self.postNotification(for: session)
+                    }
+                }
+            case .authorized, .provisional, .ephemeral:
+                self.postNotification(for: session)
+            default:
+                break
+            }
+        }
+    }
+
+    private func removeNotification(identifier: String) {
+        let client = dataSources.notificationClient
+        client.removePending([identifier])
+        client.removeDelivered([identifier])
+    }
+}

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Darwin.libproc
 import Foundation
-import UserNotifications
+@preconcurrency import UserNotifications
 import os.log
 
 let sessionManagerLogger = Logger(subsystem: "com.st0012.CctopMenubar", category: "SessionManager")
@@ -63,9 +63,7 @@ class SessionManager: ObservableObject {
             return
         }
 
-        // Notification transition guards use the same identity policy as dedup: Codex and
-        // desktop conversations are stable by session_id; other sessions keep PID identity.
-        let oldStatuses = currentStatusesByStableKey()
+        let oldSessions = sessions
 
         let jsonFiles = sessionJSONFiles(in: files)
         let allDecoded = decodedSessions(from: jsonFiles)
@@ -90,7 +88,7 @@ class SessionManager: ObservableObject {
             .filter { $0.session.lifecycle != .finished }
             .map { adjustDisplayStatus($0.session) }
         let displaySignature = SessionDisplayPolicy.signature(for: newSessions, now: now)
-        sendTransitionNotifications(for: newSessions, oldStatuses: oldStatuses)
+        syncTransitionNotifications(for: newSessions, oldSessions: oldSessions)
         // Only publish when data actually changed, or when the presentation bucket changed
         // because an active idle session crossed the stale-idle threshold.
         if newSessions != sessions || displaySignature != lastDisplaySignature {
@@ -111,17 +109,6 @@ class SessionManager: ObservableObject {
         // only by the slow, lock-held GC. No dormant file is ever deleted on this fast path.
         archiveAndRemoveFinishedNonDesktop(liveCandidates, winners: winners)
         historyManager.rebuildRecentProjects(excludingActive: Set(sessions.map(\.projectPath)))
-    }
-
-    private func sendTransitionNotifications(for newSessions: [Session], oldStatuses: [String: SessionStatus]) {
-        // Notifications: only a LIVE (active) session that NEWLY needs attention. Dormant never notifies.
-        guard dataSources.notificationsEnabled() else { return }
-        for session in newSessions where session.lifecycle == .active {
-            guard session.status.needsAttention,
-                  let oldStatus = oldStatuses[SessionIdentityPolicy.stableKey(for: session)],
-                  !oldStatus.needsAttention else { continue }
-            sendNotification(for: session)
-        }
     }
 
     private func hideAutoHiddenSessions(_ sessions: [(URL, Session)]) {
@@ -378,53 +365,6 @@ class SessionManager: ObservableObject {
                 }
             default:
                 break
-            }
-        }
-    }
-
-    private func sendNotification(for session: Session) {
-        let center = UNUserNotificationCenter.current()
-        center.getNotificationSettings { settings in
-            switch settings.authorizationStatus {
-            case .notDetermined:
-                center.requestAuthorization(options: [.alert, .sound]) { granted, error in
-                    if let error {
-                        sessionManagerLogger.error("Notification permission error: \(error, privacy: .public)")
-                    }
-                    if granted {
-                        self.postNotification(for: session)
-                    }
-                }
-            case .authorized, .provisional, .ephemeral:
-                self.postNotification(for: session)
-            default:
-                break
-            }
-        }
-    }
-
-    private func postNotification(for session: Session) {
-        let content = UNMutableNotificationContent()
-        content.title = session.displayName
-        switch session.status {
-        case .waitingPermission:
-            content.body = session.notificationMessage ?? "Permission needed"
-        case .waitingInput:
-            content.body = session.lastPrompt.map { "Waiting: \(String($0.prefix(80)))" } ?? "Waiting for input"
-        default:
-            content.body = "Needs attention"
-        }
-        content.sound = .default
-        content.userInfo = SessionIdentityPolicy.notificationUserInfo(for: session)
-
-        let request = UNNotificationRequest(
-            identifier: "session-\(session.id)",
-            content: content,
-            trigger: nil
-        )
-        UNUserNotificationCenter.current().add(request) { error in
-            if let error {
-                sessionManagerLogger.error("Failed to send notification: \(error, privacy: .public)")
             }
         }
     }

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -296,6 +296,28 @@ final class HookHandlerTests: XCTestCase {
         try handleFixture("Notification-idle", hookName: "Notification")
         let session = try loadSession()
         XCTAssertEqual(session.status, .waitingInput)
+        XCTAssertNil(session.notificationMessage)
+        XCTAssertEqual(session.contextLine, "\"Fix the login bug\"")
+    }
+
+    func testNotificationElicitationDialogPreservesMessage() throws {
+        try handleFixture("SessionStart")
+        try handleFixture("UserPromptSubmit")
+        try handleHook("""
+        {
+          "session_id": "test-session-001",
+          "cwd": "/tmp/test-project",
+          "hook_event_name": "Notification",
+          "notification_type": "elicitation_dialog",
+          "message": "Which option should I choose?"
+        }
+        """, hookName: "Notification")
+
+        let session = try loadSession()
+        XCTAssertEqual(session.status, .waitingInput)
+        XCTAssertEqual(session.notificationMessage, "Which option should I choose?")
+        XCTAssertEqual(session.contextLine, "Which option should I choose?")
+        XCTAssertEqual(session.notificationContent.body, "Which option should I choose?")
     }
 
     func testOpencodeQuestionPermissionRequestSetsWaitingPermission() throws {
@@ -319,6 +341,24 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertEqual(session.status, .waitingPermission)
         // notificationPermission is a no-op — must not clobber the earlier PermissionRequest message
         XCTAssertEqual(session.notificationMessage, "Allow Bash: rm -rf /tmp/old")
+    }
+
+    func testUnknownNotificationWithoutMessagePreservesPermissionMessage() throws {
+        try handleFixture("SessionStart")
+        try handleFixture("PermissionRequest")
+        try handleHook("""
+        {
+          "session_id": "test-session-001",
+          "cwd": "/tmp/test-project",
+          "hook_event_name": "Notification",
+          "notification_type": "future_type"
+        }
+        """, hookName: "Notification")
+
+        let session = try loadSession()
+        XCTAssertEqual(session.status, .waitingPermission)
+        XCTAssertEqual(session.notificationMessage, "Allow Bash: rm -rf /tmp/old")
+        XCTAssertEqual(session.notificationContent.body, "Allow Bash: rm -rf /tmp/old")
     }
 
     // MARK: - SubagentStart adds to active_subagents

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import UserNotifications
 @testable import CctopMenubar
 
 final class SessionTests: XCTestCase {
@@ -102,9 +103,128 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.contextLine, "\"Original user prompt\"")
     }
 
+    func testContextLineNeedsAttentionFallsBackToNeedsAttention() {
+        let session = Session.mock(status: .needsAttention)
+        XCTAssertEqual(session.contextLine, "Needs attention")
+    }
+
     func testContextLineCompacting() {
         let session = Session.mock(status: .compacting)
         XCTAssertEqual(session.contextLine, "Compacting context...")
+    }
+
+    func testNotificationContentPrefixesDistinctSessionTitleWithProject() {
+        let session = Session.mock(
+            project: "cctop",
+            sessionName: "Handle notification permission flow",
+            status: .waitingInput,
+            lastPrompt: "New comment. Keep the loop until there's a thumb up on pr description",
+            source: "codex"
+        )
+
+        XCTAssertEqual(session.notificationContent.title, "[cctop] Handle notification permission flow")
+        XCTAssertEqual(session.notificationContent.subtitle, "Codex is waiting for input")
+        XCTAssertEqual(
+            session.notificationContent.body,
+            "New comment. Keep the loop until there's a thumb up on pr description"
+        )
+    }
+
+    func testNotificationContentDoesNotDuplicateProjectTitle() {
+        let session = Session.mock(
+            project: "cctop",
+            status: .waitingInput,
+            lastPrompt: "How can I watch it",
+            source: "cc"
+        )
+
+        XCTAssertEqual(session.notificationContent.title, "cctop")
+        XCTAssertEqual(session.notificationContent.subtitle, "Claude is waiting for input")
+        XCTAssertEqual(session.notificationContent.body, "How can I watch it")
+    }
+
+    func testNotificationContentUsesDesktopProjectPrefix() {
+        let session = Session.mock(
+            project: "generated-worktree",
+            sessionName: "Handle notification permission flow",
+            status: .waitingPermission,
+            notificationMessage: "Allow Bash: make all",
+            terminal: TerminalInfo(bundleId: HostAppBundleID.codexDesktop),
+            source: "codex",
+            desktopProjectName: "cctop"
+        )
+
+        XCTAssertEqual(session.notificationContent.title, "[cctop] Handle notification permission flow")
+        XCTAssertEqual(session.notificationContent.subtitle, "Codex Desktop needs permission")
+        XCTAssertEqual(session.notificationContent.body, "Allow Bash: make all")
+    }
+
+    func testNotificationContentPrefixesTitleStartingWithProjectName() {
+        let session = Session.mock(
+            project: "optimistic-mestorf-1d360b",
+            sessionName: "CCTOP promotional video",
+            status: .waitingInput,
+            lastPrompt: "How can I watch it",
+            terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop),
+            source: "cc",
+            desktopProjectName: "cctop"
+        )
+
+        XCTAssertEqual(session.notificationContent.title, "[cctop] cctop promotional video")
+        XCTAssertEqual(session.notificationContent.subtitle, "Claude Desktop is waiting for input")
+    }
+
+    func testNotificationContentCleansAndTruncatesBody() {
+        let session = Session.mock(
+            project: "rdoc",
+            sessionName: "Identify RDoc plugin incompatibility",
+            status: .waitingInput,
+            lastPrompt: "First line\n\nSecond line with extra spacing that keeps going beyond the banner width",
+            source: "codex"
+        )
+
+        XCTAssertEqual(
+            session.notificationContent.body,
+            "First line Second line with extra spacing that keeps going beyond the..."
+        )
+    }
+
+    func testNotificationBodyPreservesUserTextCasing() {
+        let session = Session.mock(
+            project: "cctop",
+            sessionName: "Brand wording",
+            status: .waitingInput,
+            lastPrompt: "Should the body keep CCTOP uppercase?",
+            source: "codex"
+        )
+
+        XCTAssertEqual(session.notificationContent.title, "[cctop] Brand wording")
+        XCTAssertEqual(session.notificationContent.body, "Should the body keep CCTOP uppercase?")
+    }
+
+    func testNotificationBodyPrefersNotificationMessageForWaitingInput() {
+        let session = Session.mock(
+            project: "cctop",
+            sessionName: "Elicitation dialog",
+            status: .waitingInput,
+            lastPrompt: "Actual user prompt",
+            notificationMessage: "Which option should I choose?",
+            source: "codex"
+        )
+
+        XCTAssertEqual(session.notificationContent.body, "Which option should I choose?")
+    }
+
+    func testNotificationBodyFallsBackToLastPromptForWaitingInput() {
+        let session = Session.mock(
+            project: "cctop",
+            sessionName: "Generic idle prompt",
+            status: .waitingInput,
+            lastPrompt: "Actual user prompt",
+            source: "codex"
+        )
+
+        XCTAssertEqual(session.notificationContent.body, "Actual user prompt")
     }
 
     func testDecodesSessionName() throws {
@@ -260,6 +380,196 @@ final class SessionTests: XCTestCase {
         )
 
         XCTAssertEqual(matched?.sessionId, "codex-thread-1")
+    }
+
+    func testNotificationRequestIdentityUsesStableDesktopSessionIdentity() {
+        let session = Session.mock(
+            id: "claude-desktop-thread-1",
+            pid: 12345,
+            terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop),
+            source: "cc"
+        )
+
+        XCTAssertEqual(
+            SessionIdentityPolicy.notificationRequestIdentifier(for: session),
+            "session-desktop:claude-desktop-thread-1"
+        )
+        XCTAssertEqual(
+            SessionIdentityPolicy.stableKey(for: session),
+            "desktop:claude-desktop-thread-1"
+        )
+    }
+
+    func testNotificationRequestDoesNotUseVisibleThreadGrouping() {
+        let session = Session.mock(
+            id: "claude-desktop-thread-1",
+            pid: 12345,
+            terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop),
+            source: "cc"
+        )
+
+        let request = SessionManager.notificationRequest(for: session)
+
+        XCTAssertEqual(request.identifier, "session-desktop:claude-desktop-thread-1")
+        XCTAssertEqual(request.content.threadIdentifier, "")
+    }
+
+    @MainActor
+    func testPostNotificationReplacesOutstandingNotificationForSession() throws {
+        final class Recorder {
+            var events: [String] = []
+        }
+
+        let recorder = Recorder()
+        var sources = SessionDataSources.live()
+        let sessionsDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        sources.sessionsDir = sessionsDir
+        sources.notificationClient = SessionNotificationClient(
+            add: { request, completion in
+                recorder.events.append("add:\(request.identifier)")
+                completion(nil)
+            },
+            removePending: { identifiers in
+                recorder.events.append("removePending:\(identifiers.joined(separator: ","))")
+            },
+            removeDelivered: { identifiers in
+                recorder.events.append("removeDelivered:\(identifiers.joined(separator: ","))")
+            }
+        )
+        let session = Session.mock(
+            id: "claude-desktop-thread-1",
+            pid: 12345,
+            terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop),
+            source: "cc"
+        )
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: FileManager.default.temporaryDirectory),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        manager.postNotification(for: session)
+
+        XCTAssertEqual(
+            recorder.events,
+            [
+                "removePending:session-desktop:claude-desktop-thread-1",
+                "removeDelivered:session-desktop:claude-desktop-thread-1",
+                "add:session-desktop:claude-desktop-thread-1",
+            ]
+        )
+    }
+
+    func testNotificationLookupPrefersDesktopSessionIDOverPID() {
+        let first = Session.mock(
+            id: "claude-desktop-thread-1",
+            pid: 12345,
+            terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop),
+            source: "cc"
+        )
+        let second = Session.mock(
+            id: "claude-desktop-thread-2",
+            pid: 12345,
+            terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop),
+            source: "cc"
+        )
+        let userInfo = SessionIdentityPolicy.notificationUserInfo(for: second)
+
+        let matched = SessionIdentityPolicy.session(
+            matchingNotificationUserInfo: userInfo,
+            in: [first, second]
+        )
+
+        XCTAssertEqual(matched?.sessionId, "claude-desktop-thread-2")
+    }
+
+    func testNotificationActionsRemoveResolvedAttentionSession() {
+        let oldSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: "Waiting",
+            source: "codex"
+        )
+        let resolvedSession = Session.mock(
+            id: "codex-thread-1",
+            status: .working,
+            source: "codex"
+        )
+
+        XCTAssertEqual(
+            SessionManager.notificationActions(
+                newSessions: [resolvedSession],
+                oldSessions: [oldSession],
+                notificationsEnabled: true
+            ),
+            [.remove(identifier: "session-codex:codex-thread-1")]
+        )
+    }
+
+    func testNotificationActionsRemoveMissingAttentionSession() {
+        let oldSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: "Waiting",
+            source: "codex"
+        )
+
+        XCTAssertEqual(
+            SessionManager.notificationActions(
+                newSessions: [],
+                oldSessions: [oldSession],
+                notificationsEnabled: true
+            ),
+            [.remove(identifier: "session-codex:codex-thread-1")]
+        )
+    }
+
+    func testNotificationActionsPostNewAttentionSessionWhenEnabled() {
+        let oldSession = Session.mock(
+            id: "codex-thread-1",
+            status: .working,
+            source: "codex"
+        )
+        let waitingSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: "Waiting",
+            source: "codex"
+        )
+
+        XCTAssertEqual(
+            SessionManager.notificationActions(
+                newSessions: [waitingSession],
+                oldSessions: [oldSession],
+                notificationsEnabled: true
+            ),
+            [.post(session: waitingSession)]
+        )
+    }
+
+    func testNotificationActionsDoNotPostWhenNotificationsDisabled() {
+        let oldSession = Session.mock(
+            id: "codex-thread-1",
+            status: .working,
+            source: "codex"
+        )
+        let waitingSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: "Waiting",
+            source: "codex"
+        )
+
+        XCTAssertEqual(
+            SessionManager.notificationActions(
+                newSessions: [waitingSession],
+                oldSessions: [oldSession],
+                notificationsEnabled: false
+            ),
+            []
+        )
     }
 
     func testDecodesPidStartTime() throws {


### PR DESCRIPTION
## Problem

cctop notifications could be technically enabled but still hard to understand from the macOS banner. Session titles, project names, host app names, and generic idle messages were mixed together in the title/body, which made Codex and Claude Desktop sessions harder to distinguish and could leave stale attention notifications visible after a session resolved.

## Solution

- Format notification title, subtitle, and body from app-specific session context: lowercase `cctop` in titles, prefix distinct session titles with the project name, show the host as the subtitle, and use the user prompt or permission request as the body.
- Keep notification identity stable for Codex and desktop-hosted sessions while avoiding visible macOS thread grouping, so replacement and click routing use conversation identity without grouping unrelated-looking banners.
- Remove pending and delivered notifications when a session leaves an attention state, and keep notification delivery testable behind a small app-only notification extension.