### PR TITLE
Fix pipe deadlock in git command runner when stdin and stdout exceed pipe buffers

### DIFF
--- a/menubar/CctopMenubar/Services/GitWorktreeInspector.swift
+++ b/menubar/CctopMenubar/Services/GitWorktreeInspector.swift
@@ -343,16 +343,17 @@ enum GitCommand {
             worktreeInspectorLogger.debug("git failed to launch: \(error.localizedDescription, privacy: .public)")
             return GitCommandResult(exitCode: 127, stdout: "", stderr: error.localizedDescription)
         }
-        if let stdin {
-            inputPipe.fileHandleForWriting.write(Data(stdin.utf8))
-            inputPipe.fileHandleForWriting.closeFile()
-        }
-
+        // Drain stdout/stderr before writing stdin: if the child fills a pipe that
+        // nobody reads while it still waits for input, both processes block forever.
         let group = DispatchGroup()
         let stdoutReader = PipeOutputReader(fileHandle: stdout.fileHandleForReading)
         let stderrReader = PipeOutputReader(fileHandle: stderr.fileHandleForReading)
         stdoutReader.start(group: group)
         stderrReader.start(group: group)
+        if let stdin {
+            inputPipe.fileHandleForWriting.write(Data(stdin.utf8))
+            inputPipe.fileHandleForWriting.closeFile()
+        }
         process.waitUntilExit()
         group.wait()
 

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -884,6 +884,41 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(inspector.worktreeRoot(containing: symlinkedNestedPath), worktree.path)
     }
 
+    func testGitCommandWithLargeStdinAndLargeStdoutDoesNotDeadlock() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-git-command-pipe-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let initResult = GitCommand.run(cwd: root.path, arguments: ["init", "-q"])
+        try XCTSkipUnless(initResult.exitCode == 0, "git init failed: \(initResult.stderr)")
+
+        // cat-file --batch-check echoes one "<name> missing" line per stdin line, so both
+        // the stdin write and the stdout it produces exceed the ~64KB pipe buffers.
+        let lineCount = 20_000
+        let stdin = String(repeating: String(repeating: "0", count: 40) + "\n", count: lineCount)
+
+        addTeardownBlock {
+            // If the command deadlocked, kill the stuck git child so it does not leak.
+            let kill = Process()
+            kill.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
+            kill.arguments = ["-f", root.path]
+            try? kill.run()
+            kill.waitUntilExit()
+        }
+
+        var result: GitCommandResult?
+        let done = expectation(description: "git command returns")
+        DispatchQueue.global().async {
+            result = GitCommand.run(cwd: root.path, arguments: ["cat-file", "--batch-check"], stdin: stdin)
+            done.fulfill()
+        }
+        wait(for: [done], timeout: 30)
+
+        XCTAssertEqual(result?.exitCode, 0)
+        XCTAssertEqual(result?.stdout.split(whereSeparator: \.isNewline).count, lineCount)
+    }
+
     func testRegisteredSiblingWithoutEndedSessionIsNotAdded() {
         let repo = "/Users/dev/projects/billing-api"
         let historyPath = "/Users/dev/projects/billing-api/.claude/worktrees/old-session"


### PR DESCRIPTION
## Problem

`GitCommand.runProcess` in `menubar/CctopMenubar/Services/GitWorktreeInspector.swift` wrote the child's entire stdin synchronously before starting the stdout/stderr pipe readers. If the child filled its ~64KB stdout pipe while the parent still had more than ~64KB of stdin left to write, both processes blocked forever. This path is reachable via `runGitWithInput` for `git sparse-checkout check-rules -z`, whose stdin (the NUL-joined absent skip-worktree paths from `sparseCheckoutIndexOnlyPaths`) and echoed stdout can both exceed 64KB in large sparse checkouts, leaving the cleanup scan spinner stuck.

## Solution

- Reorder `runProcess` to start both `PipeOutputReader`s immediately after `process.run()`, then write and close stdin, so stdout/stderr are drained while stdin is being written.
- Add `testGitCommandWithLargeStdinAndLargeStdoutDoesNotDeadlock` to `WorktreeCleanupTests`, driving `GitCommand.run` with `git cat-file --batch-check` and ~820KB of stdin (which echoes ~980KB of stdout), guarded by an expectation timeout so a regression fails instead of hanging the suite.

## Verification

- The new test deadlocks and fails via timeout without the fix, and passes with it.
- `make all` (lint + contract + build + test) is green: 916 tests, 0 failures.