### PR TITLE
Show update download progress

### DIFF
--- a/menubar/CctopMenubar/Services/SparkleUpdater.swift
+++ b/menubar/CctopMenubar/Services/SparkleUpdater.swift
@@ -9,6 +9,7 @@ import Security
 @MainActor
 class UpdaterBase: NSObject, ObservableObject {
     @Published var pendingUpdateVersion: String?
+    @Published var downloadingUpdateVersion: String?
 
     var canCheckForUpdates: Bool { false }
     var disabledReason: DisabledReason? { nil }
@@ -72,6 +73,7 @@ final class SparkleUpdater: UpdaterBase, @preconcurrency SPUUpdaterDelegate {
     nonisolated func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
         Task { @MainActor in
             self.pendingUpdateVersion = item.displayVersionString
+            self.downloadingUpdateVersion = nil
         }
     }
 
@@ -85,6 +87,25 @@ final class SparkleUpdater: UpdaterBase, @preconcurrency SPUUpdaterDelegate {
             if choice != .dismiss {
                 self.pendingUpdateVersion = nil
             }
+        }
+    }
+
+    nonisolated func updater(_ updater: SPUUpdater, willDownloadUpdate item: SUAppcastItem, with request: NSMutableURLRequest) {
+        Task { @MainActor in
+            self.downloadingUpdateVersion = item.displayVersionString
+        }
+    }
+
+    nonisolated func updater(_ updater: SPUUpdater, didDownloadUpdate item: SUAppcastItem) {
+        Task { @MainActor in
+            self.downloadingUpdateVersion = nil
+        }
+    }
+
+    nonisolated func updater(_ updater: SPUUpdater, failedToDownloadUpdate item: SUAppcastItem, error: Error) {
+        Task { @MainActor in
+            self.downloadingUpdateVersion = nil
+            self.pendingUpdateVersion = item.displayVersionString
         }
     }
 }

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -151,7 +151,11 @@ struct SettingsSection: View {
 
     @ViewBuilder
     private var updateSection: some View {
-        if let version = updater.pendingUpdateVersion {
+        if let version = updater.downloadingUpdateVersion {
+            settingsGroup {
+                updateDownloadingSection(version: version)
+            }
+        } else if let version = updater.pendingUpdateVersion {
             settingsGroup {
                 Button {
                     updater.checkForUpdates()
@@ -186,6 +190,22 @@ struct SettingsSection: View {
     }
 
     private var currentVersion: String { Bundle.main.appVersion }
+
+    private func updateDownloadingSection(version: String) -> some View {
+        HStack {
+            Text("Downloading v\(version)\u{2026}")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Color.textPrimary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.9)
+            Spacer(minLength: 8)
+            ProgressView()
+                .controlSize(.small)
+                .accessibilityLabel("Downloading update")
+        }
+        .padding(.horizontal, AppChrome.settingsRowHorizontalPadding)
+        .padding(.vertical, 10)
+    }
 
     private var updateControlsSection: some View {
         HStack {

--- a/menubar/CctopMenubarTests/QASnapshotTests.swift
+++ b/menubar/CctopMenubarTests/QASnapshotTests.swift
@@ -90,6 +90,18 @@ final class QASnapshotTests: XCTestCase {
         try renderSettingsSnapshot(updater: updater, name: "13-settings-update-available-dark", colorScheme: .dark)
     }
 
+    func testSettingsUpdateDownloading() throws {
+        let updater = DisabledUpdater()
+        updater.downloadingUpdateVersion = "0.7.0"
+        try renderSettingsSnapshot(updater: updater, name: "13b-settings-update-downloading")
+    }
+
+    func testSettingsUpdateDownloadingDark() throws {
+        let updater = DisabledUpdater()
+        updater.downloadingUpdateVersion = "0.7.0"
+        try renderSettingsSnapshot(updater: updater, name: "13c-settings-update-downloading-dark", colorScheme: .dark)
+    }
+
     func testSettingsUpToDate() throws {
         try renderSettingsSnapshot(updater: MockQAUpdater(), name: "14-settings-up-to-date")
     }


### PR DESCRIPTION
## Problem

When a user starts installing an available update from Settings, Sparkle begins downloading the new version but the settings row stays in the same update-available state. That makes the app feel unresponsive until Sparkle shows its install-ready prompt.

## Solution

- Track the Sparkle download phase separately from the pending-update phase.
- Show a small progress indicator and `Downloading v...` row in Settings while the update asset is being downloaded.
- Return to the available-update row if the download fails, and cover the new state with light and dark QA snapshots.