### PR TITLE
Improve README presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,25 +37,47 @@ project with a keystroke.
 Each integration reports session events locally; cctop turns them into one menubar
 view and a reliable jump target.
 
-- [Claude Code / Claude Desktop](https://docs.anthropic.com/en/docs/claude-code):
-  Claude plugin + event hooks.
-- [Codex CLI / Codex Desktop](https://github.com/openai/codex): Codex event
-  hooks + trust step.
-- [opencode](https://opencode.ai): opencode plugin events.
-- [pi](https://github.com/badlogic/pi-mono): pi extension events.
+<table>
+  <tr>
+    <td align="center" width="25%">
+      <a href="https://code.claude.com/docs">
+        <img src="assets/icons/claude-code.svg" alt="Claude Code" height="36"><br>
+        <strong>Claude Code / Desktop</strong>
+      </a>
+      <br><sub>Claude plugin + event hooks</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://developers.openai.com/codex">
+        <img src="assets/icons/openai.svg" alt="OpenAI" height="36"><br>
+        <strong>Codex CLI / Desktop</strong>
+      </a>
+      <br><sub>Codex event hooks + trust step</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://opencode.ai">
+        <img src="assets/icons/opencode.svg" alt="opencode" height="28"><br>
+        <strong>opencode</strong>
+      </a>
+      <br><sub>opencode plugin events</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://pi.dev/">
+        <img src="assets/icons/pi.svg" alt="pi" height="36"><br>
+        <strong>pi</strong>
+      </a>
+      <br><sub>pi extension events</sub>
+    </td>
+  </tr>
+</table>
 
 ## Jump Support
 
 When you click a session card, or use Navigate mode, cctop tries to take you to
 the most specific place it can.
 
-- **Targets the exact session:** iTerm2, cmux, Kitty*, Ghostty*, Terminal*,
-  Codex Desktop, Zellij, tmux. cctop jumps to the right window, tab, pane,
-  surface, or desktop thread.
-- **Opens the project:** VS Code, Cursor, Windsurf, Zed. cctop focuses the
-  editor window, using the workspace file if present.
-- **Activates the app:** Claude Desktop, Warp. cctop raises the host app so you
-  can find the tab manually.
+- **Targets the exact session:** [iTerm2](https://iterm2.com/), [cmux](https://cmux.com/), [Kitty](https://sw.kovidgoyal.net/kitty/), [Ghostty](https://ghostty.org/), [Terminal](https://support.apple.com/guide/terminal/welcome/mac), [Codex Desktop](https://developers.openai.com/codex/app), [Zellij](https://zellij.dev/), [tmux](https://tmux.us/). cctop jumps to the right window, tab, pane, surface, or desktop thread.
+- **Opens the project:** [VS Code](https://code.visualstudio.com/), [Cursor](https://cursor.com/), [Windsurf](https://windsurf.com/download), [Zed](https://zed.dev/). cctop focuses the editor window, using the workspace file if present.
+- **Activates the app:** [Claude Desktop](https://claude.com/download), [Warp](https://www.warp.dev/terminal). cctop raises the host app so you can find the tab manually.
 
 <details>
 <summary>Focus details and requirements</summary>

--- a/README.md
+++ b/README.md
@@ -74,50 +74,40 @@ view and a reliable jump target.
 When you click a session card, or use Navigate mode, cctop tries to take you to
 the most specific place it can.
 
-<table>
-  <tr>
-    <th align="left">Focus level</th>
-    <th align="left">Supported apps</th>
-  </tr>
-  <tr>
-    <td>
-      <strong>Targets the exact session</strong><br>
-      <sub>Right window, tab, pane, surface, or desktop thread.</sub>
-    </td>
-    <td>
-      <img src="assets/icons/iterm2.png" alt="" height="16"> iTerm2<br>
-      <img src="assets/icons/cmux.svg" alt="" height="16"> cmux<br>
-      <img src="assets/icons/kitty.svg" alt="" height="16"> Kitty*<br>
-      <img src="assets/icons/ghostty.svg" alt="" height="16"> Ghostty*<br>
-      Terminal*<br>
-      <img src="assets/icons/openai.svg" alt="" height="16"> Codex Desktop<br>
-      <img src="assets/icons/zellij.svg" alt="" height="16"> Zellij<br>
-      <img src="assets/icons/tmux.svg" alt="" height="16"> tmux
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <strong>Opens the project</strong><br>
-      <sub>Focuses the editor window, using the workspace file if present.</sub>
-    </td>
-    <td>
-      <img src="assets/icons/vscode.svg" alt="" height="16"> VS Code<br>
-      <img src="assets/icons/cursor.svg" alt="" height="16"> Cursor<br>
-      <img src="assets/icons/windsurf.svg" alt="" height="16"> Windsurf<br>
-      <img src="assets/icons/zed.svg" alt="" height="16"> Zed
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <strong>Activates the app</strong><br>
-      <sub>Raises the app; find the tab manually.</sub>
-    </td>
-    <td>
-      <img src="assets/icons/claude.svg" alt="" height="16"> Claude Desktop<br>
-      <img src="assets/icons/warp.svg" alt="" height="16"> Warp
-    </td>
-  </tr>
-</table>
+**Targets the exact session**
+
+Right window, tab, pane, surface, or desktop thread.
+
+<p>
+  <img src="assets/icons/iterm2.png" alt="" height="16"> iTerm2 &nbsp;
+  <img src="assets/icons/cmux.svg" alt="" height="16"> cmux &nbsp;
+  <img src="assets/icons/kitty.svg" alt="" height="16"> Kitty* &nbsp;
+  <img src="assets/icons/ghostty.svg" alt="" height="16"> Ghostty* &nbsp;
+  Terminal* &nbsp;
+  <img src="assets/icons/openai.svg" alt="" height="16"> Codex Desktop &nbsp;
+  <img src="assets/icons/zellij.svg" alt="" height="16"> Zellij &nbsp;
+  <img src="assets/icons/tmux.svg" alt="" height="16"> tmux
+</p>
+
+**Opens the project**
+
+Focuses the editor window, using the workspace file if present.
+
+<p>
+  <img src="assets/icons/vscode.svg" alt="" height="16"> VS Code &nbsp;
+  <img src="assets/icons/cursor.svg" alt="" height="16"> Cursor &nbsp;
+  <img src="assets/icons/windsurf.svg" alt="" height="16"> Windsurf &nbsp;
+  <img src="assets/icons/zed.svg" alt="" height="16"> Zed
+</p>
+
+**Activates the app**
+
+Raises the app; find the tab manually.
+
+<p>
+  <img src="assets/icons/claude.svg" alt="" height="16"> Claude Desktop &nbsp;
+  <img src="assets/icons/warp.svg" alt="" height="16"> Warp
+</p>
 
 <details>
 <summary>Focus details and requirements</summary>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # cctop
 
-[![GitHub release](https://img.shields.io/github/v/release/st0012/cctop?v=1)](https://github.com/st0012/cctop/releases/latest)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+<p>
+  <a href="https://github.com/st0012/cctop/releases/latest">Latest release</a>
+  &nbsp;|&nbsp;
+  <a href="LICENSE">MIT license</a>
+</p>
 
 **Keep an eye on your AI coding sessions.**
 
@@ -14,8 +17,6 @@ project with a keystroke.
   <a href="https://github.com/st0012/cctop/releases/latest/download/cctop-macOS-x86_64.dmg">Intel</a>
   &nbsp;|&nbsp;
   <a href="https://cctop.app">Website</a>
-  &nbsp;|&nbsp;
-  <a href="https://github.com/st0012/cctop/releases/latest">Latest release</a>
 </p>
 
 <p align="center">
@@ -36,38 +37,12 @@ project with a keystroke.
 Each integration reports session events locally; cctop turns them into one menubar
 view and a reliable jump target.
 
-<table>
-  <tr>
-    <td align="center" width="25%">
-      <a href="https://docs.anthropic.com/en/docs/claude-code">
-        <img src="assets/icons/claude-code.svg" alt="Claude Code" height="36"><br>
-        <strong>Claude Code / Desktop</strong>
-      </a>
-      <br><sub>Claude plugin + event hooks</sub>
-    </td>
-    <td align="center" width="25%">
-      <a href="https://github.com/openai/codex">
-        <img src="assets/icons/openai.svg" alt="OpenAI" height="36"><br>
-        <strong>Codex CLI / Desktop</strong>
-      </a>
-      <br><sub>Codex event hooks + trust step</sub>
-    </td>
-    <td align="center" width="25%">
-      <a href="https://opencode.ai">
-        <img src="assets/icons/opencode.svg" alt="opencode" height="28"><br>
-        <strong>opencode</strong>
-      </a>
-      <br><sub>opencode plugin events</sub>
-    </td>
-    <td align="center" width="25%">
-      <a href="https://github.com/badlogic/pi-mono">
-        <img src="assets/icons/pi.svg" alt="pi" height="36"><br>
-        <strong>pi</strong>
-      </a>
-      <br><sub>pi extension events</sub>
-    </td>
-  </tr>
-</table>
+- [Claude Code / Claude Desktop](https://docs.anthropic.com/en/docs/claude-code):
+  Claude plugin + event hooks.
+- [Codex CLI / Codex Desktop](https://github.com/openai/codex): Codex event
+  hooks + trust step.
+- [opencode](https://opencode.ai): opencode plugin events.
+- [pi](https://github.com/badlogic/pi-mono): pi extension events.
 
 ## Jump Support
 

--- a/README.md
+++ b/README.md
@@ -3,203 +3,387 @@
 [![GitHub release](https://img.shields.io/github/v/release/st0012/cctop?v=1)](https://github.com/st0012/cctop/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**A keyboard-first menubar app to monitor and jump between AI coding sessions — minimum setup required.**
+**Keep an eye on your AI coding sessions.**
 
-Works with your existing editor, terminal, and workflow.
+See which session is waiting on you. Jump back to the right tab, pane, thread, or
+project with a keystroke.
 
-<table align="center">
+<p>
+  <a href="https://github.com/st0012/cctop/releases/latest/download/cctop-macOS-arm64.dmg"><strong>Download for Apple Silicon</strong></a>
+  &nbsp;|&nbsp;
+  <a href="https://github.com/st0012/cctop/releases/latest/download/cctop-macOS-x86_64.dmg">Intel</a>
+  &nbsp;|&nbsp;
+  <a href="https://cctop.app">Website</a>
+  &nbsp;|&nbsp;
+  <a href="https://github.com/st0012/cctop/releases/latest">Latest release</a>
+</p>
+
+<p align="center">
+  <img src="docs/menubar-tokyonight-dark.png" alt="cctop menubar panel showing active AI coding sessions" width="520">
+  <br>
+  <em>One compact menubar view for sessions across tools.</em>
+</p>
+
+## Why cctop
+
+- See at a glance which coding sessions are working, idle, or waiting on you.
+- Jump directly to the right editor window, terminal pane, desktop thread, or project.
+- Keep recent projects close without leaving a menubar app open all day.
+- Store session state locally as plain JSON. No analytics, telemetry, or session upload.
+
+## Works With Your Coding Tools
+
+Each integration reports session events locally; cctop turns them into one menubar
+view and a reliable jump target.
+
+<table>
   <tr>
-    <td align="center"><img src="docs/menubar-tokyonight-dark.png" alt="cctop menubar popup (Tokyo Night dark)" width="340"></td>
-    <td align="center"><img src="docs/menubar-light.png" alt="cctop menubar popup (Claude light)" width="340"></td>
-  </tr>
-  <tr>
-    <td align="center"><em>Tokyo Night (dark)</em></td>
-    <td align="center"><em>Claude (light)</em></td>
+    <td align="center" width="25%">
+      <a href="https://docs.anthropic.com/en/docs/claude-code">
+        <img src="assets/icons/claude-code.svg" alt="Claude Code" height="36"><br>
+        <strong>Claude Code / Desktop</strong>
+      </a>
+      <br><sub>Claude plugin + event hooks</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://github.com/openai/codex">
+        <img src="assets/icons/openai.svg" alt="OpenAI" height="36"><br>
+        <strong>Codex CLI / Desktop</strong>
+      </a>
+      <br><sub>Codex event hooks + trust step</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://opencode.ai">
+        <img src="assets/icons/opencode.svg" alt="opencode" height="28"><br>
+        <strong>opencode</strong>
+      </a>
+      <br><sub>opencode plugin events</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://github.com/badlogic/pi-mono">
+        <img src="assets/icons/pi.svg" alt="pi" height="36"><br>
+        <strong>pi</strong>
+      </a>
+      <br><sub>pi extension events</sub>
+    </td>
   </tr>
 </table>
 
-## Features
+## Jump Support
 
-**Draggable panel.** Drag the header to reposition the panel anywhere on screen — position persists across launches. Double-click the header to snap back to the default menubar anchor.
+When you click a session card, or use Navigate mode, cctop tries to take you to
+the most specific place it can.
 
-<p align="center">
-  <img src="docs/draggable-panel-demo.gif" alt="Dragging the cctop panel to a new position" width="680">
-</p>
-
-**Navigate mode.** Hit a global hotkey to overlay numbered badges (1–9) on every session card, then press the number to jump instantly.
-
-<p align="center">
-  <img src="docs/menubar-navigate.png" alt="cctop navigate mode with numbered badges" width="340">
-  <br><em>Navigate mode — press 1–9 to jump</em>
-</p>
-
-**Recent Projects.** A second tab keeps session history so you can reopen past projects easily.
-
-<p align="center">
-  <img src="docs/menubar-recent.png" alt="cctop recent projects tab" width="340">
-  <br><em>Recent projects tab</em>
-</p>
-
-**Smart status icon.** See session health without opening the panel:
-
-<p align="center">
-  <img src="docs/status-icon.png" alt="Status icon states: all healthy, needs attention, and notch pill" width="680">
-</p>
-
-### Supported Tools
-
-| Tool | Status | How it connects |
-|------|--------|-----------------|
-| [Claude Code / Claude Desktop](https://code.claude.com/docs) | Supported | Claude plugin + event hooks |
-| [opencode](https://opencode.ai) | Supported | opencode plugin events |
-| [pi](https://pi.dev/) | Supported | pi extension events |
-| [Codex CLI / Codex Desktop](https://developers.openai.com/codex) | Supported | Codex event hooks + trust step |
-
-### Supported Editors & Terminals
-
-When you click a session card (or jump via Navigate mode), cctop focuses the host app:
-
-| App | Focus level |
-|-----|-------------|
-| VS Code, Cursor, Windsurf, Zed | Opens the project (workspace file if present) |
-| iTerm2 | Targets the specific window, tab, and pane |
-| cmux | Targets the specific workspace surface, including already-running sessions when live cmux metadata is available |
-| Kitty | Targets the specific window via remote control |
-| Ghostty | Targets the specific terminal via AppleScript and TTY priming |
-| Terminal | Targets the specific tab by tty |
-| Codex Desktop | Targets the specific thread |
-| Claude Desktop, Warp | Activates the app (no per-tab targeting) |
-| Other | Falls back to opening the project folder in Finder |
-
-> [!NOTE]
-> iTerm2, Ghostty, and Apple Terminal require macOS Automation permission. You'll be prompted to grant it on first use.
->
-> Kitty requires `allow_remote_control socket-only` and `listen_on` in your `kitty.conf`.
-> Without remote control enabled, Kitty falls back to app activation (same as Warp).
->
-> cmux exposes workspace and surface IDs inside each terminal. cctop stores
-> those IDs when hooks run, and can recover them from a live cmux process when
-> an already-running session file is missing multiplexer metadata. It opens a
-> `cmux://` navigation URL for exact surface focus, with a CLI `focus-surface`
-> fallback for cmux reference IDs.
->
-> Ghostty requires version 1.3.0+ for AppleScript support. When a session TTY is
-> available, cctop writes a temporary OSC 7 cwd marker to that TTY, focuses the
-> matching terminal via AppleScript, then restores the real cwd. If the TTY is
-> missing or closed, cctop falls back to working-directory matching.
->
-> Apple Terminal targeting works when the shell runs directly in a tab. Inside a
-> multiplexer (tmux, screen) the captured tty is the multiplexer pane's pty, not
-> the Terminal tab's, so cctop raises Terminal without selecting a specific tab.
-
-### Terminal Multiplexers
-
-When running inside a multiplexer, cctop additionally focuses the specific pane or surface.
-This composes with any terminal emulator above.
-
-| Multiplexer | How it focuses |
-|-------------|----------------|
-| cmux | `cmux://workspace/.../surface/...` or `cmux focus-surface` — targets the exact workspace surface from stored or live cmux metadata |
-| Zellij | `zellij --session <name> action focus-pane-id <paneId>` — targets the exact pane |
-| tmux | `tmux select-window` + `select-pane` — targets the exact window and pane |
-
-## Installation
-
-### Step 1: Install the app
-
-**Download:** [Apple Silicon](https://github.com/st0012/cctop/releases/latest/download/cctop-macOS-arm64.dmg) | [Intel](https://github.com/st0012/cctop/releases/latest/download/cctop-macOS-x86_64.dmg)
-
-Signed release builds can check for updates via Sparkle. You'll be prompted when a new version is available.
+<table>
+  <tr>
+    <th align="left">Focus level</th>
+    <th align="left">Supported apps</th>
+  </tr>
+  <tr>
+    <td>
+      <strong>Targets the exact session</strong><br>
+      <sub>Right window, tab, pane, surface, or desktop thread.</sub>
+    </td>
+    <td>
+      <img src="assets/icons/iterm2.png" alt="" height="16"> iTerm2<br>
+      <img src="assets/icons/cmux.svg" alt="" height="16"> cmux<br>
+      <img src="assets/icons/kitty.svg" alt="" height="16"> Kitty*<br>
+      <img src="assets/icons/ghostty.svg" alt="" height="16"> Ghostty*<br>
+      Terminal*<br>
+      <img src="assets/icons/openai.svg" alt="" height="16"> Codex Desktop<br>
+      <img src="assets/icons/zellij.svg" alt="" height="16"> Zellij<br>
+      <img src="assets/icons/tmux.svg" alt="" height="16"> tmux
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <strong>Opens the project</strong><br>
+      <sub>Focuses the editor window, using the workspace file if present.</sub>
+    </td>
+    <td>
+      <img src="assets/icons/vscode.svg" alt="" height="16"> VS Code<br>
+      <img src="assets/icons/cursor.svg" alt="" height="16"> Cursor<br>
+      <img src="assets/icons/windsurf.svg" alt="" height="16"> Windsurf<br>
+      <img src="assets/icons/zed.svg" alt="" height="16"> Zed
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <strong>Activates the app</strong><br>
+      <sub>Raises the app; find the tab manually.</sub>
+    </td>
+    <td>
+      <img src="assets/icons/claude.svg" alt="" height="16"> Claude Desktop<br>
+      <img src="assets/icons/warp.svg" alt="" height="16"> Warp
+    </td>
+  </tr>
+</table>
 
 <details>
-<summary>Alternative: Homebrew</summary>
+<summary>Focus details and requirements</summary>
+
+- iTerm2, Ghostty, and Apple Terminal require macOS Automation permission.
+- Kitty targets the exact window when `allow_remote_control socket-only` and
+  `listen_on` are enabled in `kitty.conf`; otherwise it falls back to app
+  activation.
+- cmux targets the exact workspace surface from stored metadata, and can recover
+  live cmux metadata for already-running sessions.
+- Ghostty requires version 1.3.0+ for AppleScript support. If the session TTY is
+  unavailable, cctop falls back to working-directory matching.
+- Apple Terminal targets the tab by tty. Inside a multiplexer such as tmux or
+  screen, it falls back to raising Terminal because the captured tty belongs to
+  the multiplexer pane.
+- Other hosts fall back to opening the project folder in Finder.
+
+</details>
+
+## Designed For Scanning, Then Jumping
+
+<table>
+  <tr>
+    <td width="42%">
+      <h3>Navigate mode</h3>
+      <p>Hit a global hotkey to overlay numbered badges on every session card, then press <kbd>1</kbd> to <kbd>9</kbd> to jump instantly.</p>
+    </td>
+    <td align="center">
+      <img src="docs/menubar-navigate.png" alt="cctop navigate mode with numbered badges" width="300">
+    </td>
+  </tr>
+  <tr>
+    <td width="42%">
+      <h3>Draggable panel</h3>
+      <p>Drag the header anywhere on screen. cctop remembers the position, and double-clicking snaps it back to the menubar anchor.</p>
+    </td>
+    <td align="center">
+      <img src="docs/draggable-panel-demo.gif" alt="Dragging the cctop panel to a new position" width="430">
+    </td>
+  </tr>
+  <tr>
+    <td width="42%">
+      <h3>Smart status icon</h3>
+      <p>The menubar icon summarizes session health: healthy, needs attention, and a slim pill for laptops with a camera notch.</p>
+    </td>
+    <td align="center">
+      <img src="docs/status-icon.png" alt="Status icon states: all healthy, needs attention, and notch pill" width="430">
+    </td>
+  </tr>
+  <tr>
+    <td width="42%">
+      <h3>Recent projects</h3>
+      <p>A second tab keeps session history so you can reopen past projects without hunting through old terminals.</p>
+    </td>
+    <td align="center">
+      <img src="docs/menubar-recent.png" alt="cctop recent projects tab" width="300">
+    </td>
+  </tr>
+</table>
+
+## Install
+
+### 1. Install the app
+
+Download the latest signed and notarized build:
+
+- [Apple Silicon](https://github.com/st0012/cctop/releases/latest/download/cctop-macOS-arm64.dmg)
+- [Intel](https://github.com/st0012/cctop/releases/latest/download/cctop-macOS-x86_64.dmg)
+
+Or use Homebrew:
 
 ```bash
 brew install --cask st0012/cctop/cctop
 ```
 
-</details>
+cctop runs on macOS 13+. Signed release builds can check for updates through
+Sparkle.
 
-### Step 2: Connect your tools
+### 2. Connect your tools
 
-Open Settings > Tools. cctop shows the setup action for each detected tool:
+Open **Settings > Tools**. cctop shows the setup action for each detected tool:
 
-- **Claude Code / Claude Desktop:** click *Copy Install Command*, paste it in your terminal, and run it.
-- **opencode** and **pi:** click *Install Plugin*.
-- **Codex CLI / Codex Desktop:** click *Install Hooks*, then start a new Codex CLI session in your terminal and choose *Trust all and continue* when Codex asks to review the new hooks. Codex only executes hooks you've trusted, and cctop shows the row as *Ready* once they are. Codex Desktop shares the same trust state, so trust hooks once through the CLI.
+- Claude Code / Claude Desktop: click **Copy Install Command**, then run the
+  two commands below in a terminal.
+- opencode and pi: click **Install Plugin**.
+- Codex CLI / Codex Desktop: click **Install Hooks**, then start a new Codex CLI
+  session and choose **Trust all and continue** when Codex reviews the hooks.
+  Codex Desktop shares that trust state.
 
-Claude install command:
+Claude setup:
 
 ```bash
-claude plugin marketplace add st0012/cctop && claude plugin install cctop
+claude plugin marketplace add st0012/cctop
+```
+
+Then install the plugin:
+
+```bash
+claude plugin install cctop
 ```
 
 Restart any running sessions to pick up newly installed hooks or plugins.
 
 ## Themes
 
-Four color schemes inspired by beloved developer tools — each with dark and light variants.
+Four palettes inspired by developer tools, each with light and dark variants.
+Switch themes in **Settings > Appearance > Color**.
 
-| Claude | Tokyo Night | Gruvbox | Nord |
-|:------:|:-----------:|:-------:|:----:|
-| <img src="docs/theme-claude-dark.png" width="180"> | <img src="docs/theme-tokyoNight-dark.png" width="180"> | <img src="docs/theme-gruvbox-dark.png" width="180"> | <img src="docs/theme-nord-dark.png" width="180"> |
-
-Switch themes in Settings > Appearance > Color.
+<table>
+  <tr>
+    <th align="center">Claude</th>
+    <th align="center">Tokyo Night</th>
+    <th align="center">Gruvbox</th>
+    <th align="center">Nord</th>
+  </tr>
+  <tr>
+    <td align="center">
+      <img src="docs/theme-claude-dark.png" alt="Claude dark theme screenshot" width="180">
+    </td>
+    <td align="center">
+      <img src="docs/theme-tokyoNight-dark.png" alt="Tokyo Night dark theme screenshot" width="180">
+    </td>
+    <td align="center">
+      <img src="docs/theme-gruvbox-dark.png" alt="Gruvbox dark theme screenshot" width="180">
+    </td>
+    <td align="center">
+      <img src="docs/theme-nord-dark.png" alt="Nord dark theme screenshot" width="180">
+    </td>
+  </tr>
+</table>
 
 ## Privacy
 
-**No analytics, no telemetry, and no session upload. All session data stays on your machine.**
+**No analytics, no telemetry, and no session upload.** Session data stays on your
+machine in `~/.cctop/sessions/` as plain JSON.
 
-Signed release builds use network access for Sparkle update checks and downloads.
+Signed release builds use network access only for Sparkle update checks and
+downloads.
 
-cctop stores only:
+<details>
+<summary>What cctop stores locally</summary>
 
-- Session status (idle / working / waiting)
-- Project directory name
-- Last activity timestamp
-- Current tool or prompt context
+- Session status, such as idle, working, or waiting.
+- Project directory name.
+- Last activity timestamp.
+- Current tool or prompt context.
 
-This data lives in `~/.cctop/sessions/` as plain JSON files. You can inspect it anytime:
+Inspect the files anytime:
 
 ```bash
 ls ~/.cctop/sessions/
 cat ~/.cctop/sessions/*.json | python3 -m json.tool
 ```
 
-The session-file fields are documented in [`docs/session-files.md`](docs/session-files.md).
+The session-file fields are documented in
+[`docs/session-files.md`](docs/session-files.md).
+
+</details>
 
 ## FAQ
 
-**Does cctop slow down my coding tool?**
-No. Each integration calls the lightweight native helper (`cctop-hook`) on session events, writes a small JSON file, and returns immediately.
+<details>
+<summary>Does cctop slow down my coding tool?</summary>
 
-**Do I need to configure anything per project?**
-No. Once your tools are connected, new sessions are automatically tracked. No per-project setup required.
+No. Each integration calls the lightweight native helper (`cctop-hook`) on
+session events, writes a small JSON file, and returns immediately.
 
-**How does cctop name sessions?**
-By default, the project directory name (e.g. `/path/to/my-app` shows as "my-app"). In Claude Code, you can rename a session with `/rename` and cctop picks that up.
+</details>
 
-**No sessions are showing up — what do I check?**
-First, make sure you restarted sessions after installing the plugin. Then check if session files exist: `ls ~/.cctop/sessions/`. If the directory is empty, the plugin isn't writing data — verify it's installed correctly (see Step 2). If files exist but the menubar shows nothing, check whether those JSON files have `"hidden": true`, then try restarting the cctop app.
+<details>
+<summary>Do I need to configure anything per project?</summary>
 
-**Why does Codex Desktop need an extra trust step?**
-Codex only runs hooks you've explicitly reviewed and trusted (see the [Codex hooks docs](https://developers.openai.com/codex/hooks)). cctop can install the hooks, but Codex Desktop does not currently surface the hook-review prompt. Start one Codex CLI session in a terminal and choose *Trust all and continue* when Codex asks to review the new hooks — Codex Desktop shares that trust state and starts tracking too.
+No. Once your tools are connected, new sessions are automatically tracked.
 
-**What happens if a coding tool crashes?**
-cctop detects dead sessions automatically. It checks whether each session's process is still running and removes stale entries. No manual cleanup needed.
+</details>
 
-**Why does the app need to be in /Applications/?**
-All plugins look for `cctop-hook` inside `/Applications/cctop.app`, `~/Applications/cctop.app`, or `~/.cctop/bin/`. Installing elsewhere breaks the hook path.
+<details>
+<summary>How does cctop name sessions?</summary>
 
-**I'm on an Intel Mac and the in-app updater installed the wrong architecture.**
-cctop releases up to and including v0.15.2 shipped an appcast that confused Sparkle's update picker, so Intel Macs could receive the Apple Silicon build. The structural fix is in place going forward, but the Sparkle framework already bundled inside any installed copy of cctop ≤ 0.15.2 doesn't know about the new appcast hints. To get back on the upgrade path, manually download the Intel build once:
+By default, cctop uses the project directory name. In Claude Code, you can rename
+a session with `/rename` and cctop picks that up.
+
+</details>
+
+<details>
+<summary>No sessions are showing up. What do I check?</summary>
+
+First, restart sessions after installing the plugin or hooks. Then check whether
+session files exist:
+
+```bash
+ls ~/.cctop/sessions/
+```
+
+If the directory is empty, the integration is not writing data yet. If files
+exist but the menubar shows nothing, check whether those JSON files have
+`"hidden": true`, then try restarting cctop.
+
+</details>
+
+<details>
+<summary>Why does Codex Desktop need an extra trust step?</summary>
+
+Codex only runs hooks you have explicitly reviewed and trusted. cctop can
+install the hooks, but Codex Desktop does not currently surface the hook-review
+prompt. Start one Codex CLI session in a terminal and trust the hooks there;
+Codex Desktop shares that trust state.
+
+</details>
+
+<details>
+<summary>What happens if a coding tool crashes?</summary>
+
+cctop detects dead sessions automatically by checking whether each session's
+process is still running, then removes stale entries.
+
+</details>
+
+<details>
+<summary>Why does the app need to live in /Applications?</summary>
+
+Plugins look for `cctop-hook` inside `/Applications/cctop.app`,
+`~/Applications/cctop.app`, or `~/.cctop/bin/`. Installing elsewhere breaks the
+hook path.
+
+</details>
+
+<details>
+<summary>I am on an Intel Mac and the updater installed the wrong architecture.</summary>
+
+cctop releases up to and including v0.15.2 shipped an appcast that confused
+Sparkle's update picker, so Intel Macs could receive the Apple Silicon build.
+The fix is in place going forward, but installed copies of cctop v0.15.2 and
+older may need one manual replacement:
 
 1. Quit cctop.
 2. Download [`cctop-macOS-x86_64.dmg`](https://github.com/st0012/cctop/releases/latest/download/cctop-macOS-x86_64.dmg).
 3. Drag the new `cctop.app` into `/Applications/`, replacing the existing one.
-4. Relaunch cctop. Future updates will pick the correct architecture automatically.
+4. Relaunch cctop. Future updates will pick the correct architecture.
 
-## Uninstall
+</details>
+
+## Reference
+
+<details>
+<summary>How it works</summary>
+
+All integrations call `cctop-hook`, a single native helper that owns session
+state.
+
+```mermaid
+flowchart LR
+  tools["Claude / Codex / opencode / pi"] --> hook["cctop-hook"]
+  hook --> files["~/.cctop/sessions/*.json"]
+  files --> app["cctop menubar app"]
+```
+
+1. A tool plugin or hook translates client events into `cctop-hook` calls.
+2. `cctop-hook` writes one small JSON file per session.
+3. The menubar app watches `~/.cctop/sessions/` and renders live status.
+4. pi skips non-interactive background sessions automatically.
+
+</details>
+
+<details>
+<summary>Uninstall</summary>
 
 ```bash
 # Remove the menubar app
@@ -217,50 +401,17 @@ rm ~/.pi/agent/extensions/cctop.ts
 
 # Remove the Codex CLI / Codex Desktop hooks
 rm ~/.codex/cctop-shim.sh
-# Then remove cctop entries from ~/.codex/hooks.json (or delete it if cctop was the only user)
+# Then remove cctop entries from ~/.codex/hooks.json
 
 # Remove session data and config
 rm -rf ~/.cctop
 ```
 
-If installed via Homebrew: `brew uninstall --cask cctop`
+If installed via Homebrew:
 
-<details>
-<summary>How it works</summary>
-
-All tools go through `cctop-hook` — a single native binary that manages all session state.
-
+```bash
+brew uninstall --cask cctop
 ```
-┌─────────────┐    hook fires     ┌────────────┐
-│Claude Code /│ ────────────────> │ cctop-hook │ ──┐
-│  Desktop    │  SessionStart,    │  (Swift)   │   │
-└─────────────┘  Stop, PreTool,…  └────────────┘   │
-                                       ▲           │  writes JSON
-┌─────────────┐   plugin event    ┌────┴───────┐   │  per-session
-│  opencode   │ ────────────────> │ JS plugin  │   │
-└─────────────┘  session.status,  │ (calls     │   │
-                 tool.execute,…   │  cctop-hook│   │
-┌─────────────┐                   └────────────┘   │
-│     pi      │ ────────────────> ┌────────────┐   │
-└─────────────┘  session_start,   │ TS ext     │ ──┤
-                 tool_exec,…      │ (calls     │   ▼
-                                  │  cctop-hook│  ┌───────────────────┐
-                                  └────────────┘  │ ~/.cctop/sessions │
-                                                  │   ├── 123.json    │
-                                                  │   └── 456.json    │
-                                                  └──────────┬────────┘
-                                                             │ file watcher
-                                                             ▼
-                                                  ┌──────────────┐
-                                                  │ Menubar app  │
-                                                  │ (live status)│
-                                                  └──────────────┘
-```
-
-1. Each tool has a thin plugin that translates events into `cctop-hook` calls
-2. `cctop-hook` (Swift CLI) handles all session state and writes to `~/.cctop/sessions/`
-3. The menubar app watches this directory and displays live status
-4. **pi**: non-interactive sessions (background agents) are automatically skipped
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -74,40 +74,13 @@ view and a reliable jump target.
 When you click a session card, or use Navigate mode, cctop tries to take you to
 the most specific place it can.
 
-**Targets the exact session**
-
-Right window, tab, pane, surface, or desktop thread.
-
-<p>
-  <img src="assets/icons/iterm2.png" alt="" height="16"> iTerm2 &nbsp;
-  <img src="assets/icons/cmux.svg" alt="" height="16"> cmux &nbsp;
-  <img src="assets/icons/kitty.svg" alt="" height="16"> Kitty* &nbsp;
-  <img src="assets/icons/ghostty.svg" alt="" height="16"> Ghostty* &nbsp;
-  Terminal* &nbsp;
-  <img src="assets/icons/openai.svg" alt="" height="16"> Codex Desktop &nbsp;
-  <img src="assets/icons/zellij.svg" alt="" height="16"> Zellij &nbsp;
-  <img src="assets/icons/tmux.svg" alt="" height="16"> tmux
-</p>
-
-**Opens the project**
-
-Focuses the editor window, using the workspace file if present.
-
-<p>
-  <img src="assets/icons/vscode.svg" alt="" height="16"> VS Code &nbsp;
-  <img src="assets/icons/cursor.svg" alt="" height="16"> Cursor &nbsp;
-  <img src="assets/icons/windsurf.svg" alt="" height="16"> Windsurf &nbsp;
-  <img src="assets/icons/zed.svg" alt="" height="16"> Zed
-</p>
-
-**Activates the app**
-
-Raises the app; find the tab manually.
-
-<p>
-  <img src="assets/icons/claude.svg" alt="" height="16"> Claude Desktop &nbsp;
-  <img src="assets/icons/warp.svg" alt="" height="16"> Warp
-</p>
+- **Targets the exact session:** iTerm2, cmux, Kitty*, Ghostty*, Terminal*,
+  Codex Desktop, Zellij, tmux. cctop jumps to the right window, tab, pane,
+  surface, or desktop thread.
+- **Opens the project:** VS Code, Cursor, Windsurf, Zed. cctop focuses the
+  editor window, using the workspace file if present.
+- **Activates the app:** Claude Desktop, Warp. cctop raises the host app so you
+  can find the tab manually.
 
 <details>
 <summary>Focus details and requirements</summary>


### PR DESCRIPTION
## Problem

The README had accurate information, but its presentation was harder to scan than the cctop website. Compatibility, jump behavior, installation, privacy, and reference details competed for attention, which made the project harder to understand quickly from GitHub.

## Solution

- Rework the opening and feature sections around a cleaner product narrative with stronger screenshots and shorter copy.
- Restore the supported-agent table with shared SVG marks, and link Jump Support tool names to the same references used by cctop.app.
- Move detailed focus, privacy, FAQ, uninstall, and source-build material into concise sections so the main README reads faster.