### PR TITLE
Deduplicate snapshot test helpers into shared top-level functions

### DIFF
--- a/menubar/CctopMenubarTests/QASnapshotTests.swift
+++ b/menubar/CctopMenubarTests/QASnapshotTests.swift
@@ -223,12 +223,6 @@ final class QASnapshotTests: XCTestCase {
             .environment(\.colorScheme, .light)
     }
 
-    /// Inert manager: no home-dir IO, every flag starts deterministically
-    /// false, so snapshots never carry the developer's machine state.
-    private func inertPluginManager() -> PluginManager {
-        PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
-    }
-
     // MARK: - Rendering
 
     private func renderSnapshot(

--- a/menubar/CctopMenubarTests/SnapshotTests.swift
+++ b/menubar/CctopMenubarTests/SnapshotTests.swift
@@ -10,6 +10,114 @@ func snapshotOutputDirectory(named directoryName: String) -> String {
             .path
 }
 
+/// Inert manager: no home-dir IO, every flag starts deterministically
+/// false, so screenshots are reproducible across machines.
+@MainActor
+func inertPluginManager() -> PluginManager {
+    PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
+}
+
+/// Shared snapshot render pipeline: hosts the view in a borderless window,
+/// sizes it to fit, and writes a PNG into the named snapshot output directory.
+@MainActor
+@discardableResult
+func renderPanelScreenshot(
+    view: some View, colorScheme: ColorScheme, directoryName: String, filename: String, width: CGFloat = 320
+) throws -> NSSize {
+    let docsDir = snapshotOutputDirectory(named: directoryName)
+    let outputPath = "\(docsDir)/\(filename)"
+    try FileManager.default.createDirectory(
+        at: URL(fileURLWithPath: docsDir), withIntermediateDirectories: true
+    )
+
+    let appearance: NSAppearance.Name = colorScheme == .dark ? .darkAqua : .aqua
+    let styled = view
+        .frame(width: width)
+        .background {
+            PanelSurfaceBackground(usesMaterial: false)
+        }
+        .overlay {
+            PanelAccentHairline(cornerRadius: AppChrome.panelCornerRadius)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: AppChrome.panelCornerRadius, style: .continuous))
+        .environment(\.colorScheme, colorScheme)
+
+    let window = NSWindow(
+        contentRect: NSRect(x: 0, y: 0, width: width, height: 500),
+        styleMask: [.borderless],
+        backing: .buffered,
+        defer: false
+    )
+    window.appearance = NSAppearance(named: appearance)
+
+    let hostingView = NSHostingView(rootView: styled)
+    window.contentView = hostingView
+
+    let fittingSize = hostingView.fittingSize
+    window.setContentSize(fittingSize)
+    hostingView.frame = NSRect(origin: .zero, size: fittingSize)
+    hostingView.layoutSubtreeIfNeeded()
+
+    let bitmapRep = try XCTUnwrap(
+        hostingView.bitmapImageRepForCachingDisplay(in: hostingView.bounds),
+        "Failed to create bitmap for \(filename)"
+    )
+    hostingView.cacheDisplay(in: hostingView.bounds, to: bitmapRep)
+
+    let pngData = try XCTUnwrap(
+        bitmapRep.representation(using: .png, properties: [:]),
+        "Failed to generate PNG for \(filename)"
+    )
+
+    try pngData.write(to: URL(fileURLWithPath: outputPath))
+    print("Screenshot saved to: \(outputPath)")
+    return fittingSize
+}
+
+func worstCaseReviewCleanupCandidate(now: Date = Date()) -> WorktreeCleanupCandidate {
+    let path = "/Users/st0012/projects/cctop/.claude/worktrees/very-long-review-worktree-name-for-layout"
+    let state = WorktreeCleanupCandidate.State.review([
+        "Worktree has uncommitted tracked changes",
+        WorktreeCleanupCandidate.untrackedFilesReason,
+        "No upstream branch",
+        "Worktree is locked",
+    ])
+    return WorktreeCleanupCandidate(
+        id: path,
+        sessionName: "Investigate cleanup tab layout with very long session naming",
+        worktreePath: path,
+        worktreeName: URL(fileURLWithPath: path).lastPathComponent,
+        branchName: "claude/review-layout-with-long-branch-name-and-no-upstream",
+        lastActiveAt: now.addingTimeInterval(-86_400 * 16),
+        storageBytes: 426 * 1_024 * 1_024,
+        state: state,
+        checks: [
+            WorktreeCleanupCheck(label: "No active cctop sessions here", status: .ok),
+            WorktreeCleanupCheck(label: "Path is a registered linked worktree", status: .ok),
+            WorktreeCleanupCheck(label: "No uncommitted tracked changes", status: .review),
+            WorktreeCleanupCheck(label: "No untracked files", status: .review),
+            WorktreeCleanupCheck(label: "No ignored files", status: .ok),
+            WorktreeCleanupCheck(label: "Branch has no unique local commits", status: .review),
+            WorktreeCleanupCheck(label: "Main checkout path is known", status: .ok),
+            WorktreeCleanupCheck(label: "Worktree is not locked", status: .ok),
+            WorktreeCleanupCheck(label: "Storage size scan completed", status: .ok),
+        ],
+        reviewEvidence: WorktreeCleanupCandidate.mockReviewEvidence(for: state)
+    )
+}
+
+func repoRoot() throws -> URL {
+    var url = URL(fileURLWithPath: #filePath)
+    while url.path != "/" {
+        let candidate = url.appendingPathComponent("menubar/CctopMenubar.xcodeproj")
+        if FileManager.default.fileExists(atPath: candidate.path) {
+            return url
+        }
+        url.deleteLastPathComponent()
+    }
+    throw XCTSkip("Could not locate repository root")
+}
+
 @MainActor
 final class SnapshotTests: XCTestCase {
     /// Renders the PopupView with showcase sessions and saves light + dark screenshots.
@@ -184,107 +292,13 @@ final class SnapshotTests: XCTestCase {
         ThemeManager.shared.setTheme(.claude)
     }
 
-    /// Inert manager: no home-dir IO, every flag starts deterministically
-    /// false, so screenshots are reproducible across machines.
-    private func inertPluginManager() -> PluginManager {
-        PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
-    }
-
     @discardableResult
     private func renderScreenshot(
         view: some View, colorScheme: ColorScheme, filename: String, width: CGFloat = 320
     ) throws -> NSSize {
-        let docsDir = snapshotOutputDirectory(named: "cctop-screenshots")
-        let outputPath = "\(docsDir)/\(filename)"
-        try FileManager.default.createDirectory(
-            at: URL(fileURLWithPath: docsDir), withIntermediateDirectories: true
+        try renderPanelScreenshot(
+            view: view, colorScheme: colorScheme,
+            directoryName: "cctop-screenshots", filename: filename, width: width
         )
-
-        let appearance: NSAppearance.Name = colorScheme == .dark ? .darkAqua : .aqua
-        let styled = view
-            .frame(width: width)
-            .background {
-                PanelSurfaceBackground(usesMaterial: false)
-            }
-            .overlay {
-                PanelAccentHairline(cornerRadius: AppChrome.panelCornerRadius)
-            }
-            .clipShape(RoundedRectangle(cornerRadius: AppChrome.panelCornerRadius, style: .continuous))
-            .environment(\.colorScheme, colorScheme)
-
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: width, height: 500),
-            styleMask: [.borderless],
-            backing: .buffered,
-            defer: false
-        )
-        window.appearance = NSAppearance(named: appearance)
-
-        let hostingView = NSHostingView(rootView: styled)
-        window.contentView = hostingView
-
-        let fittingSize = hostingView.fittingSize
-        window.setContentSize(fittingSize)
-        hostingView.frame = NSRect(origin: .zero, size: fittingSize)
-        hostingView.layoutSubtreeIfNeeded()
-
-        let bitmapRep = try XCTUnwrap(
-            hostingView.bitmapImageRepForCachingDisplay(in: hostingView.bounds),
-            "Failed to create bitmap for \(filename)"
-        )
-        hostingView.cacheDisplay(in: hostingView.bounds, to: bitmapRep)
-
-        let pngData = try XCTUnwrap(
-            bitmapRep.representation(using: .png, properties: [:]),
-            "Failed to generate PNG for \(filename)"
-        )
-
-        try pngData.write(to: URL(fileURLWithPath: outputPath))
-        print("Screenshot saved to: \(outputPath)")
-        return fittingSize
-    }
-
-    private func worstCaseReviewCleanupCandidate() -> WorktreeCleanupCandidate {
-        let path = "/Users/st0012/projects/cctop/.claude/worktrees/very-long-review-worktree-name-for-layout"
-        let state = WorktreeCleanupCandidate.State.review([
-            "Worktree has uncommitted tracked changes",
-            WorktreeCleanupCandidate.untrackedFilesReason,
-            "No upstream branch",
-            "Worktree is locked",
-        ])
-        return WorktreeCleanupCandidate(
-            id: path,
-            sessionName: "Investigate cleanup tab layout with very long session naming",
-            worktreePath: path,
-            worktreeName: URL(fileURLWithPath: path).lastPathComponent,
-            branchName: "claude/review-layout-with-long-branch-name-and-no-upstream",
-            lastActiveAt: Date().addingTimeInterval(-86_400 * 16),
-            storageBytes: 426 * 1_024 * 1_024,
-            state: state,
-            checks: [
-                WorktreeCleanupCheck(label: "No active cctop sessions here", status: .ok),
-                WorktreeCleanupCheck(label: "Path is a registered linked worktree", status: .ok),
-                WorktreeCleanupCheck(label: "No uncommitted tracked changes", status: .review),
-                WorktreeCleanupCheck(label: "No untracked files", status: .review),
-                WorktreeCleanupCheck(label: "No ignored files", status: .ok),
-                WorktreeCleanupCheck(label: "Branch has no unique local commits", status: .review),
-                WorktreeCleanupCheck(label: "Main checkout path is known", status: .ok),
-                WorktreeCleanupCheck(label: "Worktree is not locked", status: .ok),
-                WorktreeCleanupCheck(label: "Storage size scan completed", status: .ok),
-            ],
-            reviewEvidence: WorktreeCleanupCandidate.mockReviewEvidence(for: state)
-        )
-    }
-
-    private func repoRoot() throws -> URL {
-        var url = URL(fileURLWithPath: #filePath)
-        while url.path != "/" {
-            let candidate = url.appendingPathComponent("menubar/CctopMenubar.xcodeproj")
-            if FileManager.default.fileExists(atPath: candidate.path) {
-                return url
-            }
-            url.deleteLastPathComponent()
-        }
-        throw XCTSkip("Could not locate repository root")
     }
 }

--- a/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
@@ -238,54 +238,10 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
     private func renderScreenshot(
         view: some View, colorScheme: ColorScheme, filename: String, width: CGFloat = 320
     ) throws -> NSSize {
-        let docsDir = snapshotOutputDirectory(named: "cctop-worktree-cleanup-screenshots")
-        let outputPath = "\(docsDir)/\(filename)"
-        try FileManager.default.createDirectory(
-            at: URL(fileURLWithPath: docsDir), withIntermediateDirectories: true
+        try renderPanelScreenshot(
+            view: view, colorScheme: colorScheme,
+            directoryName: "cctop-worktree-cleanup-screenshots", filename: filename, width: width
         )
-
-        let appearance: NSAppearance.Name = colorScheme == .dark ? .darkAqua : .aqua
-        let styled = view
-            .frame(width: width)
-            .background {
-                PanelSurfaceBackground(usesMaterial: false)
-            }
-            .overlay {
-                PanelAccentHairline(cornerRadius: AppChrome.panelCornerRadius)
-            }
-            .clipShape(RoundedRectangle(cornerRadius: AppChrome.panelCornerRadius, style: .continuous))
-            .environment(\.colorScheme, colorScheme)
-
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: width, height: 500),
-            styleMask: [.borderless],
-            backing: .buffered,
-            defer: false
-        )
-        window.appearance = NSAppearance(named: appearance)
-
-        let hostingView = NSHostingView(rootView: styled)
-        window.contentView = hostingView
-
-        let fittingSize = hostingView.fittingSize
-        window.setContentSize(fittingSize)
-        hostingView.frame = NSRect(origin: .zero, size: fittingSize)
-        hostingView.layoutSubtreeIfNeeded()
-
-        let bitmapRep = try XCTUnwrap(
-            hostingView.bitmapImageRepForCachingDisplay(in: hostingView.bounds),
-            "Failed to create bitmap for \(filename)"
-        )
-        hostingView.cacheDisplay(in: hostingView.bounds, to: bitmapRep)
-
-        let pngData = try XCTUnwrap(
-            bitmapRep.representation(using: .png, properties: [:]),
-            "Failed to generate PNG for \(filename)"
-        )
-
-        try pngData.write(to: URL(fileURLWithPath: outputPath))
-        print("Screenshot saved to: \(outputPath)")
-        return fittingSize
     }
 
     private func cleanupPopup(
@@ -425,38 +381,6 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
         )
     }
 
