### PR TITLE
Add node:test suite for the pi extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,8 @@ cctop/
 │   ├── package.json   # Plugin manifest and node:test script
 │   └── test/          # node:test coverage for opencode event translation
 ├── plugins/pi/        # pi coding agent extension (TS, translates events to cctop-hook calls)
-│   └── cctop.ts       # Extension entry point, calls cctop-hook binary
+│   ├── cctop.ts       # Extension entry point, calls cctop-hook binary
+│   └── test/          # node:test coverage for pi event translation
 ├── scripts/
 │   ├── bundle-macos.sh        # Build and bundle .app
 │   ├── sign-and-notarize.sh   # Code sign + Apple notarization
@@ -275,7 +276,7 @@ All supported clients use `cctop-hook` as the single entry point for session sta
 # Build both targets (menubar app + cctop-hook CLI)
 make build
 
-# Run all tests (OpenCode plugin node:test suite + Swift tests)
+# Run all tests (opencode + pi plugin node:test suites + Swift tests)
 make test
 
 # Lint with swiftlint --strict
@@ -354,7 +355,13 @@ Automated plugin tests live under `plugins/opencode/test/` and use Node's built-
 npm --prefix plugins/opencode test
 ```
 
-`make test` runs the opencode plugin tests before the Swift test suite. For hook event mapping changes, also run `make contract`; it verifies the hook schema, fixtures, Swift parser, and plugin hook calls stay in sync.
+The pi extension (`plugins/pi/cctop.ts`) has an equivalent `node:test` suite under `plugins/pi/test/`. It loads the TypeScript source directly via Node's built-in type stripping (Node 23.6+), so there is no build step:
+
+```bash
+node --test plugins/pi/test/*.test.mjs
+```
+
+`make test` runs the opencode and pi plugin tests before the Swift test suite. For hook event mapping changes, also run `make contract`; it verifies the hook schema, fixtures, Swift parser, and plugin hook calls stay in sync.
 
 For local development, you can manually copy your modified plugin to override the installed version:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,7 +361,7 @@ The pi extension (`plugins/pi/cctop.ts`) has an equivalent `node:test` suite und
 node --test plugins/pi/test/*.test.mjs
 ```
 
-`make test` runs the opencode and pi plugin tests before the Swift test suite. For hook event mapping changes, also run `make contract`; it verifies the hook schema, fixtures, Swift parser, and plugin hook calls stay in sync.
+`make test` runs the opencode and pi plugin tests before the Swift test suite; on Node older than 23.6 it skips the pi suite with a warning instead of failing. For hook event mapping changes, also run `make contract`; it verifies the hook schema, fixtures, Swift parser, and plugin hook calls stay in sync.
 
 For local development, you can manually copy your modified plugin to override the installed version:
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build:
 
 test:
 	npm --prefix plugins/opencode test
+	node --test plugins/pi/test/*.test.mjs
 	xcodebuild test -project $(PROJECT) -scheme CctopMenubar -configuration Debug -derivedDataPath $(DERIVED) $(SIGN)
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,11 @@ build:
 
 test:
 	npm --prefix plugins/opencode test
-	node --test plugins/pi/test/*.test.mjs
+	if node -e 'const [major, minor] = process.versions.node.split(".").map(Number); process.exit(major > 23 || (major === 23 && minor >= 6) ? 0 : 1)'; then \
+		node --test plugins/pi/test/*.test.mjs; \
+	else \
+		echo "WARNING: skipping pi extension tests: Node >= 23.6 required for TypeScript type stripping, found $$(node --version)"; \
+	fi
 	xcodebuild test -project $(PROJECT) -scheme CctopMenubar -configuration Debug -derivedDataPath $(DERIVED) $(SIGN)
 
 lint:

--- a/plugins/pi/test/cctop.test.mjs
+++ b/plugins/pi/test/cctop.test.mjs
@@ -1,0 +1,200 @@
+// Loads cctop.ts directly via Node's built-in TypeScript type stripping
+// (no build step, no dependencies). Requires Node 23.6+.
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import cctop from "../cctop.ts";
+
+function createHookHome() {
+  const home = mkdtempSync(join(tmpdir(), "cctop-pi-extension-"));
+  const hookDir = join(home, ".cctop", "bin");
+  mkdirSync(hookDir, { recursive: true });
+
+  const hookLog = join(home, "hook.log");
+  writeFileSync(hookLog, "");
+  const hookBin = join(hookDir, "cctop-hook");
+  writeFileSync(
+    hookBin,
+    `#!/bin/sh
+printf '%s\\t' "$1" >> ${JSON.stringify(hookLog)}
+cat >> ${JSON.stringify(hookLog)}
+printf '\\n' >> ${JSON.stringify(hookLog)}
+`,
+  );
+  chmodSync(hookBin, 0o755);
+
+  return { home, hookLog };
+}
+
+function loadExtension({ sessionName = null } = {}) {
+  const { home, hookLog } = createHookHome();
+  const previousHome = process.env.HOME;
+  process.env.HOME = home;
+
+  const handlers = new Map();
+  const pi = {
+    sessionName,
+    on(eventName, handler) {
+      handlers.set(eventName, handler);
+    },
+    getSessionName() {
+      return this.sessionName;
+    },
+  };
+  cctop(pi);
+
+  return {
+    pi,
+    async emit(eventName, event = {}, ctx = undefined) {
+      await handlers.get(eventName)(event, ctx);
+    },
+    handlerNames() {
+      return [...handlers.keys()];
+    },
+    readCalls() {
+      const log = readFileSync(hookLog, "utf8").trim();
+      if (!log) return [];
+
+      return log.split("\n").map((line) => {
+        const [eventName, json] = line.split("\t");
+        return { eventName, payload: JSON.parse(json) };
+      });
+    },
+    restore() {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+    },
+  };
+}
+
+function eventNames(calls) {
+  return calls.map((call) => call.eventName);
+}
+
+test("registers handlers and emits SessionStart for interactive sessions", async () => {
+  const extension = loadExtension({ sessionName: "pi session" });
+
+  try {
+    assert.deepEqual(extension.handlerNames(), [
+      "session_start",
+      "session_shutdown",
+      "input",
+      "agent_end",
+      "tool_execution_start",
+      "tool_execution_end",
+      "session_before_compact",
+      "session_compact",
+      "session_switch",
+    ]);
+
+    await extension.emit("session_start", {}, { hasUI: true, cwd: "/tmp/test-project" });
+
+    const calls = extension.readCalls();
+    assert.deepEqual(eventNames(calls), ["SessionStart"]);
+    assert.equal(calls[0].payload.session_id, `pi-${process.pid}`);
+    assert.equal(calls[0].payload.cwd, "/tmp/test-project");
+    assert.equal(calls[0].payload.harness_name, "pi");
+    assert.equal(calls[0].payload.source, "pi");
+    assert.equal(calls[0].payload.session_name, "pi session");
+  } finally {
+    extension.restore();
+  }
+});
+
+test("skips all tracking when ctx.hasUI is false", async () => {
+  const extension = loadExtension();
+
+  try {
+    await extension.emit("session_start", {}, { hasUI: false, cwd: "/tmp/test-project" });
+    await extension.emit("input", { text: "hello" });
+    await extension.emit("tool_execution_start", { toolName: "bash", args: { command: "ls" } });
+    await extension.emit("tool_execution_end", { isError: false });
+    await extension.emit("agent_end");
+    await extension.emit("session_switch");
+    await extension.emit("session_shutdown");
+
+    assert.deepEqual(extension.readCalls(), []);
+  } finally {
+    extension.restore();
+  }
+});
+
+test("maps pi events to cctop prompt, tool, and lifecycle hooks", async () => {
+  const extension = loadExtension();
+
+  try {
+    await extension.emit("session_start", {}, { hasUI: true, cwd: "/tmp/test-project" });
+    await extension.emit("input", { text: "make it so" });
+    await extension.emit("tool_execution_start", {
+      toolName: "read",
+      args: { filePath: "/tmp/test-project/README.md", ignored: true },
+    });
+    await extension.emit("agent_end");
+    await extension.emit("session_before_compact");
+    await extension.emit("session_compact");
+    await extension.emit("session_shutdown");
+
+    const calls = extension.readCalls();
+    assert.deepEqual(
+      eventNames(calls),
+      [
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "Stop",
+        "PreCompact",
+        "PostCompact",
+        "SessionEnd",
+      ],
+    );
+    assert.equal(calls[1].payload.prompt, "make it so");
+    assert.equal(calls[2].payload.tool_name, "Read");
+    assert.deepEqual(calls[2].payload.tool_input, { file_path: "/tmp/test-project/README.md" });
+  } finally {
+    extension.restore();
+  }
+});
+
+test("maps tool_execution_end to PostToolUse or PostToolUseFailure by isError", async () => {
+  const extension = loadExtension();
+
+  try {
+    await extension.emit("session_start", {}, { hasUI: true, cwd: "/tmp/test-project" });
+    await extension.emit("tool_execution_end", { isError: false, result: "ok" });
+    await extension.emit("tool_execution_end", { isError: true, result: "command exploded" });
+    await extension.emit("tool_execution_end", { isError: true, result: { message: "object message" } });
+
+    const calls = extension.readCalls();
+    assert.deepEqual(
+      eventNames(calls),
+      ["SessionStart", "PostToolUse", "PostToolUseFailure", "PostToolUseFailure"],
+    );
+    assert.equal(calls[1].payload.error, undefined);
+    assert.equal(calls[2].payload.error, "command exploded");
+    assert.equal(calls[3].payload.error, "object message");
+  } finally {
+    extension.restore();
+  }
+});
+
+test("session_switch refreshes the session name and emits SessionStart", async () => {
+  const extension = loadExtension({ sessionName: "first session" });
+
+  try {
+    await extension.emit("session_start", {}, { hasUI: true, cwd: "/tmp/test-project" });
+    extension.pi.sessionName = "renamed session";
+    await extension.emit("session_switch");
+
+    const calls = extension.readCalls();
+    assert.deepEqual(eventNames(calls), ["SessionStart", "SessionStart"]);
+    assert.equal(calls[0].payload.session_name, "first session");
+    assert.equal(calls[1].payload.session_name, "renamed session");
+  } finally {
+    extension.restore();
+  }
+});


### PR DESCRIPTION
## Problem

The pi extension (`plugins/pi/cctop.ts`) translates pi events into `cctop-hook` calls with logic equivalent to the opencode plugin, but had no behavioral tests. The opencode plugin has a full `node:test` suite under `plugins/opencode/test/` run by `make test`; pi's only automated coverage was the regex-based event-name and binary-location checks in `scripts/validate-hook-contract.py`, which cannot catch event-mapping or payload regressions.

## Solution

- Add `plugins/pi/test/cctop.test.mjs`, a `node:test` suite using the same harness approach as the opencode suite: a fake `HOME` containing a shell-script `cctop-hook` that records event names and stdin payloads, plus a stubbed `pi` object that collects the registered handlers.
- The suite imports `cctop.ts` directly via Node's built-in TypeScript type stripping (enabled by default since Node 23.6, see https://nodejs.org/api/typescript.html), so there is no build step and no new dependencies.
- Covered behaviors: `tool_execution_end` mapping to `PostToolUse` vs `PostToolUseFailure` by `isError` (including string and object error messages), the `ctx.hasUI === false` gate that skips all tracking for non-interactive sessions, `session_switch` re-reading the session name, the `SessionStart` payload fields (`session_id`/`cwd`/`harness_name`/`source`/`session_name`), prompt passthrough, tool-name and argument normalization (`read` → `Read`, `filePath` → `file_path`, non-string args dropped), and the `agent_end`/compaction/`session_shutdown` mappings.
- Wire the suite into the `make test` plugin step next to the opencode tests, and update the AGENTS.md testing references to match.

## Verification

- `node --test plugins/pi/test/*.test.mjs` passes (5/5).
- Each required behavior was mutation-tested against `cctop.ts`: inverting the `isError` branch, hardcoding `interactive` to `true`, and removing the `session_switch` session-name refresh each made exactly the targeted test fail; restoring the source made the suite pass again.
- `make all` (lint + contract + build + test) is green from the worktree root; the pi suite runs inside `make test` right after the opencode tests.