### PR TITLE
Update launch video cleanup beat

### DIFF
--- a/video/build.sh
+++ b/video/build.sh
@@ -4,7 +4,7 @@
 # touches (staged screenshots, frames, mp4, poster) lives in projects/<project>/.video-build/ (gitignored).
 set -euo pipefail
 cd "$(dirname "$0")"
-PROJECT="${1:-launch}"; PORT="${PORT:-8123}"; SCALE="${SCALE:-2}"; FPS=30; DUR="${DUR:-27.8}"; W="${W:-1920}"; H="${H:-1080}"
+PROJECT="${1:-launch}"; PORT="${PORT:-8123}"; SCALE="${SCALE:-2}"; FPS=30; DUR="${DUR:-30.0}"; W="${W:-1920}"; H="${H:-1080}"
 REPO="$(cd .. && pwd)"                 # <repo> root: needs <repo>/docs/*.png (relocate-friendly: override REPO=)
 PDIR="projects/$PROJECT"
 [ -f "$PDIR/body.html" ] || { echo "no such project: $PDIR/body.html"; exit 1; }

--- a/video/projects/launch/body.html
+++ b/video/projects/launch/body.html
@@ -333,6 +333,9 @@ function drawBand(t){
   if(t>=TL.cleanup[0]-0.1 && t<TL.stack[0]-0.1) {
     o*=(1-mix(t, TL.cleanup[0]-0.1, TL.cleanup[0]+0.3)); // suppress for standalone cleanup beat
   }
+  if(t>=TL.cta[0]-0.1) {
+    o*=(1-mix(t, TL.cta[0]-0.1, TL.cta[0]+0.3)); // suppress for final CTA card
+  }
   $('#band').style.opacity=o;
   const seg=mix(t, m0+0.55, m0+0.82);
   $('#pill .grid').style.opacity=seg; $('#pill .sbar').style.opacity=seg;

--- a/video/projects/launch/body.html
+++ b/video/projects/launch/body.html
@@ -100,37 +100,45 @@
     box-shadow:0 22px 46px -28px rgba(0,0,0,.75), inset 0 1px 0 rgba(255,255,255,.04)}
   .chip .tmark{width:26px;height:26px;flex:none;background:var(--t1);
     -webkit-mask:center/contain no-repeat;mask:center/contain no-repeat}
-  .chip .tmark.wide{width:108px}   /* opencode is a wordmark, not a glyph */
   #editors{position:absolute;left:201px;width:640px;text-align:right;top:680px;font-family:var(--mono);font-size:24px;color:#7d83a0;letter-spacing:.3px;line-height:1.5;opacity:0;will-change:transform,opacity}
 
-  /* CLEANUP card */
+  /* CLEANUP panel */
   #cleanupHead,#cleanupSub{opacity:0;will-change:transform,opacity}
