### PR TITLE
Make visible panel rows jump on first click

### DIFF
--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		T10000070000000000000002 /* AppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T10000080000000000000002 /* AppSettingsTests.swift */; };
 		PT0000010000000000000001 /* PanelToggleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PT0000020000000000000001 /* PanelToggleTests.swift */; };
 		PCT000010000000000000001 /* PanelCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PCT000020000000000000001 /* PanelCoordinatorTests.swift */; };
+		PHV000010000000000000001 /* FloatingPanelMouseEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PHV000020000000000000001 /* FloatingPanelMouseEventTests.swift */; };
 		NSN000010000000000000001 /* NSScreen+Notch.swift in Sources */ = {isa = PBXBuildFile; fileRef = NSN000020000000000000001 /* NSScreen+Notch.swift */; };
 		NPB000010000000000000001 /* NSPasteboard+Copy.swift in Sources */ = {isa = PBXBuildFile; fileRef = NPB000020000000000000001 /* NSPasteboard+Copy.swift */; };
 		NSP000010000000000000001 /* NotchStatusPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = NSP000020000000000000001 /* NotchStatusPanel.swift */; };
@@ -253,6 +254,7 @@
 		T10000080000000000000002 /* AppSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsTests.swift; sourceTree = "<group>"; };
 		PT0000020000000000000001 /* PanelToggleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelToggleTests.swift; sourceTree = "<group>"; };
 		PCT000020000000000000001 /* PanelCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelCoordinatorTests.swift; sourceTree = "<group>"; };
+		PHV000020000000000000001 /* FloatingPanelMouseEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelMouseEventTests.swift; sourceTree = "<group>"; };
 		NSN000020000000000000001 /* NSScreen+Notch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScreen+Notch.swift"; sourceTree = "<group>"; };
 		NPB000020000000000000001 /* NSPasteboard+Copy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPasteboard+Copy.swift"; sourceTree = "<group>"; };
 		NSP000020000000000000001 /* NotchStatusPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchStatusPanel.swift; sourceTree = "<group>"; };
@@ -502,6 +504,7 @@
 				HMT000020000000000000001 /* HistoryManagerTests.swift */,
 				PT0000020000000000000001 /* PanelToggleTests.swift */,
 				PCT000020000000000000001 /* PanelCoordinatorTests.swift */,
+				PHV000020000000000000001 /* FloatingPanelMouseEventTests.swift */,
 				MRT000020000000000000001 /* MenubarIconRendererTests.swift */,
 				SCT000020000000000000001 /* StatusCountsTests.swift */,
 				HVT000020000000000000001 /* StatusCountsSessionInitTests.swift */,
@@ -775,6 +778,7 @@
 				HMT000010000000000000001 /* HistoryManagerTests.swift in Sources */,
 				PT0000010000000000000001 /* PanelToggleTests.swift in Sources */,
 				PCT000010000000000000001 /* PanelCoordinatorTests.swift in Sources */,
+				PHV000010000000000000001 /* FloatingPanelMouseEventTests.swift in Sources */,
 				MRT000010000000000000001 /* MenubarIconRendererTests.swift in Sources */,
 				SCT000010000000000000001 /* StatusCountsTests.swift in Sources */,
 				HVT000010000000000000001 /* StatusCountsSessionInitTests.swift in Sources */,

--- a/menubar/CctopMenubar/FloatingPanel.swift
+++ b/menubar/CctopMenubar/FloatingPanel.swift
@@ -33,6 +33,10 @@ class FloatingPanel: NSPanel {
         sawDragEvents && originMoved
     }
 
+    static func shouldPrimeKeyWindowBeforeMouseDown(isKeyWindow: Bool, isHeaderClick: Bool) -> Bool {
+        !isKeyWindow && !isHeaderClick
+    }
+
     override init(
         contentRect: NSRect,
         styleMask: NSWindow.StyleMask,
@@ -68,14 +72,20 @@ class FloatingPanel: NSPanel {
     // MARK: - Header drag via tight event-tracking loop
 
     override func sendEvent(_ event: NSEvent) {
-        if event.type == .leftMouseDown && isInHeaderArea(event) {
-            switch Self.headerClickAction(forClickCount: event.clickCount) {
-            case .resetPosition:
-                panelDelegate?.panelDidRequestReset()
-            case .drag:
-                handleHeaderDrag()
+        if event.type == .leftMouseDown {
+            let headerClick = isInHeaderArea(event)
+            if Self.shouldPrimeKeyWindowBeforeMouseDown(isKeyWindow: isKeyWindow, isHeaderClick: headerClick) {
+                makeKey()
             }
-            return
+            if headerClick {
+                switch Self.headerClickAction(forClickCount: event.clickCount) {
+                case .resetPosition:
+                    panelDelegate?.panelDidRequestReset()
+                case .drag:
+                    handleHeaderDrag()
+                }
+                return
+            }
         }
         super.sendEvent(event)
     }

--- a/menubar/CctopMenubarTests/FloatingPanelMouseEventTests.swift
+++ b/menubar/CctopMenubarTests/FloatingPanelMouseEventTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import CctopMenubar
+
+final class FloatingPanelMouseEventTests: XCTestCase {
+    func testPrimesKeyWindowForInactiveBodyMouseDown() {
+        XCTAssertTrue(
+            FloatingPanel.shouldPrimeKeyWindowBeforeMouseDown(
+                isKeyWindow: false,
+                isHeaderClick: false
+            )
+        )
+    }
+
+    func testDoesNotPrimeKeyWindowForAlreadyKeyPanel() {
+        XCTAssertFalse(
+            FloatingPanel.shouldPrimeKeyWindowBeforeMouseDown(
+                isKeyWindow: true,
+                isHeaderClick: false
+            )
+        )
+    }
+
+    func testDoesNotPrimeKeyWindowForHeaderMouseDown() {
+        XCTAssertFalse(
+            FloatingPanel.shouldPrimeKeyWindowBeforeMouseDown(
+                isKeyWindow: false,
+                isHeaderClick: true
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Problem

After cctop jumps to a session, the nonactivating panel remains visible while the app deactivates. The next visible row click can be consumed by re-keying the panel instead of being delivered to the SwiftUI row gesture, so users often need a second click to jump back to another session or open a recent project.

## Solution

- Prime the floating panel as key before dispatching non-header mouse-down events, so the same first click reaches visible session and recent-project row actions.
- Keep header drag/reset handling on its existing path and cover the key-priming decision with focused panel tests.