### PR TITLE
Fix cleanup file access and scan state

### DIFF
--- a/menubar/CctopMenubar/Models/AppSettings.swift
+++ b/menubar/CctopMenubar/Models/AppSettings.swift
@@ -1,4 +1,5 @@
 import KeyboardShortcuts
+import Foundation
 
 enum AppearanceMode: String, CaseIterable {
     case system, light, dark
@@ -15,4 +16,9 @@ extension KeyboardShortcuts.Name {
     static let togglePanel = Self("togglePanel")
     // Storage key is "refocus" (the old name) for backward compatibility with existing user shortcuts.
     static let navigate = Self("refocus", default: .init(.n, modifiers: [.control, .command]))
+}
+
+enum FileAccessSettings {
+    static let filesAndFoldersURL = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders")!
+    static let privacySecurityURL = URL(string: "x-apple.systempreferences:com.apple.preference.security")!
 }

--- a/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
@@ -9,6 +9,7 @@ private let worktreeCleanupLogger = Logger(
 @MainActor
 class WorktreeCleanupManager: ObservableObject {
     @Published var candidates: [WorktreeCleanupCandidate] = []
+    @Published private(set) var isScanning = false
 
     private let scanner: WorktreeCleanupScanner
     private var refreshGeneration = 0
@@ -29,12 +30,14 @@ class WorktreeCleanupManager: ObservableObject {
         refreshGeneration += 1
         let generation = refreshGeneration
         let scanner = scanner
+        isScanning = true
         DispatchQueue.global(qos: .utility).async {
             let next = scanner
                 .candidates(from: sourceSessions, activeProjectPaths: activeProjectPaths)
                 .filter(\.state.isActionable)
             DispatchQueue.main.async {
                 guard generation == self.refreshGeneration else { return }
+                self.isScanning = false
                 if next != self.candidates {
                     worktreeCleanupLogger.info("cleanup candidates \(self.candidates.count) -> \(next.count)")
                     self.candidates = next

--- a/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
@@ -54,6 +54,7 @@ struct WorktreeCleanupScanner {
         for session in sessions {
             guard session.endedAt != nil else { continue }
             let rawPath = Self.standardizedPath(session.projectPath)
+            guard shouldScanEndedSessionPath(rawPath) else { continue }
             let path = resolvedPaths[rawPath] ?? {
                 let path = resolvedCandidatePath(for: rawPath)
                 resolvedPaths[rawPath] = path
@@ -311,6 +312,11 @@ struct WorktreeCleanupScanner {
 }
 
 private extension WorktreeCleanupScanner {
+    func shouldScanEndedSessionPath(_ path: String) -> Bool {
+        guard Self.isLikelyPrivacyProtectedUserPath(path) else { return true }
+        return Self.isPlausibleCleanupWorktreePath(path)
+    }
+
     func shouldResolveActiveProjectPath(_ activePath: String, candidatePaths: Set<String>) -> Bool {
         if candidatePaths.contains(where: { candidatePath in
             Self.isPath(activePath, sameAsOrDescendantOf: candidatePath)
@@ -329,6 +335,19 @@ private extension WorktreeCleanupScanner {
         let pathComponents = URL(fileURLWithPath: path).pathComponents
         guard pathComponents.count > 3, pathComponents[1] == "Users" else { return false }
         return ["Desktop", "Documents", "Downloads"].contains(pathComponents[3])
+    }
+
+    static func isPlausibleCleanupWorktreePath(_ path: String) -> Bool {
+        let pathComponents = URL(fileURLWithPath: path).pathComponents
+        guard pathComponents.count >= 3 else { return false }
+        for index in 0..<(pathComponents.count - 2) {
+            let marker = pathComponents[index]
+            guard marker == ".claude" || marker == ".codex" else { continue }
+            if pathComponents[index + 1] == "worktrees", !pathComponents[index + 2].isEmpty {
+                return true
+            }
+        }
+        return false
     }
 }
 

--- a/menubar/CctopMenubar/Views/PopupView+Cleanup.swift
+++ b/menubar/CctopMenubar/Views/PopupView+Cleanup.swift
@@ -14,6 +14,7 @@ extension PopupView {
             candidates: actionableCleanupCandidates,
             selectedIndex: selectedIndex,
             selectedCandidate: $selectedCleanupCandidate,
+            isScanning: cleanupIsScanning,
             relativeTimeNow: relativeTimeNow,
             onSelect: openCleanupDetail,
             onRemove: requestCleanupRemoval,
@@ -39,6 +40,10 @@ extension PopupView {
             selectedCleanupCandidate = nil
             cleanupRemovalNotice = nil
         }
+    }
+
+    func handleCleanupScanningChanged() {
+        notifyLayoutChanged()
     }
 
     func performCleanupRemoval(_ candidate: WorktreeCleanupCandidate) {

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -9,6 +9,7 @@ struct PopupView: View {
     let sessions: [Session]
     var recentProjects: [RecentProject] = []
     var cleanupCandidates: [WorktreeCleanupCandidate] = []
+    var cleanupIsScanning = false
     @ObservedObject var updater: UpdaterBase
     let pluginManager: PluginManager
     var navigate: NavigateController?
@@ -102,6 +103,7 @@ struct PopupView: View {
         .onChange(of: sessions) { _ in ensureSelectedTabAvailable() }
         .onChange(of: recentProjects.map(\.id)) { _ in ensureSelectedTabAvailable() }
         .onChange(of: actionableCleanupCandidates) { _ in handleCleanupCandidatesChanged() }
+        .onChange(of: cleanupIsScanning) { _ in handleCleanupScanningChanged() }
         .onChange(of: selectedCleanupCandidate?.id) { _ in
             cleanupRemovalNotice = nil
             notifyLayoutChanged()
@@ -141,15 +143,15 @@ struct PopupView: View {
             if !recentProjects.isEmpty {
                 tabButton("Recent", count: recentProjects.count, tab: .recent)
             }
-            tabButton("Cleanup", count: actionableCleanupCandidates.count, tab: .cleanup)
+            tabButton("Cleanup", count: actionableCleanupCandidates.count, tab: .cleanup, isScanning: cleanupIsScanning)
             Spacer()
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
     }
 
-    private func tabButton(_ label: String, count: Int, tab: PopupTab) -> some View {
-        TabButtonView(label: label, count: count, isSelected: selectedTab == tab) {
+    private func tabButton(_ label: String, count: Int, tab: PopupTab, isScanning: Bool = false) -> some View {
+        TabButtonView(label: label, count: count, isScanning: isScanning, isSelected: selectedTab == tab) {
             if overlayController.active != nil { closeOverlay(animated: false) }
             withAnimation(.easeInOut(duration: 0.15)) { selectedTab = tab }
             notifyLayoutChanged()

--- a/menubar/CctopMenubar/Views/PopupViewHelpers.swift
+++ b/menubar/CctopMenubar/Views/PopupViewHelpers.swift
@@ -170,6 +170,7 @@ struct RollUpEffect: ViewModifier {
 struct TabButtonView: View {
     let label: String
     let count: Int
+    var isScanning = false
     let isSelected: Bool
     let action: () -> Void
     @State private var isHovered = false
@@ -182,11 +183,18 @@ struct TabButtonView: View {
                     .foregroundStyle(isSelected ? Color.textPrimary : Color.textMuted)
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
-                Text("\(count)")
-                    .font(.system(size: 9, weight: .medium))
-                    .foregroundStyle(isSelected ? Color.textPrimary : Color.textMuted)
-                    .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
+                if isScanning {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .frame(width: 10, height: 10)
+                        .accessibilityLabel("\(label) scanning")
+                } else {
+                    Text("\(count)")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(isSelected ? Color.textPrimary : Color.textMuted)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+                }
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 4)
@@ -235,6 +243,7 @@ struct PanelContentView: View {
             sessions: sessionManager.sessions,
             recentProjects: historyManager.recentProjects,
             cleanupCandidates: cleanupManager.candidates,
+            cleanupIsScanning: cleanupManager.isScanning,
             updater: updater,
             pluginManager: pluginManager,
             navigate: navigate,

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -82,6 +82,15 @@ struct SettingsSection: View {
                 }
                 groupedDivider
                 NotificationSettingsRow(notificationPermission: notificationPermission)
+                groupedDivider
+                settingsRow("File Access") {
+                    Button("Open Settings") {
+                        openFileAccessSettings()
+                    }
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Color.segmentActiveText)
+                    .buttonStyle(.plain)
+                }
             }
         }
         .padding(AppChrome.settingsContentPadding)
@@ -236,6 +245,12 @@ struct SettingsSection: View {
             .padding(.vertical, 8)
     }
 
+    private func openFileAccessSettings() {
+        if NSWorkspace.shared.open(FileAccessSettings.filesAndFoldersURL) {
+            return
+        }
+        NSWorkspace.shared.open(FileAccessSettings.privacySecurityURL)
+    }
 }
 
 // MARK: - Monitored Tools

--- a/menubar/CctopMenubar/Views/WorktreeCleanupTabView.swift
+++ b/menubar/CctopMenubar/Views/WorktreeCleanupTabView.swift
@@ -4,6 +4,7 @@ struct WorktreeCleanupTabView: View {
     let candidates: [WorktreeCleanupCandidate]
     let selectedIndex: Int?
     @Binding var selectedCandidate: WorktreeCleanupCandidate?
+    var isScanning = false
     var relativeTimeNow = Date()
     var onSelect: (WorktreeCleanupCandidate) -> Void = { _ in }
     var onRemove: (WorktreeCleanupCandidate, WorktreeForceRemovalOffer?) -> Void = { _, _ in }
@@ -11,6 +12,18 @@ struct WorktreeCleanupTabView: View {
     var removingCandidateID: String?
 
     var body: some View {
+        if isScanning && !candidates.isEmpty {
+            VStack(spacing: 0) {
+                scanningBanner
+                cleanupContent
+            }
+        } else {
+            cleanupContent
+        }
+    }
+
+    @ViewBuilder
+    private var cleanupContent: some View {
         if let candidate = selectedCandidate {
             WorktreeCleanupDetailView(
                 candidate: candidate,
@@ -22,10 +35,16 @@ struct WorktreeCleanupTabView: View {
             )
         } else if candidates.isEmpty {
             VStack(spacing: 8) {
-                Image(systemName: "sparkles")
-                    .font(.system(size: 20))
-                    .foregroundStyle(Color.textMuted)
-                Text("No cleanup candidates")
+                if isScanning {
+                    ProgressView()
+                        .controlSize(.small)
+                        .accessibilityLabel("Scanning worktrees")
+                } else {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 20))
+                        .foregroundStyle(Color.textMuted)
+                }
+                Text(isScanning ? "Scanning worktrees..." : "No cleanup candidates")
                     .font(.system(size: 12))
                     .foregroundStyle(Color.textMuted)
                     .multilineTextAlignment(.center)
@@ -34,6 +53,27 @@ struct WorktreeCleanupTabView: View {
             .padding(.vertical, 24)
         } else {
             cleanupList
+        }
+    }
+
+    private var scanningBanner: some View {
+        HStack(spacing: 6) {
+            ProgressView()
+                .controlSize(.mini)
+                .frame(width: 12, height: 12)
+                .accessibilityLabel("Scanning worktrees")
+            Text("Scanning worktrees...")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(Color.textMuted)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 6)
+        .background(Color.panelControlBackground)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Color.panelControlBorder)
+                .frame(height: 1)
         }
     }
 

--- a/menubar/CctopMenubarTests/AppSettingsTests.swift
+++ b/menubar/CctopMenubarTests/AppSettingsTests.swift
@@ -18,6 +18,17 @@ final class AppSettingsTests: XCTestCase {
         let cases = AppearanceMode.allCases
         XCTAssertEqual(cases, [.system, .light, .dark])
     }
+
+    func testFileAccessSettingsURLsOpenPrivacySystemSettings() {
+        XCTAssertEqual(
+            FileAccessSettings.filesAndFoldersURL.absoluteString,
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders"
+        )
+        XCTAssertEqual(
+            FileAccessSettings.privacySecurityURL.absoluteString,
+            "x-apple.systempreferences:com.apple.preference.security"
+        )
+    }
 }
 
 @MainActor

--- a/menubar/CctopMenubarTests/QASnapshotTests.swift
+++ b/menubar/CctopMenubarTests/QASnapshotTests.swift
@@ -113,6 +113,15 @@ final class QASnapshotTests: XCTestCase {
         )
     }
 
+    func testSettingsFileAccessRecoveryRow() throws {
+        try renderSettingsSnapshot(
+            updater: DisabledUpdater(),
+            name: "16-settings-file-access-bottom-dark",
+            colorScheme: .dark,
+            scrollToBottom: true
+        )
+    }
+
     // MARK: - Polish review matrix
 
     func testPolishReviewMatrix() throws {

--- a/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
@@ -62,6 +62,19 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
         try renderSpecialStateScreenshots(for: scenario)
     }
 
+    func testGenerateCleanupScanningPopupScreenshot() throws {
+        let scenario = cleanupScenario()
+        let view = cleanupPopup(candidates: Array(scenario.productInputCandidates.prefix(3)), isScanning: true)
+        let size = try renderScreenshot(
+            view: view,
+            colorScheme: .dark,
+            filename: "worktree-cleanup-popup-scanning-tab-dark.png"
+        )
+
+        XCTAssertLessThanOrEqual(size.width, 320)
+        XCTAssertLessThanOrEqual(size.height, 430)
+    }
+
     private func renderListScreenshots(for scenario: Scenario) throws {
         let actionableCount = scenario.productInputCandidates.filter(\.state.isActionable).count
         XCTAssertEqual(actionableCount, scenario.allCandidates.count)
@@ -189,9 +202,36 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
             candidates: [],
             selectedIndex: nil,
             selectedCandidate: Binding<WorktreeCleanupCandidate?>.constant(nil),
+            isScanning: false,
             onRemove: { _, _ in }
         )
         try renderScreenshot(view: emptyState, colorScheme: .dark, filename: "worktree-cleanup-empty.png")
+
+        let scanningEmptyState = WorktreeCleanupTabView(
+            candidates: [],
+            selectedIndex: nil,
+            selectedCandidate: Binding<WorktreeCleanupCandidate?>.constant(nil),
+            isScanning: true,
+            onRemove: { _, _ in }
+        )
+        try renderScreenshot(
+            view: scanningEmptyState,
+            colorScheme: .dark,
+            filename: "worktree-cleanup-scanning-empty.png"
+        )
+
+        let scanningPreviousCandidates = WorktreeCleanupTabView(
+            candidates: Array(overflow.prefix(3)),
+            selectedIndex: nil,
+            selectedCandidate: Binding<WorktreeCleanupCandidate?>.constant(nil),
+            isScanning: true,
+            onRemove: { _, _ in }
+        )
+        try renderScreenshot(
+            view: scanningPreviousCandidates,
+            colorScheme: .dark,
+            filename: "worktree-cleanup-scanning-with-candidates.png"
+        )
     }
 
     @discardableResult
@@ -251,12 +291,14 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
     private func cleanupPopup(
         candidates: [WorktreeCleanupCandidate],
         selectedCandidate: WorktreeCleanupCandidate? = nil,
-        sessions: [Session] = Session.qaShowcase
+        sessions: [Session] = Session.qaShowcase,
+        isScanning: Bool = false
     ) -> PopupView {
         PopupView(
             sessions: sessions,
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: candidates,
+            cleanupIsScanning: isScanning,
             updater: DisabledUpdater(),
             pluginManager: inertPluginManager(),
             initialTab: .cleanup,

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -112,6 +112,73 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(resolvedPaths, [candidatePath])
     }
 
+    func testScannerSkipsProtectedEndedProjectPathWithoutFileProbes() {
+        let documentsProjectPath = "/Users/dev/Documents/Codex/old-session"
+        var probedPaths: [String] = []
+        var resolvedPaths: [String] = []
+        var inspectedPaths: [String] = []
+
+        let scanner = WorktreeCleanupScanner(
+            fileExists: { path in
+                probedPaths.append(path)
+                return true
+            },
+            resolveWorktreeRoot: { path in
+                resolvedPaths.append(path)
+                return nil
+            },
+            inspectGit: { path in
+                inspectedPaths.append(path)
+                return self.cleanInspection()
+            },
+            measureSize: { _ in 1_024 }
+        )
+
+        let candidates = scanner.candidates(
+            from: [historySession(path: documentsProjectPath)],
+            activeProjectPaths: []
+        )
+
+        XCTAssertEqual(candidates, [])
+        XCTAssertEqual(probedPaths, [])
+        XCTAssertEqual(resolvedPaths, [])
+        XCTAssertEqual(inspectedPaths, [])
+    }
+
+    func testScannerStillScansProtectedEndedWorktreePath() {
+        let documentsWorktreePath = "/Users/dev/Documents/app/.claude/worktrees/feature-x"
+        var probedPaths: [String] = []
+        var resolvedPaths: [String] = []
+        var inspectedPaths: [String] = []
+
+        let scanner = WorktreeCleanupScanner(
+            fileExists: { path in
+                probedPaths.append(path)
+                return path == documentsWorktreePath
+            },
+            resolveWorktreeRoot: { path in
+                resolvedPaths.append(path)
+                return path == documentsWorktreePath ? documentsWorktreePath : nil
+            },
+            inspectGit: { path in
+                inspectedPaths.append(path)
+                return self.cleanInspection(branch: "claude/feature-x")
+            },
+            measureSize: { _ in 1_024 }
+        )
+
+        let candidates = scanner.candidates(
+            from: [historySession(path: documentsWorktreePath)],
+            activeProjectPaths: []
+        )
+
+        XCTAssertEqual(candidates.map(\.id), [documentsWorktreePath])
+        XCTAssertEqual(candidates[0].branchName, "claude/feature-x")
+        XCTAssertFalse(probedPaths.isEmpty)
+        XCTAssertEqual(resolvedPaths, [documentsWorktreePath])
+        XCTAssertEqual(inspectedPaths, [documentsWorktreePath])
+    }
+
     func testActiveProjectPathPrefixSiblingDoesNotProtectCandidate() {
         let path = "/Users/dev/.codex/worktrees/billing-api"
 
@@ -971,6 +1038,19 @@ final class WorktreeCleanupTests: XCTestCase {
     }
 
     @MainActor
+    func testCleanupScanningChangeNotifiesLayout() async throws {
+        let layoutChanged = expectation(description: "cleanup scanning change notifies layout")
+        let view = popupView(
+            cleanupCandidates: [],
+            onLayoutChanged: { layoutChanged.fulfill() }
+        )
+
+        view.handleCleanupScanningChanged()
+
+        await fulfillment(of: [layoutChanged], timeout: 1)
+    }
+
+    @MainActor
     func testCleanupTabBecomingVisibleRequestsFreshCleanupScan() {
         let candidate = cleanupCandidate(path: "/Users/dev/.codex/worktrees/billing-api")
         var visibilityRefreshCount = 0
@@ -1137,6 +1217,85 @@ final class WorktreeCleanupTests: XCTestCase {
         try await waitForCleanupCandidates(manager) { candidates in
             candidates.first?.state == .review(["Worktree has untracked files"])
         }
+    }
+
+    @MainActor
+    func testRefreshPublishesScanningWhileScanIsBlockedAndClearsAfterCompletion() async throws {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let scanStarted = expectation(description: "scan started")
+        let releaseScan = DispatchSemaphore(value: 0)
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in true },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { _ in
+                    scanStarted.fulfill()
+                    releaseScan.wait()
+                    return self.cleanInspection()
+                },
+                measureSize: { _ in 1_024 }
+            )
+        )
+
+        manager.refresh(from: [session], activeProjectPaths: [], force: true)
+
+        XCTAssertTrue(manager.isScanning)
+        await fulfillment(of: [scanStarted], timeout: 1)
+
+        releaseScan.signal()
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.id == worktreePath
+        }
+        XCTAssertFalse(manager.isScanning)
+    }
+
+    @MainActor
+    func testRefreshKeepsScanningUntilLatestGenerationCompletes() async throws {
+        let firstPath = "/Users/dev/.codex/worktrees/first"
+        let secondPath = "/Users/dev/.codex/worktrees/second"
+        let firstStarted = expectation(description: "first scan started")
+        let secondStarted = expectation(description: "second scan started")
+        let releaseFirst = DispatchSemaphore(value: 0)
+        let releaseSecond = DispatchSemaphore(value: 0)
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in true },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { path in
+                    switch path {
+                    case firstPath:
+                        firstStarted.fulfill()
+                        releaseFirst.wait()
+                        return self.cleanInspection(branch: "feature/first")
+                    case secondPath:
+                        secondStarted.fulfill()
+                        releaseSecond.wait()
+                        return self.cleanInspection(branch: "feature/second")
+                    default:
+                        return self.cleanInspection()
+                    }
+                },
+                measureSize: { _ in 1_024 }
+            )
+        )
+
+        manager.refresh(from: [historySession(path: firstPath)], activeProjectPaths: [], force: true)
+        await fulfillment(of: [firstStarted], timeout: 1)
+
+        manager.refresh(from: [historySession(path: secondPath)], activeProjectPaths: [], force: true)
+        XCTAssertTrue(manager.isScanning)
+        await fulfillment(of: [secondStarted], timeout: 1)
+
+        releaseFirst.signal()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertTrue(manager.isScanning)
+
+        releaseSecond.signal()
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.id == secondPath
+        }
+        XCTAssertFalse(manager.isScanning)
     }
 
     @MainActor


### PR DESCRIPTION
## Problem

The cleanup tab could trigger macOS protected-folder prompts from stale ended-session paths before it knew whether those paths were real cleanup worktrees. If a user denied access, cctop also had no in-app route back to macOS settings to re-enable file access. During cleanup refreshes, the UI kept showing the previous candidate count or empty state without saying that cctop was still checking worktrees.

## Solution

- Skip ordinary ended-session paths under protected user folders before any filesystem or Git probes, while still checking plausible `.claude/worktrees/...` and `.codex/worktrees/...` cleanup paths.
- Add a Settings file-access recovery row that opens macOS Privacy settings.
- Publish cleanup refresh state so the Cleanup tab and panel both show that worktrees are being checked.
- Cover the scanner guard, scan-state lifecycle, settings recovery route, and visual scanning states with focused tests and snapshots.