-    private func worstCaseReviewCleanupCandidate(now: Date) -> WorktreeCleanupCandidate {
-        let path = "/Users/st0012/projects/cctop/.claude/worktrees/very-long-review-worktree-name-for-layout"
-        let state = WorktreeCleanupCandidate.State.review([
-            "Worktree has uncommitted tracked changes",
-            WorktreeCleanupCandidate.untrackedFilesReason,
-            "No upstream branch",
-            "Worktree is locked",
-        ])
-        return WorktreeCleanupCandidate(
-            id: path,
-            sessionName: "Investigate cleanup tab layout with very long session naming",
-            worktreePath: path,
-            worktreeName: URL(fileURLWithPath: path).lastPathComponent,
-            branchName: "claude/review-layout-with-long-branch-name-and-no-upstream",
-            lastActiveAt: now.addingTimeInterval(-86_400 * 16),
-            storageBytes: 426 * 1_024 * 1_024,
-            state: state,
-            checks: [
-                WorktreeCleanupCheck(label: "No active cctop sessions here", status: .ok),
-                WorktreeCleanupCheck(label: "Path is a registered linked worktree", status: .ok),
-                WorktreeCleanupCheck(label: "No uncommitted tracked changes", status: .review),
-                WorktreeCleanupCheck(label: "No untracked files", status: .review),
-                WorktreeCleanupCheck(label: "No ignored files", status: .ok),
-                WorktreeCleanupCheck(label: "Branch has no unique local commits", status: .review),
-                WorktreeCleanupCheck(label: "Main checkout path is known", status: .ok),
-                WorktreeCleanupCheck(label: "Worktree is not locked", status: .ok),
-                WorktreeCleanupCheck(label: "Storage size scan completed", status: .ok),
-            ],
-            reviewEvidence: WorktreeCleanupCandidate.mockReviewEvidence(for: state)
-        )
-    }
-
     private func unknownSafetyCandidate(now: Date) -> WorktreeCleanupCandidate {
         cleanupScenarioCandidate(
             CandidateSeed(
@@ -545,10 +469,6 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
             untrackedPreview: WorktreeCleanupUntrackedPreview(paths: untrackedPaths),
             ignoredPreview: WorktreeCleanupUntrackedPreview(paths: ignoredPaths)
         )
-    }
-
-    private func inertPluginManager() -> PluginManager {
-        PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
     }
 }
 

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -2904,21 +2904,4 @@ final class WorktreeCleanupTests: XCTestCase {
             onLayoutChanged: onLayoutChanged
         )
     }
