### PR TITLE
Log SessionEnd session-file write failures instead of swallowing them

### DIFF
--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -436,7 +436,12 @@ extension HookHandler {
                 session.disconnectedAt = session.disconnectedAt ?? endedAt
             }
             session.markWrittenByHook(version: Config.hookVersion, isNewSessionFile: false)
-            try? session.writeToFile(path: path)
+            do {
+                try session.writeToFile(path: path)
+            } catch {
+                deps.logger.logError("\(hookName): \(error)")
+                return
+            }
             deps.logger.appendHookLog(sessionId: safeId, event: hookName, label: label, transition: "-> ended")
         }
     }

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -423,6 +423,30 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertNotNil(try loadSession().endedAt)
     }
 
+    // A failed SessionEnd write must land in _errors.log and must NOT log "-> ended" —
+    // otherwise the per-session log claims the session ended while the file stayed stale,
+    // with no error trace anywhere.
+    func testSessionEndWriteFailureLogsErrorAndSkipsEndedTransition() throws {
+        try handleFixture("SessionStart")
+
+        // Pre-create the lock file so locking still succeeds once the directory is
+        // read-only; the session-file write (temp file creation) is what fails.
+        FileManager.default.createFile(atPath: sessionFilePath() + ".lock", contents: nil)
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: sessionsDir)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: sessionsDir) }
+
+        try handleFixture("SessionEnd")
+
+        let errorLogPath = (logsDir as NSString).appendingPathComponent("_errors.log")
+        let errors = (try? String(contentsOfFile: errorLogPath, encoding: .utf8)) ?? ""
+        XCTAssertTrue(errors.contains("SessionEnd"), "Write failure must be logged to _errors.log, got: \(errors)")
+
+        let sessionLogPath = (logsDir as NSString).appendingPathComponent("test-session-001.log")
+        let sessionLog = (try? String(contentsOfFile: sessionLogPath, encoding: .utf8)) ?? ""
+        XCTAssertTrue(sessionLog.contains("SessionStart"), "Per-session log must exist with the SessionStart entry")
+        XCTAssertFalse(sessionLog.contains("-> ended"), "Must not claim '-> ended' when the write failed")
+    }
+
     func testDesktopSessionEndStampsDisconnectedAt() throws {
         let deps = makeDeps(env: ["__CFBundleIdentifier": HostAppBundleID.claudeDesktop])
 


### PR DESCRIPTION
## Problem

`handleSessionEnd` in `menubar/CctopMenubar/Hook/HookHandler.swift` wrote the session file with `try? session.writeToFile(path:)` and then unconditionally appended the `-> ended` HOOK line to the per-session log. When that write failed, the session file stayed stale while the log claimed the session ended, and nothing landed in `~/.cctop/logs/_errors.log` — unlike the main `handleHook` path, where write errors propagate to `HookMain` and get logged.

## Solution

- Replace the `try?` with a do/catch that logs the failure via `deps.logger.logError("\(hookName): \(error)")`, matching the error format the main hook path writes to `_errors.log`, and return early on failure.
- Append the `-> ended` log line only after a successful write.
- Add `testSessionEndWriteFailureLogsErrorAndSkipsEndedTransition` to `HookHandlerTests`, which makes the sessions directory read-only so the SessionEnd write fails, then asserts the error is logged and `-> ended` is not.

## Verification

The new test failed before the fix (no `_errors.log` entry, `-> ended` logged despite the stale file) and passes after. `make all` (lint + contract + build + tests) is green: 916 tests, 0 failures.