-  #cleanupCard{position:absolute;left:905px;top:238px;width:700px;height:604px;border-radius:20px;
-    background:#1c1d27;border:1px solid rgba(192,202,245,.11);overflow:hidden;opacity:0;will-change:transform,opacity;
-    box-shadow:0 54px 120px -34px rgba(0,0,0,.82), 0 0 90px -34px rgba(158,206,106,.26)}
-  .cleanupTop{height:86px;display:flex;align-items:center;gap:16px;padding:0 28px;border-bottom:1px solid rgba(192,202,245,.08);
-    background:linear-gradient(180deg,rgba(192,202,245,.055),rgba(192,202,245,.02))}
-  .cleanupIcon{width:42px;height:42px;border-radius:13px;background:rgba(158,206,106,.14);border:1px solid rgba(158,206,106,.42);
-    display:flex;align-items:center;justify-content:center;color:var(--green);font-family:var(--mono);font-size:25px;font-weight:800}
-  .cleanupTitle{font-size:29px;font-weight:760;color:#E8ECFB;letter-spacing:-.3px}
-  .cleanupMeta{font-family:var(--mono);font-size:15px;color:var(--t3);margin-top:4px;letter-spacing:.4px}
-  .cleanupRows{padding:24px 26px 18px;display:grid;gap:14px}
-  .cleanupRow{height:104px;border-radius:15px;background:rgba(192,202,245,.045);border:1px solid rgba(192,202,245,.10);
-    display:grid;grid-template-columns:1fr 154px 118px;align-items:center;column-gap:16px;padding:0 18px;opacity:0;will-change:transform,opacity}
-  .cleanupName{font-size:25px;font-weight:700;color:var(--t1);letter-spacing:-.2px}
-  .cleanupPath{font-family:var(--mono);font-size:14px;color:var(--t3);margin-top:7px}
-  .statePill,.actionPill{height:42px;border-radius:12px;display:inline-flex;align-items:center;justify-content:center;
-    font-family:var(--mono);font-size:16px;font-weight:760;white-space:nowrap}
+  #cleanupCard{position:absolute;left:905px;top:222px;width:700px;height:637px;border-radius:28px;
+    background:#30312f;border:1px solid rgba(192,202,245,.12);overflow:hidden;opacity:0;will-change:transform,opacity;
+    box-shadow:none}
+  .cleanupChrome{height:90px;display:flex;align-items:center;gap:15px;padding:0 36px;border-bottom:1px solid rgba(192,202,245,.10)}
+  .cleanupBrand{display:flex;align-items:center;gap:14px;font-size:29px;font-weight:760;color:#F1F3FA}
+  .cleanupBrand .bar{width:7px;height:31px;border-radius:5px;background:var(--accent)}
+  .cleanupStatus{margin-left:auto;display:flex;gap:12px}
+  .cleanupDot{height:40px;min-width:58px;border-radius:20px;border:1px solid rgba(192,202,245,.14);display:flex;align-items:center;justify-content:center;
+    gap:8px;font-family:var(--mono);font-size:18px;font-weight:760;color:var(--t2);background:rgba(192,202,245,.045)}
+  .cleanupDot::before{content:"";width:11px;height:11px;border-radius:50%;background:currentColor}
+  .cleanupDot.red{color:var(--red)}.cleanupDot.orange{color:var(--orange)}.cleanupDot.green{color:var(--green)}
+  .cleanupTabs{height:76px;display:flex;align-items:center;padding:0 36px;gap:42px;border-bottom:1px solid rgba(192,202,245,.10);
+    font-size:22px;font-weight:740;color:rgba(218,221,235,.56)}
+  .cleanupTabs .active{height:46px;padding:0 22px;border-radius:17px;border:1px solid rgba(192,202,245,.20);
+    display:flex;align-items:center;gap:10px;color:#F4F0EA;background:rgba(192,202,245,.04)}
+  .cleanupRows{display:grid}
+  .cleanupRow{min-height:188px;border-bottom:1px solid rgba(192,202,245,.11);display:grid;grid-template-columns:minmax(0,1fr) 164px;
+    column-gap:24px;align-items:center;padding:25px 36px;opacity:0;will-change:transform,opacity}
+  .cleanupName{font-size:29px;font-weight:800;color:#F1F3FA;letter-spacing:-.5px}
+  .cleanupPath{font-family:var(--mono);font-size:23px;font-weight:650;color:#aaa89d;margin-top:9px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .cleanupActivity{font-size:21px;color:#aaa89d;margin-top:10px}
+  .cleanupRight{display:flex;flex-direction:column;align-items:flex-end;gap:16px}
+  .cleanupStorage{font-family:var(--mono);font-size:21px;font-weight:760;color:#aaa89d}
+  .statePill,.actionPill{height:43px;border-radius:14px;display:inline-flex;align-items:center;justify-content:center;
+    font-family:var(--mono);font-size:16px;font-weight:800;white-space:nowrap}
+  .statePill{min-width:93px}
   .statePill.safe{color:var(--green);background:rgba(158,206,106,.12);border:1px solid rgba(158,206,106,.36)}
   .statePill.warn{color:var(--orange);background:rgba(255,158,100,.12);border:1px solid rgba(255,158,100,.36)}
-  .statePill.stop{color:var(--red);background:rgba(247,118,142,.12);border:1px solid rgba(247,118,142,.36)}
-  .actionPill.primary{color:#122015;background:var(--green);box-shadow:0 0 28px -12px rgba(158,206,106,.9);will-change:box-shadow,transform}
-  .actionPill.review{color:#22180c;background:var(--orange)}
-  .actionPill.blocked{color:var(--t3);background:rgba(192,202,245,.07);border:1px solid rgba(192,202,245,.11)}
-  .cleanupFoot{margin:2px 26px 0;padding:19px 22px;border-radius:15px;background:rgba(158,206,106,.08);
-    border:1px solid rgba(158,206,106,.22);font-family:var(--mono);font-size:18px;color:#c8e7ad;display:flex;gap:12px;align-items:center;
-    opacity:0;will-change:transform,opacity}
-  .cleanupFoot b{font-size:23px;color:var(--green)}
+  .actionPill{min-width:162px;color:var(--orange);background:rgba(255,158,100,.07);border:1px solid rgba(255,158,100,.40);gap:8px}
+  .actionPill.primary{will-change:transform,background,border-color}
+  .trashIcon{width:18px;height:18px;stroke:currentColor;stroke-width:2.3;fill:none;stroke-linecap:round;stroke-linejoin:round}
+  .cleanupFooter{height:94px;display:flex;align-items:center;gap:26px;padding:0 36px;font-size:22px;font-weight:730;color:#a9a79f}
+  .cleanupFooter .version{font-family:var(--mono);font-size:20px;color:#aaa89d}
+  .cleanupFooter .nav{font-size:20px;color:#aaa89d}
+  .cleanupFooter .gear{margin-left:auto;font-size:32px;color:#aaa89d}
 
   /* CTA */
   #cta{position:absolute;inset:0;opacity:0}
@@ -209,40 +217,58 @@
   <div id="chips">
     <div class="chip"><span class="tmark" style="-webkit-mask-image:url(.video-build/assets/icons/claude.svg);mask-image:url(.video-build/assets/icons/claude.svg)"></span>Claude Code</div>
     <div class="chip"><span class="tmark" style="-webkit-mask-image:url(.video-build/assets/icons/openai.svg);mask-image:url(.video-build/assets/icons/openai.svg)"></span>Codex</div>
-    <div class="chip"><span class="tmark wide" style="-webkit-mask-image:url(.video-build/assets/icons/opencode.svg);mask-image:url(.video-build/assets/icons/opencode.svg)"></span></div>
+    <div class="chip">opencode</div>
     <div class="chip"><span class="tmark" style="-webkit-mask-image:url(.video-build/assets/icons/pi.svg);mask-image:url(.video-build/assets/icons/pi.svg)"></span>pi</div>
   </div>
   <div id="editors">VS Code · Cursor · Zed<br>iTerm2 · Ghostty · Warp · Kitty · cmux</div>
 
   <!-- CLEANUP -->
-  <div class="word" id="cleanupHead" style="left:251px;width:590px;text-align:right;top:344px;font-size:58px;font-weight:800;letter-spacing:-1.2px;line-height:1.08;color:#E8ECFB">Done work<br>shouldn't <span class="accent">linger.</span></div>
-  <div class="word" id="cleanupSub" style="left:221px;width:620px;text-align:right;top:500px;font-size:27px;font-weight:500;line-height:1.38;color:var(--t2)">cctop checks Git, then gives you the right remove action.</div>
+  <div class="word" id="cleanupHead" style="left:251px;width:590px;text-align:right;top:344px;font-size:58px;font-weight:800;letter-spacing:-1.2px;line-height:1.08;color:#E8ECFB">Done worktree<br>shouldn't <span class="accent">linger.</span></div>
+  <div class="word" id="cleanupSub" style="left:221px;width:620px;text-align:right;top:500px;font-size:29px;font-weight:560;line-height:1.34;color:var(--t2)">See what's safe, what needs review, and remove the right worktree.</div>
   <div id="cleanupCard">
-    <div class="cleanupTop">
-      <div class="cleanupIcon">✓</div>
-      <div>
-        <div class="cleanupTitle">Worktree Cleanup</div>
-        <div class="cleanupMeta">Leftover ended agent worktrees</div>
-      </div>
+    <div class="cleanupChrome">
+      <div class="cleanupBrand"><span class="bar"></span><span>cctop</span></div>
+      <div class="cleanupStatus"><span class="cleanupDot red">1</span><span class="cleanupDot orange">1</span><span class="cleanupDot green">3</span></div>
     </div>
+    <div class="cleanupTabs"><span>Active <b>5</b></span><span>Idle <b>1</b></span><span>Recent <b>5</b></span><span class="active">Cleanup <b id="cleanupCount">2</b></span></div>
     <div class="cleanupRows">
-      <div class="cleanupRow">
-        <div><div class="cleanupName">billing-api-fix</div><div class="cleanupPath">~/worktrees/billing-api-fix</div></div>
-        <div class="statePill safe">Git clean</div>
-        <div class="actionPill primary" id="removeAction">Remove</div>
+      <div class="cleanupRow" id="removedRow">
+        <div>
+          <div class="cleanupName">Generate invoice retry path</div>
+          <div class="cleanupPath">billing-api · feature/invoices</div>
+          <div class="cleanupActivity">Last active 2h ago · 842 MB</div>
+        </div>
+        <div class="cleanupRight">
+          <div class="statePill safe">Clean</div>
+          <div class="cleanupStorage">842 MB</div>
+          <div class="actionPill primary" id="removeAction">
+            <svg class="trashIcon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v5"/><path d="M14 11v5"/></svg>
+            <span class="actionLabel">Remove</span>
+          </div>
+        </div>
       </div>
-      <div class="cleanupRow">
-        <div><div class="cleanupName">reports-spike</div><div class="cleanupPath">~/worktrees/reports-spike</div></div>
-        <div class="statePill warn">Dirty</div>
-        <div class="actionPill review">Review</div>
-      </div>
-      <div class="cleanupRow">
-        <div><div class="cleanupName">release-check</div><div class="cleanupPath">~/worktrees/release-check</div></div>
-        <div class="statePill stop">Locked</div>
-        <div class="actionPill blocked">Blocked</div>
+      <div class="cleanupRow" id="reviewRow">
+        <div>
+          <div class="cleanupName">Try auth rewrite spike</div>
+          <div class="cleanupPath">auth-rewrite-spike · try/auth-flow</div>
+          <div class="cleanupActivity">Last active 2h ago · 1.7 GB</div>
+        </div>
+        <div class="cleanupRight">
+          <div class="statePill warn">Review</div>
+          <div class="cleanupStorage">1.7 GB</div>
+          <div class="actionPill">
+            <svg class="trashIcon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v5"/><path d="M14 11v5"/></svg>
+            <span>Remove</span>
+          </div>
+        </div>
       </div>
     </div>
-    <div class="cleanupFoot"><b>✓</b> Safety checked before removal</div>
+    <div class="cleanupFooter">
+      <span>Quit</span>
+      <span class="version">v0.19.3</span>
+      <span class="nav">^&#8984;F navigate</span>
+      <span class="gear">&#9881;</span>
+    </div>
   </div>
 
   <!-- CTA -->
@@ -260,9 +286,9 @@
 <script>
 const TL={
   hook:[0.0,3.0], morph:[2.9,4.0], reveal:[3.8,7.2], scan:[7.1,10.7],
-  jump:[10.6,13.8], payoff:[13.7,17.4], stack:[17.3,20.5], cleanup:[20.4,23.2], cta:[23.0,27.8]
+  jump:[10.6,13.8], payoff:[13.7,17.4], cleanup:[17.3,22.2], stack:[22.25,25.3], cta:[25.1,30.0]
 };
-const TOTAL=27.8;
+const TOTAL=30.0;
 const PANEL={x:905,y:176,w:680,h:781};
 const PILL={x:1630,y:30};                       // pill centre — bloom origin + dot convergence
 const DOTC=[868,914,960,1006,1052], DOTY=538;   // hook dot centres at rest
@@ -304,7 +330,9 @@ function drawBand(t){
   const [m0,m1]=TL.morph;
   let o=mix(t, m0+0.05, m0+0.5);
   if(t>=TL.payoff[0]-0.1 && t<TL.stack[0]-0.1) o*=0.70;                 // recede during payoff
-  if(t>=TL.cleanup[0]-0.1) o*=(1-mix(t, TL.cleanup[0]-0.1, TL.cleanup[0]+0.3)); // suppress for cleanup+cta
+  if(t>=TL.cleanup[0]-0.1 && t<TL.stack[0]-0.1) {
+    o*=(1-mix(t, TL.cleanup[0]-0.1, TL.cleanup[0]+0.3)); // suppress for standalone cleanup beat
+  }
   $('#band').style.opacity=o;
   const seg=mix(t, m0+0.55, m0+0.82);
   $('#pill .grid').style.opacity=seg; $('#pill .sbar').style.opacity=seg;
@@ -328,13 +356,13 @@ function drawReveal(t){
 function drawPanel(t){
   const p=$('#panel');
   const appear=3.9;   // bloom starts as the dots merge into the pill (no empty beat before the panel)
-  const win1End=(TL.payoff[0]+TL.stack[0])/2;
+  const win1End=TL.payoff[1];
   let op, bloom;
   if(t<win1End){
     op = mix(t, appear, appear+0.55) * (1 - mix(t, TL.payoff[0]-0.15, TL.payoff[0]+0.3));
     bloom = eOut(mix(t, appear, appear+0.95));
   } else {
-    op = mix(t, TL.stack[0]-0.05, TL.stack[0]+0.4) * (1 - mix(t, TL.cleanup[0]-0.15, TL.cleanup[0]+0.3));
+    op = mix(t, TL.stack[0]-0.05, TL.stack[0]+0.4) * (1 - mix(t, TL.stack[1]-0.45, TL.stack[1]-0.15));
     bloom = 1;
   }
   let bx,by,bw,bh;
@@ -409,18 +437,26 @@ function drawCleanup(t){
   const co=mix(t, a+0.25, a+0.72)*(1-mix(t,b-0.38,b-0.04));
   card.style.opacity=co;
   card.style.transform=`translateY(${lerp(54,0,cp).toFixed(1)}px) scale(${lerp(.965,1,cp).toFixed(3)})`;
-  $$('#cleanupCard .cleanupRow').forEach((row,i)=>{
-    const p=eBack(clamp(mix(t, a+0.62+i*0.13, a+1.1+i*0.13)));
-    const o=clamp(mix(t, a+0.62+i*0.13, a+0.95+i*0.13))*(1-mix(t,b-0.35,b-0.04));
-    row.style.opacity=o;
-    row.style.transform=`translateY(${lerp(24,0,p).toFixed(1)}px)`;
-  });
-  const fp=rev(t, a+1.28, a+1.76, b-0.35, b-0.04, 14);
-  $('.cleanupFoot').style.opacity=fp.o;
-  $('.cleanupFoot').style.transform=`translateY(${fp.y}px)`;
-  const glow=mix(t, a+1.15, a+1.9)*(1-mix(t,b-0.5,b-0.1));
-  $('#removeAction').style.boxShadow=`0 0 ${(28+32*glow).toFixed(0)}px -${(12-5*glow).toFixed(0)}px rgba(158,206,106,${(0.9*glow).toFixed(2)})`;
-  $('#removeAction').style.transform=`scale(${lerp(1,1.04,glow).toFixed(3)})`;
+  const rowGone=eInOut(mix(t, a+2.02, a+2.42));
+  const shift=eInOut(mix(t, a+2.42, a+3.02));
+  const removedRow=$('#removedRow');
+  const removedEntry=eBack(clamp(mix(t, a+0.62, a+1.1)));
+  const removedOpacity=clamp(mix(t, a+0.62, a+0.95))*(1-mix(t,b-0.35,b-0.04))*(1-rowGone);
+  removedRow.style.opacity=removedOpacity;
+  removedRow.style.transform=`translate(${lerp(0,54,rowGone).toFixed(1)}px,${lerp(24,0,removedEntry).toFixed(1)}px) scale(${lerp(1,.97,rowGone).toFixed(3)})`;
+  const reviewRow=$('#reviewRow');
+  const reviewEntry=eBack(clamp(mix(t, a+0.75, a+1.23)));
+  const reviewOpacity=clamp(mix(t, a+0.75, a+1.08))*(1-mix(t,b-0.35,b-0.04));
+  reviewRow.style.opacity=reviewOpacity;
+  reviewRow.style.transform=`translateY(${lerp(lerp(24,0,reviewEntry),-188,shift).toFixed(1)}px)`;
+  $('#cleanupCount').textContent = shift > 0.55 ? '1' : '2';
+  const press=mix(t, a+1.62, a+1.78)*(1-mix(t, a+1.88, a+2.04));
+  const action=$('#removeAction');
+  action.querySelector('.actionLabel').textContent = rowGone > 0.45 ? 'Removed' : 'Remove';
+  action.style.boxShadow='none';
+  action.style.background=`rgba(255,158,100,${(0.07+0.16*press).toFixed(2)})`;
+  action.style.borderColor=`rgba(255,158,100,${(0.40+0.18*press).toFixed(2)})`;
+  action.style.transform=`scale(${lerp(1,.94,press).toFixed(3)})`;
 }
 
 /* CTA */

--- a/video/projects/launch/storyboard.html
+++ b/video/projects/launch/storyboard.html
@@ -112,35 +112,43 @@
     box-shadow:0 22px 46px -28px rgba(0,0,0,.75), inset 0 1px 0 rgba(255,255,255,.04)}
   .chip .tmark{width:26px;height:26px;flex:none;background:var(--t1);
     -webkit-mask:center/contain no-repeat;mask:center/contain no-repeat}
-  .chip .tmark.wide{width:108px}
   #editors{position:absolute;font-family:var(--mono);font-size:25px;color:var(--t3);letter-spacing:.3px}
 
-  /* CLEANUP card */
-  .cleanupCard{position:absolute;left:905px;top:238px;width:700px;height:604px;border-radius:20px;
-    background:#1c1d27;border:1px solid rgba(192,202,245,.11);overflow:hidden;
-    box-shadow:0 54px 120px -34px rgba(0,0,0,.82), 0 0 90px -34px rgba(158,206,106,.26)}
-  .cleanupTop{height:86px;display:flex;align-items:center;gap:16px;padding:0 28px;border-bottom:1px solid rgba(192,202,245,.08);
-    background:linear-gradient(180deg,rgba(192,202,245,.055),rgba(192,202,245,.02))}
-  .cleanupIcon{width:42px;height:42px;border-radius:13px;background:rgba(158,206,106,.14);border:1px solid rgba(158,206,106,.42);
-    display:flex;align-items:center;justify-content:center;color:var(--green);font-family:var(--mono);font-size:25px;font-weight:800}
-  .cleanupTitle{font-size:29px;font-weight:760;color:#E8ECFB;letter-spacing:-.3px}
-  .cleanupMeta{font-family:var(--mono);font-size:15px;color:var(--t3);margin-top:4px;letter-spacing:.4px}
-  .cleanupRows{padding:24px 26px 18px;display:grid;gap:14px}
-  .cleanupRow{height:104px;border-radius:15px;background:rgba(192,202,245,.045);border:1px solid rgba(192,202,245,.10);
-    display:grid;grid-template-columns:1fr 154px 118px;align-items:center;column-gap:16px;padding:0 18px}
-  .cleanupName{font-size:25px;font-weight:700;color:var(--t1);letter-spacing:-.2px}
-  .cleanupPath{font-family:var(--mono);font-size:14px;color:var(--t3);margin-top:7px}
-  .statePill,.actionPill{height:42px;border-radius:12px;display:inline-flex;align-items:center;justify-content:center;
-    font-family:var(--mono);font-size:16px;font-weight:760;white-space:nowrap}
+  /* CLEANUP panel */
+  .cleanupCard{position:absolute;left:905px;top:222px;width:700px;height:637px;border-radius:28px;
+    background:#30312f;border:1px solid rgba(192,202,245,.12);overflow:hidden;
+    box-shadow:none}
+  .cleanupChrome{height:90px;display:flex;align-items:center;gap:15px;padding:0 36px;border-bottom:1px solid rgba(192,202,245,.10)}
+  .cleanupBrand{display:flex;align-items:center;gap:14px;font-size:29px;font-weight:760;color:#F1F3FA}
+  .cleanupBrand .bar{width:7px;height:31px;border-radius:5px;background:var(--accent)}
+  .cleanupStatus{margin-left:auto;display:flex;gap:12px}
+  .cleanupDot{height:40px;min-width:58px;border-radius:20px;border:1px solid rgba(192,202,245,.14);display:flex;align-items:center;justify-content:center;
+    gap:8px;font-family:var(--mono);font-size:18px;font-weight:760;color:var(--t2);background:rgba(192,202,245,.045)}
+  .cleanupDot::before{content:"";width:11px;height:11px;border-radius:50%;background:currentColor}
+  .cleanupDot.red{color:var(--red)}.cleanupDot.orange{color:var(--orange)}.cleanupDot.green{color:var(--green)}
+  .cleanupTabs{height:76px;display:flex;align-items:center;padding:0 36px;gap:42px;border-bottom:1px solid rgba(192,202,245,.10);
+    font-size:22px;font-weight:740;color:rgba(218,221,235,.56)}
+  .cleanupTabs .active{height:46px;padding:0 22px;border-radius:17px;border:1px solid rgba(192,202,245,.20);
+    display:flex;align-items:center;gap:10px;color:#F4F0EA;background:rgba(192,202,245,.04)}
+  .cleanupRows{display:grid}
+  .cleanupRow{min-height:188px;border-bottom:1px solid rgba(192,202,245,.11);display:grid;grid-template-columns:minmax(0,1fr) 164px;
+    column-gap:24px;align-items:center;padding:25px 36px}
+  .cleanupName{font-size:29px;font-weight:800;color:#F1F3FA;letter-spacing:-.5px}
+  .cleanupPath{font-family:var(--mono);font-size:23px;font-weight:650;color:#aaa89d;margin-top:9px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .cleanupActivity{font-size:21px;color:#aaa89d;margin-top:10px}
+  .cleanupRight{display:flex;flex-direction:column;align-items:flex-end;gap:16px}
+  .cleanupStorage{font-family:var(--mono);font-size:21px;font-weight:760;color:#aaa89d}
+  .statePill,.actionPill{height:43px;border-radius:14px;display:inline-flex;align-items:center;justify-content:center;
+    font-family:var(--mono);font-size:16px;font-weight:800;white-space:nowrap}
+  .statePill{min-width:93px}
   .statePill.safe{color:var(--green);background:rgba(158,206,106,.12);border:1px solid rgba(158,206,106,.36)}
   .statePill.warn{color:var(--orange);background:rgba(255,158,100,.12);border:1px solid rgba(255,158,100,.36)}
-  .statePill.stop{color:var(--red);background:rgba(247,118,142,.12);border:1px solid rgba(247,118,142,.36)}
-  .actionPill.primary{color:#122015;background:var(--green);box-shadow:0 0 28px -12px rgba(158,206,106,.9)}
-  .actionPill.review{color:#22180c;background:var(--orange)}
-  .actionPill.blocked{color:var(--t3);background:rgba(192,202,245,.07);border:1px solid rgba(192,202,245,.11)}
-  .cleanupFoot{margin:2px 26px 0;padding:19px 22px;border-radius:15px;background:rgba(158,206,106,.08);
-    border:1px solid rgba(158,206,106,.22);font-family:var(--mono);font-size:18px;color:#c8e7ad;display:flex;gap:12px;align-items:center}
-  .cleanupFoot b{font-size:23px;color:var(--green)}
+  .actionPill{min-width:162px;color:var(--orange);background:rgba(255,158,100,.07);border:1px solid rgba(255,158,100,.40);gap:8px}
+  .trashIcon{width:18px;height:18px;stroke:currentColor;stroke-width:2.3;fill:none;stroke-linecap:round;stroke-linejoin:round}
+  .cleanupFooter{height:94px;display:flex;align-items:center;gap:26px;padding:0 36px;font-size:22px;font-weight:730;color:#a9a79f}
+  .cleanupFooter .version{font-family:var(--mono);font-size:20px;color:#aaa89d}
+  .cleanupFooter .nav{font-size:20px;color:#aaa89d}
+  .cleanupFooter .gear{margin-left:auto;font-size:32px;color:#aaa89d}
 
   /* CTA */
   #cta #icon{width:184px;height:184px;border-radius:42px;box-shadow:0 42px 95px -24px rgba(0,0,0,.86),0 0 86px -18px rgba(247,118,142,.46)}
@@ -230,49 +238,67 @@
     </div>
   </div>
 
-  <!-- ============ FRAME 5 — STACK ============ -->
-  <div class="sframe" data-i="5">
+  <!-- ============ FRAME 6 — STACK ============ -->
+  <div class="sframe" data-i="6">
     <div style="position:absolute;left:341px;width:500px;text-align:right;top:332px;font-size:54px;font-weight:800;letter-spacing:-1px;line-height:1.08;color:#E8ECFB">Works with the<br>stack you've got.</div>
     <div id="chips" style="left:296px;top:498px">
       <div class="chip"><span class="tmark" style="-webkit-mask-image:url(.video-build/assets/icons/claude.svg);mask-image:url(.video-build/assets/icons/claude.svg)"></span>Claude Code</div>
       <div class="chip"><span class="tmark" style="-webkit-mask-image:url(.video-build/assets/icons/openai.svg);mask-image:url(.video-build/assets/icons/openai.svg)"></span>Codex</div>
-      <div class="chip"><span class="tmark wide" style="-webkit-mask-image:url(.video-build/assets/icons/opencode.svg);mask-image:url(.video-build/assets/icons/opencode.svg)"></span></div>
+      <div class="chip">opencode</div>
       <div class="chip"><span class="tmark" style="-webkit-mask-image:url(.video-build/assets/icons/pi.svg);mask-image:url(.video-build/assets/icons/pi.svg)"></span>pi</div>
     </div>
     <div id="editors" style="left:201px;width:640px;text-align:right;top:680px;font-size:24px;color:#7d83a0;line-height:1.5">VS Code · Cursor · Zed<br>iTerm2 · Ghostty · Warp · Kitty · cmux</div>
     <div class="panel" data-img="dark" style="left:905px;top:176px;width:680px;height:781px"><img src=".video-build/assets/menubar-dark.png"></div>
   </div>
 
-  <!-- ============ FRAME 6 — CLEANUP ============ -->
-  <div class="sframe" data-i="6">
-    <div style="position:absolute;left:251px;width:590px;text-align:right;top:344px;font-size:58px;font-weight:800;letter-spacing:-1.2px;line-height:1.08;color:#E8ECFB">Done work<br>shouldn't <span class="accent">linger.</span></div>
-    <div style="position:absolute;left:221px;width:620px;text-align:right;top:500px;font-size:27px;font-weight:500;line-height:1.38;color:var(--t2)">cctop checks Git, then gives you the right remove action.</div>
+  <!-- ============ FRAME 5 — CLEANUP ============ -->
+  <div class="sframe" data-i="5">
+    <div style="position:absolute;left:251px;width:590px;text-align:right;top:344px;font-size:58px;font-weight:800;letter-spacing:-1.2px;line-height:1.08;color:#E8ECFB">Done worktree<br>shouldn't <span class="accent">linger.</span></div>
+    <div style="position:absolute;left:221px;width:620px;text-align:right;top:500px;font-size:29px;font-weight:560;line-height:1.34;color:var(--t2)">See what's safe, what needs review, and remove the right worktree.</div>
     <div class="cleanupCard">
-      <div class="cleanupTop">
-        <div class="cleanupIcon">✓</div>
-        <div>
-          <div class="cleanupTitle">Worktree Cleanup</div>
-          <div class="cleanupMeta">Leftover ended agent worktrees</div>
-        </div>
+      <div class="cleanupChrome">
+        <div class="cleanupBrand"><span class="bar"></span><span>cctop</span></div>
+        <div class="cleanupStatus"><span class="cleanupDot red">1</span><span class="cleanupDot orange">1</span><span class="cleanupDot green">3</span></div>
       </div>
+      <div class="cleanupTabs"><span>Active <b>5</b></span><span>Idle <b>1</b></span><span>Recent <b>5</b></span><span class="active">Cleanup <b>2</b></span></div>
       <div class="cleanupRows">
         <div class="cleanupRow">
-          <div><div class="cleanupName">billing-api-fix</div><div class="cleanupPath">~/worktrees/billing-api-fix</div></div>
-          <div class="statePill safe">Git clean</div>
-          <div class="actionPill primary">Remove</div>
+          <div>
+            <div class="cleanupName">Generate invoice retry path</div>
+            <div class="cleanupPath">billing-api · feature/invoices</div>
+            <div class="cleanupActivity">Last active 2h ago · 842 MB</div>
+          </div>
+          <div class="cleanupRight">
+            <div class="statePill safe">Clean</div>
+            <div class="cleanupStorage">842 MB</div>
+            <div class="actionPill">
+              <svg class="trashIcon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v5"/><path d="M14 11v5"/></svg>
+              <span>Remove</span>
+            </div>
+          </div>
         </div>
         <div class="cleanupRow">
-          <div><div class="cleanupName">reports-spike</div><div class="cleanupPath">~/worktrees/reports-spike</div></div>
-          <div class="statePill warn">Dirty</div>
-          <div class="actionPill review">Review</div>
-        </div>
-        <div class="cleanupRow">
-          <div><div class="cleanupName">release-check</div><div class="cleanupPath">~/worktrees/release-check</div></div>
-          <div class="statePill stop">Locked</div>
-          <div class="actionPill blocked">Blocked</div>
+          <div>
+            <div class="cleanupName">Try auth rewrite spike</div>
+            <div class="cleanupPath">auth-rewrite-spike · try/auth-flow</div>
+            <div class="cleanupActivity">Last active 2h ago · 1.7 GB</div>
+          </div>
+          <div class="cleanupRight">
+            <div class="statePill warn">Review</div>
+            <div class="cleanupStorage">1.7 GB</div>
+            <div class="actionPill">
+              <svg class="trashIcon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v5"/><path d="M14 11v5"/></svg>
+              <span>Remove</span>
+            </div>
+          </div>
         </div>
       </div>
-      <div class="cleanupFoot"><b>✓</b> Safety checked before removal</div>
+      <div class="cleanupFooter">
+        <span>Quit</span>
+        <span class="version">v0.19.3</span>
+        <span class="nav">^&#8984;F navigate</span>
+        <span class="gear">&#9881;</span>
+      </div>
     </div>
   </div>
 
@@ -295,8 +321,8 @@
   <button data-frame="2">2 Scan</button>
   <button data-frame="3">3 Jump</button>
   <button data-frame="4">4 Payoff</button>
-  <button data-frame="5">5 Stack</button>
-  <button data-frame="6">6 Cleanup</button>
+  <button data-frame="5">5 Cleanup</button>
+  <button data-frame="6">6 Stack</button>
   <button data-frame="7">7 CTA</button>
 </div>
 
@@ -304,7 +330,7 @@
 <script>
 /* Storyboard: 8 static key frames. seek(t) shows frame round(t).
    Per-frame menubar band opacity (some beats suppress it). */
-const BAND = [0, 1.0, 0.92, 0.92, 0.70, 0.92, 0, 0];   // index = frame
+const BAND = [0, 1.0, 0.92, 0.92, 0.70, 0, 0.92, 0];   // index = frame
 const TETHER = 1;                                       // tether visible only on REVEAL
 let currentFrame = 0;
 


### PR DESCRIPTION
## Problem

The launch video did not reflect the current cleanup workflow clearly enough. The cleanup beat came after the supported-tools montage, used copy that was easy to read as generic task cleanup rather than worktree cleanup, and introduced a separate visual treatment that did not match the app panel.

## Solution

- Move the cleanup beat before the supported-tools beat so the story flows from finding a session, jumping back, then cleaning up finished worktrees.
- Update the cleanup copy to say `Done worktree` and show the app-style cleanup panel with clean and review worktree rows.
- Extend the launch render to 30 seconds so the reordered sequence and final CTA have room to play without clipping.
