### PR TITLE
Make the test target depend on cctop-hook so xcodebuild test builds it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
             deriveddata-${{ runner.os }}-xcode16.3-
       - name: Build menubar app
         run: xcodebuild build -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -configuration Debug -derivedDataPath menubar/build/ CODE_SIGN_IDENTITY="-"
-      - name: Build cctop-hook CLI
-        run: xcodebuild build -project menubar/CctopMenubar.xcodeproj -scheme cctop-hook -configuration Debug -derivedDataPath menubar/build/ CODE_SIGN_IDENTITY="-"
+      - name: Test
+        run: xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -configuration Debug -derivedDataPath menubar/build/
       - name: Smoke test cctop-hook
         run: |
           SMOKE_DIR=$(mktemp -d)
@@ -44,5 +44,3 @@ jobs:
           grep -q '"idle"' "$SESSION_FILE"
           grep -q '"ci-test"' "$SESSION_FILE"
           rm -rf "$SMOKE_DIR"
-      - name: Test
-        run: xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -configuration Debug -derivedDataPath menubar/build/

--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -156,6 +156,13 @@
 			remoteGlobalIDString = A1000000B000000000000001;
 			remoteInfo = CctopMenubar;
 		};
+		T1000000F000000000000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A1000000E000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = P10000100000000000000001;
+			remoteInfo = "cctop-hook";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -581,6 +588,7 @@
 			);
 			dependencies = (
 				T1000000C000000000000001 /* PBXTargetDependency */,
+				T10000130000000000000001 /* PBXTargetDependency */,
 			);
 			name = CctopMenubarTests;
 			productName = CctopMenubarTests;
@@ -796,6 +804,11 @@
 			isa = PBXTargetDependency;
 			target = A1000000B000000000000001 /* CctopMenubar */;
 			targetProxy = T10000050000000000000001 /* PBXContainerItemProxy */;
+		};
+		T10000130000000000000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = P10000100000000000000001 /* cctop-hook */;
+			targetProxy = T1000000F000000000000001 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 


### PR DESCRIPTION
## Problem

`ForkSessionTests` spawns the real `cctop-hook` binary from the Debug products directory and fails 4 tests with "cctop-hook not found. Run \`make build\` first." when the binary is missing. The `CctopMenubarTests` target's only dependency in `project.pbxproj` was the app target, so a bare `xcodebuild test` in a fresh checkout never built `cctop-hook`. CI only passed because `ci.yml` built the `cctop-hook` scheme in a separate step before running the tests.

## Solution

- Add a `PBXTargetDependency` on the `cctop-hook` target to `CctopMenubarTests` in `project.pbxproj`, mirroring the existing app-target dependency (one `PBXContainerItemProxy` + one `PBXTargetDependency` + one entry in the test target's dependencies list). `xcodebuild test` now builds `cctop-hook` automatically.
- Remove the now-redundant "Build cctop-hook CLI" step from `ci.yml`. The "Smoke test cctop-hook" step executes that binary, so it moves after the "Test" step, which now produces the binary via the new dependency — CI itself proves the dependency works.

## Verification

Reproduced the bug first: after `rm -rf menubar/build`, CI's exact `xcodebuild test` invocation without a prior `cctop-hook` build failed exactly the 4 `ForkSessionTests` cases with "cctop-hook not found". With the dependency added and the build directory cleaned again, the same invocation succeeds and `menubar/build/Build/Products/Debug/cctop-hook` exists, built by the test action alone. `make all` (lint, contract, build, 918 tests) is green.