### PR TITLE
Run terminal focus off the main thread

### DIFF
--- a/menubar/CctopMenubar/Services/FocusTerminal+AppRestore.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal+AppRestore.swift
@@ -16,6 +16,28 @@ func restoreAppByBundleID(_ bundleID: String) {
     NSWorkspace.shared.openApplication(at: appURL, configuration: configuration)
 }
 
+@discardableResult
+func activateAppByBundleID(_ bundleID: String) -> Bool {
+    guard let app = NSWorkspace.shared.runningApplications.first(where: {
+        $0.bundleIdentifier == bundleID
+    }) else {
+        // App not running — launch it (optimistic true; restoreAppByBundleID no-ops if the app isn't installed).
+        restoreAppByBundleID(bundleID)
+        return true
+    }
+    return restoreAndActivate(app)
+}
+
+@discardableResult
+func activateAppByName(_ program: String) -> Bool {
+    guard let app = NSWorkspace.shared.runningApplications.first(where: {
+        $0.localizedName?.lowercased().contains(program) == true
+    }) else {
+        return false
+    }
+    return restoreAndActivate(app)
+}
+
 func restoreAppAndOpenURL(bundleID: String, url: URL) {
     guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else {
         NSWorkspace.shared.open(url)

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -113,31 +113,40 @@ func resolveFocusStrategy(session: Session, multiplexerOverride: MultiplexerInfo
 
 // MARK: - Execution (AppKit side effects)
 
+/// Cmux env probing spawns `ps`, focus scripts block on Apple events, and the
+/// kitty/multiplexer CLIs wait on subprocesses — so the whole jump runs on a
+/// background queue. AppKit calls hop back to the main thread.
 func focusTerminal(session: Session) {
-    let multiplexerOverride = resolveCmuxLiveMultiplexer(session: session)
-    let strategy = resolveFocusStrategy(session: session, multiplexerOverride: multiplexerOverride)
-    let muxStrategy = resolveMultiplexerFocus(session: session, multiplexerOverride: multiplexerOverride)
-    executeFocusStrategy(strategy)
-    if let mux = muxStrategy {
-        DispatchQueue.global(qos: .userInitiated).async {
+    DispatchQueue.global(qos: .userInitiated).async {
+        let multiplexerOverride = resolveCmuxLiveMultiplexer(session: session)
+        let strategy = resolveFocusStrategy(session: session, multiplexerOverride: multiplexerOverride)
+        let muxStrategy = resolveMultiplexerFocus(session: session, multiplexerOverride: multiplexerOverride)
+        executeFocusStrategy(strategy)
+        if let mux = muxStrategy {
             executeMultiplexerFocus(mux)
         }
+        DispatchQueue.main.async {
+            NSApp.deactivate()
+        }
     }
-    NSApp.deactivate()
 }
 
+/// Runs on a background queue: script/subprocess strategies block until done,
+/// while pure-AppKit strategies dispatch to the main thread.
 private func executeFocusStrategy(_ strategy: FocusStrategy) {
     switch strategy {
     case .openWithApp(let bundleID, let target):
-        if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
-            NSWorkspace.shared.open(
-                [URL(fileURLWithPath: target)],
-                withApplicationAt: appURL,
-                configuration: NSWorkspace.OpenConfiguration()
-            )
-        } else {
-            // App not installed — open in Finder
-            NSWorkspace.shared.open(URL(fileURLWithPath: target))
+        DispatchQueue.main.async {
+            if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
+                NSWorkspace.shared.open(
+                    [URL(fileURLWithPath: target)],
+                    withApplicationAt: appURL,
+                    configuration: NSWorkspace.OpenConfiguration()
+                )
+            } else {
+                // App not installed — open in Finder
+                NSWorkspace.shared.open(URL(fileURLWithPath: target))
+            }
         }
 
     case .iTerm2(let guid):
@@ -155,30 +164,41 @@ private func executeFocusStrategy(_ strategy: FocusStrategy) {
         runScriptOrActivate(.terminal) { executeAppleTerminalScript(tty: tty) }
 
     case .activateByName(let name):
-        // If no running app matches the name, recover the bundle ID and activate (or launch) by bundle ID.
-        if !activateAppByName(name), let bundleID = HostApp.from(editorName: name).bundleID {
-            activateAppByBundleID(bundleID)
+        DispatchQueue.main.async {
+            // If no running app matches the name, recover the bundle ID and activate (or launch) by bundle ID.
+            if !activateAppByName(name), let bundleID = HostApp.from(editorName: name).bundleID {
+                activateAppByBundleID(bundleID)
+            }
         }
 
     case .activateByBundleID(let bundleID):
-        activateAppByBundleID(bundleID)
+        DispatchQueue.main.async {
+            activateAppByBundleID(bundleID)
+        }
 
     case .openURL(let url, let restoreBundleID):
-        if let restoreBundleID {
-            restoreAppAndOpenURL(bundleID: restoreBundleID, url: url)
-        } else {
-            NSWorkspace.shared.open(url)
+        DispatchQueue.main.async {
+            if let restoreBundleID {
+                restoreAppAndOpenURL(bundleID: restoreBundleID, url: url)
+            } else {
+                NSWorkspace.shared.open(url)
+            }
         }
 
     case .openInFinder(let path):
-        NSWorkspace.shared.open(URL(fileURLWithPath: path))
+        DispatchQueue.main.async {
+            NSWorkspace.shared.open(URL(fileURLWithPath: path))
+        }
     }
 }
 
-/// Run a focus script for `host`; if it fails, fall back to activating the host by bundle ID.
+/// Run a focus script for `host` (blocking, on the calling background queue);
+/// if it fails, fall back to activating the host by bundle ID on the main thread.
 private func runScriptOrActivate(_ host: HostApp, script: () -> Bool) {
     if !script(), let bundleID = host.bundleID {
-        activateAppByBundleID(bundleID)
+        DispatchQueue.main.async {
+            activateAppByBundleID(bundleID)
+        }
     }
 }
 
@@ -190,6 +210,10 @@ func extractITermGUID(from sessionId: String?) -> String? {
     return String(id[id.index(after: colonIndex)...])
 }
 
+// Called on a background queue. Per the AppleScript 10.6 release notes, OSA,
+// AppleScript, and NSAppleScript are thread-safe; each call here uses a fresh
+// instance confined to one thread anyway. OSA still executes scripting-addition
+// commands (e.g. `delay`) on the main thread for compatibility.
 private func runAppleScript(_ source: String) -> Bool {
     var error: NSDictionary?
     NSAppleScript(source: source)?.executeAndReturnError(&error)
@@ -473,28 +497,4 @@ func openInEditor(project: RecentProject) {
 
     // Final fallback: open in Finder
     NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: project.projectPath)
-}
-
-// MARK: - App activation helpers
-
-@discardableResult
-private func activateAppByBundleID(_ bundleID: String) -> Bool {
-    guard let app = NSWorkspace.shared.runningApplications.first(where: {
-        $0.bundleIdentifier == bundleID
-    }) else {
-        // App not running — launch it (optimistic true; restoreAppByBundleID no-ops if the app isn't installed).
-        restoreAppByBundleID(bundleID)
-        return true
-    }
-    return restoreAndActivate(app)
-}
-
-@discardableResult
-private func activateAppByName(_ program: String) -> Bool {
-    guard let app = NSWorkspace.shared.runningApplications.first(where: {
-        $0.localizedName?.lowercased().contains(program) == true
-    }) else {
-        return false
-    }
-    return restoreAndActivate(app)
 }

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -113,11 +113,11 @@ func resolveFocusStrategy(session: Session, multiplexerOverride: MultiplexerInfo
 
 // MARK: - Execution (AppKit side effects)
 
-/// Cmux env probing spawns `ps`, focus scripts block on Apple events, and the
-/// kitty/multiplexer CLIs wait on subprocesses — so the whole jump runs on a
-/// background queue. AppKit calls hop back to the main thread.
+private let focusQueue = DispatchQueue(label: "cctop.focus-terminal", qos: .userInitiated)
+/// Cmux `ps` probing, focus scripts, and kitty/multiplexer CLIs all block — so the whole jump runs on `focusQueue`, serial so a
+/// slow jump can't finish after (and steal focus from) a later one. AppKit calls hop back to the main thread.
 func focusTerminal(session: Session) {
-    DispatchQueue.global(qos: .userInitiated).async {
+    focusQueue.async {
         let multiplexerOverride = resolveCmuxLiveMultiplexer(session: session)
         let strategy = resolveFocusStrategy(session: session, multiplexerOverride: multiplexerOverride)
         let muxStrategy = resolveMultiplexerFocus(session: session, multiplexerOverride: multiplexerOverride)


### PR DESCRIPTION
## Problem

Jumping to a session runs `focusTerminal` on the main thread, and only the multiplexer CLI step was dispatched off it. Everything else executed synchronously on the UI thread:

- `resolveCmuxLiveMultiplexer` spawns `/bin/ps` and waits for it once per legacy cmux session (`FocusTerminal+Cmux.swift`).
- The kitty strategy spawns the kitty binary and waits for it.
- The iTerm2/Terminal/Ghostty strategies run `NSAppleScript.executeAndReturnError`; the Ghostty script retries with `repeat 5 times ... delay 0.05`, about 0.25s per candidate window.

All three call sites (the notification and navigate-key jump paths in `AppDelegate`, the session row click in `PopupView`) are UI-driven, so the app froze for the duration of the jump.

## Solution

- `focusTerminal` now runs the whole jump (cmux env probing, strategy resolution, kitty/tmux/zellij/cmux subprocesses, AppleScript execution) on `DispatchQueue.global(qos: .userInitiated)`, the same pattern the multiplexer focus step already used.
- Every AppKit call on the path (`NSWorkspace` open/openApplication, `NSRunningApplication` activation via `activateAppByName`/`activateAppByBundleID`, `NSApp.deactivate`) hops back to the main queue.
- AppleScript stays in-process and executes on the background queue: OSA, AppleScript, and `NSAppleScript` are thread-safe since Mac OS X 10.6 per the [AppleScript Release Notes](https://developer.apple.com/library/archive/releasenotes/AppleScript/RN-AppleScript/RN-10_6/RN-10_6.html), and each call creates a fresh instance confined to one thread. Switching to an `osascript` subprocess was deliberately avoided because it would change which process macOS Automation permission is attributed to. Per the same notes, OSA still runs scripting-addition commands such as `delay` on the main thread for compatibility.
- `NSApp.deactivate` keeps its ordering relative to the focus strategy: `focusTerminal` enqueues the strategy's main-queue block before the deactivate block, and the main queue is serial. One ordering does change: in navigate mode, the deactivate issued by the key handler now runs before the strategy executes because `focusTerminal` returns immediately. Every activation path still works from an inactive app (`NSWorkspace` launches with `activates = true`, script strategies activate via Apple events), but the navigate-key jump is worth covering in a manual smoke test.
- `activateAppByName`/`activateAppByBundleID` move to `FocusTerminal+AppRestore.swift` (made internal, behavior unchanged) to keep `FocusTerminal.swift` under the 500-line lint limit.

## Verification

`make all` (SwiftLint strict, contract, build, 918 tests) is green, including `FocusStrategyTests` and `MultiplexerFocusTests`. A failing-test reproduction of the main-thread blocking is not feasible in unit tests: the blocking lives in the side-effect layer (real subprocesses, Automation-gated AppleScript, `NSWorkspace`), while the pure resolvers the existing tests cover are unchanged. A manual smoke test of the jump paths (panel click and navigate-key confirm, e.g. with Ghostty and tmux hosts) is recommended before merge.