### PR TITLE
Launch the host app when jump-to-session activation finds it not running

### DIFF
--- a/menubar/CctopMenubar/Services/FocusTerminal+AppRestore.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal+AppRestore.swift
@@ -8,7 +8,8 @@ func restoreAndActivate(_ app: NSRunningApplication) -> Bool {
     return app.activate(options: [.activateAllWindows])
 }
 
-private func restoreAppByBundleID(_ bundleID: String) {
+/// Launch (or bring forward) an app by bundle ID. No-ops if the app isn't installed.
+func restoreAppByBundleID(_ bundleID: String) {
     guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else { return }
     let configuration = NSWorkspace.OpenConfiguration()
     configuration.activates = true

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -155,7 +155,10 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
         runScriptOrActivate(.terminal) { executeAppleTerminalScript(tty: tty) }
 
     case .activateByName(let name):
-        activateAppByName(name)
+        // If no running app matches the name, recover the bundle ID and activate (or launch) by bundle ID.
+        if !activateAppByName(name), let bundleID = HostApp.from(editorName: name).bundleID {
+            activateAppByBundleID(bundleID)
+        }
 
     case .activateByBundleID(let bundleID):
         activateAppByBundleID(bundleID)
@@ -479,7 +482,9 @@ private func activateAppByBundleID(_ bundleID: String) -> Bool {
     guard let app = NSWorkspace.shared.runningApplications.first(where: {
         $0.bundleIdentifier == bundleID
     }) else {
-        return false
+        // App not running — launch it (optimistic true; restoreAppByBundleID no-ops if the app isn't installed).
+        restoreAppByBundleID(bundleID)
+        return true
     }
     return restoreAndActivate(app)
 }

--- a/menubar/CctopMenubarTests/FocusTerminalTests.swift
+++ b/menubar/CctopMenubarTests/FocusTerminalTests.swift
@@ -63,4 +63,17 @@ final class FocusTerminalTests: XCTestCase {
         let session = Session.mock(terminal: nil)
         XCTAssertNil(session.terminal)
     }
+
+    // MARK: - Activation-name launch fallback
+
+    // When a .activateByName app isn't running, execution recovers its bundle ID
+    // via HostApp.from(editorName:) to launch it. Lock the round trip so every
+    // activation name maps back to its own HostApp (and thus a bundle ID).
+    func testActivationNamesRoundTripToHostAppWithBundleID() {
+        for app in HostApp.allCases {
+            guard let name = app.activationName else { continue }
+            XCTAssertEqual(HostApp.from(editorName: name), app, "activation name '\(name)' should map back to \(app)")
+            XCTAssertNotNil(app.bundleID, "\(app) has an activation name but no bundle ID to launch")
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Jump-to-session silently did nothing when the target app had already quit. The activation strategies in `executeFocusStrategy` (`FocusTerminal.swift`) discard the result of `activateAppByName` / `activateAppByBundleID`, and both helpers only search `NSWorkspace.shared.runningApplications` without ever launching. Sibling strategies already handle the not-running case (`.openWithApp` falls back to Finder, `.openURL` restore launches via `openApplication`), so clicking a Warp or Claude Desktop session after its host app quit was the one path with no recovery at all.

## Solution

- `activateAppByBundleID` now launches the app via the existing `restoreAppByBundleID` helper (made internal in `FocusTerminal+AppRestore.swift`) when no running app matches. This fixes `.activateByBundleID` (Claude Desktop) and, through `runScriptOrActivate`, the iTerm2/kitty/Terminal/Ghostty script-failure fallbacks.
- `.activateByName` (Warp, name-based fallbacks) recovers the host's bundle ID via `HostApp.from(editorName:)` when no running app matches the name and chains into the same launching activation.

## Verification

`make all` (lint, contract, build, tests) is green. A new test in `FocusTerminalTests` locks the invariant the name fallback depends on: every `HostApp.activationName` round-trips to its own `HostApp` with a non-nil `bundleID`. The `NSWorkspace` launch behavior itself has no injectable seam, so the launch path is verified by code inspection rather than automated tests.