### PR TITLE
Make plugin install failure state local to each Settings row

### DIFF
--- a/menubar/CctopMenubar/Views/CodexPluginRowView.swift
+++ b/menubar/CctopMenubar/Views/CodexPluginRowView.swift
@@ -6,9 +6,9 @@ import SwiftUI
 /// "installed" and "trusted" as separate user-visible states.
 struct CodexPluginRowView: View {
     @ObservedObject var pluginManager: PluginManager
-    @Binding var installFailed: Bool
     @StateObject private var setupFlow = CodexSetupFlow()
     @State private var removeHovered = false
+    @State private var installFailed = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -280,32 +280,24 @@ struct HooksReadyBadge: View {
 }
 
 #Preview("Not installed") {
-    CodexPluginRowView(
-        pluginManager: previewCodexPM(status: .notInstalled), installFailed: .constant(false)
-    )
-    .frame(width: 320).padding()
+    CodexPluginRowView(pluginManager: previewCodexPM(status: .notInstalled))
+        .frame(width: 320).padding()
 }
 #Preview("Untrusted") {
-    CodexPluginRowView(
-        pluginManager: previewCodexPM(status: .installedUntrusted), installFailed: .constant(false)
-    )
-    .frame(width: 320).padding()
+    CodexPluginRowView(pluginManager: previewCodexPM(status: .installedUntrusted))
+        .frame(width: 320).padding()
 }
 #Preview("Hooks disabled") {
-    CodexPluginRowView(
-        pluginManager: previewCodexPM(status: .hooksDisabled), installFailed: .constant(false)
-    )
-    .frame(width: 320).padding()
+    CodexPluginRowView(pluginManager: previewCodexPM(status: .hooksDisabled))
+        .frame(width: 320).padding()
 }
 #Preview("Trusted") {
-    CodexPluginRowView(
-        pluginManager: previewCodexPM(status: .trusted), installFailed: .constant(false)
-    )
-    .frame(width: 320).padding()
+    CodexPluginRowView(pluginManager: previewCodexPM(status: .trusted))
+        .frame(width: 320).padding()
 }
 #Preview("Stray legacy key") {
     let pm = previewCodexPM(status: .notInstalled)
     pm.codexLegacyConfigKey = true
-    return CodexPluginRowView(pluginManager: pm, installFailed: .constant(false))
+    return CodexPluginRowView(pluginManager: pm)
         .frame(width: 320).padding()
 }

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -9,7 +9,6 @@ struct SettingsSection: View {
     @StateObject private var notificationPermission: NotificationPermissionController
     @AppStorage("appearanceMode") private var appearanceMode = "system"
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
-    @State private var installFailed = false
 
     init(
         updater: UpdaterBase,
@@ -39,10 +38,7 @@ struct SettingsSection: View {
 
             sectionHeader("Tools")
             settingsGroup {
-                MonitoredToolsView(
-                    pluginManager: pluginManager,
-                    installFailed: $installFailed
-                )
+                MonitoredToolsView(pluginManager: pluginManager)
             }
 
             sectionHeader("Appearance")
@@ -257,23 +253,22 @@ struct SettingsSection: View {
 
 private struct MonitoredToolsView: View {
     @ObservedObject var pluginManager: PluginManager
-    @Binding var installFailed: Bool
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             ClaudeCodePluginRowView(pluginManager: pluginManager)
             if pluginManager.ocConfigExists {
                 PluginRowView(name: "opencode", installed: pluginManager.ocInstalled,
-                    needsUpdate: pluginManager.ocNeedsUpdate, installFailed: $installFailed,
+                    needsUpdate: pluginManager.ocNeedsUpdate,
                     install: { pluginManager.installOpenCodePlugin() },
                     remove: { pluginManager.removeOpenCodePlugin() })
             }
             if pluginManager.piConfigExists {
                 PluginRowView(name: "pi", installed: pluginManager.piInstalled,
-                    installFailed: $installFailed, install: { pluginManager.installPiPlugin() },
+                    install: { pluginManager.installPiPlugin() },
                     remove: { pluginManager.removePiPlugin() })
             }
             if pluginManager.codexConfigExists {
-                CodexPluginRowView(pluginManager: pluginManager, installFailed: $installFailed)
+                CodexPluginRowView(pluginManager: pluginManager)
             }
         }
         .padding(.horizontal, AppChrome.settingsRowHorizontalPadding)
@@ -284,9 +279,9 @@ private struct MonitoredToolsView: View {
 private struct PluginRowView: View {
     let name: String; let installed: Bool; var needsUpdate: Bool = false
     var installLabel = "Install Plugin"; var updateLabel = "Update Plugin"
-    @Binding var installFailed: Bool
     let install: () -> Bool; let remove: () -> Bool
     @State private var justInstalled = false; @State private var removeHovered = false
+    @State private var installFailed = false
 
     var body: some View {
         VStack(spacing: 4) {


### PR DESCRIPTION
## Problem

`SettingsSection` owned a single `@State installFailed` flag and passed the same Binding into every plugin row in `MonitoredToolsView`: the opencode and pi `PluginRowView` instances and `CodexPluginRowView`. When an install or remove action failed on one row, the "Failed — check permissions" hint flashed under every row, and the independent 3-second reset timers in `PluginRowView.flashFailed` and `CodexPluginRowView.flashFailed` could interleave and cut each other short.

## Solution

- Make `installFailed` a local `@State private var` in `PluginRowView` and `CodexPluginRowView`, mirroring the existing per-row `justInstalled` pattern.
- Delete the shared flag from `SettingsSection` and the Binding plumbing through `MonitoredToolsView`.
- Update the `CodexPluginRowView` previews for the changed initializer.

The failure hint now appears only under the row whose action failed; per-row rendering and the 3-second flash duration are unchanged.

## Verification

A failing-test repro was not feasible: `PluginRowView` and `MonitoredToolsView` are private structs inside `SettingsSection.swift`, the failure state is only reachable through button-action closures, and the test target has no view-interaction tooling (snapshot tests only render `SettingsSection` statically, never the failed state). Instead, the shared Binding is removed entirely — all remaining `installFailed` references are per-row local `@State`, so cross-row leakage is impossible by construction — and the full suite passed via `make all` (lint, contract, build, 915 tests including the SettingsSection snapshot tests).