### PR TITLE
Add launch video README preview and publishing workflow

### DIFF
--- a/.agents/skills/video-assets/SKILL.md
+++ b/.agents/skills/video-assets/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: video-assets
+description: Use when publishing, replacing, auditing, or linking cctop promo/demo video assets through GitHub Releases, especially the non-latest media-assets release. Trigger for requests like "upload the launch video", "add another video asset", "replace the README demo video", "where should this video live", "update media-assets", or "generate the README AVIF preview". Covers stable asset names, release selection, AVIF preview generation, README/site links, and avoiding v* product-release tags. Do not use for video narrative/storyboard work; use video-storyboard for that.
+---
+
+# Video Assets
+
+Manage cctop video files as GitHub Release assets, not as committed repo binaries. The default pattern is one non-latest media release that acts as a stable asset bucket.
+
+## Rules
+
+- Default release tag: `media-assets`.
+- Default release title: `Media assets`.
+- Always create media-only releases with `--latest=false`.
+- Do not use a `v*` tag for media-only work. In cctop, `v*` tags trigger `.github/workflows/release.yml`: app builds, notarization, GitHub Release creation, Sparkle appcast, and Homebrew updates.
+- Attach a video to a real `v*` release only when the user explicitly asks and the video truthfully demonstrates that shipped app version.
+- Keep full MP4s and other large rendered video out of git. Do not commit `video/projects/*/.video-build/`.
+- Commit a small animated README preview only when the user explicitly chooses that route and the file is intentionally small.
+- Prefer stable purpose-based asset names over dates: `cctop-launch.mp4`, `cctop-launch-720p.mp4`, `cctop-launch-preview.avif`.
+- For launch video uploads, always generate and upload the AVIF preview alongside the MP4s so the README preview and full video stay in sync.
+
+## Workflow
+
+1. Identify the source files.
+   - Launch defaults: `video/projects/launch/.video-build/launch.mp4` and `video/projects/launch/.video-build/launch-720p.mp4`.
+   - Check existence and size with `ls -lh`.
+   - Check duration/codec with `ffprobe` when available.
+
+2. Pick the release target.
+   - Use `media-assets` for reusable README/demo/launch assets.
+   - Use an existing app release such as `v0.18.4` only with explicit user direction.
+   - Inspect before mutating: `gh release view media-assets --repo st0012/cctop`.
+
+3. Pick stable asset names.
+   - Reusing the same asset name plus `--clobber` keeps the download URL stable.
+   - Use a new asset name when history matters or two variants should coexist.
+   - Remember: `gh release upload file.mp4#Label` sets a display label, not a stable download filename. Stage or copy the file to the intended asset filename before upload.
+   - Default launch asset set:
+     - `cctop-launch.mp4` from `launch.mp4`
+     - `cctop-launch-720p.mp4` from `launch-720p.mp4`
+     - `cctop-launch-preview.avif` generated from `launch-720p.mp4`
+
+4. Gate public mutations.
+   - Before creating a release, uploading, or replacing assets, state: release tag, source file, asset name, whether `--clobber` will be used, and the resulting download URL.
+   - Wait for explicit approval unless the user's latest request already clearly authorizes the upload/update.
+   - Never publish a media release as latest.
+
+5. Publish launch assets with the wrapper script. This is the default path for launch renders.
+
+```bash
+.agents/skills/video-assets/scripts/publish-launch-assets.sh --clobber
+```
+
+Use `--dry-run` first when checking paths or explaining what will happen:
+
+```bash
+.agents/skills/video-assets/scripts/publish-launch-assets.sh --clobber --dry-run
+```
+
+The wrapper:
+- Verifies both MP4s exist.
+- Generates a fresh animated AVIF preview from the 720p MP4 with `ffmpeg`.
+- Uploads all three assets to `media-assets`.
+- Keeps the stable download URLs unchanged by reusing the same asset names.
+
+6. Upload individual assets only for non-launch one-offs.
+
+```bash
+.agents/skills/video-assets/scripts/upload-video-asset.sh \
+  --file video/projects/launch/.video-build/launch.mp4 \
+  --name cctop-launch.mp4 \
+  --clobber
+```
+
+For another video:
+
+```bash
+.agents/skills/video-assets/scripts/upload-video-asset.sh \
+  --file path/to/other-video.mp4 \
+  --name cctop-other-video.mp4
+```
+
+The stable download URL shape is:
+
+```text
+https://github.com/st0012/cctop/releases/download/media-assets/<asset-name>
+```
+
+Launch URLs:
+
+```text
+https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-preview.avif
+https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-720p.mp4
+https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch.mp4
+```
+
+## README/Site Links
+
+- For an inline README animation, prefer the release-hosted AVIF preview and an `<img>` tag.
+- Use `cctop-launch-preview.avif` from the same `media-assets` release as the MP4s unless the user explicitly wants a committed preview file.
+- For the full video, link to the release asset URL.
+- Avoid `releases/latest/download/...` for media assets unless every future product release will carry the same asset name. cctop's README and site already use `releases/latest` for app downloads, so media assets should stay separate.
+
+## Helper
+
+`scripts/publish-launch-assets.sh` is the preferred launcher for cctop launch renders. It creates a fresh AVIF preview and delegates uploads to `scripts/upload-video-asset.sh`.
+
+`scripts/upload-video-asset.sh` creates `media-assets` if needed with `--latest=false`, stages the file under the intended asset filename, then uploads it. It refuses `v*` tags unless passed `--allow-v-tag`.

--- a/.agents/skills/video-assets/agents/openai.yaml
+++ b/.agents/skills/video-assets/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Video Assets"
+  short_description: "Manage cctop video release assets"
+  default_prompt: "Use $video-assets to publish or update cctop launch MP4 and AVIF preview assets on the non-latest media release."