-
-    @MainActor
-    private func inertPluginManager() -> PluginManager {
-        PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
-    }
-
-    private func repoRoot() throws -> URL {
-        var url = URL(fileURLWithPath: #filePath)
-        while url.path != "/" {
-            let candidate = url.appendingPathComponent("menubar/CctopMenubar.xcodeproj")
-            if FileManager.default.fileExists(atPath: candidate.path) {
-                return url
-            }
-            url.deleteLastPathComponent()
-        }
-        throw XCTSkip("Could not locate repository root")
-    }
 }


### PR DESCRIPTION
## Problem

The snapshot render pipeline (borderless `NSWindow` + `NSHostingView` + bitmap PNG write, ~55 lines) was copied verbatim between `SnapshotTests.swift` and `WorktreeCleanupSnapshotTests.swift`, differing only in the output directory name (`cctop-screenshots` vs `cctop-worktree-cleanup-screenshots`). The ~30-line `worstCaseReviewCleanupCandidate` fixture was likewise duplicated, differing only in `Date()` vs a `now` parameter, and smaller helpers (`inertPluginManager` in four files, `repoRoot` in two) were also copy-pasted. Any change to the render pipeline or the fixture had to be applied in multiple places.

## Solution

- Hoist one `renderPanelScreenshot(view:colorScheme:directoryName:filename:width:)` next to the existing shared `snapshotOutputDirectory(named:)` in `SnapshotTests.swift`; each snapshot class keeps a thin private `renderScreenshot` wrapper that binds its directory name, so all callsites are untouched and screenshots keep writing to the same directories.
- Share one top-level `worstCaseReviewCleanupCandidate(now: Date = Date())`, preserving both prior behaviors (default `Date()` in `SnapshotTests`, explicit `now` in `WorktreeCleanupSnapshotTests`).
- Consolidate the verbatim copies of `inertPluginManager()` (four files) and `repoRoot()` (two files) into single top-level functions in the same location.
- No new files, so no project-file changes.

## Verification

`SnapshotTests`, `QASnapshotTests`, and `WorktreeCleanupScenarioSnapshotTests` pass after wiping the output directories, and write their PNGs to the same directories as before (`$TMPDIR/cctop-screenshots`, `$TMPDIR/cctop-worktree-cleanup-screenshots`, `/tmp/cctop-qa`). `make all` (lint + contract + build + tests) is green: 918 tests, 0 failures.