### PR TITLE
Run the JS plugin test suites in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,20 @@ jobs:
       - name: SwiftLint
         run: swiftlint lint --strict
 
+  plugin-test:
+    name: Plugin Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          # pi plugin tests need >= 23.6 for built-in TypeScript type stripping
+          node-version: "24"
+      - name: Test opencode plugin
+        run: npm --prefix plugins/opencode test
+      - name: Test pi plugin
+        run: node --test plugins/pi/test/*.test.mjs
+
   swift-test:
     name: Swift Build & Test
     runs-on: macos-15


### PR DESCRIPTION
## Problem

CI covered Swift lint/build/test, but the JavaScript/TypeScript plugin suites only ran through local test commands. That left opencode and pi hook-event mapping regressions without pull-request CI coverage.

## Solution

- Add a `Plugin Tests` CI job on Ubuntu with Node 24 so the pi suite can load TypeScript directly.
- Run both plugin suites in that job: `npm --prefix plugins/opencode test` and `node --test plugins/pi/test/*.test.mjs`.