--- a/.agents/skills/video-assets/scripts/publish-launch-assets.sh
+++ b/.agents/skills/video-assets/scripts/publish-launch-assets.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="st0012/cctop"
+release_tag="media-assets"
+build_dir="video/projects/launch/.video-build"
+preview_out=""
+avif_width=800
+avif_fps=12
+avif_crf=38
+avif_preset=10
+clobber=0
+dry_run=0
+allow_v_tag=0
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  publish-launch-assets.sh [--clobber] [--dry-run]
+
+Generates the launch README AVIF preview from launch-720p.mp4, then uploads
+the standard launch asset set to the media-assets release:
+  cctop-launch.mp4
+  cctop-launch-720p.mp4
+  cctop-launch-preview.avif
+
+Options:
+  --build-dir <path>      Build output directory. Defaults to video/projects/launch/.video-build.
+  --preview-out <path>    Keep the generated AVIF at this path. Defaults to a temp file.
+  --repo <owner/repo>     GitHub repository. Defaults to st0012/cctop.
+  --release <tag>         Release tag. Defaults to media-assets.
+  --clobber               Replace existing assets with the same names.
+  --dry-run               Generate/check assets but do not change GitHub.
+  --allow-v-tag           Allow uploading to a v* product release.
+  --avif-width <px>       Preview width. Defaults to 800.
+  --avif-fps <fps>        Preview frame rate. Defaults to 12.
+  --avif-crf <value>      AV1 CRF. Defaults to 38.
+  --avif-preset <value>   SVT-AV1 preset. Defaults to 10.
+  -h, --help              Show this help.
+USAGE
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build-dir)
+      [[ $# -ge 2 ]] || die "--build-dir requires a value"
+      build_dir="$2"
+      shift 2
+      ;;
+    --preview-out)
+      [[ $# -ge 2 ]] || die "--preview-out requires a value"
+      preview_out="$2"
+      shift 2
+      ;;
+    --repo)
+      [[ $# -ge 2 ]] || die "--repo requires a value"
+      repo="$2"
+      shift 2
+      ;;
+    --release)
+      [[ $# -ge 2 ]] || die "--release requires a value"
+      release_tag="$2"
+      shift 2
+      ;;
+    --clobber)
+      clobber=1
+      shift
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --allow-v-tag)
+      allow_v_tag=1
+      shift
+      ;;
+    --avif-width)
+      [[ $# -ge 2 ]] || die "--avif-width requires a value"
+      avif_width="$2"
+      shift 2
+      ;;
+    --avif-fps)
+      [[ $# -ge 2 ]] || die "--avif-fps requires a value"
+      avif_fps="$2"
+      shift 2
+      ;;
+    --avif-crf)
+      [[ $# -ge 2 ]] || die "--avif-crf requires a value"
+      avif_crf="$2"
+      shift 2
+      ;;
+    --avif-preset)
+      [[ $# -ge 2 ]] || die "--avif-preset requires a value"
+      avif_preset="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ "$avif_width" =~ ^[0-9]+$ ]] || die "--avif-width must be an integer"
+[[ "$avif_fps" =~ ^[0-9]+$ ]] || die "--avif-fps must be an integer"
+[[ "$avif_preset" =~ ^[0-9]+$ ]] || die "--avif-preset must be an integer"
+[[ "$avif_crf" =~ ^[0-9]+([.][0-9]+)?$ ]] || die "--avif-crf must be numeric"
+
+full_mp4="$build_dir/launch.mp4"
+mp4_720="$build_dir/launch-720p.mp4"
+[[ -f "$full_mp4" ]] || die "missing full render: $full_mp4"
+[[ -f "$mp4_720" ]] || die "missing 720p render: $mp4_720"
+
+command -v ffmpeg >/dev/null 2>&1 || die "ffmpeg is required to generate the AVIF preview"
+
+tmp_dir=""
+if [[ -z "$preview_out" ]]; then
+  tmp_dir="$(mktemp -d)"
+  preview_out="$tmp_dir/cctop-launch-preview.avif"
+fi
+
+cleanup() {
+  if [[ -n "$tmp_dir" ]]; then
+    rm -rf "$tmp_dir"
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "$(dirname "$preview_out")"
+
+printf 'Generating AVIF preview: %s\n' "$preview_out"
+ffmpeg -y -hide_banner -loglevel error \
+  -i "$mp4_720" \
+  -vf "fps=${avif_fps},scale=${avif_width}:-2" \
+  -c:v libsvtav1 \
+  -crf "$avif_crf" \
+  -preset "$avif_preset" \
+  -an \
+  "$preview_out"
+
+ls -lh "$full_mp4" "$mp4_720" "$preview_out"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+upload_script="$script_dir/upload-video-asset.sh"
+[[ -x "$upload_script" ]] || die "upload helper is not executable: $upload_script"
+
+upload_args=(--repo "$repo" --release "$release_tag")
+if [[ "$clobber" -eq 1 ]]; then
+  upload_args+=(--clobber)
+fi
+if [[ "$dry_run" -eq 1 ]]; then
+  upload_args+=(--dry-run)
+fi
+if [[ "$allow_v_tag" -eq 1 ]]; then
+  upload_args+=(--allow-v-tag)
+fi
+
+"$upload_script" --file "$full_mp4" --name cctop-launch.mp4 "${upload_args[@]}"
+"$upload_script" --file "$mp4_720" --name cctop-launch-720p.mp4 "${upload_args[@]}"
+"$upload_script" --file "$preview_out" --name cctop-launch-preview.avif "${upload_args[@]}"
+
+printf 'Launch asset URLs:\n'
+printf '  https://github.com/%s/releases/download/%s/cctop-launch-preview.avif\n' "$repo" "$release_tag"
+printf '  https://github.com/%s/releases/download/%s/cctop-launch-720p.mp4\n' "$repo" "$release_tag"
+printf '  https://github.com/%s/releases/download/%s/cctop-launch.mp4\n' "$repo" "$release_tag"

--- a/.agents/skills/video-assets/scripts/upload-video-asset.sh
+++ b/.agents/skills/video-assets/scripts/upload-video-asset.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="st0012/cctop"
+release_tag="media-assets"
+release_title="Media assets"
+source_file=""
+asset_name=""
+clobber=0
+dry_run=0
+allow_v_tag=0
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  upload-video-asset.sh --file <path> [--name <asset-name>] [--clobber]
+
+Options:
+  --file <path>         Source video/image file to upload.
+  --name <asset-name>   Release asset filename. Defaults to source basename.
+  --release <tag>       Release tag. Defaults to media-assets.
+  --title <title>       Title when creating a missing release.
+  --repo <owner/repo>   GitHub repository. Defaults to st0012/cctop.
+  --clobber             Replace an existing asset with the same name.
+  --dry-run             Print what would happen without changing GitHub.
+  --allow-v-tag         Allow uploading to a v* product release.
+  -h, --help            Show this help.
+USAGE
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --file)
+      [[ $# -ge 2 ]] || die "--file requires a value"
+      source_file="$2"
+      shift 2
+      ;;
+    --name)
+      [[ $# -ge 2 ]] || die "--name requires a value"
+      asset_name="$2"
+      shift 2
+      ;;
+    --release)
+      [[ $# -ge 2 ]] || die "--release requires a value"
+      release_tag="$2"
+      shift 2
+      ;;
+    --title)
+      [[ $# -ge 2 ]] || die "--title requires a value"
+      release_title="$2"
+      shift 2
+      ;;
+    --repo)
+      [[ $# -ge 2 ]] || die "--repo requires a value"
+      repo="$2"
+      shift 2
+      ;;
+    --clobber)
+      clobber=1
+      shift
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --allow-v-tag)
+      allow_v_tag=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$source_file" ]] || die "--file is required"
+[[ -f "$source_file" ]] || die "file not found: $source_file"
+
+if [[ -z "$asset_name" ]]; then
+  asset_name="$(basename "$source_file")"
+fi
+
+[[ "$asset_name" != */* ]] || die "--name must be a filename, not a path"
+[[ "$asset_name" != .* ]] || die "--name should not be hidden"
+
+if [[ "$release_tag" == v* && "$allow_v_tag" -ne 1 ]]; then
+  die "refusing v* product release tag '$release_tag' without --allow-v-tag"
+fi
+
+download_url="https://github.com/${repo}/releases/download/${release_tag}/${asset_name}"
+
+printf 'repo: %s\n' "$repo"
+printf 'release: %s\n' "$release_tag"
+printf 'source: %s\n' "$source_file"
+printf 'asset: %s\n' "$asset_name"
+printf 'replace existing: %s\n' "$([[ "$clobber" -eq 1 ]] && echo yes || echo no)"
+printf 'download URL: %s\n' "$download_url"
+
+if [[ "$dry_run" -eq 1 ]]; then
+  printf 'dry run: no GitHub changes made\n'
+  exit 0
+fi
+
+command -v gh >/dev/null 2>&1 || die "gh is required"
+gh auth status >/dev/null
+
+latest_tag="$(gh release view --repo "$repo" --json tagName --jq '.tagName' 2>/dev/null || true)"
+if [[ "$release_tag" == "media-assets" && "$latest_tag" == "$release_tag" ]]; then
+  die "media-assets is marked latest; fix the release state before uploading"
+fi
+
+if ! gh release view "$release_tag" --repo "$repo" >/dev/null 2>&1; then
+  gh release create "$release_tag" \
+    --repo "$repo" \
+    --title "$release_title" \
+    --notes "Shared README and launch video assets for cctop. This release is intentionally not the latest app release." \
+    --latest=false
+fi
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+staged_file="$tmp_dir/$asset_name"
+cp "$source_file" "$staged_file"
+
+args=(release upload "$release_tag" "$staged_file" --repo "$repo")
+if [[ "$clobber" -eq 1 ]]; then
+  args+=(--clobber)
+fi
+
+gh "${args[@]}"
+printf 'uploaded: %s\n' "$download_url"

--- a/.agents/skills/video-storyboard/SKILL.md
+++ b/.agents/skills/video-storyboard/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: video-storyboard
-description: Use when designing, scripting, or storyboarding a short demo, launch, explainer, or marketing video (especially for a developer tool, app, or SaaS), OR when auditing, critiquing, or improving an existing video's narrative, hook, pacing, or storyboard. Runs a verified 6-stage process — positioning, message spine, beat sheet, script, storyboard, review — embedding StoryBrand, Before-After-Bridge / PAS / AIDA, the Pixar Story Spine, and the But/Therefore rule. Invoke whenever the work is about the STORY of a video rather than its rendering, including phrasings like "storyboard this", "what's the hook", "make the video more compelling", "the video falls flat", "script a launch video", or "audit this video". Do not use for the encoding/rendering pipeline itself.
+description: Use when designing, scripting, or storyboarding a short demo, launch, explainer, or marketing video (especially for a developer tool, app, or SaaS), OR when auditing, critiquing, or improving an existing video's narrative, hook, pacing, or storyboard. Runs a verified 6-stage process — positioning, message spine, beat sheet, script, storyboard, review — embedding StoryBrand, Before-After-Bridge / PAS / AIDA, the Pixar Story Spine, and the But/Therefore rule. Invoke whenever the work is about the STORY of a video rather than its rendering, including phrasings like "storyboard this", "what's the hook", "make the video more compelling", "the video falls flat", "script a launch video", or "audit this video". After an approved render, hand off publishing to video-assets so MP4 and AVIF release assets stay in sync. Do not use this skill for the encoding/rendering pipeline itself.
 ---
 
 # Video Storyboard
 
 A repeatable process for the part of a video that decides whether it works: the **narrative**. Rendering executes the story; this skill designs it.
+
+For cctop launch videos, this is the first half of the workflow:
+
+1. Use this skill for story/script/storyboard/audit decisions.
+2. Render through the repo video pipeline (`cd video && ./build.sh launch` for the launch cut).
+3. After the user approves the rendered video, switch to `$video-assets` and publish with its confirmation gate. That workflow uploads `cctop-launch.mp4`, `cctop-launch-720p.mp4`, and a freshly generated `cctop-launch-preview.avif` together to the non-latest `media-assets` release.
 
 It has two modes:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,44 @@ This file is the canonical guide for agents helping develop cctop. cctop itself 
 - Do not commit temporary explanation artifacts, local investigation HTML, screenshots, scratch scripts, or generated debugging files unless they are intentional product/docs assets.
 - Keep canonical agent guidance in this file. Pointer files such as `CLAUDE.md` should redirect here instead of duplicating instructions that will drift.
 
+## Video Workflow
+
+cctop has a repo-local video pipeline under `video/`. Treat video work as a two-skill flow:
+
+1. Use `$video-storyboard` for story, pacing, storyboard, and narrative critique.
+2. Use `$video-assets` for publishing rendered video assets after the user approves a render.
+
+The current launch video source lives at `video/projects/launch/body.html` with `storyboard.html` as its visual reference. Build from `video/`:
+
+```bash
+./build.sh launch
+```
+
+This writes gitignored outputs under `video/projects/launch/.video-build/`, including:
+
+- `launch.mp4`
+- `launch-720p.mp4`
+
+When a render is approved for publishing, do not manually upload one-off files. Run the `$video-assets` launch workflow instead. It regenerates the README AVIF preview from the 720p MP4 and publishes the full asset set to the non-latest `media-assets` GitHub Release:
+
+```bash
+.agents/skills/video-assets/scripts/publish-launch-assets.sh --clobber --dry-run
+```
+
+Before doing the real upload, report the release tag, source files, stable asset names, `--clobber` behavior, and resulting URLs, then wait for explicit approval unless the latest user message clearly authorizes publishing. The real publish command is:
+
+```bash
+.agents/skills/video-assets/scripts/publish-launch-assets.sh --clobber
+```
+
+The stable launch asset URLs are:
+
+- `https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-preview.avif`
+- `https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-720p.mp4`
+- `https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch.mp4`
+
+Do not use `v*` product-release tags for media-only work, and do not commit rendered MP4s or `.video-build/` outputs. README inline preview should use the release-hosted AVIF unless the developer explicitly asks for a committed preview asset.
+
 ## PR Standards
 
 - PR titles must be plain human-readable titles. Never prefix them with `[codex]`, tool names, or agent tags.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ project with a keystroke.
 </p>
 
 <p align="center">
-  <img src="docs/menubar-tokyonight-dark.png" alt="cctop menubar panel showing active AI coding sessions" width="520">
+  <img src="https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-preview.avif" alt="Animated preview of cctop tracking and jumping between AI coding sessions" width="780">
   <br>
   <em>One compact menubar view for sessions across tools.</em>
+  <br>
+  <a href="https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch.mp4">Full launch video (MP4)</a>
 </p>
 
 ## Why cctop

--- a/video/DELIVERABLES.md
+++ b/video/DELIVERABLES.md
@@ -1,20 +1,33 @@
 # Video deliverables
 
 Rendered mp4s are **gitignored** (they live in each project's `.video-build/`, regenerable with
-`./build.sh <project>`). The *source* is what's versioned. The approved cut of each video is
-published as a **GitHub Release asset**; this file is the durable pointer from a project to its
-published mp4 and the commit it was built from.
+`./build.sh <project>`). The *source* is what's versioned. Approved cctop video assets are published
+to the non-latest `media-assets` GitHub Release through the repo-local `$video-assets` workflow.
 
-| project | published asset | source commit | notes |
-|---------|-----------------|---------------|-------|
-| launch  | _not published yet_ | _pending_ | ~28s launch video (1080p + 720p) |
+| project | published assets | source commit | notes |
+|---------|------------------|---------------|-------|
+| launch  | [`preview.avif`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-preview.avif), [`720p.mp4`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-720p.mp4), [`1080p.mp4`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch.mp4) | _pending source commit_ | ~28s launch video; AVIF is the README inline preview |
 
 ## Publishing a cut
 
 1. `./build.sh <project>` and get explicit approval on the rendered preview.
-2. `gh release create video-<project>-vN projects/<project>/.video-build/<project>.mp4` (and the `-720p`).
-3. Record the asset URL + the source commit in the table above. Point the README/site at the
-   Release asset, **never** an in-tree binary.
+2. Use `$video-assets`, not ad hoc `gh release create` commands. For the launch cut, dry-run first:
+
+   ```bash
+   .agents/skills/video-assets/scripts/publish-launch-assets.sh --clobber --dry-run
+   ```
+
+3. Report the release tag, source files, stable asset names, `--clobber` behavior, and resulting URLs.
+   Wait for explicit approval unless the latest user message clearly authorizes publishing.
+4. Publish:
+
+   ```bash
+   .agents/skills/video-assets/scripts/publish-launch-assets.sh --clobber
+   ```
+
+5. Record the asset URLs + the source commit in the table above. Point README/site preview images at
+   the release-hosted AVIF, and point full video links at the release MP4s. Do not commit rendered
+   MP4s or `.video-build/`.
 
 ## Archive
 

--- a/video/framework.md
+++ b/video/framework.md
@@ -1,7 +1,8 @@
 # cctop Video Framework
 
 A small, reproducible system for making cctop's videos — and the hard-won findings behind it.
-Pairs with the **video-storyboard skill** (the narrative half) and the video-pipeline memory.
+Pairs with the **video-storyboard skill** (the narrative half), the **video-assets skill**
+(release publishing), and the video-pipeline memory.
 
 The split it's built around: **story → engine → theme → video**. You change one layer without
 touching the others. Recolour the app? Edit `theme.css`. New 15s "for teams" cut? Add a project
@@ -58,6 +59,34 @@ headlessly at 2× (supersampled), encodes, then runs `engine/check.sh` on the re
 **Iterate fast:** while authoring, render a few keyframes instead of the whole thing —
 `node engine/render.mjs --url=http://127.0.0.1:8123/projects/launch/body.html --out=/tmp/k --times=3.6,9,14 --scale=1`.
 
+## Publish
+
+Publishing is intentionally separate from rendering. First render and get explicit approval on the
+preview. Then use the repo-local **video-assets skill** so the README preview and full videos stay in
+sync.
+
+From the repo root, dry-run the standard launch asset set:
+
+```bash
+.agents/skills/video-assets/scripts/publish-launch-assets.sh --clobber --dry-run
+```
+
+Report the release tag, source files, stable asset names, and resulting URLs, then wait for explicit
+approval unless the latest user message clearly authorizes publishing. The real upload is:
+
+```bash
+.agents/skills/video-assets/scripts/publish-launch-assets.sh --clobber
+```
+
+That regenerates `cctop-launch-preview.avif` from `launch-720p.mp4`, then uploads:
+
+- `cctop-launch-preview.avif`
+- `cctop-launch-720p.mp4`
+- `cctop-launch.mp4`
+
+All three live on the non-latest `media-assets` GitHub Release. Do not create `v*` media-only
+releases, and do not commit `.video-build/` outputs.
+
 ---
 
 ## Recipe 1 — restyle after a colour change
@@ -82,7 +111,8 @@ multiple palettes, copy `theme.css` to `themes/<name>.css` and point a video's `
    and the `whenReady(seek)` boot, and replace the **scene content and timeline**.
 3. Edit the `TL` object (scene start/end times) and the per-scene `draw*()` functions / DOM.
    Reuse `rev()`, `mix()`, easings (and `whenReady`) from `lib.js`. Put any new screenshots in `<repo>/docs/` and the project's asset list.
-4. `DUR=<seconds> ./build.sh <angle>`, then QA it (Recipe 3).
+4. `DUR=<seconds> ./build.sh <angle>`, then QA it (Recipe 3). If the user approves the cut for
+   publishing, use the video-assets publishing workflow above rather than uploading one-off files.
 
 A video's structure (see `projects/launch/body.html`): a `TL` map of named scenes → `[start,end]`, a `seek(t)`
 that dispatches to small `draw*()` functions, each computing its elements from `t`. The launch cut's
@@ -172,15 +202,16 @@ The **screenshots** the videos use are already in `<repo>/docs/*.png`, so `build
 build time rather than duplicating. The **heavy, regenerable** parts — `frames/` (~1 GB/run at 2×) and the
 mp4s — are `.gitignore`d.
 
-So **a separate repo isn't needed.** Only consider one if you want to archive many large *finished*
-videos long-term — and even then, prefer GitHub Releases / object storage over a git repo for binary
-mp4s. The deliverable mp4 (~3.5 MB) can be committed as a release artifact if useful, but never
-`frames/`.
+So **a separate repo isn't needed.** Keep finished binaries on GitHub Releases / object storage, not
+in git. For the launch cut, the canonical release bucket is `media-assets`, with stable asset names
+managed by `$video-assets`.
 
 ---
 
 ## See also
 - **the video-storyboard skill** — the narrative process: positioning → spine → beats → script →
   storyboard → review, plus the failure-mode checklist.
+- **the video-assets skill** — the release asset process: generate the AVIF preview, upload the MP4s
+  and AVIF together, and keep README links stable.
 - **the video-pipeline memory** — the pipeline at a glance.
 - the v1 making-of is parked in the gitignored `.video-archive/` (it documents the superseded pipeline).

--- a/video/projects/launch/body.html
+++ b/video/projects/launch/body.html
@@ -12,6 +12,8 @@
      radial-gradient(1200px 900px at 24% 16%, #1d2034 0%, rgba(29,32,52,0) 60%),
      radial-gradient(1100px 820px at 82% 92%, #1e1b26 0%, rgba(30,27,38,0) 60%),
      linear-gradient(160deg,#15161f 0%, #1A1B26 46%, #191a28 100%);}
+  #stage::after{content:"";position:absolute;inset:0;pointer-events:none;z-index:1;
+    box-shadow:inset 0 0 190px rgba(2,3,10,.36)}
   .head{color:#E8ECFB}
   .accent{color:var(--accent)}
 
@@ -91,28 +93,29 @@
   #payReply,#payRun{opacity:0;will-change:transform,opacity}
 
   /* STACK chips */
-  #chips{position:absolute;display:grid;grid-template-columns:repeat(2,248px);gap:18px;left:327px;top:498px}
-  .chip{display:flex;align-items:center;gap:14px;padding:0 24px;height:64px;border-radius:16px;opacity:0;will-change:transform,opacity;
+  #chips{position:absolute;display:grid;grid-template-columns:repeat(2,278px);gap:18px;left:296px;top:498px}
+  .chip{display:flex;align-items:center;justify-content:center;gap:14px;padding:0 20px;height:64px;border-radius:16px;opacity:0;will-change:transform,opacity;
     background:rgba(192,202,245,.05);border:1px solid rgba(192,202,245,.11);
-    font-family:var(--mono);font-size:27px;font-weight:600;color:var(--t1);white-space:nowrap}
+    font-family:var(--mono);font-size:26px;font-weight:600;color:var(--t1);white-space:nowrap;text-align:center;
+    box-shadow:0 22px 46px -28px rgba(0,0,0,.75), inset 0 1px 0 rgba(255,255,255,.04)}
   .chip .tmark{width:26px;height:26px;flex:none;background:var(--t1);
     -webkit-mask:center/contain no-repeat;mask:center/contain no-repeat}
   .chip .tmark.wide{width:108px}   /* opencode is a wordmark, not a glyph */
   #editors{position:absolute;left:201px;width:640px;text-align:right;top:680px;font-family:var(--mono);font-size:24px;color:#7d83a0;letter-spacing:.3px;line-height:1.5;opacity:0;will-change:transform,opacity}
 
   /* THEMES fan */
-  .thpanel{position:absolute;overflow:hidden;border-radius:16px;border:1px solid rgba(255,255,255,.06);opacity:0;will-change:transform,opacity;
-    box-shadow:0 34px 70px -28px rgba(0,0,0,.8);transform-origin:bottom center}
+  .thpanel{position:absolute;overflow:hidden;border-radius:16px;border:1px solid rgba(255,255,255,.08);opacity:0;will-change:transform,opacity;
+    box-shadow:0 38px 80px -28px rgba(0,0,0,.82), 0 0 46px -34px rgba(192,202,245,.42);transform-origin:bottom center}
   .thpanel img{display:block;width:100%}
 
   /* CTA */
   #cta{position:absolute;inset:0;opacity:0}
-  #cta #icon{width:168px;height:168px;border-radius:38px;box-shadow:0 40px 90px -25px rgba(0,0,0,.8),0 0 70px -18px rgba(247,118,142,.4);will-change:transform,opacity}
-  #cta .nm{font-size:108px;font-weight:700;letter-spacing:-4px;color:#E8ECFB}
-  #cta .tg{font-size:38px;color:var(--t2);font-weight:500}
+  #cta #icon{width:184px;height:184px;border-radius:42px;box-shadow:0 42px 95px -24px rgba(0,0,0,.86),0 0 86px -18px rgba(247,118,142,.46);will-change:transform,opacity}
+  #cta .nm{font-size:120px;font-weight:700;letter-spacing:-4px;color:#E8ECFB}
+  #cta .tg{font-size:41px;color:#C0CAF5;font-weight:520}
   #cta .meta{font-family:var(--mono);font-size:25px;color:var(--t3);letter-spacing:1px}
-  #cta .url{font-size:56px;font-weight:700;color:var(--accent);letter-spacing:-.5px;position:relative}
-  #cta .url::after{content:"";position:absolute;left:50%;transform:translateX(-50%);bottom:-10px;height:3px;background:var(--accent);width:0%}
+  #cta .url{font-size:64px;font-weight:750;color:var(--accent);letter-spacing:-.5px;position:relative;text-shadow:0 0 42px rgba(247,118,142,.25)}
+  #cta .url::after{content:"";position:absolute;left:50%;transform:translateX(-50%);bottom:-12px;height:4px;background:var(--accent);width:0%;border-radius:4px}
 
   #tether{position:absolute;left:1500px;top:48px;opacity:0;z-index:40;will-change:opacity}
 </style>
@@ -182,7 +185,7 @@
   <div id="chips">
     <div class="chip"><span class="tmark" style="-webkit-mask-image:url(.video-build/assets/icons/claude.svg);mask-image:url(.video-build/assets/icons/claude.svg)"></span>Claude Code</div>
     <div class="chip"><span class="tmark" style="-webkit-mask-image:url(.video-build/assets/icons/openai.svg);mask-image:url(.video-build/assets/icons/openai.svg)"></span>Codex</div>
-    <div class="chip" style="justify-content:center"><span class="tmark wide" style="-webkit-mask-image:url(.video-build/assets/icons/opencode.svg);mask-image:url(.video-build/assets/icons/opencode.svg)"></span></div>
+    <div class="chip"><span class="tmark wide" style="-webkit-mask-image:url(.video-build/assets/icons/opencode.svg);mask-image:url(.video-build/assets/icons/opencode.svg)"></span></div>
     <div class="chip"><span class="tmark" style="-webkit-mask-image:url(.video-build/assets/icons/pi.svg);mask-image:url(.video-build/assets/icons/pi.svg)"></span>pi</div>
   </div>
   <div id="editors">VS Code · Cursor · Zed<br>iTerm2 · Ghostty · Warp · Kitty · cmux</div>
@@ -198,11 +201,11 @@
 
   <!-- CTA -->
   <div id="cta">
-    <div class="ctr" style="top:262px"><img id="icon" src=".video-build/assets/appicon.png"></div>
-    <div class="ctr nm" id="ctaNm" style="top:454px">cctop</div>
+    <div class="ctr" style="top:246px"><img id="icon" src=".video-build/assets/appicon.png"></div>
+    <div class="ctr nm" id="ctaNm" style="top:450px">cctop</div>
     <div class="ctr tg" id="ctaTg" style="top:606px">Find the agent that needs you, and jump straight in.</div>
-    <div class="ctr meta" id="ctaMeta" style="top:678px">Free &amp; open source · macOS menubar app</div>
-    <div class="ctr url" id="ctaUrl" style="top:742px">cctop.app</div>
+    <div class="ctr meta" id="ctaMeta" style="top:682px">Free &amp; open source · macOS menubar app</div>
+    <div class="ctr url" id="ctaUrl" style="top:750px">cctop.app</div>
   </div>
 
 </div>
@@ -210,10 +213,10 @@
 <script src="../../lib.js"></script>
 <script>
 const TL={
-  hook:[0.0,3.2], morph:[3.1,4.2], reveal:[4.0,7.6], scan:[7.5,11.2],
-  jump:[11.1,14.3], payoff:[14.2,17.9], stack:[17.8,21.1], themes:[21.0,23.9], cta:[23.8,28.2]
+  hook:[0.0,3.0], morph:[2.9,4.0], reveal:[3.8,7.2], scan:[7.1,10.7],
+  jump:[10.6,13.8], payoff:[13.7,17.4], stack:[17.3,20.5], themes:[20.4,23.2], cta:[23.0,27.8]
 };
-const TOTAL=28.2;
+const TOTAL=27.8;
 const PANEL={x:905,y:176,w:680,h:781};
 const PILL={x:1630,y:30};                       // pill centre — bloom origin + dot convergence
 const DOTC=[868,914,960,1006,1052], DOTY=538;   // hook dot centres at rest
@@ -330,6 +333,8 @@ function drawPayoff(t){
   const r=rev(t, a+0.95, a+1.35, b-0.4, b-0.05, 18);
   $('#payReply').style.opacity=r.o; $('#payReply').style.transform=`translateY(${r.y}px)`;
   const flip=mix(t, a+1.5, a+1.8);
+  const glow=mix(t, a+1.55, a+2.15);
+  card.style.boxShadow = `0 54px 120px -34px rgba(0,0,0,.85), 0 0 90px -34px rgba(${lerp(255,158,glow).toFixed(0)},${lerp(158,206,glow).toFixed(0)},${lerp(100,106,glow).toFixed(0)},.34)`;
   $('#payStatDot').style.background = flip>0.5?'var(--green)':'var(--orange)';
   $('#payStatT').textContent = flip>0.5?'Working':'Waiting on you';
   $('#payStat').style.color = flip>0.5?'var(--green)':'var(--orange)';
@@ -364,15 +369,15 @@ function drawThemes(t){
 /* CTA */
 function drawCTA(t){
   const [a,b]=TL.cta;
-  const root=$('#cta'); const o=mix(t,a+0.1,a+0.55); root.style.opacity=o; if(o<=0) return;
+  const root=$('#cta'); const o=mix(t,a+0.05,a+0.45); root.style.opacity=o; if(o<=0) return;
   const ic=$('#icon'); const ip=eBack(clamp(mix(t,a+0.15,a+0.95)));
   ic.style.opacity=clamp(mix(t,a+0.15,a+0.5));
   ic.style.transform=`translateY(${lerp(40,0,ip).toFixed(1)}px) scale(${lerp(.6,1,ip).toFixed(3)}) rotate(${lerp(-8,0,ip).toFixed(2)}deg)`;
-  set($('#ctaNm'), rev(t,a+0.5,a+1.0));
-  set($('#ctaTg'), rev(t,a+0.7,a+1.2));
-  set($('#ctaMeta'), rev(t,a+1.0,a+1.5));
-  set($('#ctaUrl'), rev(t,a+1.2,a+1.7));
-  const uw=clamp(mix(t,a+1.6,a+2.4))*100;
+  set($('#ctaNm'), rev(t,a+0.45,a+0.92));
+  set($('#ctaTg'), rev(t,a+0.68,a+1.12));
+  set($('#ctaMeta'), rev(t,a+0.95,a+1.38));
+  set($('#ctaUrl'), rev(t,a+1.15,a+1.58));
+  const uw=clamp(mix(t,a+1.48,a+2.2))*100;
   $('#ctaUrlStyle').textContent=`#cta .url::after{width:${uw}%}`;
 }
 

--- a/video/projects/launch/storyboard.html
+++ b/video/projects/launch/storyboard.html
@@ -6,12 +6,21 @@
 <link rel="stylesheet" href="../../theme.css">
 <style>
   *{margin:0;padding:0;box-sizing:border-box}
-  html,body{width:1920px;height:1080px;overflow:hidden;background:var(--bg);color:var(--t1);
+  html,body{width:100vw;height:100vh;overflow:hidden;background:var(--bg);color:var(--t1);
     font-family:var(--disp);-webkit-font-smoothing:antialiased;text-rendering:geometricPrecision}
-  #stage{position:absolute;inset:0;width:1920px;height:1080px;background:
+  #stage{position:absolute;left:0;top:0;width:1920px;height:1080px;transform-origin:top left;background:
      radial-gradient(1200px 900px at 24% 16%, #1d2034 0%, rgba(29,32,52,0) 60%),
      radial-gradient(1100px 820px at 82% 92%, #1e1b26 0%, rgba(30,27,38,0) 60%),
      linear-gradient(160deg,#15161f 0%, #1A1B26 46%, #191a28 100%);}
+  #storyControls{display:none;position:fixed;left:0;right:0;bottom:0;z-index:100;gap:8px;align-items:center;
+    padding:12px 16px;background:rgba(13,14,22,.92);border-top:1px solid rgba(192,202,245,.11);
+    box-shadow:0 -18px 50px rgba(0,0,0,.38);backdrop-filter:blur(18px)}
+  body.viewer-mode #storyControls{display:flex}
+  #storyControls .label{font-family:var(--mono);font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:var(--t3);margin-right:8px}
+  #storyControls button{height:36px;border:1px solid rgba(192,202,245,.14);border-radius:10px;background:rgba(192,202,245,.05);
+    color:var(--t2);font:600 13px var(--mono);padding:0 11px;cursor:pointer}
+  #storyControls button.active{border-color:rgba(247,118,142,.72);background:rgba(247,118,142,.15);color:#fbdce2;
+    box-shadow:0 0 22px -12px rgba(247,118,142,.75)}
 
   .head{color:#E8ECFB}
   .accent{color:var(--accent)}
@@ -96,26 +105,27 @@
   #payCard .run .ok{font-weight:700}
 
   /* STACK chips */
-  #chips{position:absolute;display:grid;grid-template-columns:repeat(2,248px);gap:18px}
-  .chip{display:flex;align-items:center;gap:14px;padding:0 24px;height:64px;border-radius:16px;
+  #chips{position:absolute;display:grid;grid-template-columns:repeat(2,278px);gap:18px}
+  .chip{display:flex;align-items:center;justify-content:center;gap:14px;padding:0 20px;height:64px;border-radius:16px;
     background:rgba(192,202,245,.05);border:1px solid rgba(192,202,245,.11);
-    font-family:var(--mono);font-size:27px;font-weight:600;color:var(--t1);white-space:nowrap}
+    font-family:var(--mono);font-size:26px;font-weight:600;color:var(--t1);white-space:nowrap;text-align:center;
+    box-shadow:0 22px 46px -28px rgba(0,0,0,.75), inset 0 1px 0 rgba(255,255,255,.04)}
   .chip .tmark{width:26px;height:26px;flex:none;background:var(--t1);
     -webkit-mask:center/contain no-repeat;mask:center/contain no-repeat}
   .chip .tmark.wide{width:108px}
   #editors{position:absolute;font-family:var(--mono);font-size:25px;color:var(--t3);letter-spacing:.3px}
 
   /* THEMES fan */
-  .thpanel{position:absolute;overflow:hidden;border-radius:16px;border:1px solid rgba(255,255,255,.06);
-    box-shadow:0 34px 70px -28px rgba(0,0,0,.8);transform-origin:bottom center}
+  .thpanel{position:absolute;overflow:hidden;border-radius:16px;border:1px solid rgba(255,255,255,.08);
+    box-shadow:0 38px 80px -28px rgba(0,0,0,.82), 0 0 46px -34px rgba(192,202,245,.42);transform-origin:bottom center}
   .thpanel img{display:block;width:100%}
 
   /* CTA */
-  #cta #icon{width:168px;height:168px;border-radius:38px;box-shadow:0 40px 90px -25px rgba(0,0,0,.8),0 0 70px -18px rgba(247,118,142,.4)}
-  #cta .nm{font-size:108px;font-weight:700;letter-spacing:-4px;color:#E8ECFB}
-  #cta .tg{font-size:38px;color:var(--t2);font-weight:500}
+  #cta #icon{width:184px;height:184px;border-radius:42px;box-shadow:0 42px 95px -24px rgba(0,0,0,.86),0 0 86px -18px rgba(247,118,142,.46)}
+  #cta .nm{font-size:120px;font-weight:700;letter-spacing:-4px;color:#E8ECFB}
+  #cta .tg{font-size:41px;color:#C0CAF5;font-weight:520}
   #cta .meta{font-family:var(--mono);font-size:25px;color:var(--t3);letter-spacing:1px}
-  #cta .url{font-size:56px;font-weight:700;color:var(--accent);letter-spacing:-.5px}
+  #cta .url{font-size:64px;font-weight:750;color:var(--accent);letter-spacing:-.5px;text-shadow:0 0 42px rgba(247,118,142,.25)}
 
   /* tether (reveal) */
   #tether{position:absolute;opacity:0;z-index:40}
@@ -201,10 +211,10 @@
   <!-- ============ FRAME 5 — STACK ============ -->
   <div class="sframe" data-i="5">
     <div style="position:absolute;left:341px;width:500px;text-align:right;top:332px;font-size:54px;font-weight:800;letter-spacing:-1px;line-height:1.08;color:#E8ECFB">Works with the<br>stack you've got.</div>
-    <div id="chips" style="left:327px;top:498px">
+    <div id="chips" style="left:296px;top:498px">
       <div class="chip"><span class="tmark" style="-webkit-mask-image:url(.video-build/assets/icons/claude.svg);mask-image:url(.video-build/assets/icons/claude.svg)"></span>Claude Code</div>
       <div class="chip"><span class="tmark" style="-webkit-mask-image:url(.video-build/assets/icons/openai.svg);mask-image:url(.video-build/assets/icons/openai.svg)"></span>Codex</div>
-      <div class="chip" style="justify-content:center"><span class="tmark wide" style="-webkit-mask-image:url(.video-build/assets/icons/opencode.svg);mask-image:url(.video-build/assets/icons/opencode.svg)"></span></div>
+      <div class="chip"><span class="tmark wide" style="-webkit-mask-image:url(.video-build/assets/icons/opencode.svg);mask-image:url(.video-build/assets/icons/opencode.svg)"></span></div>
       <div class="chip"><span class="tmark" style="-webkit-mask-image:url(.video-build/assets/icons/pi.svg);mask-image:url(.video-build/assets/icons/pi.svg)"></span>pi</div>
     </div>
     <div id="editors" style="left:201px;width:640px;text-align:right;top:680px;font-size:24px;color:#7d83a0;line-height:1.5">VS Code · Cursor · Zed<br>iTerm2 · Ghostty · Warp · Kitty · cmux</div>
@@ -223,14 +233,25 @@
   <!-- ============ FRAME 7 — CTA ============ -->
   <div class="sframe" data-i="7">
     <div id="cta">
-      <div class="ctr" style="top:262px"><img id="icon" src=".video-build/assets/appicon.png"></div>
-      <div class="ctr nm" style="top:454px">cctop</div>
+      <div class="ctr" style="top:246px"><img id="icon" src=".video-build/assets/appicon.png"></div>
+      <div class="ctr nm" style="top:450px">cctop</div>
       <div class="ctr tg" style="top:606px">Find the agent that needs you, and jump straight in.</div>
-      <div class="ctr meta" style="top:678px">Free &amp; open source · macOS menubar app</div>
-      <div class="ctr url" style="top:742px">cctop.app</div>
+      <div class="ctr meta" style="top:682px">Free &amp; open source · macOS menubar app</div>
+      <div class="ctr url" style="top:750px">cctop.app</div>
     </div>
   </div>
 
+</div>
+<div id="storyControls" aria-label="Storyboard frames">
+  <span class="label">Frames</span>
+  <button data-frame="0">0 Hook</button>
+  <button data-frame="1">1 Reveal</button>
+  <button data-frame="2">2 Scan</button>
+  <button data-frame="3">3 Jump</button>
+  <button data-frame="4">4 Payoff</button>
+  <button data-frame="5">5 Stack</button>
+  <button data-frame="6">6 Themes</button>
+  <button data-frame="7">7 CTA</button>
 </div>
 
 <script src="../../lib.js"></script>
@@ -239,14 +260,35 @@
    Per-frame menubar band opacity (some beats suppress it). */
 const BAND = [0, 1.0, 0.92, 0.92, 0.70, 0.92, 0, 0];   // index = frame
 const TETHER = 1;                                       // tether visible only on REVEAL
+let currentFrame = 0;
 
 function seek(t){
   const f = Math.max(0, Math.min(7, Math.round(t)));
+  currentFrame = f;
   $$('.sframe').forEach(el=>el.classList.toggle('on', +el.dataset.i===f));
   $('#band').style.opacity = BAND[f];
   $('#tether').style.opacity = f===TETHER ? 1 : 0;
   $('#pill').classList.toggle('hero', f===TETHER);   // pill is the hero on the REVEAL beat
+  $$('#storyControls button').forEach(btn=>btn.classList.toggle('active', +btn.dataset.frame===f));
 }
+function fitStoryboard(){
+  const interactive = window.innerWidth < 1910 || window.innerHeight < 1070;
+  document.body.classList.toggle('viewer-mode', interactive);
+  const controls = $('#storyControls');
+  const pad = interactive ? 18 : 0;
+  const controlsH = interactive ? controls.offsetHeight : 0;
+  const scale = interactive ? Math.min((window.innerWidth-pad*2)/1920, (window.innerHeight-controlsH-pad*2)/1080) : 1;
+  const x = interactive ? Math.max(pad, (window.innerWidth-1920*scale)/2) : 0;
+  const y = interactive ? Math.max(pad, (window.innerHeight-controlsH-1080*scale)/2) : 0;
+  $('#stage').style.transform = `translate(${x.toFixed(1)}px,${y.toFixed(1)}px) scale(${scale.toFixed(4)})`;
+}
+$$('#storyControls button').forEach(btn=>btn.addEventListener('click',()=>seek(+btn.dataset.frame)));
+window.addEventListener('resize', fitStoryboard);
+document.addEventListener('keydown', event=>{
+  if(event.key==='ArrowRight'){ seek(currentFrame+1); }
+  if(event.key==='ArrowLeft'){ seek(currentFrame-1); }
+});
+fitStoryboard();
 whenReady(seek);   // shared boot handshake (lib.js)
 </script>
 </body>


### PR DESCRIPTION
## Problem

The launch video now has release-hosted MP4 assets, but the repo did not yet give reviewers or future agents a reliable way to keep the README preview, full MP4s, and render source in sync. GitHub README rendering also strips raw `<video>` embeds, so the README needs a GitHub-compatible preview path.

The launch storyboard and stack scene also needed small polish so the source matches the approved render: the storyboard should fit normal browser windows, and tool chips should stay centered and roomy.

## Solution

- Use a release-hosted animated AVIF preview in the README, with a link to the full launch MP4.
- Polish the launch video source and storyboard for chip alignment, CTA timing/scale, and browser-fit storyboard navigation.
- Add the `$video-assets` project skill and helper scripts so publishing the launch render always regenerates the AVIF preview and uploads it with both MP4s to the non-latest `media-assets` release.
- Document the render-to-publish handoff in the project guide and video docs so a fresh agent starts with the right workflow and confirmation gate.