### PR TITLE
Polish worktree cleanup removal flow

### DIFF
--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -121,13 +121,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     ) async -> WorktreeRemovalService.RemovalAction {
         let cleanupSnapshot = sessionManager.cleanupSnapshotForRemoval()
         let removalService = cleanupRemovalService
-        return await Task.detached(priority: .utility) {
+        let action = await Task.detached(priority: .utility) {
             removalService.selectedAction(
                 for: candidate,
                 cleanupSources: cleanupSnapshot.cleanupSources,
                 activeProjectPaths: cleanupSnapshot.activeProjectPaths
             )
         }.value
+        if case .blocked = action {
+            cleanupRefreshGate.refreshIfVisible(force: true)
+        }
+        return action
     }
 
     @MainActor private func executeCleanupRemovalAction(
@@ -143,10 +147,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             )
         }.value
 
-        if case .removed = result {
+        switch result {
+        case .removed, .refused:
             await MainActor.run {
                 cleanupRefreshGate.refreshIfVisible(force: true)
             }
+        case .failed:
+            break
         }
         return result
     }

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -98,11 +98,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             updater: updater,
             pluginManager: pluginManager,
             navigate: navigateController,
-            onRemoveCleanupCandidate: { [weak self] candidate in
-                await self?.removeCleanupCandidate(candidate) ?? .refused(candidate)
+            onSelectCleanupRemovalAction: { [weak self] candidate in
+                await self?.selectCleanupRemovalAction(candidate) ?? .blocked(candidate, "Cleanup is unavailable right now.")
             },
-            onForceRemoveCleanupCandidate: { [weak self] offer in
-                await self?.forceRemoveCleanupCandidate(offer) ?? .refused(offer.candidate)
+            onExecuteCleanupRemovalAction: { [weak self] action in
+                await self?.executeCleanupRemovalAction(action) ?? .refused(action.candidate)
             },
             onCleanupTabVisible: { [weak self] in
                 Task { @MainActor in self?.setCleanupVisible(true) }
@@ -116,35 +116,28 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         )
     }
 
-    @MainActor private func removeCleanupCandidate(
+    @MainActor private func selectCleanupRemovalAction(
         _ candidate: WorktreeCleanupCandidate
-    ) async -> WorktreeRemovalService.RemovalResult {
+    ) async -> WorktreeRemovalService.RemovalAction {
         let cleanupSnapshot = sessionManager.cleanupSnapshotForRemoval()
         let removalService = cleanupRemovalService
-        let result = await Task.detached(priority: .utility) {
-            removalService.remove(
-                candidate,
+        return await Task.detached(priority: .utility) {
+            removalService.selectedAction(
+                for: candidate,
                 cleanupSources: cleanupSnapshot.cleanupSources,
                 activeProjectPaths: cleanupSnapshot.activeProjectPaths
             )
         }.value
-
-        if case .removed = result {
-            await MainActor.run {
-                cleanupRefreshGate.refreshIfVisible(force: true)
-            }
-        }
-        return result
     }
 
-    @MainActor private func forceRemoveCleanupCandidate(
-        _ offer: WorktreeForceRemovalOffer
+    @MainActor private func executeCleanupRemovalAction(
+        _ action: WorktreeRemovalService.RemovalAction
     ) async -> WorktreeRemovalService.RemovalResult {
         let cleanupSnapshot = sessionManager.cleanupSnapshotForRemoval()
         let removalService = cleanupRemovalService
         let result = await Task.detached(priority: .utility) {
-            removalService.forceRemove(
-                offer,
+            removalService.executeConfirmed(
+                action,
                 cleanupSources: cleanupSnapshot.cleanupSources,
                 activeProjectPaths: cleanupSnapshot.activeProjectPaths
             )

--- a/menubar/CctopMenubar/Models/WorktreeCleanupCandidate.swift
+++ b/menubar/CctopMenubar/Models/WorktreeCleanupCandidate.swift
@@ -4,6 +4,7 @@ struct WorktreeCleanupCandidate: Identifiable, Equatable {
     static let untrackedFilesReason = "Worktree has untracked files"
     static let ignoredFilesReason = "Worktree has ignored files"
     static let trackedChangesReason = "Worktree has uncommitted tracked changes"
+    static let lockedReason = "Worktree is locked"
     static let initializedSubmodulesReason = "Worktree contains initialized submodules"
     static let indexHiddenTrackedFilesReason = "Worktree has tracked files hidden by Git index flags"
     static let statusUnreadableReason = "Git status could not be read"

--- a/menubar/CctopMenubar/Models/WorktreeCleanupCandidate.swift
+++ b/menubar/CctopMenubar/Models/WorktreeCleanupCandidate.swift
@@ -86,6 +86,12 @@ struct WorktreeCleanupCandidate: Identifiable, Equatable {
         Self.formatStorage(bytes: storageBytes)
     }
 
+    var requiresForceWorktreeRemoval: Bool {
+        state.reasons.contains(Self.untrackedFilesReason)
+            || state.reasons.contains(Self.ignoredFilesReason)
+            || state.reasons.contains(Self.trackedChangesReason)
+    }
+
     func visibleReviewReasons(limit: Int = 3) -> [String] {
         let reasons = state.reasons
         guard limit > 0 else { return [] }
@@ -214,77 +220,97 @@ struct WorktreeCleanupCheck: Equatable {
     let status: Status
 }
 
-struct WorktreeForceRemovalOffer: Equatable {
-    let candidate: WorktreeCleanupCandidate
-    let failure: GitCommandResult
-}
-
 enum WorktreeRemovalConfirmation: Identifiable, Equatable {
-    case reviewWarning(WorktreeCleanupCandidate)
-    case final(WorktreeCleanupCandidate)
-    case force(WorktreeForceRemovalOffer)
+    case review(WorktreeRemovalService.RemovalAction)
+
+    private static let branchRetentionCopy = "Removing the worktree does not delete the branch."
 
     var id: String {
         switch self {
-        case .reviewWarning(let candidate):
-            return "review-warning-\(candidate.id)"
-        case .final(let candidate):
-            return "final-\(candidate.id)"
-        case .force(let offer):
-            return "force-\(offer.candidate.id)"
+        case .review(let action):
+            return "review-\(action.candidate.id)-\(action.isForce ? "force" : "normal")"
         }
     }
 
     var candidate: WorktreeCleanupCandidate {
         switch self {
-        case .reviewWarning(let candidate), .final(let candidate):
-            return candidate
-        case .force(let offer):
-            return offer.candidate
+        case .review(let action):
+            return action.candidate
         }
     }
 
     var title: String {
         switch self {
-        case .reviewWarning:
-            return "Review Worktree?"
-        case .final:
-            return "Remove Worktree?"
-        case .force:
-            return "Force Remove Worktree?"
+        case .review(let action):
+            return action.isForce ? "Force Remove Worktree?" : "Remove Review Worktree?"
         }
     }
 
     var message: String {
         switch self {
-        case .reviewWarning:
-            return "This worktree needs review. Removal uses plain git worktree remove, and Git may refuse it."
-        case .final(let candidate):
-            return "Runs git worktree remove for \(candidate.worktreeName). The branch is left intact."
-        case .force(let offer):
-            let candidate = offer.candidate
-            return "Runs git worktree remove --force for \(candidate.worktreeName) at \(candidate.worktreePath) on \(candidate.branchName). "
-                + "This can delete uncommitted tracked changes plus untracked or ignored files in that worktree. The branch is left intact."
+        case .review(.normalRemove(let candidate)):
+            return "Runs git worktree remove for \(candidate.worktreeName). "
+                + "\(Self.reviewEvidenceCopy(for: candidate)) \(Self.branchRetentionCopy)"
+        case .review(.forceRemove(let candidate)):
+            return "Runs git worktree remove --force for \(candidate.worktreeName). "
+                + "\(Self.reviewEvidenceCopy(for: candidate)) "
+                + "This removes local file changes and files in that worktree. \(Self.branchRetentionCopy)"
+        case .review(.blocked(_, let reason)):
+            return reason
         }
     }
 
     var primaryButtonTitle: String {
         switch self {
-        case .reviewWarning:
-            return "Continue"
-        case .final:
-            return "Remove"
-        case .force:
-            return "Force Remove"
+        case .review(let action):
+            return action.isForce ? "Force Remove" : "Remove"
         }
     }
 
-    var confirmedReviewWarning: WorktreeRemovalConfirmation? {
-        guard case .reviewWarning(let candidate) = self else { return nil }
-        return .final(candidate)
+    static func review(for action: WorktreeRemovalService.RemovalAction) -> WorktreeRemovalConfirmation? {
+        switch action {
+        case .normalRemove(let candidate) where candidate.state.isClean:
+            return nil
+        case .normalRemove, .forceRemove:
+            return .review(action)
+        case .blocked:
+            return nil
+        }
     }
 
-    static func initial(for candidate: WorktreeCleanupCandidate) -> WorktreeRemovalConfirmation {
-        candidate.state.isClean ? .final(candidate) : .reviewWarning(candidate)
+    private static func reviewEvidenceCopy(for candidate: WorktreeCleanupCandidate) -> String {
+        var parts: [String] = []
+        let reasons = candidate.visibleReviewReasons()
+        if !reasons.isEmpty {
+            var reasonCopy = "Reasons: " + reasons.joined(separator: "; ")
+            let remainingCount = candidate.remainingReviewReasonCount()
+            if remainingCount > 0 {
+                reasonCopy += "; and \(remainingCount) more"
+            }
+            parts.append(reasonCopy + ".")
+        }
+
+        if let preview = candidate.reviewEvidence.untrackedPreview {
+            parts.append("Untracked files: \(preview.decisionEvidenceText).")
+        }
+        if let preview = candidate.reviewEvidence.ignoredPreview {
+            parts.append("Ignored files: \(preview.decisionEvidenceText).")
+        }
+
+        return parts.joined(separator: " ")
+    }
+}
+
+extension WorktreeRemovalService.RemovalAction {
+    var candidate: WorktreeCleanupCandidate {
+        switch self {
+        case .normalRemove(let candidate), .forceRemove(let candidate), .blocked(let candidate, _):
+            return candidate
+        }
+    }
+
+    var isForce: Bool {
+        if case .forceRemove = self { return true }
+        return false
     }
 }

--- a/menubar/CctopMenubar/Models/WorktreeCleanupCandidate.swift
+++ b/menubar/CctopMenubar/Models/WorktreeCleanupCandidate.swift
@@ -8,6 +8,9 @@ struct WorktreeCleanupCandidate: Identifiable, Equatable {
     static let initializedSubmodulesReason = "Worktree contains initialized submodules"
     static let indexHiddenTrackedFilesReason = "Worktree has tracked files hidden by Git index flags"
     static let statusUnreadableReason = "Git status could not be read"
+    static let branchUnknownReason = "Branch is unknown or detached"
+    static let mainWorktreePathUnverifiedReason = "Main checkout path could not be verified"
+    static let commitSafetyUnknownReason = "Branch upstream or commit safety could not be verified"
     private static let localFileReasons = [untrackedFilesReason, ignoredFilesReason]
 
     enum State: Equatable {
@@ -89,7 +92,6 @@ struct WorktreeCleanupCandidate: Identifiable, Equatable {
 
     var requiresForceWorktreeRemoval: Bool {
         state.reasons.contains(Self.untrackedFilesReason)
-            || state.reasons.contains(Self.ignoredFilesReason)
             || state.reasons.contains(Self.trackedChangesReason)
     }
 
@@ -134,13 +136,16 @@ struct WorktreeCleanupReviewEvidence: Equatable {
 
     let untrackedPreview: WorktreeCleanupUntrackedPreview?
     let ignoredPreview: WorktreeCleanupUntrackedPreview?
+    let trackedPathSignature: [String]
 
     init(
         untrackedPreview: WorktreeCleanupUntrackedPreview? = nil,
-        ignoredPreview: WorktreeCleanupUntrackedPreview? = nil
+        ignoredPreview: WorktreeCleanupUntrackedPreview? = nil,
+        trackedPathSignature: [String] = []
     ) {
         self.untrackedPreview = untrackedPreview
         self.ignoredPreview = ignoredPreview
+        self.trackedPathSignature = trackedPathSignature
     }
 
     var hasLocalFilePreview: Bool {
@@ -296,6 +301,9 @@ enum WorktreeRemovalConfirmation: Identifiable, Equatable {
         }
         if let preview = candidate.reviewEvidence.ignoredPreview {
             parts.append("Ignored files: \(preview.decisionEvidenceText).")
+            if !candidate.requiresForceWorktreeRemoval {
+                parts.append("Ignored files will be removed with this worktree.")
+            }
         }
 
         return parts.joined(separator: " ")

--- a/menubar/CctopMenubar/Services/GitWorktreeInspector.swift
+++ b/menubar/CctopMenubar/Services/GitWorktreeInspector.swift
@@ -84,14 +84,14 @@ struct GitWorktreeInspector {
         if let fallback, !fallback.isEmpty {
             return fallback
         }
-        failures.append("Branch is unknown or detached")
+        failures.append(WorktreeCleanupCandidate.branchUnknownReason)
         return nil
     }
 
     private func statusEntries(path: String, failures: inout [String]) -> [String]? {
         let result = runGit(path, ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--ignored=traditional"])
         guard result.exitCode == 0 else {
-            failures.append("Git status could not be read")
+            failures.append(WorktreeCleanupCandidate.statusUnreadableReason)
             return nil
         }
         return Self.parseStatusEntries(result.stdout)

--- a/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
@@ -217,10 +217,10 @@ struct WorktreeCleanupScanner {
     private static func reviewReasons(for inspection: GitWorktreeInspection, storageBytes: Int64?) -> [String] {
         var reasons = inspection.failureReasons
         if inspection.branchName?.isEmpty ?? true {
-            reasons.appendUnique("Branch is unknown or detached")
+            reasons.appendUnique(WorktreeCleanupCandidate.branchUnknownReason)
         }
         if inspection.mainWorktreePath == nil {
-            reasons.appendUnique("Main checkout path could not be verified")
+            reasons.appendUnique(WorktreeCleanupCandidate.mainWorktreePathUnverifiedReason)
         }
         if inspection.isLocked {
             reasons.appendUnique(WorktreeCleanupCandidate.lockedReason)
@@ -243,7 +243,7 @@ struct WorktreeCleanupScanner {
                 reasons.appendUnique("Branch has \(count) unique local commit\(count == 1 ? "" : "s")")
             }
         } else if !reasons.contains(where: Self.isCommitSafetyReason) {
-            reasons.appendUnique("Branch upstream or commit safety could not be verified")
+            reasons.appendUnique(WorktreeCleanupCandidate.commitSafetyUnknownReason)
         }
         return reasons
     }
@@ -275,6 +275,20 @@ struct WorktreeCleanupScanner {
         }
     }
 
+    static func trackedPaths(fromStatusEntries entries: [String]) -> [String] {
+        Array(Set(entries.compactMap { entry in
+            guard entry.count >= 3,
+                  entry[entry.index(entry.startIndex, offsetBy: 2)] == " ",
+                  !entry.hasPrefix("?? "),
+                  !entry.hasPrefix("!! "),
+                  entry.prefix(2).contains(where: { $0 != " " }) else {
+                return nil
+            }
+            let pathStart = entry.index(entry.startIndex, offsetBy: 3)
+            return String(entry[pathStart...])
+        })).sorted()
+    }
+
     private static func paths(fromStatusEntries entries: [String], prefix: String) -> [String] {
         entries.compactMap { entry in
             guard entry.hasPrefix(prefix) else { return nil }
@@ -288,12 +302,14 @@ struct WorktreeCleanupScanner {
         }
         let untrackedPreview = WorktreeCleanupUntrackedPreview(paths: untrackedPaths(fromStatusEntries: statusEntries))
         let ignoredPreview = WorktreeCleanupUntrackedPreview(paths: ignoredPaths(fromStatusEntries: statusEntries))
-        guard untrackedPreview != nil || ignoredPreview != nil else {
+        let trackedPathSignature = trackedPaths(fromStatusEntries: statusEntries)
+        guard untrackedPreview != nil || ignoredPreview != nil || !trackedPathSignature.isEmpty else {
             return .empty
         }
         return WorktreeCleanupReviewEvidence(
             untrackedPreview: untrackedPreview,
-            ignoredPreview: ignoredPreview
+            ignoredPreview: ignoredPreview,
+            trackedPathSignature: trackedPathSignature
         )
     }
 

--- a/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
@@ -223,7 +223,7 @@ struct WorktreeCleanupScanner {
             reasons.appendUnique("Main checkout path could not be verified")
         }
         if inspection.isLocked {
-            reasons.appendUnique("Worktree is locked")
+            reasons.appendUnique(WorktreeCleanupCandidate.lockedReason)
         }
         if let statusEntries = inspection.statusEntries {
             if !Self.untrackedPaths(fromStatusEntries: statusEntries).isEmpty {

--- a/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
+++ b/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
@@ -71,6 +71,10 @@ struct WorktreeRemovalService {
         cleanupSources: [SessionCleanupSource],
         activeProjectPaths: Set<String>
     ) -> RemovalResult {
+        if case .blocked(let candidate, _) = action {
+            return .refused(candidate)
+        }
+
         let refreshedAction = selectedAction(
             for: action.candidate,
             cleanupSources: cleanupSources,
@@ -236,25 +240,17 @@ private extension WorktreeCleanupCandidate {
                 confirmedPreview: candidate.reviewEvidence.ignoredPreview
             ),
         ]
-        return localFileEvidencePairs.contains { pair in
+        let changedPreview = localFileEvidencePairs.contains { pair in
             let addedReason = state.reasons.contains(pair.reason) && !confirmedReasons.contains(pair.reason)
             return pair.preflightPreview != pair.confirmedPreview || addedReason
         }
+        return changedPreview || reviewEvidence.trackedPathSignature != candidate.reviewEvidence.trackedPathSignature
     }
 
     func matchesConfirmedRemovalEvidence(comparedTo candidate: WorktreeCleanupCandidate) -> Bool {
         !changesWorktreeIdentity(comparedTo: candidate)
             && !changesLocalFileReviewEvidence(comparedTo: candidate)
             && Set(state.reasons) == Set(candidate.state.reasons)
-            && localFileReasonSet == candidate.localFileReasonSet
-    }
-
-    private var localFileReasonSet: Set<String> {
-        Set(state.reasons.filter { reason in
-            reason == WorktreeCleanupCandidate.untrackedFilesReason
-                || reason == WorktreeCleanupCandidate.ignoredFilesReason
-                || reason == WorktreeCleanupCandidate.trackedChangesReason
-        })
     }
 
     var blockedRemovalReason: String {
@@ -270,10 +266,10 @@ private extension WorktreeCleanupCandidate {
         if state.reasons.contains(Self.lockedReason) {
             return "This worktree is locked. Unlock it before removing."
         }
-        if state.reasons.contains("Branch is unknown or detached") {
+        if state.reasons.contains(Self.branchUnknownReason) {
             return "The branch is unknown or detached, so cctop cannot verify branch safety."
         }
-        if state.reasons.contains("Main checkout path could not be verified") {
+        if state.reasons.contains(Self.mainWorktreePathUnverifiedReason) {
             return "The main checkout path could not be verified, so cctop cannot run worktree removal safely."
         }
         return state.reasons.first ?? "Cleanup evidence changed. Review the updated worktree before removing."

--- a/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
+++ b/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
@@ -1,10 +1,15 @@
 import Foundation
 
 struct WorktreeRemovalService {
+    enum RemovalAction: Equatable {
+        case normalRemove(WorktreeCleanupCandidate)
+        case forceRemove(WorktreeCleanupCandidate)
+        case blocked(WorktreeCleanupCandidate, String)
+    }
+
     enum RemovalResult: Equatable {
         case removed(GitCommandResult)
         case refused(WorktreeCleanupCandidate)
-        case forceRequired(WorktreeForceRemovalOffer)
         case failed(GitCommandResult)
     }
 
@@ -23,44 +28,80 @@ struct WorktreeRemovalService {
         )
     }
 
+    func selectedAction(
+        for candidate: WorktreeCleanupCandidate,
+        cleanupSources: [SessionCleanupSource],
+        activeProjectPaths: Set<String>
+    ) -> RemovalAction {
+        switch readyCandidate(candidate, cleanupSources: cleanupSources, activeProjectPaths: activeProjectPaths) {
+        case .ready(let readiness):
+            if readiness.candidate.requiresForceWorktreeRemoval {
+                return .forceRemove(readiness.candidate)
+            }
+            return .normalRemove(readiness.candidate)
+        case .refused(let latestCandidate):
+            return .blocked(latestCandidate, latestCandidate.blockedRemovalReason)
+        }
+    }
+
+    func execute(_ action: RemovalAction) -> RemovalResult {
+        switch action {
+        case .normalRemove(let candidate):
+            guard let readiness = removalReadiness(from: candidate) else {
+                return .refused(candidate)
+            }
+            let result = runGit(removeArguments(for: readiness, force: false))
+            return result.exitCode == 0 ? .removed(result) : .failed(result)
+        case .forceRemove(let candidate):
+            guard let readiness = removalReadiness(from: candidate) else {
+                return .refused(candidate)
+            }
+            let result = runGit(removeArguments(for: readiness, force: true))
+            return result.exitCode == 0 ? .removed(result) : .failed(result)
+        case .blocked(let candidate, _):
+            return .refused(candidate)
+        }
+    }
+
+    func executeConfirmed(
+        _ action: RemovalAction,
+        cleanupSources: [SessionCleanupSource],
+        activeProjectPaths: Set<String>
+    ) -> RemovalResult {
+        let refreshedAction = selectedAction(
+            for: action.candidate,
+            cleanupSources: cleanupSources,
+            activeProjectPaths: activeProjectPaths
+        )
+
+        switch (action, refreshedAction) {
+        case (.normalRemove(let confirmedCandidate), .normalRemove(let refreshedCandidate)):
+            guard refreshedCandidate.matchesConfirmedRemovalEvidence(comparedTo: confirmedCandidate) else {
+                return .refused(refreshedCandidate)
+            }
+            return execute(.normalRemove(refreshedCandidate))
+        case (.forceRemove(let confirmedCandidate), .forceRemove(let refreshedCandidate)):
+            guard refreshedCandidate.matchesConfirmedRemovalEvidence(comparedTo: confirmedCandidate) else {
+                return .refused(refreshedCandidate)
+            }
+            return execute(.forceRemove(refreshedCandidate))
+        case (_, .blocked(let refreshedCandidate, _)):
+            return .refused(refreshedCandidate)
+        case (_, .normalRemove(let refreshedCandidate)), (_, .forceRemove(let refreshedCandidate)):
+            return .refused(refreshedCandidate)
+        }
+    }
+
     func remove(
         _ candidate: WorktreeCleanupCandidate,
         cleanupSources: [SessionCleanupSource],
         activeProjectPaths: Set<String>
     ) -> RemovalResult {
-        switch readyCandidate(candidate, cleanupSources: cleanupSources, activeProjectPaths: activeProjectPaths) {
-        case .ready(let readiness):
-            let result = runGit(removeArguments(for: readiness, force: false))
-            guard result.exitCode == 0 else {
-                guard readiness.candidate.canOfferForceRemoval(for: result) else {
-                    return .failed(result)
-                }
-                return .forceRequired(WorktreeForceRemovalOffer(candidate: readiness.candidate, failure: result))
-            }
-            return .removed(result)
-        case .refused(let latestCandidate):
-            return .refused(latestCandidate)
-        }
-    }
-
-    func forceRemove(
-        _ offer: WorktreeForceRemovalOffer,
-        cleanupSources: [SessionCleanupSource],
-        activeProjectPaths: Set<String>
-    ) -> RemovalResult {
-        switch readyCandidate(offer.candidate, cleanupSources: cleanupSources, activeProjectPaths: activeProjectPaths) {
-        case .ready(let readiness):
-            guard readiness.candidate.hasSameForceRemovalReasons(as: offer.candidate) else {
-                return .refused(readiness.candidate)
-            }
-            guard readiness.candidate.canOfferForceRemoval(for: offer.failure) else {
-                return .refused(readiness.candidate)
-            }
-            let result = runGit(removeArguments(for: readiness, force: true))
-            return result.exitCode == 0 ? .removed(result) : .failed(result)
-        case .refused(let latestCandidate):
-            return .refused(latestCandidate)
-        }
+        executeConfirmed(
+            .normalRemove(candidate),
+            cleanupSources: cleanupSources,
+            activeProjectPaths: activeProjectPaths
+        )
     }
 
     private enum ReadinessResult {
@@ -112,6 +153,14 @@ struct WorktreeRemovalService {
         }
 
         return .ready(RemovalReadiness(candidate: finalCandidate, mainWorktreePath: mainWorktreePath))
+    }
+
+    private func removalReadiness(from candidate: WorktreeCleanupCandidate) -> RemovalReadiness? {
+        guard let mainWorktreePath = candidate.mainWorktreePath,
+              candidate.state.isActionable else {
+            return nil
+        }
+        return RemovalReadiness(candidate: candidate, mainWorktreePath: mainWorktreePath)
     }
 
     private func removeArguments(for readiness: RemovalReadiness, force: Bool) -> [String] {
@@ -190,28 +239,40 @@ private extension WorktreeCleanupCandidate {
         }
     }
 
-    func canOfferForceRemoval(for result: GitCommandResult) -> Bool {
-        isForceEligibleGitFailure(result)
-            && state.reasons.allSatisfy(Self.isForceEligibleReason)
+    func matchesConfirmedRemovalEvidence(comparedTo candidate: WorktreeCleanupCandidate) -> Bool {
+        !changesWorktreeIdentity(comparedTo: candidate)
+            && !changesLocalFileReviewEvidence(comparedTo: candidate)
+            && Set(state.reasons) == Set(candidate.state.reasons)
+            && localFileReasonSet == candidate.localFileReasonSet
     }
 
-    func hasSameForceRemovalReasons(as candidate: WorktreeCleanupCandidate) -> Bool {
-        Set(state.reasons) == Set(candidate.state.reasons)
+    private var localFileReasonSet: Set<String> {
+        Set(state.reasons.filter { reason in
+            reason == WorktreeCleanupCandidate.untrackedFilesReason
+                || reason == WorktreeCleanupCandidate.ignoredFilesReason
+                || reason == WorktreeCleanupCandidate.trackedChangesReason
+        })
     }
 
-    private func isForceEligibleGitFailure(_ result: GitCommandResult) -> Bool {
-        guard result.exitCode != 0 else { return false }
-        let output = "\(result.stderr)\n\(result.stdout)".lowercased()
-        guard output.contains("--force") else { return false }
-        return output.contains("modified")
-            || output.contains("untracked")
-            || output.contains("dirty")
-            || output.contains("local changes")
-    }
-
-    private static func isForceEligibleReason(_ reason: String) -> Bool {
-        reason == WorktreeCleanupCandidate.untrackedFilesReason
-            || reason == WorktreeCleanupCandidate.ignoredFilesReason
-            || reason == WorktreeCleanupCandidate.trackedChangesReason
+    var blockedRemovalReason: String {
+        if state.reasons.contains(Self.statusUnreadableReason) {
+            return "Git status could not be read, so cctop cannot verify what removal would delete."
+        }
+        if state.reasons.contains(Self.initializedSubmodulesReason) {
+            return "This worktree contains initialized submodules, which cctop cannot safely remove yet."
+        }
+        if state.reasons.contains(Self.indexHiddenTrackedFilesReason) {
+            return "This worktree has tracked files hidden by Git index flags, so cctop cannot verify local changes safely."
+        }
+        if state.reasons.contains("Worktree is locked") {
+            return "This worktree is locked. Unlock it before removing."
+        }
+        if state.reasons.contains("Branch is unknown or detached") {
+            return "The branch is unknown or detached, so cctop cannot verify branch safety."
+        }
+        if state.reasons.contains("Main checkout path could not be verified") {
+            return "The main checkout path could not be verified, so cctop cannot run worktree removal safely."
+        }
+        return state.reasons.first ?? "Cleanup evidence changed. Review the updated worktree before removing."
     }
 }

--- a/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
+++ b/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
@@ -35,6 +35,9 @@ struct WorktreeRemovalService {
     ) -> RemovalAction {
         switch readyCandidate(candidate, cleanupSources: cleanupSources, activeProjectPaths: activeProjectPaths) {
         case .ready(let readiness):
+            if readiness.candidate.state.reasons.contains(WorktreeCleanupCandidate.lockedReason) {
+                return .blocked(readiness.candidate, readiness.candidate.blockedRemovalReason)
+            }
             if readiness.candidate.requiresForceWorktreeRemoval {
                 return .forceRemove(readiness.candidate)
             }
@@ -264,7 +267,7 @@ private extension WorktreeCleanupCandidate {
         if state.reasons.contains(Self.indexHiddenTrackedFilesReason) {
             return "This worktree has tracked files hidden by Git index flags, so cctop cannot verify local changes safely."
         }
-        if state.reasons.contains("Worktree is locked") {
+        if state.reasons.contains(Self.lockedReason) {
             return "This worktree is locked. Unlock it before removing."
         }
         if state.reasons.contains("Branch is unknown or detached") {

--- a/menubar/CctopMenubar/Views/PopupView+Cleanup.swift
+++ b/menubar/CctopMenubar/Views/PopupView+Cleanup.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 
 extension PopupView {
+    static func noticeAfterCleanupCandidatesChanged(_ notice: WorktreeRemovalNotice?) -> WorktreeRemovalNotice? {
+        notice?.blocksRemoval == true ? notice : nil
+    }
+
     static func syncedCleanupCandidate(
         _ selectedCandidate: WorktreeCleanupCandidate?,
         in candidates: [WorktreeCleanupCandidate]

--- a/menubar/CctopMenubar/Views/PopupView+Cleanup.swift
+++ b/menubar/CctopMenubar/Views/PopupView+Cleanup.swift
@@ -23,11 +23,39 @@ extension PopupView {
         )
     }
 
-    func requestCleanupRemoval(_ candidate: WorktreeCleanupCandidate, forceOffer: WorktreeForceRemovalOffer?) {
-        if let forceOffer {
-            pendingRemovalConfirmation = .force(forceOffer)
-        } else {
-            pendingRemovalConfirmation = .initial(for: candidate)
+    func requestCleanupRemoval(_ candidate: WorktreeCleanupCandidate) {
+        guard let onSelectCleanupRemovalAction else { return }
+        let selectsCandidateOnResult = selectedCleanupCandidate?.id == candidate.id
+        cleanupRemovalNotice = nil
+        removingCleanupCandidateID = candidate.id
+        notifyLayoutChanged()
+
+        Task {
+            let action = await onSelectCleanupRemovalAction(candidate)
+            await MainActor.run {
+                removingCleanupCandidateID = nil
+                if selectsCandidateOnResult {
+                    selectedCleanupCandidate = action.candidate
+                }
+
+                switch action {
+                case .blocked(_, let reason):
+                    cleanupRemovalNotice = WorktreeRemovalNotice(
+                        title: "Removal Blocked",
+                        message: reason,
+                        blocksRemoval: true
+                    )
+                default:
+                    if let confirmation = WorktreeRemovalConfirmation.review(for: action) {
+                        cleanupRemovalSelectsCandidateOnResult = selectsCandidateOnResult
+                        pendingRemovalConfirmation = confirmation
+                    } else {
+                        performCleanupRemovalAction(action, selectsCandidateOnResult: selectsCandidateOnResult)
+                    }
+                }
+
+                notifyLayoutChanged()
+            }
         }
     }
 
@@ -46,33 +74,25 @@ extension PopupView {
         notifyLayoutChanged()
     }
 
-    func performCleanupRemoval(_ candidate: WorktreeCleanupCandidate) {
-        guard let onRemoveCleanupCandidate else { return }
+    func performCleanupRemovalAction(
+        _ action: WorktreeRemovalService.RemovalAction,
+        selectsCandidateOnResult: Bool = true
+    ) {
+        guard let onExecuteCleanupRemovalAction else { return }
+        let candidate = action.candidate
         cleanupRemovalNotice = nil
         removingCleanupCandidateID = candidate.id
         notifyLayoutChanged()
 
         Task {
-            let result = await onRemoveCleanupCandidate(candidate)
+            let result = await onExecuteCleanupRemovalAction(action)
             await MainActor.run {
                 removingCleanupCandidateID = nil
-                handleCleanupRemovalResult(result, originalCandidate: candidate)
-                notifyLayoutChanged()
-            }
-        }
-    }
-
-    func performCleanupForceRemoval(_ offer: WorktreeForceRemovalOffer) {
-        guard let onForceRemoveCleanupCandidate else { return }
-        cleanupRemovalNotice = nil
-        removingCleanupCandidateID = offer.candidate.id
-        notifyLayoutChanged()
-
-        Task {
-            let result = await onForceRemoveCleanupCandidate(offer)
-            await MainActor.run {
-                removingCleanupCandidateID = nil
-                handleCleanupRemovalResult(result, originalCandidate: offer.candidate)
+                handleCleanupRemovalResult(
+                    result,
+                    originalCandidate: candidate,
+                    selectsCandidateOnResult: selectsCandidateOnResult
+                )
                 notifyLayoutChanged()
             }
         }
@@ -80,27 +100,26 @@ extension PopupView {
 
     func handleCleanupRemovalResult(
         _ result: WorktreeRemovalService.RemovalResult,
-        originalCandidate: WorktreeCleanupCandidate
+        originalCandidate: WorktreeCleanupCandidate,
+        selectsCandidateOnResult: Bool = true
     ) {
         switch result {
         case .removed:
             selectedCleanupCandidate = nil
             cleanupRemovalNotice = nil
-        case .forceRequired(let offer):
-            selectedCleanupCandidate = offer.candidate
-            cleanupRemovalNotice = WorktreeRemovalNotice(
-                title: "Remove Failed",
-                message: cleanupForceOfferMessage(),
-                forceOffer: offer
-            )
         case .refused(let latestCandidate):
-            selectedCleanupCandidate = latestCandidate
+            if selectsCandidateOnResult {
+                selectedCleanupCandidate = latestCandidate
+            }
             cleanupRemovalNotice = WorktreeRemovalNotice(
-                title: "Review Required",
-                message: latestCandidate.state.reasons.first ?? "The worktree is no longer safe to remove automatically."
+                title: "Removal Blocked",
+                message: latestCandidate.state.reasons.first ?? "Cleanup cannot confidently remove this worktree right now.",
+                blocksRemoval: true
             )
         case .failed(let gitResult):
-            selectedCleanupCandidate = originalCandidate
+            if selectsCandidateOnResult {
+                selectedCleanupCandidate = originalCandidate
+            }
             cleanupRemovalNotice = WorktreeRemovalNotice(
                 title: "Remove Failed",
                 message: cleanupFailureMessage(from: gitResult)
@@ -114,38 +133,17 @@ extension PopupView {
             ?? "git exited with status \(result.exitCode)"
     }
 
-    func cleanupForceOfferMessage() -> String {
-        "Plain removal failed; Git suggested --force for local files."
-    }
-
     func removalAlert(for confirmation: WorktreeRemovalConfirmation) -> Alert {
         switch confirmation {
-        case .reviewWarning(let candidate):
-            return Alert(
-                title: Text(confirmation.title),
-                message: Text(confirmation.message),
-                primaryButton: .default(Text(confirmation.primaryButtonTitle)) {
-                    DispatchQueue.main.async {
-                        pendingRemovalConfirmation = .final(candidate)
-                    }
-                },
-                secondaryButton: .cancel()
-            )
-        case .final(let candidate):
+        case .review(let action):
             return Alert(
                 title: Text(confirmation.title),
                 message: Text(confirmation.message),
                 primaryButton: .destructive(Text(confirmation.primaryButtonTitle)) {
-                    performCleanupRemoval(candidate)
-                },
-                secondaryButton: .cancel()
-            )
-        case .force(let offer):
-            return Alert(
-                title: Text(confirmation.title),
-                message: Text(confirmation.message),
-                primaryButton: .destructive(Text(confirmation.primaryButtonTitle)) {
-                    performCleanupForceRemoval(offer)
+                    performCleanupRemovalAction(
+                        action,
+                        selectsCandidateOnResult: cleanupRemovalSelectsCandidateOnResult
+                    )
                 },
                 secondaryButton: .cancel()
             )

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -488,7 +488,7 @@ extension PopupView {
     func handleCleanupCandidatesChanged() {
         ensureSelectedTabAvailable()
         syncSelectedCleanupCandidate()
-        cleanupRemovalNotice = nil
+        cleanupRemovalNotice = Self.noticeAfterCleanupCandidatesChanged(cleanupRemovalNotice)
         notifyLayoutChanged()
     }
 

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -16,8 +16,8 @@ struct PopupView: View {
     @ObservedObject var overlayController: OverlayController = OverlayController()
     var initialTab: PopupTab = .active
     var initialCleanupCandidate: WorktreeCleanupCandidate?
-    var onRemoveCleanupCandidate: ((WorktreeCleanupCandidate) async -> WorktreeRemovalService.RemovalResult)?
-    var onForceRemoveCleanupCandidate: ((WorktreeForceRemovalOffer) async -> WorktreeRemovalService.RemovalResult)?
+    var onSelectCleanupRemovalAction: ((WorktreeCleanupCandidate) async -> WorktreeRemovalService.RemovalAction)?
+    var onExecuteCleanupRemovalAction: ((WorktreeRemovalService.RemovalAction) async -> WorktreeRemovalService.RemovalResult)?
     var onCleanupTabVisible: () -> Void = {}
     var onCleanupTabHidden: () -> Void = {}
     /// Called (async on main) whenever content layout changes so the host can resize the panel.
@@ -31,6 +31,7 @@ struct PopupView: View {
     @State var cleanupRemovalNotice: WorktreeRemovalNotice?
     @State var removingCleanupCandidateID: String?
     @State var pendingRemovalConfirmation: WorktreeRemovalConfirmation?
+    @State var cleanupRemovalSelectsCandidateOnResult = true
     @State private var ocBannerInstalled = false
     @State private var lastFocusTime: Date = .distantPast
     @State private var piBannerInstalled = false
@@ -105,7 +106,6 @@ struct PopupView: View {
         .onChange(of: actionableCleanupCandidates) { _ in handleCleanupCandidatesChanged() }
         .onChange(of: cleanupIsScanning) { _ in handleCleanupScanningChanged() }
         .onChange(of: selectedCleanupCandidate?.id) { _ in
-            cleanupRemovalNotice = nil
             notifyLayoutChanged()
         }
         .alert(item: $pendingRemovalConfirmation) { confirmation in
@@ -493,6 +493,7 @@ extension PopupView {
     }
 
     func openCleanupDetail(_ candidate: WorktreeCleanupCandidate) {
+        cleanupRemovalNotice = nil
         selectedCleanupCandidate = candidate
     }
 

--- a/menubar/CctopMenubar/Views/PopupViewHelpers.swift
+++ b/menubar/CctopMenubar/Views/PopupViewHelpers.swift
@@ -229,8 +229,8 @@ struct PanelContentView: View {
     @ObservedObject var updater: UpdaterBase
     @ObservedObject var pluginManager: PluginManager
     @ObservedObject var navigate: NavigateController
-    var onRemoveCleanupCandidate: ((WorktreeCleanupCandidate) async -> WorktreeRemovalService.RemovalResult)?
-    var onForceRemoveCleanupCandidate: ((WorktreeForceRemovalOffer) async -> WorktreeRemovalService.RemovalResult)?
+    var onSelectCleanupRemovalAction: ((WorktreeCleanupCandidate) async -> WorktreeRemovalService.RemovalAction)?
+    var onExecuteCleanupRemovalAction: ((WorktreeRemovalService.RemovalAction) async -> WorktreeRemovalService.RemovalResult)?
     var onCleanupTabVisible: () -> Void = {}
     var onCleanupTabHidden: () -> Void = {}
     /// Called (async on main) whenever content layout changes so the host can resize the panel.
@@ -248,8 +248,8 @@ struct PanelContentView: View {
             pluginManager: pluginManager,
             navigate: navigate,
             overlayController: overlayController,
-            onRemoveCleanupCandidate: onRemoveCleanupCandidate,
-            onForceRemoveCleanupCandidate: onForceRemoveCleanupCandidate,
+            onSelectCleanupRemovalAction: onSelectCleanupRemovalAction,
+            onExecuteCleanupRemovalAction: onExecuteCleanupRemovalAction,
             onCleanupTabVisible: onCleanupTabVisible,
             onCleanupTabHidden: onCleanupTabHidden,
             onLayoutChanged: onLayoutChanged

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -9,6 +9,7 @@ struct SettingsSection: View {
     @StateObject private var notificationPermission: NotificationPermissionController
     @AppStorage("appearanceMode") private var appearanceMode = "system"
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
+    @State private var showFileAccessHelp = false
 
     init(
         updater: UpdaterBase,
@@ -79,14 +80,7 @@ struct SettingsSection: View {
                 groupedDivider
                 NotificationSettingsRow(notificationPermission: notificationPermission)
                 groupedDivider
-                settingsRow("File Access") {
-                    Button("Open Settings") {
-                        openFileAccessSettings()
-                    }
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(Color.segmentActiveText)
-                    .buttonStyle(.plain)
-                }
+                fileAccessRow
             }
         }
         .padding(AppChrome.settingsContentPadding)
@@ -149,6 +143,46 @@ struct SettingsSection: View {
             }
             Spacer()
             ShortcutBadge(name: .navigate)
+        }
+        .padding(.horizontal, AppChrome.settingsRowHorizontalPadding)
+        .padding(.vertical, 8)
+    }
+
+    private var fileAccessRow: some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("File Access")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Color.textPrimary)
+                    .lineLimit(1)
+                Text("Required only for Cleanup in protected folders.")
+                    .font(.system(size: 10))
+                    .foregroundStyle(Color.textMuted)
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 8)
+            Button {
+                showFileAccessHelp.toggle()
+            } label: {
+                Image(systemName: "questionmark.circle")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(Color.textMuted)
+            }
+            .buttonStyle(.plain)
+            .help("File Access help")
+            .popover(isPresented: $showFileAccessHelp) {
+                Text("Used only for Cleanup. macOS may require access when worktrees live in protected folders.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color.textPrimary)
+                    .frame(width: 220, alignment: .leading)
+                    .padding(10)
+            }
+            Button("Open Settings") {
+                openFileAccessSettings()
+            }
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(Color.segmentActiveText)
+            .buttonStyle(.plain)
         }
         .padding(.horizontal, AppChrome.settingsRowHorizontalPadding)
         .padding(.vertical, 8)

--- a/menubar/CctopMenubar/Views/WorktreeCleanupCardView.swift
+++ b/menubar/CctopMenubar/Views/WorktreeCleanupCardView.swift
@@ -4,48 +4,15 @@ struct WorktreeCleanupCardView: View {
     let candidate: WorktreeCleanupCandidate
     var isSelected = false
     var relativeTimeNow = Date()
+    var isRemoving = false
+    var onSelect: () -> Void = {}
+    var onRemove: () -> Void = {}
     @State private var isHovered = false
 
     var body: some View {
         HStack(alignment: .center, spacing: 10) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(candidate.sessionName)
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(Color.textPrimary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-
-                HStack(spacing: 5) {
-                    Text(candidate.worktreeName)
-                        .font(.system(size: 10, design: .monospaced))
-                        .foregroundStyle(Color.textSecondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                    Text("\u{00B7}")
-                        .font(.system(size: 10))
-                        .foregroundStyle(Color.textMuted.opacity(0.6))
-                    Text(candidate.branchName)
-                        .font(.system(size: 10, design: .monospaced))
-                        .foregroundStyle(Color.textMuted)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                }
-
-                Text("Last active \(candidate.lastActiveAt.relativeDescription(asOf: relativeTimeNow))")
-                    .font(.system(size: 10))
-                    .foregroundStyle(Color.textMuted)
-                    .lineLimit(1)
-            }
-
-            Spacer(minLength: 6)
-
-            VStack(alignment: .trailing, spacing: 5) {
-                cleanupBadge
-                Text(candidate.formattedStorage)
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(Color.textMuted)
-                    .lineLimit(1)
-            }
+            selectionButton
+            actionColumn
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 9)
@@ -56,6 +23,84 @@ struct WorktreeCleanupCardView: View {
         .animation(.easeOut(duration: 0.15), value: isHovered)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(candidate.sessionName), \(candidate.state.label), \(candidate.formattedStorage)")
+    }
+
+    private var selectionButton: some View {
+        Button(action: onSelect) {
+            HStack(alignment: .center, spacing: 10) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(candidate.sessionName)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color.textPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+
+                    HStack(spacing: 5) {
+                        Text(candidate.worktreeName)
+                            .font(.system(size: 10, design: .monospaced))
+                            .foregroundStyle(Color.textSecondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Text("\u{00B7}")
+                            .font(.system(size: 10))
+                            .foregroundStyle(Color.textMuted.opacity(0.6))
+                        Text(candidate.branchName)
+                            .font(.system(size: 10, design: .monospaced))
+                            .foregroundStyle(Color.textMuted)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+
+                    Text("Last active \(candidate.lastActiveAt.relativeDescription(asOf: relativeTimeNow))")
+                        .font(.system(size: 10))
+                        .foregroundStyle(Color.textMuted)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Click to review cleanup details")
+    }
+
+    private var actionColumn: some View {
+        VStack(alignment: .trailing, spacing: 5) {
+            cleanupBadge
+            Text(candidate.formattedStorage)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Color.textMuted)
+                .lineLimit(1)
+            removeButton
+        }
+    }
+
+    private var removeButton: some View {
+        Button(action: onRemove) {
+            HStack(spacing: 4) {
+                Image(systemName: isRemoving ? "hourglass" : "trash")
+                    .font(.system(size: 9, weight: .semibold))
+                Text(isRemoving ? "Removing" : "Remove")
+                    .font(.system(size: 9, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+            }
+            .foregroundStyle(Color.statusAttention)
+            .frame(width: 74, height: 23)
+            .background {
+                RoundedRectangle(cornerRadius: AppChrome.controlCornerRadius, style: .continuous)
+                    .fill(Color.statusAttention.opacity(isRemoving ? 0.06 : 0.10))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: AppChrome.controlCornerRadius, style: .continuous)
+                    .stroke(Color.statusAttention.opacity(0.24), lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(isRemoving)
+        .help("Remove worktree")
     }
 
     private var cleanupBadge: some View {

--- a/menubar/CctopMenubar/Views/WorktreeCleanupDetailView.swift
+++ b/menubar/CctopMenubar/Views/WorktreeCleanupDetailView.swift
@@ -149,7 +149,7 @@ struct WorktreeCleanupDetailView: View {
 
     @ViewBuilder
     private var actionSection: some View {
-        if candidate.state.isActionable {
+        if candidate.state.isActionable && removalNotice?.blocksRemoval != true {
             actionRow
                 .padding(.horizontal, 16)
                 .padding(.top, 8)
@@ -329,17 +329,14 @@ struct WorktreeCleanupDetailView: View {
 
 private extension WorktreeCleanupDetailView {
     var removeHelp: String {
-        if removalNotice?.forceOffer != nil {
-            return "Run git worktree remove --force after confirming; local changes in the worktree can be deleted"
-        }
         if candidate.state.isClean {
-            return "Run git worktree remove after confirming"
+            return "Run git worktree remove"
         }
-        return "Run git worktree remove after an extra confirmation; Git may refuse unsafe worktrees"
+        return "Review the cleanup evidence before removing this worktree"
     }
 
     var actionTitle: String {
-        isRemoving ? "Removing..." : (removalNotice?.forceOffer == nil ? "Remove" : "Force Remove...")
+        isRemoving ? "Removing..." : "Remove"
     }
 
     var showsNoticeLocalFileEvidence: Bool {
@@ -463,7 +460,7 @@ private struct CleanupDetailActionButton: View {
 struct WorktreeRemovalNotice: Equatable {
     let title: String
     let message: String
-    var forceOffer: WorktreeForceRemovalOffer?
+    var blocksRemoval = false
 }
 
 #Preview("Clean detail") {

--- a/menubar/CctopMenubar/Views/WorktreeCleanupTabView.swift
+++ b/menubar/CctopMenubar/Views/WorktreeCleanupTabView.swift
@@ -52,7 +52,39 @@ struct WorktreeCleanupTabView: View {
             .frame(maxWidth: .infinity)
             .padding(.vertical, 24)
         } else {
-            cleanupList
+            VStack(spacing: 0) {
+                listRemovalNotice
+                cleanupList
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var listRemovalNotice: some View {
+        if let removalNotice {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(removalNotice.title)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(removalNotice.blocksRemoval ? Color.statusAttention : Color.textPrimary)
+                Text(removalNotice.message)
+                    .font(.system(size: 10))
+                    .foregroundStyle(Color.textSecondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background {
+                RoundedRectangle(cornerRadius: AppChrome.groupCornerRadius, style: .continuous)
+                    .fill(Color.statusAttention.opacity(removalNotice.blocksRemoval ? 0.08 : 0.04))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: AppChrome.groupCornerRadius, style: .continuous)
+                    .stroke(Color.statusAttention.opacity(removalNotice.blocksRemoval ? 0.22 : 0.12), lineWidth: 1)
+            }
+            .padding(.horizontal, 14)
+            .padding(.top, 8)
         }
     }
 

--- a/menubar/CctopMenubar/Views/WorktreeCleanupTabView.swift
+++ b/menubar/CctopMenubar/Views/WorktreeCleanupTabView.swift
@@ -7,7 +7,7 @@ struct WorktreeCleanupTabView: View {
     var isScanning = false
     var relativeTimeNow = Date()
     var onSelect: (WorktreeCleanupCandidate) -> Void = { _ in }
-    var onRemove: (WorktreeCleanupCandidate, WorktreeForceRemovalOffer?) -> Void = { _, _ in }
+    var onRemove: (WorktreeCleanupCandidate) -> Void = { _ in }
     var removalNotice: WorktreeRemovalNotice?
     var removingCandidateID: String?
 
@@ -29,7 +29,7 @@ struct WorktreeCleanupTabView: View {
                 candidate: candidate,
                 relativeTimeNow: relativeTimeNow,
                 onBack: { selectedCandidate = nil },
-                onRemove: { onRemove(candidate, removalNotice?.forceOffer) },
+                onRemove: { onRemove(candidate) },
                 removalNotice: removalNotice,
                 isRemoving: removingCandidateID == candidate.id
             )
@@ -105,13 +105,17 @@ struct WorktreeCleanupTabView: View {
     }
 
     private func cleanupCard(_ candidate: WorktreeCleanupCandidate, isSelected: Bool = false) -> some View {
-        WorktreeCleanupCardView(candidate: candidate, isSelected: isSelected, relativeTimeNow: relativeTimeNow)
-            .contentShape(Rectangle())
-            .onTapGesture {
+        WorktreeCleanupCardView(
+            candidate: candidate,
+            isSelected: isSelected,
+            relativeTimeNow: relativeTimeNow,
+            isRemoving: removingCandidateID == candidate.id,
+            onSelect: {
                 selectedCandidate = candidate
                 onSelect(candidate)
-            }
-            .help("Click to review cleanup details")
+            },
+            onRemove: { onRemove(candidate) }
+        )
     }
 }
 
@@ -120,7 +124,7 @@ struct WorktreeCleanupTabView: View {
         candidates: WorktreeCleanupCandidate.mockCandidates,
         selectedIndex: nil,
         selectedCandidate: .constant(nil),
-        onRemove: { _, _ in }
+        onRemove: { _ in }
     )
     .frame(width: 320)
 }

--- a/menubar/CctopMenubar/Views/WorktreeCleanupTabView.swift
+++ b/menubar/CctopMenubar/Views/WorktreeCleanupTabView.swift
@@ -33,7 +33,17 @@ struct WorktreeCleanupTabView: View {
                 removalNotice: removalNotice,
                 isRemoving: removingCandidateID == candidate.id
             )
-        } else if candidates.isEmpty {
+        } else {
+            VStack(spacing: 0) {
+                listRemovalNotice
+                listOrEmptyContent
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var listOrEmptyContent: some View {
+        if candidates.isEmpty {
             VStack(spacing: 8) {
                 if isScanning {
                     ProgressView()
@@ -52,10 +62,7 @@ struct WorktreeCleanupTabView: View {
             .frame(maxWidth: .infinity)
             .padding(.vertical, 24)
         } else {
-            VStack(spacing: 0) {
-                listRemovalNotice
-                cleanupList
-            }
+            cleanupList
         }
     }
 

--- a/menubar/CctopMenubarTests/AppSettingsTests.swift
+++ b/menubar/CctopMenubarTests/AppSettingsTests.swift
@@ -29,6 +29,31 @@ final class AppSettingsTests: XCTestCase {
             "x-apple.systempreferences:com.apple.preference.security"
         )
     }
+
+    func testFileAccessSettingsCopyIsCleanupScopedAndHasHelpPopover() throws {
+        let root = try repoRoot()
+        let source = try String(
+            contentsOf: root.appendingPathComponent("menubar/CctopMenubar/Views/SettingsSection.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(source.contains("Required only for Cleanup in protected folders."))
+        XCTAssertTrue(source.contains("worktrees live in protected folders"))
+        XCTAssertTrue(source.contains("Used only for Cleanup."))
+        XCTAssertTrue(source.contains("questionmark.circle"))
+        XCTAssertTrue(source.contains(".popover(isPresented: $showFileAccessHelp)"))
+    }
+
+    private func repoRoot() throws -> URL {
+        var url = URL(fileURLWithPath: #filePath)
+        while url.path != "/" {
+            url.deleteLastPathComponent()
+            if FileManager.default.fileExists(atPath: url.appendingPathComponent("menubar").path) {
+                return url
+            }
+        }
+        throw NSError(domain: "AppSettingsTests", code: 1)
+    }
 }
 
 @MainActor

--- a/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
@@ -117,18 +117,17 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
             colorScheme: .dark,
             filename: "worktree-cleanup-detail-unknown-safety.png"
         )
-        let forceOffer = forceRemovalOffer(for: scenario.untrackedOnly)
-        let forceOfferSize = try renderScreenshot(
+        let blockedSize = try renderScreenshot(
             view: cleanupDetail(
                 candidate: scenario.untrackedOnly,
                 notice: WorktreeRemovalNotice(
-                    title: "Remove Failed",
-                    message: cleanupForceOfferNoticeMessage(),
-                    forceOffer: forceOffer
+                    title: "Removal Blocked",
+                    message: "Cleanup evidence changed. Review the updated worktree before removing.",
+                    blocksRemoval: true
                 )
             ),
             colorScheme: .dark,
-            filename: "worktree-cleanup-force-offer.png"
+            filename: "worktree-cleanup-blocked-removal.png"
         )
         let forceFailureSize = try renderScreenshot(
             view: cleanupDetail(
@@ -147,40 +146,42 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
         XCTAssertLessThanOrEqual(longSize.width, 320)
         XCTAssertLessThanOrEqual(untrackedOnlySize.width, 320)
         XCTAssertLessThanOrEqual(unknownSize.width, 320)
-        XCTAssertLessThanOrEqual(forceOfferSize.width, 320)
+        XCTAssertLessThanOrEqual(blockedSize.width, 320)
         XCTAssertLessThanOrEqual(forceFailureSize.width, 320)
         XCTAssertLessThanOrEqual(cleanSize.height, 430)
         XCTAssertLessThanOrEqual(reviewSize.height, 430)
         XCTAssertLessThanOrEqual(longSize.height, 430)
         XCTAssertLessThanOrEqual(untrackedOnlySize.height, 430)
         XCTAssertLessThanOrEqual(unknownSize.height, 430)
-        XCTAssertLessThanOrEqual(forceOfferSize.height, 430)
+        XCTAssertLessThanOrEqual(blockedSize.height, 430)
         XCTAssertLessThanOrEqual(forceFailureSize.height, 430)
         XCTAssertEqual(scenario.unknownSafety.formattedStorage, "Unknown")
     }
 
     private func renderConfirmationScreenshots(for scenario: Scenario) throws {
+        XCTAssertFalse(
+            scenario.secondaryReview.requiresForceWorktreeRemoval,
+            "Normal-review confirmation proof must use a review candidate that does not require --force."
+        )
+        XCTAssertTrue(
+            scenario.untrackedOnly.requiresForceWorktreeRemoval,
+            "Force confirmation proof must use a review candidate with local file loss evidence."
+        )
+
         let reviewSize = try renderScreenshot(
-            view: CleanupConfirmationProofView(confirmation: .reviewWarning(scenario.review)),
+            view: CleanupConfirmationProofView(confirmation: .review(.normalRemove(scenario.secondaryReview))),
             colorScheme: .dark,
             filename: "worktree-cleanup-confirmation-review.png"
         )
-        let finalSize = try renderScreenshot(
-            view: CleanupConfirmationProofView(confirmation: .final(scenario.clean)),
-            colorScheme: .dark,
-            filename: "worktree-cleanup-confirmation-final.png"
-        )
         let forceSize = try renderScreenshot(
-            view: CleanupConfirmationProofView(confirmation: .force(forceRemovalOffer(for: scenario.review))),
+            view: CleanupConfirmationProofView(confirmation: .review(.forceRemove(scenario.untrackedOnly))),
             colorScheme: .dark,
             filename: "worktree-cleanup-confirmation-force.png"
         )
 
         XCTAssertLessThanOrEqual(reviewSize.width, 320)
-        XCTAssertLessThanOrEqual(finalSize.width, 320)
         XCTAssertLessThanOrEqual(forceSize.width, 320)
         XCTAssertLessThanOrEqual(reviewSize.height, 430)
-        XCTAssertLessThanOrEqual(finalSize.height, 430)
         XCTAssertLessThanOrEqual(forceSize.height, 430)
     }
 
@@ -192,7 +193,7 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
             candidates: overflow,
             selectedIndex: 1,
             selectedCandidate: Binding<WorktreeCleanupCandidate?>.constant(nil),
-            onRemove: { _, _ in }
+            onRemove: { _ in }
         )
         try renderScreenshot(
             view: selectedRow, colorScheme: .dark, filename: "worktree-cleanup-list-keyboard-selected.png"
@@ -203,7 +204,7 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
             selectedIndex: nil,
             selectedCandidate: Binding<WorktreeCleanupCandidate?>.constant(nil),
             isScanning: false,
-            onRemove: { _, _ in }
+            onRemove: { _ in }
         )
         try renderScreenshot(view: emptyState, colorScheme: .dark, filename: "worktree-cleanup-empty.png")
 
@@ -212,7 +213,7 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
             selectedIndex: nil,
             selectedCandidate: Binding<WorktreeCleanupCandidate?>.constant(nil),
             isScanning: true,
-            onRemove: { _, _ in }
+            onRemove: { _ in }
         )
         try renderScreenshot(
             view: scanningEmptyState,
@@ -225,7 +226,7 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
             selectedIndex: nil,
             selectedCandidate: Binding<WorktreeCleanupCandidate?>.constant(nil),
             isScanning: true,
-            onRemove: { _, _ in }
+            onRemove: { _ in }
         )
         try renderScreenshot(
             view: scanningPreviousCandidates,
@@ -313,25 +314,6 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
         WorktreeCleanupDetailView(candidate: candidate, onBack: {}, removalNotice: notice)
     }
 
-    private func forceRemovalOffer(for candidate: WorktreeCleanupCandidate) -> WorktreeForceRemovalOffer {
-        WorktreeForceRemovalOffer(
-            candidate: candidate,
-            failure: GitCommandResult(
-                exitCode: 128,
-                stdout: "",
-                stderr: cleanupForceEligibleFailureMessage(for: candidate)
-            )
-        )
-    }
-
-    private func cleanupForceEligibleFailureMessage(for candidate: WorktreeCleanupCandidate) -> String {
-        "fatal: '\(candidate.worktreePath)' contains modified or untracked files; use --force to delete it"
-    }
-
-    private func cleanupForceOfferNoticeMessage() -> String {
-        "Plain removal failed; Git suggested --force for local files."
-    }
-
     private func cleanupScenario(now: Date = Date()) -> Scenario {
         let clean = cleanupScenarioCandidate(
             CandidateSeed(
@@ -395,7 +377,7 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
                 storageBytes: 16 * 1_024 * 1_024,
                 state: .review([
                     "No upstream branch",
-                    "Branch commit safety could not be verified",
+                    "Branch has 2 unique local commits",
                 ])
             )
         )

--- a/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
@@ -214,6 +214,21 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
             view: listBlockedNotice, colorScheme: .dark, filename: "worktree-cleanup-list-blocked-notice.png"
         )
 
+        let emptyBlockedNotice = WorktreeCleanupTabView(
+            candidates: [],
+            selectedIndex: nil,
+            selectedCandidate: Binding<WorktreeCleanupCandidate?>.constant(nil),
+            onRemove: { _ in },
+            removalNotice: WorktreeRemovalNotice(
+                title: "Removal Blocked",
+                message: "Cleanup evidence changed. Review the updated worktree before removing.",
+                blocksRemoval: true
+            )
+        )
+        try renderScreenshot(
+            view: emptyBlockedNotice, colorScheme: .dark, filename: "worktree-cleanup-empty-blocked-notice.png"
+        )
+
         let emptyState = WorktreeCleanupTabView(
             candidates: [],
             selectedIndex: nil,

--- a/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
@@ -199,6 +199,21 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
             view: selectedRow, colorScheme: .dark, filename: "worktree-cleanup-list-keyboard-selected.png"
         )
 
+        let listBlockedNotice = WorktreeCleanupTabView(
+            candidates: Array(overflow.prefix(3)),
+            selectedIndex: nil,
+            selectedCandidate: Binding<WorktreeCleanupCandidate?>.constant(nil),
+            onRemove: { _ in },
+            removalNotice: WorktreeRemovalNotice(
+                title: "Removal Blocked",
+                message: "This worktree is locked. Unlock it before removing.",
+                blocksRemoval: true
+            )
+        )
+        try renderScreenshot(
+            view: listBlockedNotice, colorScheme: .dark, filename: "worktree-cleanup-list-blocked-notice.png"
+        )
+
         let emptyState = WorktreeCleanupTabView(
             candidates: [],
             selectedIndex: nil,

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1498,12 +1498,12 @@ final class WorktreeCleanupTests: XCTestCase {
             branchName: "feature/invoices",
             lastActiveAt: now,
             storageBytes: 1_024,
-            state: .review(["Worktree has untracked files"]),
+            state: .review(["Branch has 1 unique local commit"]),
             checks: []
         )
         var gitArguments: [[String]] = []
         let service = WorktreeRemovalService(
-            scanner: scanner(existingPaths: [worktreePath], inspections: [worktreePath: cleanInspection()]),
+            scanner: scanner(existingPaths: [worktreePath], inspections: [worktreePath: cleanInspection(uniqueCommitCount: 1)]),
             runGit: { arguments in
                 gitArguments.append(arguments)
                 return GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
@@ -1514,6 +1514,389 @@ final class WorktreeCleanupTests: XCTestCase {
 
         XCTAssertEqual(gitArguments, [["-C", mainPath, "worktree", "remove", worktreePath]])
         XCTAssertEqual(result, .removed(GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")))
+    }
+
+    func testRemovalServiceSelectsNormalActionForCleanCandidate() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let candidate = cleanupCandidate(path: worktreePath)
+        let service = WorktreeRemovalService(
+            scanner: scanner(existingPaths: [worktreePath], inspections: [worktreePath: cleanInspection()]),
+            runGit: { _ in
+                XCTFail("Selecting a removal action should not run Git removal")
+                return GitCommandResult(exitCode: 1, stdout: "", stderr: "")
+            }
+        )
+
+        let action = service.selectedAction(for: candidate, cleanupSources: [session], activeProjectPaths: [])
+
+        guard case .normalRemove(let selectedCandidate) = action else {
+            return XCTFail("Expected normal removal for clean candidate, got \(action)")
+        }
+        XCTAssertEqual(selectedCandidate.id, candidate.id)
+        XCTAssertEqual(selectedCandidate.state, .clean)
+    }
+
+    func testRemovalServiceSelectsNormalActionForUniqueLocalCommitsOnly() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let candidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Branch review",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review(["Branch has 2 unique local commits"]),
+            checks: []
+        )
+        let service = WorktreeRemovalService(
+            scanner: scanner(
+                existingPaths: [worktreePath],
+                inspections: [worktreePath: cleanInspection(uniqueCommitCount: 2)]
+            ),
+            runGit: { _ in
+                XCTFail("Selecting a removal action should not run Git removal")
+                return GitCommandResult(exitCode: 1, stdout: "", stderr: "")
+            }
+        )
+
+        let action = service.selectedAction(for: candidate, cleanupSources: [session], activeProjectPaths: [])
+
+        guard case .normalRemove(let selectedCandidate) = action else {
+            return XCTFail("Expected normal removal for unique local commits only, got \(action)")
+        }
+        XCTAssertEqual(selectedCandidate.state, .review(["Branch has 2 unique local commits"]))
+    }
+
+    func testRemovalServiceSelectsForceActionForDirtyFilesEvenWithUniqueLocalCommits() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let candidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Dirty branch review",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([
+                WorktreeCleanupCandidate.untrackedFilesReason,
+                "Branch has 1 unique local commit",
+            ]),
+            checks: [],
+            reviewEvidence: WorktreeCleanupReviewEvidence(
+                untrackedPreview: WorktreeCleanupUntrackedPreview(paths: ["scratch.txt"])
+            )
+        )
+        let service = WorktreeRemovalService(
+            scanner: scanner(
+                existingPaths: [worktreePath],
+                inspections: [worktreePath: cleanInspection(statusEntries: ["?? scratch.txt"], uniqueCommitCount: 1)]
+            ),
+            runGit: { _ in
+                XCTFail("Selecting a removal action should not run Git removal")
+                return GitCommandResult(exitCode: 1, stdout: "", stderr: "")
+            }
+        )
+
+        let action = service.selectedAction(for: candidate, cleanupSources: [session], activeProjectPaths: [])
+
+        guard case .forceRemove(let selectedCandidate) = action else {
+            return XCTFail("Expected force removal for dirty files, got \(action)")
+        }
+        XCTAssertTrue(selectedCandidate.state.reasons.contains(WorktreeCleanupCandidate.untrackedFilesReason))
+        XCTAssertTrue(selectedCandidate.state.reasons.contains("Branch has 1 unique local commit"))
+    }
+
+    func testRemovalServiceExecutesSelectedForceActionDirectly() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let mainPath = "/Users/dev/projects/billing-api"
+        let candidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Dirty branch review",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: mainPath,
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([WorktreeCleanupCandidate.untrackedFilesReason]),
+            checks: [],
+            reviewEvidence: WorktreeCleanupReviewEvidence(
+                untrackedPreview: WorktreeCleanupUntrackedPreview(paths: ["scratch.txt"])
+            )
+        )
+        let success = GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
+        var gitArguments: [[String]] = []
+        let service = WorktreeRemovalService(
+            scanner: scanner(existingPaths: [worktreePath], inspections: [worktreePath: cleanInspection()]),
+            runGit: { arguments in
+                gitArguments.append(arguments)
+                return success
+            }
+        )
+
+        let result = service.execute(.forceRemove(candidate))
+
+        XCTAssertEqual(gitArguments, [["-C", mainPath, "worktree", "remove", "--force", worktreePath]])
+        XCTAssertEqual(result, .removed(success))
+    }
+
+    func testRemovalServiceRefusesConfirmedForceWhenUntrackedEvidenceChangesBeforeExecute() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let confirmedCandidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Dirty branch review",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([WorktreeCleanupCandidate.untrackedFilesReason]),
+            checks: [],
+            reviewEvidence: WorktreeCleanupReviewEvidence(
+                untrackedPreview: WorktreeCleanupUntrackedPreview(paths: ["scratch.txt"])
+            )
+        )
+        var gitArguments: [[String]] = []
+        let service = WorktreeRemovalService(
+            scanner: scanner(
+                existingPaths: [worktreePath],
+                inspections: [worktreePath: cleanInspection(statusEntries: ["?? other.txt"])]
+            ),
+            runGit: { arguments in
+                gitArguments.append(arguments)
+                return GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
+            }
+        )
+
+        let result = service.executeConfirmed(
+            .forceRemove(confirmedCandidate),
+            cleanupSources: [session],
+            activeProjectPaths: []
+        )
+
+        XCTAssertTrue(gitArguments.isEmpty)
+        guard case .refused(let latestCandidate) = result else {
+            return XCTFail("Expected changed force evidence to refuse removal, got \(result)")
+        }
+        XCTAssertEqual(latestCandidate.reviewEvidence.untrackedPreview?.items, ["other.txt"])
+    }
+
+    func testRemovalServiceRefusesConfirmedForceWhenPathBecomesActiveBeforeExecute() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let confirmedCandidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Dirty branch review",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([WorktreeCleanupCandidate.untrackedFilesReason]),
+            checks: [],
+            reviewEvidence: WorktreeCleanupReviewEvidence(
+                untrackedPreview: WorktreeCleanupUntrackedPreview(paths: ["scratch.txt"])
+            )
+        )
+        var gitArguments: [[String]] = []
+        let service = WorktreeRemovalService(
+            scanner: scanner(
+                existingPaths: [worktreePath],
+                inspections: [worktreePath: cleanInspection(statusEntries: ["?? scratch.txt"])]
+            ),
+            runGit: { arguments in
+                gitArguments.append(arguments)
+                return GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
+            }
+        )
+
+        let result = service.executeConfirmed(
+            .forceRemove(confirmedCandidate),
+            cleanupSources: [session],
+            activeProjectPaths: [worktreePath]
+        )
+
+        XCTAssertTrue(gitArguments.isEmpty)
+        guard case .refused(let latestCandidate) = result else {
+            return XCTFail("Expected active path to refuse removal, got \(result)")
+        }
+        XCTAssertEqual(latestCandidate.id, confirmedCandidate.id)
+    }
+
+    func testRemovalServiceExecutesConfirmedForceWhenFreshEvidenceStillMatches() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let mainPath = "/Users/dev/projects/billing-api"
+        let session = historySession(path: worktreePath)
+        let confirmedCandidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Dirty branch review",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: mainPath,
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([WorktreeCleanupCandidate.untrackedFilesReason]),
+            checks: [],
+            reviewEvidence: WorktreeCleanupReviewEvidence(
+                untrackedPreview: WorktreeCleanupUntrackedPreview(paths: ["scratch.txt"])
+            )
+        )
+        let success = GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
+        var gitArguments: [[String]] = []
+        let service = WorktreeRemovalService(
+            scanner: scanner(
+                existingPaths: [worktreePath],
+                inspections: [worktreePath: cleanInspection(statusEntries: ["?? scratch.txt"])]
+            ),
+            runGit: { arguments in
+                gitArguments.append(arguments)
+                return success
+            }
+        )
+
+        let result = service.executeConfirmed(
+            .forceRemove(confirmedCandidate),
+            cleanupSources: [session],
+            activeProjectPaths: []
+        )
+
+        XCTAssertEqual(gitArguments, [["-C", mainPath, "worktree", "remove", "--force", worktreePath]])
+        XCTAssertEqual(result, .removed(success))
+    }
+
+    func testRemovalServiceRefusesConfirmedNormalWhenFreshEvidenceRequiresForce() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let confirmedCandidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Branch review",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review(["Branch has 2 unique local commits"]),
+            checks: []
+        )
+        var gitArguments: [[String]] = []
+        let service = WorktreeRemovalService(
+            scanner: scanner(
+                existingPaths: [worktreePath],
+                inspections: [worktreePath: cleanInspection(statusEntries: ["?? scratch.txt"], uniqueCommitCount: 2)]
+            ),
+            runGit: { arguments in
+                gitArguments.append(arguments)
+                return GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
+            }
+        )
+
+        let result = service.executeConfirmed(
+            .normalRemove(confirmedCandidate),
+            cleanupSources: [session],
+            activeProjectPaths: []
+        )
+
+        XCTAssertTrue(gitArguments.isEmpty)
+        guard case .refused(let latestCandidate) = result else {
+            return XCTFail("Expected normal-to-force evidence change to refuse removal, got \(result)")
+        }
+        XCTAssertTrue(latestCandidate.state.reasons.contains(WorktreeCleanupCandidate.untrackedFilesReason))
+    }
+
+    func testRemovalServiceRefusesConfirmedNormalWhenReviewEvidenceChangesBeforeExecute() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let confirmedCandidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Branch review",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review(["Branch has 1 unique local commit"]),
+            checks: []
+        )
+        var gitArguments: [[String]] = []
+        let service = WorktreeRemovalService(
+            scanner: scanner(
+                existingPaths: [worktreePath],
+                inspections: [worktreePath: cleanInspection(uniqueCommitCount: 2)]
+            ),
+            runGit: { arguments in
+                gitArguments.append(arguments)
+                return GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
+            }
+        )
+
+        let result = service.executeConfirmed(
+            .normalRemove(confirmedCandidate),
+            cleanupSources: [session],
+            activeProjectPaths: []
+        )
+
+        XCTAssertTrue(gitArguments.isEmpty)
+        guard case .refused(let latestCandidate) = result else {
+            return XCTFail("Expected changed normal-review evidence to refuse removal, got \(result)")
+        }
+        XCTAssertEqual(latestCandidate.state, .review(["Branch has 2 unique local commits"]))
+    }
+
+    func testRemovalServiceSelectsBlockedActionWhenFreshStatusCannotBeRead() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let candidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Unknown safety",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([WorktreeCleanupCandidate.statusUnreadableReason]),
+            checks: []
+        )
+        let unreadableStatusInspection = GitWorktreeInspection(
+            isRegisteredWorktree: true,
+            isLinkedWorktree: true,
+            isLocked: false,
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: "feature/invoices",
+            statusEntries: nil,
+            uniqueCommitCount: 0,
+            failureReasons: []
+        )
+        let service = WorktreeRemovalService(
+            scanner: scanner(
+                existingPaths: [worktreePath],
+                inspections: [worktreePath: unreadableStatusInspection]
+            ),
+            runGit: { _ in
+                XCTFail("Blocked action selection should not run Git removal")
+                return GitCommandResult(exitCode: 1, stdout: "", stderr: "")
+            }
+        )
+
+        let action = service.selectedAction(for: candidate, cleanupSources: [session], activeProjectPaths: [])
+
+        guard case .blocked(let blockedCandidate, let reason) = action else {
+            return XCTFail("Expected blocked action for unreadable status, got \(action)")
+        }
+        XCTAssertTrue(blockedCandidate.state.reasons.contains(WorktreeCleanupCandidate.statusUnreadableReason))
+        XCTAssertTrue(reason.localizedCaseInsensitiveContains("status"))
     }
 
     func testRemovalServiceRefusesWhenPreflightWorktreeIdentityChanges() {
@@ -1591,7 +1974,7 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(preflightCandidate.state, .review([WorktreeCleanupCandidate.initializedSubmodulesReason]))
     }
 
-    func testRemovalServiceLetsGitRefuseReviewCandidateWithDirtyPreflight() {
+    func testRemovalServiceReturnsFailureForNormalSafeReviewCandidate() {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
         let session = historySession(path: worktreePath)
         let reviewCandidate = WorktreeCleanupCandidate(
@@ -1603,11 +1986,8 @@ final class WorktreeCleanupTests: XCTestCase {
             branchName: "feature/invoices",
             lastActiveAt: now,
             storageBytes: 1_024,
-            state: .review(["Worktree has untracked files"]),
-            checks: [],
-            reviewEvidence: WorktreeCleanupReviewEvidence(
-                untrackedPreview: WorktreeCleanupUntrackedPreview(paths: ["scratch.txt"])
-            )
+            state: .review(["Branch has 1 unique local commit"]),
+            checks: []
         )
         let failure = GitCommandResult(
             exitCode: 128,
@@ -1618,7 +1998,7 @@ final class WorktreeCleanupTests: XCTestCase {
         let service = WorktreeRemovalService(
             scanner: scanner(
                 existingPaths: [worktreePath],
-                inspections: [worktreePath: cleanInspection(statusEntries: ["?? scratch.txt"])]
+                inspections: [worktreePath: cleanInspection(uniqueCommitCount: 1)]
             ),
             runGit: { _ in
                 didRunGit = true
@@ -1632,109 +2012,12 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(result, .failed(failure))
     }
 
-    func testRemovalServiceOffersForceAfterDirtyGitFailureWhenFreshEvidenceMatches() {
+    func testRemovalServiceRemoveHelperRefusesForceRequiredCandidate() {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
-        let mainPath = "/Users/dev/projects/billing-api"
         let session = historySession(path: worktreePath)
         let reviewCandidate = WorktreeCleanupCandidate(
             id: worktreePath,
             sessionName: "Needs force review",
-            worktreePath: worktreePath,
-            worktreeName: "billing-api",
-            mainWorktreePath: mainPath,
-            branchName: "feature/invoices",
-            lastActiveAt: now,
-            storageBytes: 1_024,
-            state: .review([WorktreeCleanupCandidate.untrackedFilesReason]),
-            checks: [],
-            reviewEvidence: WorktreeCleanupReviewEvidence(
-                untrackedPreview: WorktreeCleanupUntrackedPreview(paths: ["scratch.txt"])
-            )
-        )
-        let failure = GitCommandResult(
-            exitCode: 128,
-            stdout: "",
-            stderr: "fatal: '\(worktreePath)' contains modified or untracked files, use --force to delete it\n"
-        )
-        var gitArguments: [[String]] = []
-        let service = WorktreeRemovalService(
-            scanner: scanner(
-                existingPaths: [worktreePath],
-                inspections: [worktreePath: cleanInspection(statusEntries: ["?? scratch.txt"])]
-            ),
-            runGit: { arguments in
-                gitArguments.append(arguments)
-                return failure
-            }
-        )
-
-        let result = service.remove(reviewCandidate, cleanupSources: [session], activeProjectPaths: [])
-
-        XCTAssertEqual(gitArguments, [["-C", mainPath, "worktree", "remove", worktreePath]])
-        guard case .forceRequired(let offer) = result else {
-            return XCTFail("Expected dirty remove failure to offer force, got \(result)")
-        }
-        XCTAssertEqual(offer.candidate.reviewEvidence.untrackedPreview?.items, ["scratch.txt"])
-        XCTAssertEqual(offer.failure, failure)
-    }
-
-    func testRemovalServiceForceRemoveRunsGitForceAfterFreshChecksPass() {
-        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
-        let mainPath = "/Users/dev/projects/billing-api"
-        let session = historySession(path: worktreePath)
-        let reviewCandidate = WorktreeCleanupCandidate(
-            id: worktreePath,
-            sessionName: "Needs force review",
-            worktreePath: worktreePath,
-            worktreeName: "billing-api",
-            mainWorktreePath: mainPath,
-            branchName: "feature/invoices",
-            lastActiveAt: now,
-            storageBytes: 1_024,
-            state: .review([WorktreeCleanupCandidate.untrackedFilesReason]),
-            checks: [],
-            reviewEvidence: WorktreeCleanupReviewEvidence(
-                untrackedPreview: WorktreeCleanupUntrackedPreview(paths: ["scratch.txt"])
-            )
-        )
-        let plainFailure = GitCommandResult(
-            exitCode: 128,
-            stdout: "",
-            stderr: "fatal: '\(worktreePath)' contains modified or untracked files, use --force to delete it\n"
-        )
-        let forceSuccess = GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
-        var gitArguments: [[String]] = []
-        let service = WorktreeRemovalService(
-            scanner: scanner(
-                existingPaths: [worktreePath],
-                inspections: [worktreePath: cleanInspection(statusEntries: ["?? scratch.txt"])]
-            ),
-            runGit: { arguments in
-                gitArguments.append(arguments)
-                return arguments.contains("--force") ? forceSuccess : plainFailure
-            }
-        )
-
-        let plainResult = service.remove(reviewCandidate, cleanupSources: [session], activeProjectPaths: [])
-        guard case .forceRequired(let offer) = plainResult else {
-            return XCTFail("Expected dirty remove failure to offer force, got \(plainResult)")
-        }
-
-        let forceResult = service.forceRemove(offer, cleanupSources: [session], activeProjectPaths: [])
-
-        XCTAssertEqual(gitArguments, [
-            ["-C", mainPath, "worktree", "remove", worktreePath],
-            ["-C", mainPath, "worktree", "remove", "--force", worktreePath],
-        ])
-        XCTAssertEqual(forceResult, .removed(forceSuccess))
-    }
-
-    func testRemovalServiceDoesNotOfferForceForUnrelatedGitFailure() {
-        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
-        let session = historySession(path: worktreePath)
-        let reviewCandidate = WorktreeCleanupCandidate(
-            id: worktreePath,
-            sessionName: "Needs review",
             worktreePath: worktreePath,
             worktreeName: "billing-api",
             mainWorktreePath: "/Users/dev/projects/billing-api",
@@ -1747,11 +2030,47 @@ final class WorktreeCleanupTests: XCTestCase {
                 untrackedPreview: WorktreeCleanupUntrackedPreview(paths: ["scratch.txt"])
             )
         )
-        let failure = GitCommandResult(exitCode: 128, stdout: "", stderr: "fatal: worktree is locked\n")
+        var gitArguments: [[String]] = []
         let service = WorktreeRemovalService(
             scanner: scanner(
                 existingPaths: [worktreePath],
                 inspections: [worktreePath: cleanInspection(statusEntries: ["?? scratch.txt"])]
+            ),
+            runGit: { arguments in
+                gitArguments.append(arguments)
+                return GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
+            }
+        )
+
+        let result = service.remove(reviewCandidate, cleanupSources: [session], activeProjectPaths: [])
+
+        XCTAssertTrue(gitArguments.isEmpty)
+        guard case .refused(let latestCandidate) = result else {
+            return XCTFail("Expected force-required candidate to refuse normal remove helper, got \(result)")
+        }
+        XCTAssertTrue(latestCandidate.state.reasons.contains(WorktreeCleanupCandidate.untrackedFilesReason))
+    }
+
+    func testRemovalServiceReturnsFailureForUnrelatedGitFailure() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let reviewCandidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Needs review",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review(["Branch has 1 unique local commit"]),
+            checks: []
+        )
+        let failure = GitCommandResult(exitCode: 128, stdout: "", stderr: "fatal: worktree is locked\n")
+        let service = WorktreeRemovalService(
+            scanner: scanner(
+                existingPaths: [worktreePath],
+                inspections: [worktreePath: cleanInspection(uniqueCommitCount: 1)]
             ),
             runGit: { _ in failure }
         )
@@ -1761,7 +2080,7 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(result, .failed(failure))
     }
 
-    func testRemovalServiceDoesNotOfferForceWhenHardBlockerAppears() {
+    func testRemovalServiceReturnsFailureWhenGitFailsForNormalSafeReviewCandidate() {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
         let session = historySession(path: worktreePath)
         let reviewCandidate = WorktreeCleanupCandidate(
@@ -1838,100 +2157,6 @@ final class WorktreeCleanupTests: XCTestCase {
             return XCTFail("Expected unreadable fresh status to refuse removal, got \(result)")
         }
         XCTAssertTrue(preflightCandidate.state.reasons.contains(WorktreeCleanupCandidate.statusUnreadableReason))
-    }
-
-    func testRemovalServiceRefusesForceWhenFreshEvidenceChangesBeforeForce() {
-        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
-        let session = historySession(path: worktreePath)
-        let candidate = WorktreeCleanupCandidate(
-            id: worktreePath,
-            sessionName: "Needs force review",
-            worktreePath: worktreePath,
-            worktreeName: "billing-api",
-            mainWorktreePath: "/Users/dev/projects/billing-api",
-            branchName: "feature/invoices",
-            lastActiveAt: now,
-            storageBytes: 1_024,
-            state: .review([WorktreeCleanupCandidate.untrackedFilesReason]),
-            checks: [],
-            reviewEvidence: WorktreeCleanupReviewEvidence(
-                untrackedPreview: WorktreeCleanupUntrackedPreview(paths: ["scratch.txt"])
-            )
-        )
-        let offer = WorktreeForceRemovalOffer(
-            candidate: candidate,
-            failure: GitCommandResult(
-                exitCode: 128,
-                stdout: "",
-                stderr: "fatal: '\(worktreePath)' contains modified or untracked files, use --force to delete it\n"
-            )
-        )
-        var gitArguments: [[String]] = []
-        let service = WorktreeRemovalService(
-            scanner: scanner(
-                existingPaths: [worktreePath],
-                inspections: [worktreePath: cleanInspection(statusEntries: ["?? other.txt"])]
-            ),
-            runGit: { arguments in
-                gitArguments.append(arguments)
-                return GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
-            }
-        )
-
-        let result = service.forceRemove(offer, cleanupSources: [session], activeProjectPaths: [])
-
-        XCTAssertTrue(gitArguments.isEmpty)
-        guard case .refused(let latestCandidate) = result else {
-            return XCTFail("Expected force removal to refuse changed evidence, got \(result)")
-        }
-        XCTAssertEqual(latestCandidate.reviewEvidence.untrackedPreview?.items, ["other.txt"])
-    }
-
-    func testRemovalServiceRefusesForceWhenTrackedChangesAppearBeforeForce() {
-        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
-        let session = historySession(path: worktreePath)
-        let candidate = WorktreeCleanupCandidate(
-            id: worktreePath,
-            sessionName: "Needs force review",
-            worktreePath: worktreePath,
-            worktreeName: "billing-api",
-            mainWorktreePath: "/Users/dev/projects/billing-api",
-            branchName: "feature/invoices",
-            lastActiveAt: now,
-            storageBytes: 1_024,
-            state: .review([WorktreeCleanupCandidate.untrackedFilesReason]),
-            checks: [],
-            reviewEvidence: WorktreeCleanupReviewEvidence(
-                untrackedPreview: WorktreeCleanupUntrackedPreview(paths: ["scratch.txt"])
-            )
-        )
-        let offer = WorktreeForceRemovalOffer(
-            candidate: candidate,
-            failure: GitCommandResult(
-                exitCode: 128,
-                stdout: "",
-                stderr: "fatal: '\(worktreePath)' contains modified or untracked files, use --force to delete it\n"
-            )
-        )
-        var gitArguments: [[String]] = []
-        let service = WorktreeRemovalService(
-            scanner: scanner(
-                existingPaths: [worktreePath],
-                inspections: [worktreePath: cleanInspection(statusEntries: ["?? scratch.txt", " M tracked.swift"])]
-            ),
-            runGit: { arguments in
-                gitArguments.append(arguments)
-                return GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
-            }
-        )
-
-        let result = service.forceRemove(offer, cleanupSources: [session], activeProjectPaths: [])
-
-        XCTAssertTrue(gitArguments.isEmpty)
-        guard case .refused(let latestCandidate) = result else {
-            return XCTFail("Expected force removal to refuse newly tracked changes, got \(result)")
-        }
-        XCTAssertTrue(latestCandidate.state.reasons.contains(WorktreeCleanupCandidate.trackedChangesReason))
     }
 
     func testRemovalServiceKeepsCleanPreflightSafetyWhenCandidateDowngradesToReview() {
@@ -2683,19 +2908,89 @@ final class WorktreeCleanupTests: XCTestCase {
             checks: []
         )
 
-        XCTAssertEqual(WorktreeRemovalConfirmation.initial(for: clean), .final(clean))
-        XCTAssertEqual(WorktreeRemovalConfirmation.initial(for: review), .reviewWarning(review))
-        XCTAssertEqual(WorktreeRemovalConfirmation.reviewWarning(review).confirmedReviewWarning, .final(review))
-        XCTAssertEqual(WorktreeRemovalConfirmation.reviewWarning(review).primaryButtonTitle, "Continue")
-        XCTAssertEqual(WorktreeRemovalConfirmation.final(clean).primaryButtonTitle, "Remove")
-        let offer = WorktreeForceRemovalOffer(
-            candidate: review,
-            failure: GitCommandResult(exitCode: 128, stdout: "", stderr: "use --force\n")
+        XCTAssertNil(WorktreeRemovalConfirmation.review(for: .normalRemove(clean)))
+        XCTAssertEqual(
+            WorktreeRemovalConfirmation.review(for: .normalRemove(review)),
+            .review(.normalRemove(review))
         )
-        XCTAssertEqual(WorktreeRemovalConfirmation.force(offer).primaryButtonTitle, "Force Remove")
-        XCTAssertTrue(WorktreeRemovalConfirmation.force(offer).message.contains("git worktree remove --force"))
-        XCTAssertTrue(WorktreeRemovalConfirmation.force(offer).message.contains(review.worktreePath))
-        XCTAssertTrue(WorktreeRemovalConfirmation.force(offer).message.contains(review.branchName))
+        XCTAssertEqual(WorktreeRemovalConfirmation.review(.normalRemove(review)).primaryButtonTitle, "Remove")
+    }
+
+    func testReviewRemovalConfirmationExplainsNormalReviewRemovalAndBranchRetention() {
+        let review = WorktreeCleanupCandidate(
+            id: "/Users/dev/.codex/worktrees/review",
+            sessionName: "Needs review",
+            worktreePath: "/Users/dev/.codex/worktrees/review",
+            worktreeName: "review",
+            mainWorktreePath: "/Users/dev/projects/app",
+            branchName: "feature/review",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review(["Branch has 2 unique local commits"]),
+            checks: []
+        )
+        let confirmation = WorktreeRemovalConfirmation.review(.normalRemove(review))
+
+        XCTAssertEqual(confirmation.primaryButtonTitle, "Remove")
+        XCTAssertTrue(confirmation.message.contains("git worktree remove"))
+        XCTAssertFalse(confirmation.message.contains("--force"))
+        XCTAssertTrue(confirmation.message.contains("does not delete the branch"))
+    }
+
+    func testReviewRemovalConfirmationExplainsForceRemovalAndBranchRetention() {
+        let review = WorktreeCleanupCandidate(
+            id: "/Users/dev/.codex/worktrees/review",
+            sessionName: "Needs review",
+            worktreePath: "/Users/dev/.codex/worktrees/review",
+            worktreeName: "review",
+            mainWorktreePath: "/Users/dev/projects/app",
+            branchName: "feature/review",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([
+                WorktreeCleanupCandidate.untrackedFilesReason,
+                "Branch has 1 unique local commit",
+            ]),
+            checks: []
+        )
+        let confirmation = WorktreeRemovalConfirmation.review(.forceRemove(review))
+
+        XCTAssertEqual(confirmation.primaryButtonTitle, "Force Remove")
+        XCTAssertTrue(confirmation.message.contains("git worktree remove --force"))
+        XCTAssertTrue(confirmation.message.contains("local file changes and files"))
+        XCTAssertTrue(confirmation.message.contains("does not delete the branch"))
+    }
+
+    func testReviewRemovalConfirmationIncludesReasonsAndEvidence() {
+        let review = WorktreeCleanupCandidate(
+            id: "/Users/dev/.codex/worktrees/review",
+            sessionName: "Needs review",
+            worktreePath: "/Users/dev/.codex/worktrees/review",
+            worktreeName: "review",
+            mainWorktreePath: "/Users/dev/projects/app",
+            branchName: "feature/review",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([
+                WorktreeCleanupCandidate.trackedChangesReason,
+                WorktreeCleanupCandidate.untrackedFilesReason,
+            ]),
+            checks: [],
+            reviewEvidence: WorktreeCleanupReviewEvidence(
+                untrackedPreview: WorktreeCleanupUntrackedPreview(paths: [
+                    "scratch notes.md",
+                    "generated/output.log",
+                    "tmp/cache.db",
+                    "tmp/extra.db",
+                ])
+            )
+        )
+        let confirmation = WorktreeRemovalConfirmation.review(.forceRemove(review))
+
+        XCTAssertTrue(confirmation.message.contains(WorktreeCleanupCandidate.trackedChangesReason))
+        XCTAssertTrue(confirmation.message.contains(WorktreeCleanupCandidate.untrackedFilesReason))
+        XCTAssertTrue(confirmation.message.contains("scratch notes.md"))
+        XCTAssertTrue(confirmation.message.contains("and 1 more"))
     }
 
     func testCleanupViewsExposeOnlyRemoveActions() throws {
@@ -2718,6 +3013,44 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertFalse(cleanupViewSources.contains("onCopyPath"))
         XCTAssertFalse(cleanupViewSources.contains("Remove Worktree..."))
         XCTAssertTrue(cleanupViewSources.contains("\"Remove\""))
+    }
+
+    func testCleanupRowSelectionIsSeparatedFromRemoveButton() throws {
+        let root = try repoRoot()
+        let tabViewSource = try String(
+            contentsOf: root.appendingPathComponent("menubar/CctopMenubar/Views/WorktreeCleanupTabView.swift"),
+            encoding: .utf8
+        )
+        let cardViewSource = try String(
+            contentsOf: root.appendingPathComponent("menubar/CctopMenubar/Views/WorktreeCleanupCardView.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertFalse(tabViewSource.contains(".onTapGesture"))
+        XCTAssertTrue(cardViewSource.contains("var onSelect: () -> Void"))
+        XCTAssertTrue(cardViewSource.contains("selectionButton"))
+        XCTAssertTrue(cardViewSource.contains("Button(action: onRemove)"))
+    }
+
+    func testCleanupRowRemoveDoesNotSelectDetailThroughRemovalState() throws {
+        let root = try repoRoot()
+        let popupViewSource = try String(
+            contentsOf: root.appendingPathComponent("menubar/CctopMenubar/Views/PopupView.swift"),
+            encoding: .utf8
+        )
+        let cleanupSource = try String(
+            contentsOf: root.appendingPathComponent("menubar/CctopMenubar/Views/PopupView+Cleanup.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(cleanupSource.contains("let selectsCandidateOnResult = selectedCleanupCandidate?.id == candidate.id"))
+        XCTAssertTrue(cleanupSource.contains("if selectsCandidateOnResult {\n                    selectedCleanupCandidate = action.candidate"))
+        XCTAssertTrue(cleanupSource.contains("cleanupRemovalSelectsCandidateOnResult = selectsCandidateOnResult"))
+        XCTAssertTrue(cleanupSource.contains("selectsCandidateOnResult: cleanupRemovalSelectsCandidateOnResult"))
+        XCTAssertTrue(cleanupSource.contains("if selectsCandidateOnResult {\n                selectedCleanupCandidate = latestCandidate"))
+        XCTAssertTrue(cleanupSource.contains("if selectsCandidateOnResult {\n                selectedCleanupCandidate = originalCandidate"))
+        XCTAssertFalse(popupViewSource.contains(".onChange(of: selectedCleanupCandidate?.id) { _ in\n            cleanupRemovalNotice = nil"))
+        XCTAssertTrue(popupViewSource.contains("func openCleanupDetail(_ candidate: WorktreeCleanupCandidate) {\n        cleanupRemovalNotice = nil"))
     }
 
     private func scanner(

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1612,6 +1612,48 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertTrue(selectedCandidate.state.reasons.contains("Branch has 1 unique local commit"))
     }
 
+    func testRemovalServiceSelectsBlockedActionForLockedDirtyWorktree() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let candidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Locked dirty review",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([
+                WorktreeCleanupCandidate.lockedReason,
+                WorktreeCleanupCandidate.untrackedFilesReason,
+            ]),
+            checks: [],
+            reviewEvidence: WorktreeCleanupReviewEvidence(
+                untrackedPreview: WorktreeCleanupUntrackedPreview(paths: ["scratch.txt"])
+            )
+        )
+        let service = WorktreeRemovalService(
+            scanner: scanner(
+                existingPaths: [worktreePath],
+                inspections: [worktreePath: cleanInspection(statusEntries: ["?? scratch.txt"], isLocked: true)]
+            ),
+            runGit: { _ in
+                XCTFail("Blocked action selection should not run Git removal")
+                return GitCommandResult(exitCode: 1, stdout: "", stderr: "")
+            }
+        )
+
+        let action = service.selectedAction(for: candidate, cleanupSources: [session], activeProjectPaths: [])
+
+        guard case .blocked(let blockedCandidate, let reason) = action else {
+            return XCTFail("Expected locked dirty worktree to be blocked, got \(action)")
+        }
+        XCTAssertTrue(blockedCandidate.state.reasons.contains(WorktreeCleanupCandidate.lockedReason))
+        XCTAssertTrue(blockedCandidate.state.reasons.contains(WorktreeCleanupCandidate.untrackedFilesReason))
+        XCTAssertEqual(reason, "This worktree is locked. Unlock it before removing.")
+    }
+
     func testRemovalServiceExecutesSelectedForceActionDirectly() {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
         let mainPath = "/Users/dev/projects/billing-api"
@@ -3038,6 +3080,10 @@ final class WorktreeCleanupTests: XCTestCase {
             contentsOf: root.appendingPathComponent("menubar/CctopMenubar/Views/PopupView.swift"),
             encoding: .utf8
         )
+        let tabViewSource = try String(
+            contentsOf: root.appendingPathComponent("menubar/CctopMenubar/Views/WorktreeCleanupTabView.swift"),
+            encoding: .utf8
+        )
         let cleanupSource = try String(
             contentsOf: root.appendingPathComponent("menubar/CctopMenubar/Views/PopupView+Cleanup.swift"),
             encoding: .utf8
@@ -3051,6 +3097,8 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertTrue(cleanupSource.contains("if selectsCandidateOnResult {\n                selectedCleanupCandidate = originalCandidate"))
         XCTAssertFalse(popupViewSource.contains(".onChange(of: selectedCleanupCandidate?.id) { _ in\n            cleanupRemovalNotice = nil"))
         XCTAssertTrue(popupViewSource.contains("func openCleanupDetail(_ candidate: WorktreeCleanupCandidate) {\n        cleanupRemovalNotice = nil"))
+        XCTAssertTrue(tabViewSource.contains("listRemovalNotice"))
+        XCTAssertTrue(tabViewSource.contains("if let removalNotice"))
     }
 
     private func scanner(

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1612,6 +1612,43 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertTrue(selectedCandidate.state.reasons.contains("Branch has 1 unique local commit"))
     }
 
+    func testRemovalServiceSelectsNormalActionForIgnoredFilesOnly() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let candidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Ignored files review",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([WorktreeCleanupCandidate.ignoredFilesReason]),
+            checks: [],
+            reviewEvidence: WorktreeCleanupReviewEvidence(
+                ignoredPreview: WorktreeCleanupUntrackedPreview(paths: [".env.local"])
+            )
+        )
+        let service = WorktreeRemovalService(
+            scanner: scanner(
+                existingPaths: [worktreePath],
+                inspections: [worktreePath: cleanInspection(statusEntries: ["!! .env.local"])]
+            ),
+            runGit: { _ in
+                XCTFail("Selecting a removal action should not run Git removal")
+                return GitCommandResult(exitCode: 1, stdout: "", stderr: "")
+            }
+        )
+
+        let action = service.selectedAction(for: candidate, cleanupSources: [session], activeProjectPaths: [])
+
+        guard case .normalRemove(let selectedCandidate) = action else {
+            return XCTFail("Expected normal removal for ignored-only worktree, got \(action)")
+        }
+        XCTAssertEqual(selectedCandidate.state, .review([WorktreeCleanupCandidate.ignoredFilesReason]))
+    }
+
     func testRemovalServiceSelectsBlockedActionForLockedDirtyWorktree() {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
         let session = historySession(path: worktreePath)
@@ -1729,6 +1766,49 @@ final class WorktreeCleanupTests: XCTestCase {
             return XCTFail("Expected changed force evidence to refuse removal, got \(result)")
         }
         XCTAssertEqual(latestCandidate.reviewEvidence.untrackedPreview?.items, ["other.txt"])
+    }
+
+    func testRemovalServiceRefusesConfirmedForceWhenTrackedEvidenceChangesBeforeExecute() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let confirmedCandidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Tracked changes review",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([WorktreeCleanupCandidate.trackedChangesReason]),
+            checks: [],
+            reviewEvidence: WorktreeCleanupReviewEvidence(
+                trackedPathSignature: ["Sources/Billing.swift"]
+            )
+        )
+        var gitArguments: [[String]] = []
+        let service = WorktreeRemovalService(
+            scanner: scanner(
+                existingPaths: [worktreePath],
+                inspections: [worktreePath: cleanInspection(statusEntries: [" M Sources/Invoice.swift"])]
+            ),
+            runGit: { arguments in
+                gitArguments.append(arguments)
+                return GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
+            }
+        )
+
+        let result = service.executeConfirmed(
+            .forceRemove(confirmedCandidate),
+            cleanupSources: [session],
+            activeProjectPaths: []
+        )
+
+        XCTAssertTrue(gitArguments.isEmpty)
+        guard case .refused(let latestCandidate) = result else {
+            return XCTFail("Expected changed tracked evidence to refuse removal, got \(result)")
+        }
+        XCTAssertEqual(latestCandidate.reviewEvidence.trackedPathSignature, ["Sources/Invoice.swift"])
     }
 
     func testRemovalServiceRefusesConfirmedForceWhenPathBecomesActiveBeforeExecute() {
@@ -1894,6 +1974,84 @@ final class WorktreeCleanupTests: XCTestCase {
             return XCTFail("Expected changed normal-review evidence to refuse removal, got \(result)")
         }
         XCTAssertEqual(latestCandidate.state, .review(["Branch has 2 unique local commits"]))
+    }
+
+    func testRemovalServiceRefusesConfirmedForceWhenFreshEvidenceNoLongerRequiresForce() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let confirmedCandidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Dirty branch review",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([WorktreeCleanupCandidate.untrackedFilesReason]),
+            checks: [],
+            reviewEvidence: WorktreeCleanupReviewEvidence(
+                untrackedPreview: WorktreeCleanupUntrackedPreview(paths: ["scratch.txt"])
+            )
+        )
+        var gitArguments: [[String]] = []
+        let service = WorktreeRemovalService(
+            scanner: scanner(
+                existingPaths: [worktreePath],
+                inspections: [worktreePath: cleanInspection()]
+            ),
+            runGit: { arguments in
+                gitArguments.append(arguments)
+                return GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
+            }
+        )
+
+        let result = service.executeConfirmed(
+            .forceRemove(confirmedCandidate),
+            cleanupSources: [session],
+            activeProjectPaths: []
+        )
+
+        XCTAssertTrue(gitArguments.isEmpty)
+        guard case .refused(let latestCandidate) = result else {
+            return XCTFail("Expected force-to-normal evidence change to refuse removal, got \(result)")
+        }
+        XCTAssertEqual(latestCandidate.state, .clean)
+    }
+
+    func testRemovalServiceRefusesBlockedConfirmedActionWithoutInvokingGit() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let candidate = WorktreeCleanupCandidate(
+            id: worktreePath,
+            sessionName: "Blocked review",
+            worktreePath: worktreePath,
+            worktreeName: "billing-api",
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: "feature/invoices",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([WorktreeCleanupCandidate.statusUnreadableReason]),
+            checks: []
+        )
+        let service = WorktreeRemovalService(
+            scanner: scanner(existingPaths: [worktreePath], inspections: [worktreePath: cleanInspection()]),
+            runGit: { _ in
+                XCTFail("Blocked confirmed action should not run Git removal")
+                return GitCommandResult(exitCode: 1, stdout: "", stderr: "")
+            }
+        )
+
+        let result = service.executeConfirmed(
+            .blocked(candidate, "Git status could not be read, so cctop cannot verify what removal would delete."),
+            cleanupSources: [session],
+            activeProjectPaths: []
+        )
+
+        guard case .refused(let refusedCandidate) = result else {
+            return XCTFail("Expected blocked confirmed action to refuse removal, got \(result)")
+        }
+        XCTAssertEqual(refusedCandidate, candidate)
     }
 
     func testRemovalServiceSelectsBlockedActionWhenFreshStatusCannotBeRead() {
@@ -2979,6 +3137,31 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertTrue(confirmation.message.contains("does not delete the branch"))
     }
 
+    func testReviewRemovalConfirmationExplainsNormalIgnoredRemovalDeletesIgnoredFiles() {
+        let review = WorktreeCleanupCandidate(
+            id: "/Users/dev/.codex/worktrees/review",
+            sessionName: "Needs review",
+            worktreePath: "/Users/dev/.codex/worktrees/review",
+            worktreeName: "review",
+            mainWorktreePath: "/Users/dev/projects/app",
+            branchName: "feature/review",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([WorktreeCleanupCandidate.ignoredFilesReason]),
+            checks: [],
+            reviewEvidence: WorktreeCleanupReviewEvidence(
+                ignoredPreview: WorktreeCleanupUntrackedPreview(paths: [".env.local"])
+            )
+        )
+        let confirmation = WorktreeRemovalConfirmation.review(.normalRemove(review))
+
+        XCTAssertEqual(confirmation.primaryButtonTitle, "Remove")
+        XCTAssertTrue(confirmation.message.contains("git worktree remove"))
+        XCTAssertFalse(confirmation.message.contains("--force"))
+        XCTAssertTrue(confirmation.message.contains("Ignored files will be removed"))
+        XCTAssertTrue(confirmation.message.contains(".env.local"))
+    }
+
     func testReviewRemovalConfirmationExplainsForceRemovalAndBranchRetention() {
         let review = WorktreeCleanupCandidate(
             id: "/Users/dev/.codex/worktrees/review",
@@ -3099,6 +3282,17 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertTrue(popupViewSource.contains("func openCleanupDetail(_ candidate: WorktreeCleanupCandidate) {\n        cleanupRemovalNotice = nil"))
         XCTAssertTrue(tabViewSource.contains("listRemovalNotice"))
         XCTAssertTrue(tabViewSource.contains("if let removalNotice"))
+    }
+
+    func testCleanupRemovalRefreshesAfterRefusedOrBlockedEvidence() throws {
+        let root = try repoRoot()
+        let appDelegateSource = try String(
+            contentsOf: root.appendingPathComponent("menubar/CctopMenubar/AppDelegate.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(appDelegateSource.contains("case .blocked = action"))
+        XCTAssertTrue(appDelegateSource.contains("case .removed, .refused"))
     }
 
     private func scanner(

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1116,6 +1116,31 @@ final class WorktreeCleanupTests: XCTestCase {
     }
 
     @MainActor
+    func testCleanupCandidateChangePreservesBlockingRemovalNotice() {
+        let notice = WorktreeRemovalNotice(
+            title: "Removal Blocked",
+            message: "Cleanup evidence changed. Review the updated worktree before removing.",
+            blocksRemoval: true
+        )
+
+        let result = PopupView.noticeAfterCleanupCandidatesChanged(notice)
+
+        XCTAssertEqual(result, notice)
+    }
+
+    @MainActor
+    func testCleanupCandidateChangeClearsNonBlockingRemovalNotice() {
+        let notice = WorktreeRemovalNotice(
+            title: "Remove Failed",
+            message: "fatal: could not remove worktree"
+        )
+
+        let result = PopupView.noticeAfterCleanupCandidatesChanged(notice)
+
+        XCTAssertNil(result)
+    }
+
+    @MainActor
     func testCleanupScanningChangeNotifiesLayout() async throws {
         let layoutChanged = expectation(description: "cleanup scanning change notifies layout")
         let view = popupView(


### PR DESCRIPTION
## Problem

The cleanup tab could identify old worktrees, but the removal workflow still made developers do too much interpretation and too many actions. Review worktrees could require a normal remove attempt, a failure, and then a separate force decision, while the UI also kept older utility affordances that did not map to the actual developer workflow.

## Solution

- Make Remove the only primary cleanup action, with clean worktrees removing directly and review worktrees showing a focused confirmation that names the actual Git operation.
- Select `git worktree remove` versus `git worktree remove --force` from preflight evidence up front, then revalidate the worktree evidence immediately before executing any confirmed removal.
- Keep removal blocked when cctop cannot confidently prove the current worktree state, and surface scanning/removal state in the Cleanup tab and panel.
- Keep File Access settings copy concise and scoped to Cleanup, with a working help affordance for protected-folder cases.
