### PR TITLE
Scope worktree removal preflight to the target candidate

### DIFF
--- a/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
@@ -346,6 +346,42 @@ struct WorktreeCleanupScanner {
     }
 }
 
+extension WorktreeCleanupScanner {
+    func candidate(
+        withID id: String,
+        from cleanupSources: [SessionCleanupSource],
+        activeProjectPaths: Set<String>
+    ) -> WorktreeCleanupCandidate? {
+        let id = Self.standardizedPath(id)
+        guard let context = candidateContext(withID: id, from: cleanupSources) else { return nil }
+        let activePaths = resolvedActiveProjectPaths(activeProjectPaths, candidatePaths: Set([id]))
+        return candidate(from: context, activeProjectPaths: activePaths)
+    }
+
+    private func candidateContext(withID id: String, from cleanupSources: [SessionCleanupSource]) -> CandidateContext? {
+        var result: CandidateContext?
+        var resolvedPaths: [String: String] = [:]
+        for source in cleanupSources {
+            let rawPath = Self.standardizedPath(source.projectPath)
+            guard shouldScanCleanupSourcePath(rawPath) else { continue }
+            let path = resolvedPaths[rawPath] ?? {
+                let path = resolvedCandidatePath(for: rawPath)
+                resolvedPaths[rawPath] = path
+                return path
+            }()
+            guard path == id else { continue }
+            guard let existing = result else {
+                result = CandidateContext(source: source, path: path)
+                continue
+            }
+            if source.lastActiveAt > existing.lastActiveAt {
+                result = CandidateContext(source: source, path: path)
+            }
+        }
+        return result
+    }
+}
+
 private extension WorktreeCleanupScanner {
     func shouldScanCleanupSourcePath(_ path: String) -> Bool {
         guard Self.isLikelyPrivacyProtectedUserPath(path) else { return true }

--- a/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
+++ b/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
@@ -125,9 +125,11 @@ struct WorktreeRemovalService {
             return .refused(candidate)
         }
 
-        guard let preflightCandidate = scanner
-            .candidates(from: cleanupSources, activeProjectPaths: activeProjectPaths)
-            .first(where: { $0.id == candidate.id }) else {
+        guard let preflightCandidate = scanner.candidate(
+            withID: candidate.id,
+            from: cleanupSources,
+            activeProjectPaths: activeProjectPaths
+        ) else {
             return .refused(candidate)
         }
 

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1510,6 +1510,105 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(result, .removed(GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")))
     }
 
+    func testRemovalServiceNormalPreflightOnlyInspectsAndMeasuresTargetWorktree() {
+        let targetPath = "/Users/dev/.codex/worktrees/billing-api"
+        let otherPath = "/Users/dev/.codex/worktrees/reporting-api"
+        let cleanupSources = [
+            historySession(id: "target", path: targetPath),
+            historySession(id: "other", path: otherPath, name: "Reporting cleanup", branch: "feature/reports"),
+        ]
+        var inspectedPaths: [String] = []
+        var measuredPaths: [String] = []
+        let scanner = WorktreeCleanupScanner(
+            fileExists: { $0 == targetPath || $0 == otherPath },
+            resolveWorktreeRoot: { _ in nil },
+            inspectGit: { path in
+                inspectedPaths.append(path)
+                return self.cleanInspection()
+            },
+            measureSize: { path in
+                measuredPaths.append(path)
+                return 1_024
+            }
+        )
+        let service = WorktreeRemovalService(
+            scanner: scanner,
+            runGit: { _ in GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "") }
+        )
+
+        let result = service.remove(
+            cleanupCandidate(path: targetPath),
+            cleanupSources: cleanupSources,
+            activeProjectPaths: []
+        )
+
+        XCTAssertEqual(result, .removed(GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")))
+        XCTAssertEqual(inspectedPaths, [targetPath, targetPath])
+        XCTAssertEqual(measuredPaths, [targetPath])
+    }
+
+    func testRemovalServiceConfirmedForcePreflightOnlyInspectsAndMeasuresTargetWorktree() {
+        let targetPath = "/Users/dev/.codex/worktrees/billing-api"
+        let otherPath = "/Users/dev/.codex/worktrees/reporting-api"
+        let mainPath = "/Users/dev/projects/billing-api"
+        let cleanupSources = [
+            historySession(id: "target", path: targetPath),
+            historySession(id: "other", path: otherPath, name: "Reporting cleanup", branch: "feature/reports"),
+        ]
+        let confirmedCandidate = WorktreeCleanupCandidate(
+            id: targetPath,
+            sessionName: "Dirty branch review",
+            worktreePath: targetPath,
+            worktreeName: "billing-api",
+            mainWorktreePath: mainPath,
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([WorktreeCleanupCandidate.untrackedFilesReason]),
+            checks: [],
+            reviewEvidence: WorktreeCleanupReviewEvidence(
+                untrackedPreview: WorktreeCleanupUntrackedPreview(paths: ["scratch.txt"])
+            )
+        )
+        var inspectedPaths: [String] = []
+        var measuredPaths: [String] = []
+        let success = GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
+        var gitArguments: [[String]] = []
+        let scanner = WorktreeCleanupScanner(
+            fileExists: { $0 == targetPath || $0 == otherPath },
+            resolveWorktreeRoot: { _ in nil },
+            inspectGit: { path in
+                inspectedPaths.append(path)
+                if path == targetPath {
+                    return self.cleanInspection(statusEntries: ["?? scratch.txt"])
+                }
+                return self.cleanInspection()
+            },
+            measureSize: { path in
+                measuredPaths.append(path)
+                return 1_024
+            }
+        )
+        let service = WorktreeRemovalService(
+            scanner: scanner,
+            runGit: { arguments in
+                gitArguments.append(arguments)
+                return success
+            }
+        )
+
+        let result = service.executeConfirmed(
+            .forceRemove(confirmedCandidate),
+            cleanupSources: cleanupSources,
+            activeProjectPaths: []
+        )
+
+        XCTAssertEqual(result, .removed(success))
+        XCTAssertEqual(gitArguments, [["-C", mainPath, "worktree", "remove", "--force", targetPath]])
+        XCTAssertEqual(inspectedPaths, [targetPath, targetPath])
+        XCTAssertEqual(measuredPaths, [targetPath])
+    }
+
     func testRemovalServiceRunsGitWorktreeRemoveWithArgumentArrayForReviewCandidate() {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
         let mainPath = "/Users/dev/projects/billing-api"


### PR DESCRIPTION
## Problem

When removing a worktree, `WorktreeRemovalService.readyCandidate` re-verified the target by calling `WorktreeCleanupScanner.candidates(from:activeProjectPaths:)` over all ended sessions, then picking out the one candidate by id. That full scan runs `inspectGit` (several git subprocesses per worktree) and `measureSize` (a full FileManager walk) on every candidate worktree, so removing one worktree re-inspected and re-measured every unrelated candidate while the user watched the "Removing..." spinner.

## Solution

- Add `WorktreeCleanupScanner.candidate(withID:from:activeProjectPaths:)`, which reuses the existing `candidateContexts` path resolution (symlink-alias session paths and latest-ended-session-per-path selection are unchanged) but resolves active-path protection and builds/inspects only the target candidate.
- Call it from `WorktreeRemovalService.readyCandidate` instead of the full scan. Both `remove` and `forceRemove` go through this path.
- The second `inspectGit` double-check just before removal is kept as is.

## Verification

Added `testRemovalServicePreflightOnlyInspectsAndMeasuresTargetWorktree` to `WorktreeCleanupTests`, which counts `inspectGit`/`measureSize` invocations during removal with a second unrelated ended-session worktree present. It failed before the fix (the unrelated worktree was inspected and measured) and passes after, asserting only the target is inspected (preflight plus the kept double-check) and measured. `make all` (lint + contract + build + tests) passes.