### PR TITLE
Make Recent useful for archived desktop sessions

### DIFF
--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -23,11 +23,13 @@
 		SBV000010000000000000001 /* SourceBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SBV000020000000000000001 /* SourceBadgeView.swift */; };
 		D10000070000000000000001 /* PopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000080000000000000001 /* PopupView.swift */; };
 		PVH000010000000000000001 /* PopupViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = PVH000020000000000000001 /* PopupViewHelpers.swift */; };
+		PVR000010000000000000001 /* PopupView+Recent.swift in Sources */ = {isa = PBXBuildFile; fileRef = PVR000020000000000000001 /* PopupView+Recent.swift */; };
 		D10000090000000000000001 /* QuitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000000A000000000000001 /* QuitButton.swift */; };
 		E10000010000000000000001 /* FocusTerminal.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000020000000000000001 /* FocusTerminal.swift */; };
 		EAPPRESTORE0010000000001 /* FocusTerminal+AppRestore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAPPRESTORE0020000000001 /* FocusTerminal+AppRestore.swift */; };
 		ECMUX001000000000000001 /* FocusTerminal+Cmux.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECMUX002000000000000001 /* FocusTerminal+Cmux.swift */; };
 		EMUX0010000000000000001 /* FocusTerminal+Multiplexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EMUX0020000000000000001 /* FocusTerminal+Multiplexer.swift */; };
+		ERCT00010000000000000001 /* FocusTerminal+Recent.swift in Sources */ = {isa = PBXBuildFile; fileRef = ERCT00020000000000000001 /* FocusTerminal+Recent.swift */; };
 		EK0000010000000000000001 /* HostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EK0000020000000000000001 /* HostApp.swift */; };
 		F10000010000000000000001 /* Session+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000020000000000000001 /* Session+Mock.swift */; };
 		FK0000010000000000000001 /* ForkSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FK0000020000000000000001 /* ForkSessionTests.swift */; };
@@ -63,6 +65,7 @@
 		MIR000010000000000000001 /* MenubarIconRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = MIR000020000000000000001 /* MenubarIconRenderer.swift */; };
 		OB0000010000000000000001 /* OpenCodeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = OB0000020000000000000001 /* OpenCodeBanner.swift */; };
 		RP0000010000000000000001 /* RecentProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = RP0000020000000000000001 /* RecentProject.swift */; };
+		RRT000010000000000000001 /* RecentResumeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = RRT000020000000000000001 /* RecentResumeTarget.swift */; };
 		RPM000010000000000000001 /* RecentProject+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = RPM000020000000000000001 /* RecentProject+Mock.swift */; };
 		RV0000010000000000000001 /* RecentProjectCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = RV0000020000000000000001 /* RecentProjectCardView.swift */; };
 		N10000030000000000000001 /* HookEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = N10000040000000000000001 /* HookEvent.swift */; };
@@ -203,6 +206,7 @@
 		EAPPRESTORE0020000000001 /* FocusTerminal+AppRestore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FocusTerminal+AppRestore.swift"; sourceTree = "<group>"; };
 		ECMUX002000000000000001 /* FocusTerminal+Cmux.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FocusTerminal+Cmux.swift"; sourceTree = "<group>"; };
 		EMUX0020000000000000001 /* FocusTerminal+Multiplexer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FocusTerminal+Multiplexer.swift"; sourceTree = "<group>"; };
+		ERCT00020000000000000001 /* FocusTerminal+Recent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FocusTerminal+Recent.swift"; sourceTree = "<group>"; };
 		EK0000020000000000000001 /* HostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostApp.swift; sourceTree = "<group>"; };
 		F10000020000000000000001 /* Session+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Session+Mock.swift"; sourceTree = "<group>"; };
 		FK0000020000000000000001 /* ForkSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForkSessionTests.swift; sourceTree = "<group>"; };
@@ -234,6 +238,7 @@
 		MIR000020000000000000001 /* MenubarIconRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarIconRenderer.swift; sourceTree = "<group>"; };
 		OB0000020000000000000001 /* OpenCodeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeBanner.swift; sourceTree = "<group>"; };
 		RP0000020000000000000001 /* RecentProject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentProject.swift; sourceTree = "<group>"; };
+		RRT000020000000000000001 /* RecentResumeTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentResumeTarget.swift; sourceTree = "<group>"; };
 		RPM000020000000000000001 /* RecentProject+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentProject+Mock.swift"; sourceTree = "<group>"; };
 		RV0000020000000000000001 /* RecentProjectCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentProjectCardView.swift; sourceTree = "<group>"; };
 		N10000040000000000000001 /* HookEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookEvent.swift; sourceTree = "<group>"; };
@@ -305,6 +310,7 @@
 		PNV000020000000000000001 /* PopupNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupNavigation.swift; sourceTree = "<group>"; };
 		PES000020000000000000001 /* PopupView+EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PopupView+EmptyState.swift"; sourceTree = "<group>"; };
 		PCU000020000000000000001 /* PopupView+Cleanup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PopupView+Cleanup.swift"; sourceTree = "<group>"; };
+		PVR000020000000000000001 /* PopupView+Recent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PopupView+Recent.swift"; sourceTree = "<group>"; };
 		WCV000020000000000000001 /* WorktreeCleanupCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCleanupCardView.swift; sourceTree = "<group>"; };
 		WDV000020000000000000001 /* WorktreeCleanupDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCleanupDetailView.swift; sourceTree = "<group>"; };
 		WTV000020000000000000001 /* WorktreeCleanupTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCleanupTabView.swift; sourceTree = "<group>"; };
@@ -368,6 +374,7 @@
 				EAPPRESTORE0020000000001 /* FocusTerminal+AppRestore.swift */,
 				ECMUX002000000000000001 /* FocusTerminal+Cmux.swift */,
 				EMUX0020000000000000001 /* FocusTerminal+Multiplexer.swift */,
+				ERCT00020000000000000001 /* FocusTerminal+Recent.swift */,
 				SP0000020000000000000001 /* SparkleUpdater.swift */,
 				PM0000020000000000000001 /* PluginManager.swift */,
 				CIM000020000000000000001 /* CodexIntegrationManager.swift */,
@@ -438,6 +445,7 @@
 				TMG000020000000000000001 /* ThemeManager.swift */,
 				K10000020000000000000001 /* Color+Theme.swift */,
 				RP0000020000000000000001 /* RecentProject.swift */,
+				RRT000020000000000000001 /* RecentResumeTarget.swift */,
 				RPM000020000000000000001 /* RecentProject+Mock.swift */,
 				EK0000020000000000000001 /* HostApp.swift */,
 				STC000020000000000000001 /* StatusColors.swift */,
@@ -461,6 +469,7 @@
 				PNV000020000000000000001 /* PopupNavigation.swift */,
 				PES000020000000000000001 /* PopupView+EmptyState.swift */,
 				PCU000020000000000000001 /* PopupView+Cleanup.swift */,
+				PVR000020000000000000001 /* PopupView+Recent.swift */,
 				PVH000020000000000000001 /* PopupViewHelpers.swift */,
 				D1000000A000000000000001 /* QuitButton.swift */,
 				J10000020000000000000001 /* SettingsSection.swift */,
@@ -695,6 +704,7 @@
 				EAPPRESTORE0010000000001 /* FocusTerminal+AppRestore.swift in Sources */,
 				ECMUX001000000000000001 /* FocusTerminal+Cmux.swift in Sources */,
 				EMUX0010000000000000001 /* FocusTerminal+Multiplexer.swift in Sources */,
+				ERCT00010000000000000001 /* FocusTerminal+Recent.swift in Sources */,
 				F10000010000000000000001 /* Session+Mock.swift in Sources */,
 				G10000010000000000000001 /* FloatingPanel.swift in Sources */,
 				G10000030000000000000001 /* AppDelegate.swift in Sources */,
@@ -725,6 +735,7 @@
 				N10000050000000000000001 /* Config.swift in Sources */,
 				SN0000050000000000000001 /* SessionNameLookup.swift in Sources */,
 				RP0000010000000000000001 /* RecentProject.swift in Sources */,
+				RRT000010000000000000001 /* RecentResumeTarget.swift in Sources */,
 				RV0000010000000000000001 /* RecentProjectCardView.swift in Sources */,
 				OB0000010000000000000001 /* OpenCodeBanner.swift in Sources */,
 				AB0000010000000000000001 /* AboutView.swift in Sources */,
@@ -752,6 +763,7 @@
 				PNV000010000000000000001 /* PopupNavigation.swift in Sources */,
 				PES000010000000000000001 /* PopupView+EmptyState.swift in Sources */,
 				PCU000010000000000000001 /* PopupView+Cleanup.swift in Sources */,
+				PVR000010000000000000001 /* PopupView+Recent.swift in Sources */,
 				WCV000010000000000000001 /* WorktreeCleanupCardView.swift in Sources */,
 				WDV000010000000000000001 /* WorktreeCleanupDetailView.swift in Sources */,
 				WTV000010000000000000001 /* WorktreeCleanupTabView.swift in Sources */,

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -49,20 +49,60 @@ enum HostApp: CaseIterable {
     }
 
     /// Stricter program-name match for Recent Projects open targets.
-    static func projectEditor(fromProgramName name: String?) -> HostApp? {
+    static func projectOpener(fromProgramName name: String?) -> HostApp? {
         guard let name, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return nil
         }
         let tokens = Set(name.lowercased().split { !$0.isLetter && !$0.isNumber }.map(String.init))
+        guard tokens.isDisjoint(with: ["claude", "codex", "opencode", "openai"]) else { return nil }
+
         if tokens.contains("cursor") { return .cursor }
         if tokens.contains("windsurf") { return .windsurf }
         if tokens.contains("zed") { return .zed }
         if tokens.contains("vscode") { return .vscode }
-        if tokens.contains("code")
-            && tokens.isDisjoint(with: ["claude", "codex", "opencode", "openai"]) {
-            return .vscode
-        }
+        if tokens.contains("code") { return .vscode }
+        if tokens.contains("iterm") || tokens.contains("iterm2") { return .iterm2 }
+        if tokens.contains("warp") { return .warp }
+        if tokens.contains("terminal") { return .terminal }
+        if tokens.contains("ghostty") { return .ghostty }
+        if tokens.contains("kitty") { return .kitty }
         return nil
+    }
+
+    static func projectOpener(fromBundleIdentifier bundleIdentifier: String?) -> HostApp? {
+        guard let hostApp = from(bundleIdentifier: bundleIdentifier),
+              hostApp.canOpenRecentProject else {
+            return nil
+        }
+        return hostApp
+    }
+
+    var canOpenRecentProject: Bool {
+        switch self {
+        case .vscode, .cursor, .windsurf, .zed,
+             .iterm2, .warp, .terminal, .ghostty, .kitty:
+            return true
+        case .cmux, .claudeDesktop, .codexDesktop, .unknown:
+            return false
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .vscode: return "VS Code"
+        case .cursor: return "Cursor"
+        case .windsurf: return "Windsurf"
+        case .zed: return "Zed"
+        case .iterm2: return "iTerm2"
+        case .warp: return "Warp"
+        case .terminal: return "Terminal"
+        case .ghostty: return "Ghostty"
+        case .kitty: return "Kitty"
+        case .cmux: return "cmux"
+        case .claudeDesktop: return "Claude Desktop"
+        case .codexDesktop: return "Codex Desktop"
+        case .unknown: return "Unknown"
+        }
     }
 
     var bundleID: String? {

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -48,6 +48,23 @@ enum HostApp: CaseIterable {
         return .unknown
     }
 
+    /// Stricter program-name match for Recent Projects open targets.
+    static func projectEditor(fromProgramName name: String?) -> HostApp? {
+        guard let name, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        let tokens = Set(name.lowercased().split { !$0.isLetter && !$0.isNumber }.map(String.init))
+        if tokens.contains("cursor") { return .cursor }
+        if tokens.contains("windsurf") { return .windsurf }
+        if tokens.contains("zed") { return .zed }
+        if tokens.contains("vscode") { return .vscode }
+        if tokens.contains("code")
+            && tokens.isDisjoint(with: ["claude", "codex", "opencode", "openai"]) {
+            return .vscode
+        }
+        return nil
+    }
+
     var bundleID: String? {
         switch self {
         case .vscode: return "com.microsoft.VSCode"

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -256,7 +256,8 @@ extension HostApp {
     /// Returns nil when the app has no session-jump scheme, or `sessionId` isn't a
     /// canonical UUID — the URL handler rejects non-UUID values, so we mirror its
     /// validation client-side and fall back to plain app activation upstream.
-    /// - Codex Desktop: `codex://threads/<uuid>` — navigates to a local conversation.
+    /// - Codex Desktop: `codex://threads/<uuid>` — used for non-archived
+    ///   local conversations. Archived Recent rows intentionally activate only.
     /// - Claude Desktop: no deep link. `claude://resume?session=<uuid>` exists but
     ///   forks the conversation rather than focusing the existing one, which would
     ///   silently pollute the user's history. We just activate the app instead.

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -62,7 +62,7 @@ enum HostApp: CaseIterable {
         if tokens.contains("vscode") { return .vscode }
         if tokens.contains("code") { return .vscode }
         if tokens.contains("iterm") || tokens.contains("iterm2") { return .iterm2 }
-        if tokens.contains("warp") { return .warp }
+        if tokens.contains("warp") || tokens.contains("warpterminal") { return .warp }
         if tokens.contains("terminal") { return .terminal }
         if tokens.contains("ghostty") { return .ghostty }
         if tokens.contains("kitty") { return .kitty }

--- a/menubar/CctopMenubar/Models/RecentProject+Mock.swift
+++ b/menubar/CctopMenubar/Models/RecentProject+Mock.swift
@@ -7,6 +7,7 @@ extension RecentProject {
         daysAgo: Int = 1,
         sessionCount: Int = 3,
         editor: String? = "Cursor",
+        agent: String? = "Codex",
         workspaceFile: String? = nil
     ) -> RecentProject {
         RecentProject(
@@ -16,20 +17,21 @@ extension RecentProject {
             lastSessionAt: Date().addingTimeInterval(TimeInterval(-daysAgo * 86400)),
             sessionCount: sessionCount,
             lastEditor: editor,
+            lastAgent: agent,
             workspaceFile: workspaceFile
         )
     }
 
     static let mockRecents: [RecentProject] = [
         .mock(project: "billing-api", branch: "feature/invoices",
-              daysAgo: 0, sessionCount: 12, editor: "Cursor"),
+              daysAgo: 0, sessionCount: 12, editor: "Cursor", agent: "Codex"),
         .mock(project: "landing-page", branch: "redesign",
-              daysAgo: 1, sessionCount: 5, editor: "Code"),
+              daysAgo: 1, sessionCount: 5, editor: "Code", agent: "Claude Code"),
         .mock(project: "infra", branch: "main",
-              daysAgo: 3, sessionCount: 8, editor: "iTerm2"),
+              daysAgo: 3, sessionCount: 8, editor: nil, agent: "opencode"),
         .mock(project: "mobile-app", branch: "release/2.0",
-              daysAgo: 5, sessionCount: 2, editor: "Cursor"),
+              daysAgo: 5, sessionCount: 2, editor: "Cursor", agent: "pi"),
         .mock(project: "data-pipeline", branch: "fix/backfill",
-              daysAgo: 7, sessionCount: 1, editor: nil),
+              daysAgo: 7, sessionCount: 1, editor: nil, agent: "Claude Code"),
     ]
 }

--- a/menubar/CctopMenubar/Models/RecentProject.swift
+++ b/menubar/CctopMenubar/Models/RecentProject.swift
@@ -17,12 +17,12 @@ struct RecentProject: Identifiable, Equatable {
     }
 
     var editorIcon: String {
-        guard let editorHostApp else { return "folder" }
-        return editorHostApp.sfSymbol
+        guard let openerHostApp else { return "folder" }
+        return openerHostApp.sfSymbol
     }
 
-    var opensWithProjectEditor: Bool {
-        editorHostApp != nil
+    var opensWithProjectApp: Bool {
+        openerHostApp != nil
     }
 
     var openActionLabel: String {
@@ -59,10 +59,9 @@ struct RecentProject: Identifiable, Equatable {
         return parts
     }
 
-    static func projectEditorName(from terminal: TerminalInfo?) -> String? {
-        guard let program = terminal?.program, !program.isEmpty else { return nil }
-        guard HostApp.projectEditor(fromProgramName: program) != nil else { return nil }
-        return program
+    static func projectOpenerName(from terminal: TerminalInfo?) -> String? {
+        guard let hostApp = projectOpener(from: terminal) else { return nil }
+        return hostApp.displayName
     }
 
     static func agentName(from session: Session) -> String? {
@@ -78,18 +77,18 @@ struct RecentProject: Identifiable, Equatable {
         }
     }
 
-    private var editorHostApp: HostApp? {
-        HostApp.projectEditor(fromProgramName: lastEditor)
+    private static func projectOpener(from terminal: TerminalInfo?) -> HostApp? {
+        guard let terminal else { return nil }
+        return HostApp.projectOpener(fromBundleIdentifier: terminal.bundleId)
+            ?? HostApp.projectOpener(fromProgramName: terminal.program)
+    }
+
+    private var openerHostApp: HostApp? {
+        HostApp.projectOpener(fromProgramName: lastEditor)
     }
 
     private var openerName: String? {
-        switch editorHostApp {
-        case .vscode?: return "VS Code"
-        case .cursor?: return "Cursor"
-        case .windsurf?: return "Windsurf"
-        case .zed?: return "Zed"
-        default: return nil
-        }
+        openerHostApp?.displayName
     }
 
     private var displayBranch: String? {

--- a/menubar/CctopMenubar/Models/RecentProject.swift
+++ b/menubar/CctopMenubar/Models/RecentProject.swift
@@ -7,6 +7,7 @@ struct RecentProject: Identifiable, Equatable {
     let lastSessionAt: Date
     let sessionCount: Int
     let lastEditor: String?
+    let lastAgent: String?
     let workspaceFile: String?
 
     var id: String { projectPath }
@@ -16,6 +17,93 @@ struct RecentProject: Identifiable, Equatable {
     }
 
     var editorIcon: String {
-        HostApp.from(editorName: lastEditor).sfSymbol
+        guard let editorHostApp else { return "folder" }
+        return editorHostApp.sfSymbol
+    }
+
+    var opensWithProjectEditor: Bool {
+        editorHostApp != nil
+    }
+
+    var openActionLabel: String {
+        guard let openerName else { return "Open Project Folder" }
+        return "Open in \(openerName)"
+    }
+
+    var openHelpText: String {
+        guard let openerName else { return "Click to open project folder" }
+        return "Click to open project in \(openerName)"
+    }
+
+    var metadataText: String {
+        metadataParts.joined(separator: " \u{00B7} ")
+    }
+
+    var pathContext: String {
+        compactProjectPath
+    }
+
+    var metadataEvidenceText: String {
+        metadataEvidenceParts.joined(separator: " \u{00B7} ")
+    }
+
+    var metadataParts: [String] {
+        [pathContext] + metadataEvidenceParts
+    }
+
+    private var metadataEvidenceParts: [String] {
+        var parts: [String] = []
+        if let displayBranch { parts.append(displayBranch) }
+        if let lastAgent { parts.append(lastAgent) }
+        parts.append("\(sessionCount) session\(sessionCount == 1 ? "" : "s")")
+        return parts
+    }
+
+    static func projectEditorName(from terminal: TerminalInfo?) -> String? {
+        guard let program = terminal?.program, !program.isEmpty else { return nil }
+        guard HostApp.projectEditor(fromProgramName: program) != nil else { return nil }
+        return program
+    }
+
+    static func agentName(from session: Session) -> String? {
+        if session.isCodexDesktopHost { return "Codex Desktop" }
+        if session.isClaudeDesktopHost { return "Claude Desktop" }
+        switch session.source {
+        case Session.codexSource?: return "Codex"
+        case Session.ccSource?: return "Claude Code"
+        case Session.opencodeSource?: return "opencode"
+        case Session.piSource?: return "pi"
+        case .some(let source) where !source.isEmpty: return source
+        default: return nil
+        }
+    }
+
+    private var editorHostApp: HostApp? {
+        HostApp.projectEditor(fromProgramName: lastEditor)
+    }
+
+    private var openerName: String? {
+        switch editorHostApp {
+        case .vscode?: return "VS Code"
+        case .cursor?: return "Cursor"
+        case .windsurf?: return "Windsurf"
+        case .zed?: return "Zed"
+        default: return nil
+        }
+    }
+
+    private var displayBranch: String? {
+        let trimmed = lastBranch.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.lowercased() != "unknown" else { return nil }
+        return trimmed
+    }
+
+    private var compactProjectPath: String {
+        let home = NSHomeDirectory()
+        if projectPath == home { return "~" }
+        if projectPath.hasPrefix(home + "/") {
+            return "~" + String(projectPath.dropFirst(home.count))
+        }
+        return projectPath
     }
 }

--- a/menubar/CctopMenubar/Models/RecentResumeTarget.swift
+++ b/menubar/CctopMenubar/Models/RecentResumeTarget.swift
@@ -144,6 +144,9 @@ enum RecentResumeTarget: Identifiable, Equatable {
                   let thread = DesktopThread(session: record.candidate.session, sourceApp: sourceApp) else {
                 continue
             }
+            if shouldSkipArchivedCodexDesktopThread(thread.sessionId, sourceApp: sourceApp, evidence: classification.evidence) {
+                continue
+            }
             let target = RecentResumeTarget.desktopThread(thread)
             if let existing = targetsByID[target.id],
                existing.lastSessionAt >= target.lastSessionAt {
@@ -165,6 +168,15 @@ enum RecentResumeTarget: Identifiable, Equatable {
              .orphanedEndedClaudeDesktop, .claudeDesktopStartupPlaceholder:
             return nil
         }
+    }
+
+    private static func shouldSkipArchivedCodexDesktopThread(
+        _ sessionId: String,
+        sourceApp: HostApp,
+        evidence: SessionClassificationEvidence
+    ) -> Bool {
+        guard sourceApp == .codexDesktop else { return false }
+        return evidence.codexSubagentThreadIDs.contains(sessionId) || evidence.codexExecHelperThreadIDs.contains(sessionId)
     }
 
     private static func joinedMetadata(_ parts: [String]) -> String {

--- a/menubar/CctopMenubar/Models/RecentResumeTarget.swift
+++ b/menubar/CctopMenubar/Models/RecentResumeTarget.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+enum RecentResumeTarget: Identifiable, Equatable {
+    struct DesktopThread: Equatable {
+        let sessionId: String
+        let title: String
+        let projectPath: String
+        let projectName: String
+        let sourceApp: HostApp
+        let lastActiveAt: Date
+    }
+
+    case project(RecentProject)
+    case desktopThread(DesktopThread)
+
+    var id: String {
+        switch self {
+        case .project(let project):
+            return "project:\(project.id)"
+        case .desktopThread(let thread):
+            return "desktop:\(thread.sourceApp.displayName):\(thread.sessionId)"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .project(let project):
+            return project.projectName
+        case .desktopThread(let thread):
+            return thread.title
+        }
+    }
+
+    var projectPath: String {
+        switch self {
+        case .project(let project):
+            return project.projectPath
+        case .desktopThread(let thread):
+            return thread.projectPath
+        }
+    }
+
+    var lastSessionAt: Date {
+        switch self {
+        case .project(let project):
+            return project.lastSessionAt
+        case .desktopThread(let thread):
+            return thread.lastActiveAt
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .project(let project):
+            return project.editorIcon
+        case .desktopThread(let thread):
+            return thread.sourceApp.sfSymbol
+        }
+    }
+
+    var opensProjectInApp: Bool {
+        switch self {
+        case .project(let project):
+            return project.opensWithProjectApp
+        case .desktopThread:
+            return false
+        }
+    }
+
+    var showsFinderAction: Bool {
+        switch self {
+        case .project:
+            return opensProjectInApp
+        case .desktopThread:
+            return false
+        }
+    }
+
+    var showsCopyPathAction: Bool {
+        switch self {
+        case .project:
+            return true
+        case .desktopThread:
+            return false
+        }
+    }
+
+    var openActionLabel: String {
+        switch self {
+        case .project(let project):
+            return project.openActionLabel
+        case .desktopThread(let thread):
+            return "Open \(thread.sourceApp.displayName)"
+        }
+    }
+
+    var inlineActionLabel: String? {
+        switch self {
+        case .project:
+            return nil
+        case .desktopThread(let thread) where thread.sourceApp == .codexDesktop:
+            return "Open Codex"
+        case .desktopThread(let thread) where thread.sourceApp == .claudeDesktop:
+            return "Open Claude"
+        case .desktopThread(let thread):
+            return "Open \(thread.sourceApp.displayName)"
+        }
+    }
+
+    var openHelpText: String {
+        switch self {
+        case .project(let project):
+            return project.openHelpText
+        case .desktopThread(let thread):
+            return "Open \(thread.sourceApp.displayName) to find this archived session"
+        }
+    }
+
+    var metadataText: String {
+        switch self {
+        case .project(let project):
+            return Self.joinedMetadata([project.metadataEvidenceText, project.pathContext])
+        case .desktopThread(let thread):
+            return Self.joinedMetadata(["Archived", thread.sourceApp.shortDesktopName, Self.compactProjectPath(thread.projectPath)])
+        }
+    }
+
+    static func build(
+        projects: [RecentProject],
+        classification: SessionClassificationSnapshot,
+        limit: Int = 10
+    ) -> [RecentResumeTarget] {
+        let projectTargets = projects.map(RecentResumeTarget.project)
+        let desktopTargets = desktopThreadTargets(from: classification)
+        return Array((projectTargets + desktopTargets)
+            .sorted { $0.lastSessionAt > $1.lastSessionAt }
+            .prefix(limit))
+    }
+
+    private static func desktopThreadTargets(from classification: SessionClassificationSnapshot) -> [RecentResumeTarget] {
+        var targetsByID: [String: RecentResumeTarget] = [:]
+        for record in classification.records {
+            guard let sourceApp = desktopThreadSourceApp(for: record.disposition),
+                  let thread = DesktopThread(session: record.candidate.session, sourceApp: sourceApp) else {
+                continue
+            }
+            let target = RecentResumeTarget.desktopThread(thread)
+            if let existing = targetsByID[target.id],
+               existing.lastSessionAt >= target.lastSessionAt {
+                continue
+            }
+            targetsByID[target.id] = target
+        }
+        return Array(targetsByID.values)
+    }
+
+    private static func desktopThreadSourceApp(for disposition: SessionDisposition) -> HostApp? {
+        guard case .hidden(let reason) = disposition else { return nil }
+        switch reason {
+        case .archivedCodexDesktop:
+            return .codexDesktop
+        case .archivedClaudeDesktop:
+            return .claudeDesktop
+        case .persistedHidden, .autoHidden, .missingCodexDesktopThread, .codexSubagent, .codexExecHelper,
+             .orphanedEndedClaudeDesktop, .claudeDesktopStartupPlaceholder:
+            return nil
+        }
+    }
+
+    private static func joinedMetadata(_ parts: [String]) -> String {
+        parts
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " \u{00B7} ")
+    }
+
+    private static func compactProjectPath(_ path: String) -> String {
+        let home = NSHomeDirectory()
+        if path == home { return "~" }
+        if path.hasPrefix(home + "/") {
+            return "~" + String(path.dropFirst(home.count))
+        }
+        return path
+    }
+}
+
+extension RecentResumeTarget.DesktopThread {
+    init?(session: Session, sourceApp: HostApp) {
+        let title = Self.displayTitle(for: session)
+        guard !title.isEmpty else { return nil }
+        self.init(
+            sessionId: session.sessionId,
+            title: title,
+            projectPath: session.projectPath,
+            projectName: session.desktopProjectName ?? session.projectName,
+            sourceApp: sourceApp,
+            lastActiveAt: session.effectiveEndDate
+        )
+    }
+
+    private static func displayTitle(for session: Session) -> String {
+        [
+            session.sessionName,
+            session.lastPrompt,
+            session.desktopProjectName,
+            session.projectName,
+        ]
+        .compactMap { value -> String? in
+            let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return trimmed.isEmpty ? nil : trimmed
+        }
+        .first ?? ""
+    }
+}
+
+private extension HostApp {
+    var shortDesktopName: String {
+        switch self {
+        case .codexDesktop:
+            return "Codex"
+        case .claudeDesktop:
+            return "Claude"
+        default:
+            return displayName
+        }
+    }
+}

--- a/menubar/CctopMenubar/Services/FocusTerminal+Recent.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal+Recent.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+func resolveRecentResumeTargetOpenStrategy(target: RecentResumeTarget) -> FocusStrategy {
+    switch target {
+    case .project(let project):
+        return resolveRecentProjectOpenStrategy(project: project)
+    case .desktopThread(let thread):
+        guard let bundleID = thread.sourceApp.bundleID else {
+            return .openInFinder(thread.projectPath)
+        }
+        // Archived desktop rows are manual find/unarchive aids. Codex thread URLs
+        // can foreground the app without landing on the archived thread.
+        return .activateByBundleID(bundleID)
+    }
+}

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -461,15 +461,20 @@ private func executeKittyFocusWindow(binaryPath: String, socket: String, windowI
 // MARK: - Open recent project in editor
 
 func resolveRecentProjectOpenStrategy(project: RecentProject) -> FocusStrategy {
-    guard let editor = project.lastEditor,
-          let hostApp = HostApp.projectEditor(fromProgramName: editor),
+    guard let opener = project.lastEditor,
+          let hostApp = HostApp.projectOpener(fromProgramName: opener),
           let bundleID = hostApp.bundleID else {
         return .openInFinder(project.projectPath)
     }
 
-    let target = project.workspaceFile
-        ?? Session.findWorkspaceFile(in: project.projectPath)
-        ?? project.projectPath
+    let target: String
+    if hostApp.usesWorkspaceFile {
+        target = project.workspaceFile
+            ?? Session.findWorkspaceFile(in: project.projectPath)
+            ?? project.projectPath
+    } else {
+        target = project.projectPath
+    }
     return .openWithApp(bundleID: bundleID, target: target)
 }
 

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -460,41 +460,19 @@ private func executeKittyFocusWindow(binaryPath: String, socket: String, windowI
 
 // MARK: - Open recent project in editor
 
+func resolveRecentProjectOpenStrategy(project: RecentProject) -> FocusStrategy {
+    guard let editor = project.lastEditor,
+          let hostApp = HostApp.projectEditor(fromProgramName: editor),
+          let bundleID = hostApp.bundleID else {
+        return .openInFinder(project.projectPath)
+    }
+
+    let target = project.workspaceFile
+        ?? Session.findWorkspaceFile(in: project.projectPath)
+        ?? project.projectPath
+    return .openWithApp(bundleID: bundleID, target: target)
+}
+
 func openInEditor(project: RecentProject) {
-    guard let editor = project.lastEditor, !editor.isEmpty else {
-        NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: project.projectPath)
-        return
-    }
-
-    let hostApp = HostApp.from(editorName: editor)
-
-    // For code editors, prefer stored workspace file, fallback to dynamic lookup
-    let target: String
-    if hostApp.usesWorkspaceFile {
-        target = project.workspaceFile
-            ?? Session.findWorkspaceFile(in: project.projectPath)
-            ?? project.projectPath
-    } else {
-        target = project.projectPath
-    }
-
-    // Try bundle ID launch first
-    if let bundleID = hostApp.bundleID,
-       let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
-        NSWorkspace.shared.open(
-            [URL(fileURLWithPath: target)],
-            withApplicationAt: appURL,
-            configuration: NSWorkspace.OpenConfiguration()
-        )
-        return
-    }
-
-    // Fallback: try `open -a <editor> <path>`
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-    process.arguments = ["-a", editor, target]
-    if (try? process.run()) != nil { return }
-
-    // Final fallback: open in Finder
-    NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: project.projectPath)
+    executeFocusStrategy(resolveRecentProjectOpenStrategy(project: project))
 }

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -481,3 +481,7 @@ func resolveRecentProjectOpenStrategy(project: RecentProject) -> FocusStrategy {
 func openInEditor(project: RecentProject) {
     executeFocusStrategy(resolveRecentProjectOpenStrategy(project: project))
 }
+
+func openRecentResumeTarget(_ target: RecentResumeTarget) {
+    executeFocusStrategy(resolveRecentResumeTargetOpenStrategy(target: target))
+}

--- a/menubar/CctopMenubar/Services/HistoryManager.swift
+++ b/menubar/CctopMenubar/Services/HistoryManager.swift
@@ -84,38 +84,76 @@ class HistoryManager: ObservableObject {
     /// filter active, sort by date, cap at 10.
     static func buildRecentProjects(
         from sessions: [Session],
-        excludingActive activePaths: Set<String> = []
+        excludingActive activePaths: Set<String> = [],
+        projectPathExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
     ) -> [RecentProject] {
-        var grouped: [String: (latest: Session, count: Int)] = [:]
+        let activeProjectPaths = Set(activePaths.map(canonicalRecentProjectPath))
+        var grouped: [String: (latest: Session, count: Int, projectPath: String)] = [:]
         for session in sessions {
             if session.isHostedByDesktopApp { continue }
-            if let existing = grouped[session.projectPath] {
+            let canonicalProjectPath = canonicalRecentProjectPath(session.projectPath)
+            guard isDurableRecentProjectPath(canonicalProjectPath, projectPathExists: projectPathExists) else {
+                continue
+            }
+            if activeProjectPaths.contains(canonicalProjectPath) { continue }
+            if let existing = grouped[canonicalProjectPath] {
                 let newer = session.effectiveEndDate > existing.latest.effectiveEndDate
-                grouped[session.projectPath] = (
+                grouped[canonicalProjectPath] = (
                     latest: newer ? session : existing.latest,
-                    count: existing.count + 1
+                    count: existing.count + 1,
+                    projectPath: canonicalProjectPath
                 )
             } else {
-                grouped[session.projectPath] = (latest: session, count: 1)
+                grouped[canonicalProjectPath] = (latest: session, count: 1, projectPath: canonicalProjectPath)
             }
         }
 
         return grouped.values
-            .filter { !activePaths.contains($0.latest.projectPath) }
             .sorted { $0.latest.effectiveEndDate > $1.latest.effectiveEndDate }
             .prefix(10)
             .map { entry in
                 RecentProject(
-                    projectPath: entry.latest.projectPath,
+                    projectPath: entry.projectPath,
                     projectName: entry.latest.projectName,
                     lastBranch: entry.latest.branch,
                     lastSessionAt: entry.latest.effectiveEndDate,
                     sessionCount: entry.count,
-                    lastEditor: RecentProject.projectEditorName(from: entry.latest.terminal),
+                    lastEditor: RecentProject.projectOpenerName(from: entry.latest.terminal),
                     lastAgent: RecentProject.agentName(from: entry.latest),
                     workspaceFile: entry.latest.workspaceFile
                 )
             }
+    }
+
+    static func isDurableRecentProjectPath(
+        _ path: String,
+        projectPathExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    ) -> Bool {
+        let canonicalPath = canonicalRecentProjectPath(path)
+        guard projectPathExists(canonicalPath) else { return false }
+        return !nonDurableRecentProjectRootPaths.contains { root in
+            canonicalPath == root || canonicalPath.hasPrefix(root + "/")
+        }
+    }
+
+    static func canonicalRecentProjectPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
+    private static var nonDurableRecentProjectRootPaths: [String] {
+        [
+            "/tmp",
+            "/private/tmp",
+            NSTemporaryDirectory(),
+            "/var/folders",
+            NSHomeDirectory() + "/Library/Caches",
+            NSHomeDirectory() + "/.cache",
+        ].flatMap(comparableRecentProjectPaths)
+    }
+
+    private static func comparableRecentProjectPaths(_ path: String) -> [String] {
+        let trimmed = path.hasSuffix("/") ? String(path.dropLast()) : path
+        return Array(Set([trimmed, canonicalRecentProjectPath(trimmed)]))
     }
 
     // MARK: - Internal (testable)

--- a/menubar/CctopMenubar/Services/HistoryManager.swift
+++ b/menubar/CctopMenubar/Services/HistoryManager.swift
@@ -111,7 +111,8 @@ class HistoryManager: ObservableObject {
                     lastBranch: entry.latest.branch,
                     lastSessionAt: entry.latest.effectiveEndDate,
                     sessionCount: entry.count,
-                    lastEditor: entry.latest.terminal?.program,
+                    lastEditor: RecentProject.projectEditorName(from: entry.latest.terminal),
+                    lastAgent: RecentProject.agentName(from: entry.latest),
                     workspaceFile: entry.latest.workspaceFile
                 )
             }

--- a/menubar/CctopMenubar/Services/HistoryManager.swift
+++ b/menubar/CctopMenubar/Services/HistoryManager.swift
@@ -132,8 +132,12 @@ class HistoryManager: ObservableObject {
     ) -> Bool {
         let canonicalPath = canonicalRecentProjectPath(path)
         guard projectPathExists(canonicalPath) else { return false }
-        if nonProjectRecentProjectPaths.contains(canonicalPath) { return false }
-        return !nonDurableRecentProjectRootPaths.contains { root in
+        return !isExcludedRecentProjectPath(canonicalPath)
+    }
+
+    private static func isExcludedRecentProjectPath(_ canonicalPath: String) -> Bool {
+        if nonProjectRecentProjectPaths.contains(canonicalPath) { return true }
+        return nonDurableRecentProjectRootPaths.contains { root in
             canonicalPath == root || canonicalPath.hasPrefix(root + "/")
         }
     }
@@ -203,38 +207,38 @@ class HistoryManager: ObservableObject {
     }
 
     func filesToPrune(
-        from decoded: [(url: URL, session: Session)]
+        from decoded: [(url: URL, session: Session)],
+        projectPathExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
     ) -> [URL] {
         var seenProjects: Set<String> = []
-        var toKeep: [(url: URL, session: Session)] = []
+        var capEligibleKeep: [(url: URL, session: Session)] = []
         var toRemove: [URL] = []
-
-        // Keep only the most recent entry per project
-        for entry in decoded {
-            if seenProjects.contains(entry.session.projectPath) {
-                toRemove.append(entry.url)
-            } else {
-                seenProjects.insert(entry.session.projectPath)
-                toKeep.append(entry)
-            }
-        }
-
-        // Remove entries older than maxAgeDays
         let cutoff = Date().addingTimeInterval(
             TimeInterval(-Self.maxAgeDays * 86400)
         )
-        var finalKeep: [(url: URL, session: Session)] = []
-        for entry in toKeep {
-            if entry.session.effectiveEndDate < cutoff {
+
+        // Keep only the most recent entry per canonical project path. Paths that
+        // can never become Recent rows are pruned; currently missing project paths
+        // are preserved for restore, but do not count against the durable-project cap.
+        for entry in decoded {
+            let canonicalPath = Self.canonicalRecentProjectPath(entry.session.projectPath)
+            if entry.session.isHostedByDesktopApp || Self.isExcludedRecentProjectPath(canonicalPath) {
+                toRemove.append(entry.url)
+            } else if seenProjects.contains(canonicalPath) {
+                toRemove.append(entry.url)
+            } else if entry.session.effectiveEndDate < cutoff {
                 toRemove.append(entry.url)
             } else {
-                finalKeep.append(entry)
+                seenProjects.insert(canonicalPath)
+                if projectPathExists(canonicalPath) {
+                    capEligibleKeep.append(entry)
+                }
             }
         }
 
-        // If still over maxFiles, remove oldest
-        if finalKeep.count > Self.maxFiles {
-            toRemove.append(contentsOf: finalKeep[Self.maxFiles...].map(\.url))
+        // If still over maxFiles, remove oldest durable project entries.
+        if capEligibleKeep.count > Self.maxFiles {
+            toRemove.append(contentsOf: capEligibleKeep[Self.maxFiles...].map(\.url))
         }
         return toRemove
     }

--- a/menubar/CctopMenubar/Services/HistoryManager.swift
+++ b/menubar/CctopMenubar/Services/HistoryManager.swift
@@ -63,12 +63,13 @@ class HistoryManager: ObservableObject {
     func rebuildRecentProjects(
         excludingActive activePaths: Set<String> = []
     ) -> Bool {
-        let fingerprint = historyFingerprint(excludingActive: activePaths)
+        let decoded = loadDecodedHistoryFiles()
+        let fingerprint = historyFingerprint(from: decoded, excludingActive: activePaths)
         if let fingerprint, fingerprint == lastRebuildFingerprint {
             return false
         }
 
-        let sessions = loadDecodedHistoryFiles().map(\.session)
+        let sessions = decoded.map(\.session)
         lastDecodedHistorySessions = sessions
         let nextRecentProjects = Self.buildRecentProjects(
             from: sessions, excludingActive: activePaths
@@ -250,7 +251,10 @@ class HistoryManager: ObservableObject {
         }
     }
 
-    private func historyFingerprint(excludingActive activePaths: Set<String>) -> HistoryRebuildFingerprint? {
+    private func historyFingerprint(
+        from decoded: [(url: URL, session: Session)],
+        excludingActive activePaths: Set<String>
+    ) -> HistoryRebuildFingerprint? {
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(
             at: historyDir,
@@ -271,7 +275,24 @@ class HistoryManager: ObservableObject {
             ))
         }
         files.sort { $0.path < $1.path }
-        return HistoryRebuildFingerprint(files: files, activePaths: activePaths)
+        return HistoryRebuildFingerprint(
+            files: files,
+            activePaths: activePaths,
+            projectPaths: recentProjectPathFingerprints(from: decoded.map(\.session))
+        )
+    }
+
+    private func recentProjectPathFingerprints(from sessions: [Session]) -> [HistoryProjectPathFingerprint] {
+        var states: [String: Bool] = [:]
+        for session in sessions where !session.isHostedByDesktopApp {
+            let canonicalPath = Self.canonicalRecentProjectPath(session.projectPath)
+            if states[canonicalPath] == nil {
+                states[canonicalPath] = Self.isDurableRecentProjectPath(canonicalPath)
+            }
+        }
+        return states
+            .map { HistoryProjectPathFingerprint(path: $0.key, isDurable: $0.value) }
+            .sorted { $0.path < $1.path }
     }
 
     private func sanitizeFilenameComponent(_ name: String) -> String {
@@ -298,10 +319,16 @@ private extension ISO8601DateFormatter {
 private struct HistoryRebuildFingerprint: Equatable {
     let files: [HistoryFileFingerprint]
     let activePaths: Set<String>
+    let projectPaths: [HistoryProjectPathFingerprint]
 }
 
 private struct HistoryFileFingerprint: Equatable {
     let path: String
     let modificationDate: Date
     let fileSize: Int
+}
+
+private struct HistoryProjectPathFingerprint: Equatable {
+    let path: String
+    let isDurable: Bool
 }

--- a/menubar/CctopMenubar/Services/HistoryManager.swift
+++ b/menubar/CctopMenubar/Services/HistoryManager.swift
@@ -131,6 +131,7 @@ class HistoryManager: ObservableObject {
     ) -> Bool {
         let canonicalPath = canonicalRecentProjectPath(path)
         guard projectPathExists(canonicalPath) else { return false }
+        if nonProjectRecentProjectPaths.contains(canonicalPath) { return false }
         return !nonDurableRecentProjectRootPaths.contains { root in
             canonicalPath == root || canonicalPath.hasPrefix(root + "/")
         }
@@ -151,8 +152,16 @@ class HistoryManager: ObservableObject {
         ].flatMap(comparableRecentProjectPaths)
     }
 
+    private static var nonProjectRecentProjectPaths: Set<String> {
+        Set([
+            "/",
+            NSHomeDirectory(),
+            NSHomeDirectory() + "/projects",
+        ].flatMap(comparableRecentProjectPaths))
+    }
+
     private static func comparableRecentProjectPaths(_ path: String) -> [String] {
-        let trimmed = path.hasSuffix("/") ? String(path.dropLast()) : path
+        let trimmed = path == "/" ? path : (path.hasSuffix("/") ? String(path.dropLast()) : path)
         return Array(Set([trimmed, canonicalRecentProjectPath(trimmed)]))
     }
 

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -15,6 +15,7 @@ struct WorktreeCleanupSessionSnapshot {
 // swiftlint:disable:next type_body_length
 class SessionManager: ObservableObject {
     @Published var sessions: [Session] = []
+    @Published var recentResumeTargets: [RecentResumeTarget] = []
 
     let historyManager: HistoryManager
     let dataSources: SessionDataSources
@@ -69,6 +70,7 @@ class SessionManager: ObservableObject {
             lastLoadLogSignature = nil
             sessionFileCache.removeAll()
             sessions = []
+            publishRecentResumeTargets(historyManager.recentProjects.map(RecentResumeTarget.project))
             return
         }
 
@@ -118,7 +120,14 @@ class SessionManager: ObservableObject {
         archiveAndRemoveFinishedNonDesktop(classification.finishedNonDesktopCandidates, winners: winners)
         let activeProjectPaths = classification.protectedProjectPathsForCleanup
         _ = historyManager.rebuildRecentProjects(excludingActive: activeProjectPaths)
+        publishRecentResumeTargets(RecentResumeTarget.build(projects: historyManager.recentProjects, classification: classification))
         refreshCleanupSources(from: classification.cleanupSources, activeProjectPaths: activeProjectPaths)
+    }
+
+    private func publishRecentResumeTargets(_ targets: [RecentResumeTarget]) {
+        if targets != recentResumeTargets {
+            recentResumeTargets = targets
+        }
     }
 
     func cleanupSnapshotForRemoval() -> WorktreeCleanupSessionSnapshot {

--- a/menubar/CctopMenubar/Views/PopupNavigation.swift
+++ b/menubar/CctopMenubar/Views/PopupNavigation.swift
@@ -37,19 +37,32 @@ enum PopupTab {
 struct PopupSelectionContext {
     let activeSessions: [Session]
     let idleSessions: [Session]
-    let recentProjects: [RecentProject]
+    let recentTargets: [RecentResumeTarget]
     let cleanupCandidates: [WorktreeCleanupCandidate]
+
+    init(
+        activeSessions: [Session],
+        idleSessions: [Session],
+        recentProjects: [RecentProject] = [],
+        recentResumeTargets: [RecentResumeTarget]? = nil,
+        cleanupCandidates: [WorktreeCleanupCandidate]
+    ) {
+        self.activeSessions = activeSessions
+        self.idleSessions = idleSessions
+        self.recentTargets = recentResumeTargets ?? recentProjects.map(RecentResumeTarget.project)
+        self.cleanupCandidates = cleanupCandidates
+    }
 }
 
 enum PopupSelectionTarget: Equatable {
     case activeSession(Session)
     case idleSession(Session)
-    case recentProject(RecentProject)
+    case recentTarget(RecentResumeTarget)
     case cleanupCandidate(WorktreeCleanupCandidate)
 
     var confirmsNavigate: Bool {
         switch self {
-        case .activeSession, .idleSession, .recentProject:
+        case .activeSession, .idleSession, .recentTarget:
             return true
         case .cleanupCandidate:
             return false
@@ -69,8 +82,8 @@ enum PopupSelectionTarget: Equatable {
             guard index < context.idleSessions.count else { return nil }
             return .idleSession(context.idleSessions[index])
         case .recent:
-            guard index < context.recentProjects.count else { return nil }
-            return .recentProject(context.recentProjects[index])
+            guard index < context.recentTargets.count else { return nil }
+            return .recentTarget(context.recentTargets[index])
         case .cleanup:
             guard index < context.cleanupCandidates.count else { return nil }
             return .cleanupCandidate(context.cleanupCandidates[index])

--- a/menubar/CctopMenubar/Views/PopupNavigation.swift
+++ b/menubar/CctopMenubar/Views/PopupNavigation.swift
@@ -5,12 +5,12 @@ enum PopupTab {
 
     static func availableTabs(
         hasIdleSessions: Bool,
-        hasRecentProjects: Bool,
+        hasRecentProjects _: Bool,
         hasCleanupCandidates: Bool
     ) -> [PopupTab] {
         var tabs: [PopupTab] = [.active]
         if hasIdleSessions { tabs.append(.idle) }
-        if hasRecentProjects { tabs.append(.recent) }
+        tabs.append(.recent)
         tabs.append(.cleanup)
         return tabs
     }

--- a/menubar/CctopMenubar/Views/PopupView+Recent.swift
+++ b/menubar/CctopMenubar/Views/PopupView+Recent.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+extension PopupView {
+    @ViewBuilder
+    var recentContent: some View {
+        if recentTargets.isEmpty {
+            emptyPlaceholder(systemImage: "clock", title: "No recent items yet\nFinished projects and archived sessions appear here")
+        } else {
+            panelList(recentTargets, tab: .recent) { _, target, isSelected in
+                recentCard(target, isSelected: isSelected)
+            }
+        }
+    }
+
+    var recentTargets: [RecentResumeTarget] {
+        recentResumeTargets ?? recentProjects.map(RecentResumeTarget.project)
+    }
+
+    func recentCard(_ target: RecentResumeTarget, isSelected: Bool = false) -> some View {
+        RecentProjectCardView(target: target, isSelected: isSelected, relativeTimeNow: relativeTimeNow)
+            .contentShape(Rectangle())
+            .onTapGesture { openRecentResumeTarget(target); NSApp.deactivate() }
+            .contextMenu {
+                Button { openRecentResumeTarget(target); NSApp.deactivate() } label: {
+                    Label(target.openActionLabel, systemImage: target.icon)
+                }
+                if target.showsFinderAction {
+                    Button { openInFinder(path: target.projectPath) } label: { Label("Open Project in Finder", systemImage: "folder") }
+                }
+                if target.showsCopyPathAction {
+                    Button { copyPath(target.projectPath) } label: {
+                        Label("Copy Project Path", systemImage: "doc.on.doc")
+                    }
+                }
+            }
+            .help(target.openHelpText)
+    }
+}

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -210,16 +210,16 @@ struct PopupView: View {
             .onTapGesture { openInEditor(project: project); NSApp.deactivate() }
             .contextMenu {
                 Button { openInEditor(project: project); NSApp.deactivate() } label: {
-                    Label("Open in Editor", systemImage: "macwindow")
+                    Label(project.openActionLabel, systemImage: project.editorIcon)
                 }
-                Button { openInFinder(path: project.projectPath) } label: {
-                    Label("Open in Finder", systemImage: "folder")
+                if project.opensWithProjectEditor {
+                    Button { openInFinder(path: project.projectPath) } label: { Label("Open in Finder", systemImage: "folder") }
                 }
                 Button { copyPath(project.projectPath) } label: {
                     Label("Copy Project Path", systemImage: "doc.on.doc")
                 }
             }
-            .help("Click to open in \(project.lastEditor ?? "editor")")
+            .help(project.openHelpText)
     }
 
     private func sessionList(_ list: [Session], tab: PopupTab, showNavigateNumbers: Bool = false) -> some View {

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -140,9 +140,7 @@ struct PopupView: View {
             if !sortedIdleSessions.isEmpty {
                 tabButton("Idle", count: sortedIdleSessions.count, tab: .idle)
             }
-            if !recentProjects.isEmpty {
-                tabButton("Recent", count: recentProjects.count, tab: .recent)
-            }
+            tabButton("Recent", count: recentProjects.count, tab: .recent)
             tabButton("Cleanup", count: actionableCleanupCandidates.count, tab: .cleanup, isScanning: cleanupIsScanning)
             Spacer()
         }
@@ -196,7 +194,7 @@ struct PopupView: View {
     @ViewBuilder
     private var recentContent: some View {
         if recentProjects.isEmpty {
-            emptyPlaceholder(systemImage: "clock", title: "Recent projects will appear here\nafter sessions end")
+            emptyPlaceholder(systemImage: "clock", title: "No resumable recent projects yet\nFinished projects appear here when folders exist")
         } else {
             panelList(recentProjects, tab: .recent) { _, project, isSelected in
                 recentCard(project, isSelected: isSelected)
@@ -212,7 +210,7 @@ struct PopupView: View {
                 Button { openInEditor(project: project); NSApp.deactivate() } label: {
                     Label(project.openActionLabel, systemImage: project.editorIcon)
                 }
-                if project.opensWithProjectEditor {
+                if project.opensWithProjectApp {
                     Button { openInFinder(path: project.projectPath) } label: { Label("Open in Finder", systemImage: "folder") }
                 }
                 Button { copyPath(project.projectPath) } label: {

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -8,6 +8,7 @@ private let relativeTimeRefresh = Timer.publish(every: 10, on: .main, in: .commo
 struct PopupView: View {
     let sessions: [Session]
     var recentProjects: [RecentProject] = []
+    var recentResumeTargets: [RecentResumeTarget]?
     var cleanupCandidates: [WorktreeCleanupCandidate] = []
     var cleanupIsScanning = false
     @ObservedObject var updater: UpdaterBase
@@ -102,7 +103,7 @@ struct PopupView: View {
         .onReceive(relativeTimeRefresh) { relativeTimeNow = $0 }
         .onChange(of: selectedTab) { handleSelectedTabChanged($0) }
         .onChange(of: sessions) { _ in ensureSelectedTabAvailable() }
-        .onChange(of: recentProjects.map(\.id)) { _ in ensureSelectedTabAvailable() }
+        .onChange(of: recentTargets.map(\.id)) { _ in ensureSelectedTabAvailable() }
         .onChange(of: actionableCleanupCandidates) { _ in handleCleanupCandidatesChanged() }
         .onChange(of: cleanupIsScanning) { _ in handleCleanupScanningChanged() }
         .onChange(of: selectedCleanupCandidate?.id) { _ in
@@ -140,7 +141,7 @@ struct PopupView: View {
             if !sortedIdleSessions.isEmpty {
                 tabButton("Idle", count: sortedIdleSessions.count, tab: .idle)
             }
-            tabButton("Recent", count: recentProjects.count, tab: .recent)
+            tabButton("Recent", count: recentTargets.count, tab: .recent)
             tabButton("Cleanup", count: actionableCleanupCandidates.count, tab: .cleanup, isScanning: cleanupIsScanning)
             Spacer()
         }
@@ -190,36 +191,6 @@ struct PopupView: View {
             sessionList(sortedIdleSessions, tab: .idle)
         }
     }
-    // MARK: - Recent tab
-    @ViewBuilder
-    private var recentContent: some View {
-        if recentProjects.isEmpty {
-            emptyPlaceholder(systemImage: "clock", title: "No resumable recent projects yet\nFinished projects appear here when folders exist")
-        } else {
-            panelList(recentProjects, tab: .recent) { _, project, isSelected in
-                recentCard(project, isSelected: isSelected)
-            }
-        }
-    }
-
-    private func recentCard(_ project: RecentProject, isSelected: Bool = false) -> some View {
-        RecentProjectCardView(project: project, isSelected: isSelected, relativeTimeNow: relativeTimeNow)
-            .contentShape(Rectangle())
-            .onTapGesture { openInEditor(project: project); NSApp.deactivate() }
-            .contextMenu {
-                Button { openInEditor(project: project); NSApp.deactivate() } label: {
-                    Label(project.openActionLabel, systemImage: project.editorIcon)
-                }
-                if project.opensWithProjectApp {
-                    Button { openInFinder(path: project.projectPath) } label: { Label("Open in Finder", systemImage: "folder") }
-                }
-                Button { copyPath(project.projectPath) } label: {
-                    Label("Copy Project Path", systemImage: "doc.on.doc")
-                }
-            }
-            .help(project.openHelpText)
-    }
-
     private func sessionList(_ list: [Session], tab: PopupTab, showNavigateNumbers: Bool = false) -> some View {
         panelList(list, tab: tab) { index, session, isSelected in
             SessionCardView(
@@ -245,7 +216,7 @@ struct PopupView: View {
         }
     }
 
-    private func panelList<Item: Identifiable, Row: View>(
+    func panelList<Item: Identifiable, Row: View>(
         _ list: [Item],
         tab: PopupTab,
         @ViewBuilder row: @escaping (Int, Item, Bool) -> Row
@@ -384,7 +355,7 @@ extension PopupView {
     private var availableTabs: [PopupTab] {
         PopupTab.availableTabs(
             hasIdleSessions: !sortedIdleSessions.isEmpty,
-            hasRecentProjects: !recentProjects.isEmpty,
+            hasRecentProjects: !recentTargets.isEmpty,
             hasCleanupCandidates: !actionableCleanupCandidates.isEmpty
         )
     }
@@ -430,7 +401,7 @@ extension PopupView {
         switch selectedTab {
         case .active: count = sortedActiveSessions.count
         case .idle: count = sortedIdleSessions.count
-        case .recent: count = recentProjects.count
+        case .recent: count = recentTargets.count
         case .cleanup: count = actionableCleanupCandidates.count
         }
         guard count > 0 else { return }
@@ -446,6 +417,7 @@ extension PopupView {
                 activeSessions: sortedActiveSessions,
                 idleSessions: sortedIdleSessions,
                 recentProjects: recentProjects,
+                recentResumeTargets: recentTargets,
                 cleanupCandidates: actionableCleanupCandidates
             )
         ) else {
@@ -454,8 +426,8 @@ extension PopupView {
         switch target {
         case .activeSession(let session), .idleSession(let session):
             focusSession(session)
-        case .recentProject(let project):
-            openInEditor(project: project)
+        case .recentTarget(let target):
+            openRecentResumeTarget(target)
             NSApp.deactivate()
         case .cleanupCandidate(let candidate):
             openCleanupDetail(candidate)

--- a/menubar/CctopMenubar/Views/PopupViewHelpers.swift
+++ b/menubar/CctopMenubar/Views/PopupViewHelpers.swift
@@ -242,6 +242,7 @@ struct PanelContentView: View {
         PopupView(
             sessions: sessionManager.sessions,
             recentProjects: historyManager.recentProjects,
+            recentResumeTargets: sessionManager.recentResumeTargets,
             cleanupCandidates: cleanupManager.candidates,
             cleanupIsScanning: cleanupManager.isScanning,
             updater: updater,

--- a/menubar/CctopMenubar/Views/RecentProjectCardView.swift
+++ b/menubar/CctopMenubar/Views/RecentProjectCardView.swift
@@ -1,24 +1,36 @@
 import SwiftUI
 
 struct RecentProjectCardView: View {
-    let project: RecentProject
+    let target: RecentResumeTarget
     var isSelected = false
     var relativeTimeNow = Date()
     @State private var isHovered = false
 
+    init(target: RecentResumeTarget, isSelected: Bool = false, relativeTimeNow: Date = Date()) {
+        self.target = target
+        self.isSelected = isSelected
+        self.relativeTimeNow = relativeTimeNow
+    }
+
+    init(project: RecentProject, isSelected: Bool = false, relativeTimeNow: Date = Date()) {
+        self.init(target: .project(project), isSelected: isSelected, relativeTimeNow: relativeTimeNow)
+    }
+
     var body: some View {
         HStack(spacing: 8) {
-            Image(systemName: project.editorIcon)
+            Image(systemName: target.icon)
                 .font(.system(size: 11))
                 .foregroundStyle(Color.textMuted)
                 .frame(width: 16, height: 16)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(project.projectName)
+                Text(target.title)
                     .font(.system(size: 12))
                     .foregroundStyle(Color.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
 
-                Text(project.metadataText)
+                Text(target.metadataText)
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .font(.system(size: 9))
@@ -26,10 +38,20 @@ struct RecentProjectCardView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            Text(project.lastSessionAt.relativeDescription(asOf: relativeTimeNow))
-                .font(.system(size: 10))
-                .foregroundStyle(Color.textMuted)
-                .layoutPriority(1)
+            VStack(alignment: .trailing, spacing: 2) {
+                if let inlineActionLabel = target.inlineActionLabel {
+                    Text(inlineActionLabel)
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(Color.textSecondary)
+                        .lineLimit(1)
+                }
+
+                Text(target.lastSessionAt.relativeDescription(asOf: relativeTimeNow))
+                    .font(.system(size: 10))
+                    .foregroundStyle(Color.textMuted)
+                    .lineLimit(1)
+            }
+            .layoutPriority(1)
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)

--- a/menubar/CctopMenubar/Views/RecentProjectCardView.swift
+++ b/menubar/CctopMenubar/Views/RecentProjectCardView.swift
@@ -19,25 +19,26 @@ struct RecentProjectCardView: View {
                     .foregroundStyle(Color.textPrimary)
 
                 HStack(spacing: 5) {
-                    Text(project.lastBranch)
-                        .font(.system(size: 9, design: .monospaced))
-                        .foregroundStyle(Color.textMuted)
+                    Text(project.pathContext)
                         .lineLimit(1)
+                        .truncationMode(.middle)
+                        .layoutPriority(0)
 
                     Text("\u{00B7}")
-                        .foregroundStyle(Color.textMuted)
 
-                    Text("\(project.sessionCount) session\(project.sessionCount == 1 ? "" : "s")")
-                        .font(.system(size: 9))
-                        .foregroundStyle(Color.textMuted)
+                    Text(project.metadataEvidenceText)
+                        .lineLimit(1)
+                        .layoutPriority(1)
                 }
+                .font(.system(size: 9))
+                .foregroundStyle(Color.textMuted)
             }
-
-            Spacer()
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             Text(project.lastSessionAt.relativeDescription(asOf: relativeTimeNow))
                 .font(.system(size: 10))
                 .foregroundStyle(Color.textMuted)
+                .layoutPriority(1)
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)

--- a/menubar/CctopMenubar/Views/RecentProjectCardView.swift
+++ b/menubar/CctopMenubar/Views/RecentProjectCardView.swift
@@ -18,20 +18,11 @@ struct RecentProjectCardView: View {
                     .font(.system(size: 12))
                     .foregroundStyle(Color.textPrimary)
 
-                HStack(spacing: 5) {
-                    Text(project.pathContext)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .layoutPriority(0)
-
-                    Text("\u{00B7}")
-
-                    Text(project.metadataEvidenceText)
-                        .lineLimit(1)
-                        .layoutPriority(1)
-                }
-                .font(.system(size: 9))
-                .foregroundStyle(Color.textMuted)
+                Text(project.metadataText)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .font(.system(size: 9))
+                    .foregroundStyle(Color.textMuted)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -323,8 +323,8 @@ final class FocusStrategyTests: XCTestCase {
     }
 
     func testCodexDesktopUsesDeepLinkWhenSessionIdIsUUID() {
-        // Codex's URL handler routes codex://threads/<uuid> to the conversation
-        // and rejects anything that's not a canonical UUID — we mirror that check.
+        // Active Codex Desktop focus can use codex://threads/<uuid>, but archived
+        // Recent rows deliberately activate the app only.
         let uuid = "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
         let bundleID = HostApp.codexDesktop.bundleID!
         let session = makeSession(

--- a/menubar/CctopMenubarTests/FocusTerminalTests.swift
+++ b/menubar/CctopMenubarTests/FocusTerminalTests.swift
@@ -95,11 +95,11 @@ final class FocusTerminalTests: XCTestCase {
         )
     }
 
-    func testRecentProjectTerminalProgramOpensProjectInFinder() {
-        let project = RecentProject.mock(editor: "iTerm2")
+    func testRecentProjectKnownTerminalOpensProjectPathWithApp() {
+        let project = RecentProject.mock(editor: "Ghostty")
         XCTAssertEqual(
             resolveRecentProjectOpenStrategy(project: project),
-            .openInFinder(project.projectPath)
+            .openWithApp(bundleID: "com.mitchellh.ghostty", target: project.projectPath)
         )
     }
 

--- a/menubar/CctopMenubarTests/FocusTerminalTests.swift
+++ b/menubar/CctopMenubarTests/FocusTerminalTests.swift
@@ -77,6 +77,27 @@ final class FocusTerminalTests: XCTestCase {
         }
     }
 
+    // MARK: - Recent project opener matching
+
+    func testRecentProjectProgramNameRecognizesWarpTerminal() {
+        XCTAssertEqual(HostApp.projectOpener(fromProgramName: "WarpTerminal"), .warp)
+        XCTAssertEqual(HostApp.projectOpener(fromProgramName: "warpterminal"), .warp)
+    }
+
+    func testRecentProjectProgramNameRejectsAgentLikeStrings() {
+        let agentLikeNames = [
+            "Codex",
+            "Claude Code",
+            "OpenAI Codex",
+            "opencode",
+            "Codex WarpTerminal",
+        ]
+
+        for name in agentLikeNames {
+            XCTAssertNil(HostApp.projectOpener(fromProgramName: name), name)
+        }
+    }
+
     // MARK: - Recent project open strategy
 
     func testRecentProjectWithoutEditorOpensProjectInFinder() {

--- a/menubar/CctopMenubarTests/FocusTerminalTests.swift
+++ b/menubar/CctopMenubarTests/FocusTerminalTests.swift
@@ -76,4 +76,47 @@ final class FocusTerminalTests: XCTestCase {
             XCTAssertNotNil(app.bundleID, "\(app) has an activation name but no bundle ID to launch")
         }
     }
+
+    // MARK: - Recent project open strategy
+
+    func testRecentProjectWithoutEditorOpensProjectInFinder() {
+        let project = RecentProject.mock(editor: nil)
+        XCTAssertEqual(
+            resolveRecentProjectOpenStrategy(project: project),
+            .openInFinder(project.projectPath)
+        )
+    }
+
+    func testRecentProjectUnknownEditorOpensProjectInFinder() {
+        let project = RecentProject.mock(editor: "Codex")
+        XCTAssertEqual(
+            resolveRecentProjectOpenStrategy(project: project),
+            .openInFinder(project.projectPath)
+        )
+    }
+
+    func testRecentProjectTerminalProgramOpensProjectInFinder() {
+        let project = RecentProject.mock(editor: "iTerm2")
+        XCTAssertEqual(
+            resolveRecentProjectOpenStrategy(project: project),
+            .openInFinder(project.projectPath)
+        )
+    }
+
+    func testRecentProjectKnownEditorOpensWorkspaceFileWithApp() {
+        let workspaceFile = "/Users/dev/projects/my-project/my-project.code-workspace"
+        let project = RecentProject.mock(editor: "Cursor", workspaceFile: workspaceFile)
+        XCTAssertEqual(
+            resolveRecentProjectOpenStrategy(project: project),
+            .openWithApp(bundleID: "com.todesktop.230313mzl4w4u92", target: workspaceFile)
+        )
+    }
+
+    func testRecentProjectKnownEditorFallsBackToProjectPath() {
+        let project = RecentProject.mock(editor: "Code")
+        XCTAssertEqual(
+            resolveRecentProjectOpenStrategy(project: project),
+            .openWithApp(bundleID: "com.microsoft.VSCode", target: project.projectPath)
+        )
+    }
 }

--- a/menubar/CctopMenubarTests/FocusTerminalTests.swift
+++ b/menubar/CctopMenubarTests/FocusTerminalTests.swift
@@ -140,4 +140,48 @@ final class FocusTerminalTests: XCTestCase {
             .openWithApp(bundleID: "com.microsoft.VSCode", target: project.projectPath)
         )
     }
+
+    func testRecentResumeTargetProjectDelegatesToProjectOpenStrategy() {
+        let project = RecentProject.mock(editor: "Ghostty")
+        let target = RecentResumeTarget.project(project)
+
+        XCTAssertEqual(
+            resolveRecentResumeTargetOpenStrategy(target: target),
+            .openWithApp(bundleID: "com.mitchellh.ghostty", target: project.projectPath)
+        )
+    }
+
+    func testRecentResumeTargetCodexDesktopActivatesAppOnly() {
+        let uuid = "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
+        let target = RecentResumeTarget.desktopThread(.init(
+            sessionId: uuid,
+            title: "Can you use product design skills for the cctop logo",
+            projectPath: "/Users/dev/projects/cctop",
+            projectName: "cctop",
+            sourceApp: .codexDesktop,
+            lastActiveAt: Date()
+        ))
+
+        XCTAssertEqual(
+            resolveRecentResumeTargetOpenStrategy(target: target),
+            .activateByBundleID(HostApp.codexDesktop.bundleID!)
+        )
+    }
+
+    func testRecentResumeTargetClaudeDesktopActivatesAppOnly() {
+        let uuid = "39253133-4a65-48fb-af2b-844463d3b5bb"
+        let target = RecentResumeTarget.desktopThread(.init(
+            sessionId: uuid,
+            title: "Run plugin node:test suites in CI",
+            projectPath: "/Users/dev/projects/cctop",
+            projectName: "cctop",
+            sourceApp: .claudeDesktop,
+            lastActiveAt: Date()
+        ))
+
+        XCTAssertEqual(
+            resolveRecentResumeTargetOpenStrategy(target: target),
+            .activateByBundleID(HostApp.claudeDesktop.bundleID!)
+        )
+    }
 }

--- a/menubar/CctopMenubarTests/HistoryManagerTests.swift
+++ b/menubar/CctopMenubarTests/HistoryManagerTests.swift
@@ -516,6 +516,35 @@ final class HistoryManagerTests: XCTestCase {
         XCTAssertEqual(sut.lastDecodedHistorySessions.map(\.projectName), ["cached-app"])
     }
 
+    func testRebuildRecentProjectsRefreshesWhenProjectPathExistenceChanges() throws {
+        let projectDir = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".cctop-history-path-state-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: projectDir) }
+
+        let endedAt = Date(timeIntervalSince1970: 1_000)
+        let session = mockSession(
+            project: "path-state-app",
+            projectPath: projectDir.path,
+            endedAt: endedAt,
+            lastActivity: endedAt
+        )
+        try session.writeToFile(path: historyDir.appendingPathComponent("path-state.json").path)
+
+        XCTAssertTrue(sut.rebuildRecentProjects())
+        XCTAssertEqual(sut.recentProjects.map(\.projectName), ["path-state-app"])
+
+        try FileManager.default.removeItem(at: projectDir)
+
+        XCTAssertTrue(sut.rebuildRecentProjects())
+        XCTAssertTrue(sut.recentProjects.isEmpty)
+
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+
+        XCTAssertTrue(sut.rebuildRecentProjects())
+        XCTAssertEqual(sut.recentProjects.map(\.projectName), ["path-state-app"])
+    }
+
     // MARK: - relativeDescription tests
 
     func testRelativeTimeJustNow() {

--- a/menubar/CctopMenubarTests/HistoryManagerTests.swift
+++ b/menubar/CctopMenubarTests/HistoryManagerTests.swift
@@ -27,6 +27,7 @@ final class HistoryManagerTests: XCTestCase {
 
     private func mockSession(
         project: String,
+        projectPath: String? = nil,
         endedAt: Date? = nil,
         lastActivity: Date = Date(),
         terminal: TerminalInfo? = TerminalInfo(program: "Code"),
@@ -34,7 +35,7 @@ final class HistoryManagerTests: XCTestCase {
     ) -> Session {
         Session(
             sessionId: UUID().uuidString,
-            projectPath: "/Users/test/\(project)",
+            projectPath: projectPath ?? "/Users/test/\(project)",
             projectName: project,
             branch: "main",
             status: .idle,
@@ -61,6 +62,18 @@ final class HistoryManagerTests: XCTestCase {
         )
         let url = historyDir.appendingPathComponent("\(UUID().uuidString).json")
         return (url, session)
+    }
+
+    private func recentProjects(
+        from sessions: [Session],
+        excludingActive activePaths: Set<String> = [],
+        existingPaths: Set<String>? = nil
+    ) -> [RecentProject] {
+        HistoryManager.buildRecentProjects(
+            from: sessions,
+            excludingActive: activePaths,
+            projectPathExists: { existingPaths?.contains($0) ?? true }
+        )
     }
 
     // MARK: - filesToPrune tests
@@ -143,7 +156,7 @@ final class HistoryManagerTests: XCTestCase {
             mockSession(project: "app", endedAt: now.addingTimeInterval(-3600)),
             mockSession(project: "app", endedAt: now.addingTimeInterval(-7200)),
         ]
-        let result = HistoryManager.buildRecentProjects(from: sessions)
+        let result = recentProjects(from: sessions)
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result[0].sessionCount, 3)
         XCTAssertEqual(result[0].projectName, "app")
@@ -155,7 +168,7 @@ final class HistoryManagerTests: XCTestCase {
             mockSession(project: "active", endedAt: now),
             mockSession(project: "inactive", endedAt: now),
         ]
-        let result = HistoryManager.buildRecentProjects(
+        let result = recentProjects(
             from: sessions,
             excludingActive: ["/Users/test/active"]
         )
@@ -170,7 +183,7 @@ final class HistoryManagerTests: XCTestCase {
             mockSession(project: "new", endedAt: now),
             mockSession(project: "mid", endedAt: now.addingTimeInterval(-3600)),
         ]
-        let result = HistoryManager.buildRecentProjects(from: sessions)
+        let result = recentProjects(from: sessions)
         XCTAssertEqual(result.map(\.projectName), ["new", "mid", "old"])
     }
 
@@ -183,7 +196,7 @@ final class HistoryManagerTests: XCTestCase {
                 endedAt: now.addingTimeInterval(TimeInterval(-i * 3600))
             ))
         }
-        let result = HistoryManager.buildRecentProjects(from: sessions)
+        let result = recentProjects(from: sessions)
         XCTAssertEqual(result.count, 10)
     }
 
@@ -194,7 +207,7 @@ final class HistoryManagerTests: XCTestCase {
             endedAt: now.addingTimeInterval(-60),
             lastActivity: now.addingTimeInterval(-7200)
         )
-        let result = HistoryManager.buildRecentProjects(from: [session])
+        let result = recentProjects(from: [session])
         XCTAssertEqual(result.count, 1)
         // lastSessionAt should use endedAt (60s ago), not lastActivity (2h ago)
         let elapsed = Int(-result[0].lastSessionAt.timeIntervalSinceNow)
@@ -214,9 +227,113 @@ final class HistoryManagerTests: XCTestCase {
                 mockSession(project: app.project, endedAt: Date(), terminal: terminal),
                 mockSession(project: "vscode-thing", endedAt: Date()),
             ]
-            let result = HistoryManager.buildRecentProjects(from: sessions)
+            let result = recentProjects(from: sessions)
             XCTAssertEqual(result.map(\.projectName), ["vscode-thing"], "for \(app.bundleId)")
         }
+    }
+
+    func testRecentProjectDurabilityRejectsMissingPath() {
+        XCTAssertFalse(
+            HistoryManager.isDurableRecentProjectPath(
+                "/Users/test/missing-project",
+                projectPathExists: { _ in false }
+            )
+        )
+    }
+
+    func testRecentProjectDurabilityRejectsTemporaryAndCachePaths() {
+        let tempPaths = [
+            "/tmp/cctop-noise",
+            "/private/tmp/cctop-noise",
+            NSTemporaryDirectory() + "cctop-noise",
+            "/var/folders/zz/cctop-noise",
+            NSHomeDirectory() + "/Library/Caches/cctop-noise",
+            NSHomeDirectory() + "/.cache/cctop-noise",
+        ]
+
+        for path in tempPaths {
+            XCTAssertFalse(
+                HistoryManager.isDurableRecentProjectPath(path, projectPathExists: { _ in true }),
+                path
+            )
+        }
+    }
+
+    func testRecentProjectDurabilityKeepsExistingDurablePath() {
+        XCTAssertTrue(
+            HistoryManager.isDurableRecentProjectPath(
+                "/Users/test/projects/rdoc",
+                projectPathExists: { _ in true }
+            )
+        )
+    }
+
+    func testBuildRecentProjectsFiltersNonDurablePathsBeforeRankingAndCounting() {
+        let now = Date()
+        let realPath = "/Users/test/projects/rdoc"
+        let sessions = [
+            mockSession(
+                project: "tmp-newest",
+                projectPath: "/tmp/cctop-noise",
+                endedAt: now
+            ),
+            mockSession(
+                project: "missing-newer",
+                projectPath: "/Users/test/projects/missing",
+                endedAt: now.addingTimeInterval(-60)
+            ),
+            mockSession(
+                project: "cache-newer",
+                projectPath: NSHomeDirectory() + "/Library/Caches/cctop-noise",
+                endedAt: now.addingTimeInterval(-120)
+            ),
+            mockSession(
+                project: "rdoc",
+                projectPath: realPath,
+                endedAt: now.addingTimeInterval(-180)
+            ),
+            mockSession(
+                project: "rdoc",
+                projectPath: realPath,
+                endedAt: now.addingTimeInterval(-240)
+            ),
+        ]
+
+        let result = recentProjects(
+            from: sessions,
+            existingPaths: [
+                "/tmp/cctop-noise",
+                NSHomeDirectory() + "/Library/Caches/cctop-noise",
+                realPath,
+            ]
+        )
+
+        XCTAssertEqual(result.map(\.projectName), ["rdoc"])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].sessionCount, 2)
+    }
+
+    func testBuildRecentProjectsGroupsByCanonicalProjectPath() {
+        let now = Date()
+        let canonicalPath = "/Users/test/projects/rdoc"
+        let sessions = [
+            mockSession(
+                project: "rdoc",
+                projectPath: "/Users/test/projects/../projects/rdoc",
+                endedAt: now
+            ),
+            mockSession(
+                project: "rdoc",
+                projectPath: canonicalPath,
+                endedAt: now.addingTimeInterval(-60)
+            ),
+        ]
+
+        let result = recentProjects(from: sessions, existingPaths: [canonicalPath])
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].projectPath, canonicalPath)
+        XCTAssertEqual(result[0].sessionCount, 2)
     }
 
     func testArchiveSessionSkipsDesktopAppSessions() {
@@ -252,7 +369,7 @@ final class HistoryManagerTests: XCTestCase {
             notificationMessage: nil,
             endedAt: Date()
         )
-        let result = HistoryManager.buildRecentProjects(from: [session])
+        let result = recentProjects(from: [session])
         XCTAssertEqual(result[0].lastEditor, "Cursor")
     }
 
@@ -261,7 +378,7 @@ final class HistoryManagerTests: XCTestCase {
             project: "agent-created",
             terminal: TerminalInfo(program: "codex")
         )
-        let result = HistoryManager.buildRecentProjects(from: [session])
+        let result = recentProjects(from: [session])
         XCTAssertEqual(result[0].projectName, "agent-created")
         XCTAssertNil(result[0].lastEditor)
     }
@@ -272,19 +389,24 @@ final class HistoryManagerTests: XCTestCase {
             terminal: TerminalInfo(program: "Claude Code"),
             source: Session.ccSource
         )
-        let result = HistoryManager.buildRecentProjects(from: [session])
+        let result = recentProjects(from: [session])
         XCTAssertNil(result[0].lastEditor)
         XCTAssertEqual(result[0].lastAgent, "Claude Code")
     }
 
-    func testBuildRecentProjectsIgnoresTerminalProgramAsProjectOpener() {
+    func testBuildRecentProjectsKeepsKnownTerminalProgramAsProjectOpener() {
         let session = mockSession(
             project: "terminal-created",
-            terminal: TerminalInfo(program: "iTerm2")
+            terminal: TerminalInfo(
+                program: "ghostty",
+                sessionId: nil,
+                tty: nil,
+                bundleId: "com.mitchellh.ghostty"
+            )
         )
-        let result = HistoryManager.buildRecentProjects(from: [session])
+        let result = recentProjects(from: [session])
         XCTAssertEqual(result[0].projectName, "terminal-created")
-        XCTAssertNil(result[0].lastEditor)
+        XCTAssertEqual(result[0].lastEditor, "Ghostty")
     }
 
     func testRecentProjectMetadataSkipsUnknownBranch() {
@@ -317,6 +439,40 @@ final class HistoryManagerTests: XCTestCase {
         XCTAssertEqual(project.pathContext, "~/projects/cctop")
         XCTAssertEqual(project.metadataEvidenceText, "master \u{00B7} Claude Code \u{00B7} 1 session")
         XCTAssertEqual(project.metadataText, "~/projects/cctop \u{00B7} master \u{00B7} Claude Code \u{00B7} 1 session")
+    }
+
+    func testRecentProjectKnownTerminalOpenerUsesTerminalActionCopy() {
+        let project = RecentProject(
+            projectPath: NSHomeDirectory() + "/projects/irb",
+            projectName: "irb",
+            lastBranch: "master",
+            lastSessionAt: Date(),
+            sessionCount: 2,
+            lastEditor: "Ghostty",
+            lastAgent: "Claude Code",
+            workspaceFile: nil
+        )
+
+        XCTAssertTrue(project.opensWithProjectApp)
+        XCTAssertEqual(project.editorIcon, "terminal")
+        XCTAssertEqual(project.openActionLabel, "Open in Ghostty")
+    }
+
+    func testRecentProjectAgentOpenerUsesFolderActionCopy() {
+        let project = RecentProject(
+            projectPath: NSHomeDirectory() + "/projects/cctop",
+            projectName: "cctop",
+            lastBranch: "master",
+            lastSessionAt: Date(),
+            sessionCount: 1,
+            lastEditor: "Codex",
+            lastAgent: "Codex",
+            workspaceFile: nil
+        )
+
+        XCTAssertFalse(project.opensWithProjectApp)
+        XCTAssertEqual(project.editorIcon, "folder")
+        XCTAssertEqual(project.openActionLabel, "Open Project Folder")
     }
 
     func testRebuildCachesDecodedHistorySessionsAndKeepsCacheOnNoopRebuild() throws {

--- a/menubar/CctopMenubarTests/HistoryManagerTests.swift
+++ b/menubar/CctopMenubarTests/HistoryManagerTests.swift
@@ -259,6 +259,21 @@ final class HistoryManagerTests: XCTestCase {
         }
     }
 
+    func testRecentProjectDurabilityRejectsObviousNonProjectRoots() {
+        let nonProjectRoots = [
+            "/",
+            NSHomeDirectory(),
+            NSHomeDirectory() + "/projects",
+        ]
+
+        for path in nonProjectRoots {
+            XCTAssertFalse(
+                HistoryManager.isDurableRecentProjectPath(path, projectPathExists: { _ in true }),
+                path
+            )
+        }
+    }
+
     func testRecentProjectDurabilityKeepsExistingDurablePath() {
         XCTAssertTrue(
             HistoryManager.isDurableRecentProjectPath(
@@ -266,6 +281,20 @@ final class HistoryManagerTests: XCTestCase {
                 projectPathExists: { _ in true }
             )
         )
+    }
+
+    func testRecentProjectDurabilityKeepsChildProjectPaths() {
+        let childProjects = [
+            NSHomeDirectory() + "/projects/rdoc",
+            NSHomeDirectory() + "/work/client-app",
+        ]
+
+        for path in childProjects {
+            XCTAssertTrue(
+                HistoryManager.isDurableRecentProjectPath(path, projectPathExists: { _ in true }),
+                path
+            )
+        }
     }
 
     func testBuildRecentProjectsFiltersNonDurablePathsBeforeRankingAndCounting() {

--- a/menubar/CctopMenubarTests/HistoryManagerTests.swift
+++ b/menubar/CctopMenubarTests/HistoryManagerTests.swift
@@ -29,7 +29,8 @@ final class HistoryManagerTests: XCTestCase {
         project: String,
         endedAt: Date? = nil,
         lastActivity: Date = Date(),
-        terminal: TerminalInfo? = TerminalInfo(program: "Code")
+        terminal: TerminalInfo? = TerminalInfo(program: "Code"),
+        source: String? = nil
     ) -> Session {
         Session(
             sessionId: UUID().uuidString,
@@ -45,6 +46,7 @@ final class HistoryManagerTests: XCTestCase {
             lastTool: nil,
             lastToolDetail: nil,
             notificationMessage: nil,
+            source: source,
             endedAt: endedAt
         )
     }
@@ -252,6 +254,69 @@ final class HistoryManagerTests: XCTestCase {
         )
         let result = HistoryManager.buildRecentProjects(from: [session])
         XCTAssertEqual(result[0].lastEditor, "Cursor")
+    }
+
+    func testBuildRecentProjectsIgnoresUnknownProgramAsProjectOpener() {
+        let session = mockSession(
+            project: "agent-created",
+            terminal: TerminalInfo(program: "codex")
+        )
+        let result = HistoryManager.buildRecentProjects(from: [session])
+        XCTAssertEqual(result[0].projectName, "agent-created")
+        XCTAssertNil(result[0].lastEditor)
+    }
+
+    func testBuildRecentProjectsKeepsAgentMetadataSeparateFromProjectOpener() {
+        let session = mockSession(
+            project: "agent-created",
+            terminal: TerminalInfo(program: "Claude Code"),
+            source: Session.ccSource
+        )
+        let result = HistoryManager.buildRecentProjects(from: [session])
+        XCTAssertNil(result[0].lastEditor)
+        XCTAssertEqual(result[0].lastAgent, "Claude Code")
+    }
+
+    func testBuildRecentProjectsIgnoresTerminalProgramAsProjectOpener() {
+        let session = mockSession(
+            project: "terminal-created",
+            terminal: TerminalInfo(program: "iTerm2")
+        )
+        let result = HistoryManager.buildRecentProjects(from: [session])
+        XCTAssertEqual(result[0].projectName, "terminal-created")
+        XCTAssertNil(result[0].lastEditor)
+    }
+
+    func testRecentProjectMetadataSkipsUnknownBranch() {
+        let project = RecentProject(
+            projectPath: NSHomeDirectory() + "/projects/cctop",
+            projectName: "cctop",
+            lastBranch: "unknown",
+            lastSessionAt: Date(),
+            sessionCount: 4,
+            lastEditor: nil,
+            lastAgent: "Codex",
+            workspaceFile: nil
+        )
+        XCTAssertEqual(project.pathContext, "~/projects/cctop")
+        XCTAssertEqual(project.metadataEvidenceText, "Codex \u{00B7} 4 sessions")
+        XCTAssertEqual(project.metadataText, "~/projects/cctop \u{00B7} Codex \u{00B7} 4 sessions")
+    }
+
+    func testRecentProjectMetadataIncludesMeaningfulBranch() {
+        let project = RecentProject(
+            projectPath: NSHomeDirectory() + "/projects/cctop",
+            projectName: "cctop",
+            lastBranch: "master",
+            lastSessionAt: Date(),
+            sessionCount: 1,
+            lastEditor: "Cursor",
+            lastAgent: "Claude Code",
+            workspaceFile: nil
+        )
+        XCTAssertEqual(project.pathContext, "~/projects/cctop")
+        XCTAssertEqual(project.metadataEvidenceText, "master \u{00B7} Claude Code \u{00B7} 1 session")
+        XCTAssertEqual(project.metadataText, "~/projects/cctop \u{00B7} master \u{00B7} Claude Code \u{00B7} 1 session")
     }
 
     func testRebuildCachesDecodedHistorySessionsAndKeepsCacheOnNoopRebuild() throws {

--- a/menubar/CctopMenubarTests/HistoryManagerTests.swift
+++ b/menubar/CctopMenubarTests/HistoryManagerTests.swift
@@ -54,14 +54,28 @@ final class HistoryManagerTests: XCTestCase {
 
     private func mockEntry(
         project: String,
+        projectPath: String? = nil,
         endedAt: Date? = nil,
         lastActivity: Date = Date()
     ) -> (url: URL, session: Session) {
         let session = mockSession(
-            project: project, endedAt: endedAt, lastActivity: lastActivity
+            project: project,
+            projectPath: projectPath,
+            endedAt: endedAt,
+            lastActivity: lastActivity
         )
         let url = historyDir.appendingPathComponent("\(UUID().uuidString).json")
         return (url, session)
+    }
+
+    private func filesToPrune(
+        from entries: [(url: URL, session: Session)],
+        existingPaths: Set<String>? = nil
+    ) -> [URL] {
+        sut.filesToPrune(
+            from: entries,
+            projectPathExists: { existingPaths?.contains($0) ?? true }
+        )
     }
 
     private func recentProjects(
@@ -79,7 +93,7 @@ final class HistoryManagerTests: XCTestCase {
     // MARK: - filesToPrune tests
 
     func testFilesToPruneEmptyInput() {
-        let result = sut.filesToPrune(from: [])
+        let result = filesToPrune(from: [])
         XCTAssertTrue(result.isEmpty)
     }
 
@@ -90,7 +104,7 @@ final class HistoryManagerTests: XCTestCase {
             mockEntry(project: "app", endedAt: now.addingTimeInterval(-3600)),
             mockEntry(project: "app", endedAt: now.addingTimeInterval(-7200)),
         ]
-        let result = sut.filesToPrune(from: entries)
+        let result = filesToPrune(from: entries)
         XCTAssertEqual(result.count, 2, "Should prune 2 older duplicates")
         XCTAssertTrue(result.contains(entries[1].url))
         XCTAssertTrue(result.contains(entries[2].url))
@@ -104,7 +118,7 @@ final class HistoryManagerTests: XCTestCase {
             mockEntry(project: "recent-proj", endedAt: recent),
             mockEntry(project: "old-proj", endedAt: old),
         ]
-        let result = sut.filesToPrune(from: entries)
+        let result = filesToPrune(from: entries)
         XCTAssertEqual(result.count, 1)
         XCTAssertTrue(result.contains(entries[1].url))
     }
@@ -112,7 +126,7 @@ final class HistoryManagerTests: XCTestCase {
     func testFilesToPruneKeepsRecentEntries() {
         let recent = Date().addingTimeInterval(-86400) // 1 day ago
         let entries = [mockEntry(project: "proj", endedAt: recent)]
-        let result = sut.filesToPrune(from: entries)
+        let result = filesToPrune(from: entries)
         XCTAssertTrue(result.isEmpty)
     }
 
@@ -125,7 +139,7 @@ final class HistoryManagerTests: XCTestCase {
                 endedAt: now.addingTimeInterval(TimeInterval(-i * 3600))
             ))
         }
-        let result = sut.filesToPrune(from: entries)
+        let result = filesToPrune(from: entries)
         XCTAssertEqual(result.count, 5, "Should prune 5 excess entries beyond maxFiles=50")
     }
 
@@ -141,10 +155,70 @@ final class HistoryManagerTests: XCTestCase {
             // Recent entry for proj-c (keep)
             mockEntry(project: "proj-c", endedAt: now.addingTimeInterval(-7200)),
         ]
-        let result = sut.filesToPrune(from: entries)
+        let result = filesToPrune(from: entries)
         XCTAssertEqual(result.count, 2)
         XCTAssertTrue(result.contains(entries[1].url), "Duplicate should be pruned")
         XCTAssertTrue(result.contains(entries[2].url), "Old entry should be pruned")
+    }
+
+    func testFilesToPruneDoesNotLetNonDurableRowsEvictDurableProjects() {
+        let now = Date()
+        let durableRoot = "/Users/test/projects"
+        var entries: [(url: URL, session: Session)] = []
+        for i in 0..<HistoryManager.maxFiles {
+            entries.append(mockEntry(
+                project: "durable-\(i)",
+                projectPath: "\(durableRoot)/durable-\(i)",
+                endedAt: now.addingTimeInterval(TimeInterval(-(i + 3) * 60))
+            ))
+        }
+
+        let tempEntry = mockEntry(
+            project: "tmp-noise",
+            projectPath: "/tmp/cctop-noise",
+            endedAt: now
+        )
+        let cacheEntry = mockEntry(
+            project: "cache-noise",
+            projectPath: NSHomeDirectory() + "/Library/Caches/cctop-noise",
+            endedAt: now.addingTimeInterval(-60)
+        )
+        let missingEntry = mockEntry(
+            project: "missing-restorable",
+            projectPath: "\(durableRoot)/missing-restorable",
+            endedAt: now.addingTimeInterval(-120)
+        )
+        let allEntries = [tempEntry, cacheEntry, missingEntry] + entries
+        let existingPaths = Set(entries.map { HistoryManager.canonicalRecentProjectPath($0.session.projectPath) })
+
+        let result = filesToPrune(from: allEntries, existingPaths: existingPaths)
+
+        XCTAssertTrue(result.contains(tempEntry.url))
+        XCTAssertTrue(result.contains(cacheEntry.url))
+        XCTAssertFalse(result.contains(missingEntry.url))
+        XCTAssertFalse(entries.contains { result.contains($0.url) })
+    }
+
+    func testFilesToPruneDeduplicatesByCanonicalProjectPath() {
+        let now = Date()
+        let newest = mockEntry(
+            project: "rdoc",
+            projectPath: "/Users/test/projects/rdoc",
+            endedAt: now
+        )
+        let older = mockEntry(
+            project: "rdoc",
+            projectPath: "/Users/test/projects/../projects/rdoc",
+            endedAt: now.addingTimeInterval(-60)
+        )
+
+        let result = filesToPrune(
+            from: [newest, older],
+            existingPaths: ["/Users/test/projects/rdoc"]
+        )
+
+        XCTAssertFalse(result.contains(newest.url))
+        XCTAssertTrue(result.contains(older.url))
     }
 
     // MARK: - buildRecentProjects tests

--- a/menubar/CctopMenubarTests/SessionLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/SessionLifecycleTests.swift
@@ -670,6 +670,51 @@ final class SessionLifecycleTests: XCTestCase {
         XCTAssertTrue(RecentResumeTarget.build(projects: [], classification: classification).isEmpty)
     }
 
+    func testRecentResumeTargetsExcludeArchivedCodexHelperThreads() {
+        let visibleArchived = candidate(
+            sessionId: "archived-visible",
+            pid: 1,
+            bundleId: HostAppBundleID.codexDesktop,
+            lifecycleRank: SessionLifecycle.dormant.rawValue,
+            source: Session.codexSource,
+            path: "/archived-visible.json"
+        ) { session in
+            session.sessionName = "Visible archived thread"
+        }
+        let archivedSubagent = candidate(
+            sessionId: "archived-subagent",
+            pid: 2,
+            bundleId: HostAppBundleID.codexDesktop,
+            lifecycleRank: SessionLifecycle.dormant.rawValue,
+            source: Session.codexSource,
+            path: "/archived-subagent.json"
+        ) { session in
+            session.sessionName = "Archived subagent helper"
+        }
+        let archivedExecHelper = candidate(
+            sessionId: "archived-exec-helper",
+            pid: 3,
+            bundleId: HostAppBundleID.codexDesktop,
+            lifecycleRank: SessionLifecycle.dormant.rawValue,
+            source: Session.codexSource,
+            path: "/archived-exec-helper.json"
+        ) { session in
+            session.sessionName = "Archived exec helper"
+        }
+        let classification = SessionManager.sessionClassificationSnapshot(
+            in: [visibleArchived, archivedSubagent, archivedExecHelper],
+            codexThreads: StubCodexThreadState(
+                archived: ["archived-visible", "archived-subagent", "archived-exec-helper"],
+                subagents: ["archived-subagent"],
+                execHelpers: ["archived-exec-helper"]
+            )
+        )
+
+        let targets = RecentResumeTarget.build(projects: [], classification: classification)
+
+        XCTAssertEqual(targets.map(\.title), ["Visible archived thread"])
+    }
+
     @MainActor
     func testSessionManagerPublishesArchivedDesktopThreadsAsRecentTargets() throws {
         let root = NSTemporaryDirectory() + "cctop-recent-desktop-targets-\(UUID().uuidString)"

--- a/menubar/CctopMenubarTests/SessionLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/SessionLifecycleTests.swift
@@ -593,6 +593,150 @@ final class SessionLifecycleTests: XCTestCase {
         XCTAssertEqual(state.protectedProjectPathsForCleanup, ["/tmp/p"])
     }
 
+    func testRecentResumeTargetsIncludeArchivedDesktopThreadsFromClassificationSnapshot() {
+        let codexID = "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
+        let claudeID = "39253133-4a65-48fb-af2b-844463d3b5bb"
+        let codex = candidate(
+            sessionId: codexID,
+            pid: 1,
+            bundleId: HostAppBundleID.codexDesktop,
+            lifecycleRank: SessionLifecycle.dormant.rawValue,
+            source: Session.codexSource,
+            lastActivity: Date(timeIntervalSince1970: 3000),
+            path: "/codex.json"
+        ) { session in
+            session.sessionName = "Can you use product design skills for the cctop logo"
+            session.desktopProjectName = "cctop"
+        }
+        let claude = candidate(
+            sessionId: claudeID,
+            pid: 2,
+            bundleId: HostAppBundleID.claudeDesktop,
+            lifecycleRank: SessionLifecycle.dormant.rawValue,
+            source: Session.ccSource,
+            lastActivity: Date(timeIntervalSince1970: 2000),
+            path: "/claude.json"
+        ) { session in
+            session.sessionName = "Run plugin node:test suites in CI"
+        }
+        let classification = SessionManager.sessionClassificationSnapshot(
+            in: [claude, codex],
+            claudeMetadata: ClaudeDesktopSessionMetadataSnapshot(
+                matchedSessionIDs: [claudeID],
+                archivedSessionIDs: [claudeID],
+                isAuthoritative: true
+            ),
+            codexThreads: StubCodexThreadState(archived: [codexID])
+        )
+
+        let targets = RecentResumeTarget.build(projects: [], classification: classification)
+
+        XCTAssertEqual(targets.map(\.title), [
+            "Can you use product design skills for the cctop logo",
+            "Run plugin node:test suites in CI",
+        ])
+        XCTAssertEqual(targets.map(\.openActionLabel), [
+            "Open Codex Desktop",
+            "Open Claude Desktop",
+        ])
+        XCTAssertEqual(targets.map(\.inlineActionLabel), [
+            "Open Codex",
+            "Open Claude",
+        ])
+        XCTAssertEqual(targets.map(\.metadataText), [
+            "Archived \u{00B7} Codex \u{00B7} /tmp/p",
+            "Archived \u{00B7} Claude \u{00B7} /tmp/p",
+        ])
+        XCTAssertFalse(targets.contains { $0.openActionLabel.contains("Thread") || ($0.inlineActionLabel?.contains("Thread") ?? false) })
+        XCTAssertFalse(targets.contains { $0.showsFinderAction })
+        XCTAssertFalse(targets.contains { $0.showsCopyPathAction })
+    }
+
+    func testRecentResumeTargetsExcludeNonArchivedDesktopHiddenReasons() {
+        let missing = candidate(
+            sessionId: "missing-thread",
+            pid: 1,
+            bundleId: HostAppBundleID.codexDesktop,
+            lifecycleRank: SessionLifecycle.dormant.rawValue,
+            source: Session.codexSource,
+            path: "/missing.json"
+        )
+        let classification = SessionManager.sessionClassificationSnapshot(
+            in: [missing],
+            claudeMetadata: nil,
+            codexThreads: StubCodexThreadState(existing: [], archived: [])
+        )
+
+        XCTAssertTrue(RecentResumeTarget.build(projects: [], classification: classification).isEmpty)
+    }
+
+    @MainActor
+    func testSessionManagerPublishesArchivedDesktopThreadsAsRecentTargets() throws {
+        let root = NSTemporaryDirectory() + "cctop-recent-desktop-targets-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let codexID = "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
+        var codex = codexDesktopSession(sessionId: codexID, projectPath: "\(NSHomeDirectory())/projects/cctop")
+        codex.sessionName = "Can you use product design skills for the cctop logo"
+        codex.lastActivity = Date(timeIntervalSince1970: 3000)
+        try codex.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("codex-\(codexID).json"))
+
+        let claudeID = "39253133-4a65-48fb-af2b-844463d3b5bb"
+        var claude = claudeDesktopSession(sessionId: claudeID, projectPath: "\(NSHomeDirectory())/projects/cctop")
+        claude.sessionName = "Run plugin node:test suites in CI"
+        claude.lastActivity = Date(timeIntervalSince1970: 2000)
+        try claude.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("\(claudeID).json"))
+
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
+        sources.codexThreads = StubCodexThreadState(archived: [codexID])
+        sources.claudeDesktopSessions = StubClaudeDesktopState(snapshot: ClaudeDesktopSessionMetadataSnapshot(
+            matchedSessionIDs: [claudeID],
+            archivedSessionIDs: [claudeID],
+            isAuthoritative: true
+        ))
+        sources.desktopAppConnection = DesktopAppConnectionLookup { _ in false }
+        sources.processAlive = { _ in false }
+
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertEqual(manager.recentResumeTargets.map(\.title), [
+            "Can you use product design skills for the cctop logo",
+            "Run plugin node:test suites in CI",
+        ])
+        XCTAssertEqual(manager.recentResumeTargets.map(\.openActionLabel), [
+            "Open Codex Desktop",
+            "Open Claude Desktop",
+        ])
+    }
+
+    func testRecentResumeTargetProjectMetadataKeepsEvidenceBeforePath() {
+        let project = RecentProject(
+            projectPath: "/Users/dev/projects/a-very-long-parent-path/billing-api",
+            projectName: "billing-api",
+            lastBranch: "unknown",
+            lastSessionAt: Date(),
+            sessionCount: 2,
+            lastEditor: "Cursor",
+            lastAgent: "Codex",
+            workspaceFile: nil
+        )
+
+        XCTAssertEqual(
+            RecentResumeTarget.project(project).metadataText,
+            "Codex \u{00B7} 2 sessions \u{00B7} /Users/dev/projects/a-very-long-parent-path/billing-api"
+        )
+    }
+
     func testClassificationSnapshotDoesNotEmitCleanupSourceForArchivedDesktopWithoutKnownPath() {
         var session = Session(
             sessionId: "archived-root",

--- a/menubar/CctopMenubarTests/SnapshotTests.swift
+++ b/menubar/CctopMenubarTests/SnapshotTests.swift
@@ -226,68 +226,89 @@ final class SnapshotTests: XCTestCase {
         let durableTerminalPath = "\(home)/projects/irb"
         let durableFallbackPath = "\(home)/projects/rdoc"
         let missingPath = "\(home)/projects/missing-recent-proof"
+        let projectContainerPath = "\(home)/projects"
         let cachePath = "\(home)/Library/Caches/cctop-recent-noise"
 
         let sessions = [
             recentProofSession(
-                projectPath: "/tmp/cctop-noise", projectName: "cctop-noise",
-                branch: "main", source: Session.codexSource,
-                terminal: TerminalInfo(program: "Cursor"),
+                projectPath: "/", projectName: "root",
+                branch: "main", source: Session.ccSource,
+                terminal: TerminalInfo(program: "Terminal", bundleId: "com.apple.Terminal"),
                 endedAt: now
             ),
             recentProofSession(
-                projectPath: "/private/tmp/cctop-noise", projectName: "private-noise",
+                projectPath: home, projectName: URL(fileURLWithPath: home).lastPathComponent,
                 branch: "main", source: Session.ccSource,
                 terminal: TerminalInfo(program: "ghostty", bundleId: "com.mitchellh.ghostty"),
                 endedAt: now.addingTimeInterval(-30)
             ),
             recentProofSession(
+                projectPath: projectContainerPath, projectName: "projects",
+                branch: "main", source: Session.codexSource,
+                terminal: TerminalInfo(program: "Cursor"),
+                endedAt: now.addingTimeInterval(-60)
+            ),
+            recentProofSession(
+                projectPath: "/tmp/cctop-noise", projectName: "cctop-noise",
+                branch: "main", source: Session.codexSource,
+                terminal: TerminalInfo(program: "Cursor"),
+                endedAt: now.addingTimeInterval(-90)
+            ),
+            recentProofSession(
+                projectPath: "/private/tmp/cctop-noise", projectName: "private-noise",
+                branch: "main", source: Session.ccSource,
+                terminal: TerminalInfo(program: "ghostty", bundleId: "com.mitchellh.ghostty"),
+                endedAt: now.addingTimeInterval(-120)
+            ),
+            recentProofSession(
                 projectPath: "/var/folders/zz/cctop-noise", projectName: "var-noise",
                 branch: "main", source: Session.opencodeSource,
                 terminal: TerminalInfo(program: "Terminal", bundleId: "com.apple.Terminal"),
-                endedAt: now.addingTimeInterval(-60)
+                endedAt: now.addingTimeInterval(-150)
             ),
             recentProofSession(
                 projectPath: cachePath, projectName: "cache-noise",
                 branch: "main", source: Session.piSource,
                 terminal: TerminalInfo(program: "Zed"),
-                endedAt: now.addingTimeInterval(-90)
+                endedAt: now.addingTimeInterval(-180)
             ),
             recentProofSession(
                 projectPath: missingPath, projectName: "missing-noise",
                 branch: "main", source: Session.codexSource,
                 terminal: TerminalInfo(program: "Code"),
-                endedAt: now.addingTimeInterval(-120)
+                endedAt: now.addingTimeInterval(-210)
             ),
             recentProofSession(
                 projectPath: durableEditorPath, projectName: "cctop",
                 branch: "codex/recent-projects-open-project", source: Session.codexSource,
                 terminal: TerminalInfo(program: "Cursor", bundleId: "com.todesktop.230313mzl4w4u92"),
-                endedAt: now.addingTimeInterval(-180)
+                endedAt: now.addingTimeInterval(-240)
             ),
             recentProofSession(
                 projectPath: durableEditorPath, projectName: "cctop",
                 branch: "codex/recent-projects-open-project", source: Session.ccSource,
                 terminal: TerminalInfo(program: "Cursor"),
-                endedAt: now.addingTimeInterval(-240)
+                endedAt: now.addingTimeInterval(-300)
             ),
             recentProofSession(
                 projectPath: durableTerminalPath, projectName: "irb",
                 branch: "master", source: Session.ccSource,
                 terminal: TerminalInfo(program: "ghostty", bundleId: "com.mitchellh.ghostty"),
-                endedAt: now.addingTimeInterval(-300)
+                endedAt: now.addingTimeInterval(-360)
             ),
             recentProofSession(
                 projectPath: durableFallbackPath, projectName: "rdoc",
                 branch: "unknown", source: Session.codexSource,
                 terminal: TerminalInfo(program: "Codex"),
-                endedAt: now.addingTimeInterval(-360)
+                endedAt: now.addingTimeInterval(-420)
             ),
         ]
 
         let recentProjects = HistoryManager.buildRecentProjects(
             from: sessions,
-            projectPathExists: { [durableEditorPath, durableTerminalPath, durableFallbackPath, cachePath].contains($0) }
+            projectPathExists: {
+                ["/", home, projectContainerPath, durableEditorPath, durableTerminalPath, durableFallbackPath, cachePath].contains($0)
+            }
         )
 
         XCTAssertEqual(recentProjects.map(\.projectName), ["cctop", "irb", "rdoc"])

--- a/menubar/CctopMenubarTests/SnapshotTests.swift
+++ b/menubar/CctopMenubarTests/SnapshotTests.swift
@@ -219,6 +219,144 @@ final class SnapshotTests: XCTestCase {
         try renderScreenshot(view: view, colorScheme: .dark, filename: "menubar-recent.png")
     }
 
+    func testGenerateRecentProjectsReworkProof() throws {
+        let home = NSHomeDirectory()
+        let now = Date()
+        let durableEditorPath = "\(home)/projects/cctop"
+        let durableTerminalPath = "\(home)/projects/irb"
+        let durableFallbackPath = "\(home)/projects/rdoc"
+        let missingPath = "\(home)/projects/missing-recent-proof"
+        let cachePath = "\(home)/Library/Caches/cctop-recent-noise"
+
+        let sessions = [
+            recentProofSession(
+                projectPath: "/tmp/cctop-noise", projectName: "cctop-noise",
+                branch: "main", source: Session.codexSource,
+                terminal: TerminalInfo(program: "Cursor"),
+                endedAt: now
+            ),
+            recentProofSession(
+                projectPath: "/private/tmp/cctop-noise", projectName: "private-noise",
+                branch: "main", source: Session.ccSource,
+                terminal: TerminalInfo(program: "ghostty", bundleId: "com.mitchellh.ghostty"),
+                endedAt: now.addingTimeInterval(-30)
+            ),
+            recentProofSession(
+                projectPath: "/var/folders/zz/cctop-noise", projectName: "var-noise",
+                branch: "main", source: Session.opencodeSource,
+                terminal: TerminalInfo(program: "Terminal", bundleId: "com.apple.Terminal"),
+                endedAt: now.addingTimeInterval(-60)
+            ),
+            recentProofSession(
+                projectPath: cachePath, projectName: "cache-noise",
+                branch: "main", source: Session.piSource,
+                terminal: TerminalInfo(program: "Zed"),
+                endedAt: now.addingTimeInterval(-90)
+            ),
+            recentProofSession(
+                projectPath: missingPath, projectName: "missing-noise",
+                branch: "main", source: Session.codexSource,
+                terminal: TerminalInfo(program: "Code"),
+                endedAt: now.addingTimeInterval(-120)
+            ),
+            recentProofSession(
+                projectPath: durableEditorPath, projectName: "cctop",
+                branch: "codex/recent-projects-open-project", source: Session.codexSource,
+                terminal: TerminalInfo(program: "Cursor", bundleId: "com.todesktop.230313mzl4w4u92"),
+                endedAt: now.addingTimeInterval(-180)
+            ),
+            recentProofSession(
+                projectPath: durableEditorPath, projectName: "cctop",
+                branch: "codex/recent-projects-open-project", source: Session.ccSource,
+                terminal: TerminalInfo(program: "Cursor"),
+                endedAt: now.addingTimeInterval(-240)
+            ),
+            recentProofSession(
+                projectPath: durableTerminalPath, projectName: "irb",
+                branch: "master", source: Session.ccSource,
+                terminal: TerminalInfo(program: "ghostty", bundleId: "com.mitchellh.ghostty"),
+                endedAt: now.addingTimeInterval(-300)
+            ),
+            recentProofSession(
+                projectPath: durableFallbackPath, projectName: "rdoc",
+                branch: "unknown", source: Session.codexSource,
+                terminal: TerminalInfo(program: "Codex"),
+                endedAt: now.addingTimeInterval(-360)
+            ),
+        ]
+
+        let recentProjects = HistoryManager.buildRecentProjects(
+            from: sessions,
+            projectPathExists: { [durableEditorPath, durableTerminalPath, durableFallbackPath, cachePath].contains($0) }
+        )
+
+        XCTAssertEqual(recentProjects.map(\.projectName), ["cctop", "irb", "rdoc"])
+        XCTAssertEqual(recentProjects.count, 3)
+        XCTAssertEqual(recentProjects[0].sessionCount, 2)
+        XCTAssertEqual(recentProjects[0].editorIcon, "chevron.left.forwardslash.chevron.right")
+        XCTAssertEqual(recentProjects[0].openActionLabel, "Open in Cursor")
+        XCTAssertEqual(recentProjects[1].editorIcon, "terminal")
+        XCTAssertEqual(recentProjects[1].openActionLabel, "Open in Ghostty")
+        XCTAssertEqual(recentProjects[2].editorIcon, "folder")
+        XCTAssertEqual(recentProjects[2].openActionLabel, "Open Project Folder")
+        XCTAssertEqual(recentProjects[2].metadataEvidenceText, "Codex \u{00B7} 1 session")
+
+        let view = PopupView(
+            sessions: [],
+            recentProjects: recentProjects,
+            updater: DisabledUpdater(),
+            pluginManager: inertPluginManager(),
+            initialTab: .recent
+        )
+        try renderPanelScreenshot(
+            view: view,
+            colorScheme: .dark,
+            directoryName: "cctop-recent-rework-proof",
+            filename: "recent-projects-rework.png"
+        )
+    }
+
+    func testGenerateRecentProjectsFilteredEmptyProof() throws {
+        let home = NSHomeDirectory()
+        let sessions = [
+            recentProofSession(
+                projectPath: "/tmp/cctop-noise", projectName: "tmp-noise",
+                branch: "main", source: Session.codexSource,
+                terminal: TerminalInfo(program: "Cursor"),
+                endedAt: Date()
+            ),
+            recentProofSession(
+                projectPath: "\(home)/Library/Caches/cctop-noise", projectName: "cache-noise",
+                branch: "main", source: Session.ccSource,
+                terminal: TerminalInfo(program: "Ghostty"),
+                endedAt: Date().addingTimeInterval(-60)
+            ),
+            recentProofSession(
+                projectPath: "\(home)/projects/missing-recent-proof", projectName: "missing-noise",
+                branch: "main", source: Session.codexSource,
+                terminal: TerminalInfo(program: "Code"),
+                endedAt: Date().addingTimeInterval(-120)
+            ),
+        ]
+        let recentProjects = HistoryManager.buildRecentProjects(from: sessions, projectPathExists: { _ in false })
+
+        XCTAssertTrue(recentProjects.isEmpty)
+
+        let view = PopupView(
+            sessions: [],
+            recentProjects: recentProjects,
+            updater: DisabledUpdater(),
+            pluginManager: inertPluginManager(),
+            initialTab: .recent
+        )
+        try renderPanelScreenshot(
+            view: view,
+            colorScheme: .dark,
+            directoryName: "cctop-recent-rework-proof",
+            filename: "recent-projects-all-filtered.png"
+        )
+    }
+
     func testGenerateCleanupScreenshot() throws {
         let view = PopupView(
             sessions: Session.qaShowcase,
@@ -320,5 +458,32 @@ final class SnapshotTests: XCTestCase {
         XCTAssertFalse(source.contains("repeatForever"))
         XCTAssertFalse(source.contains("BlinkingCaret("))
         XCTAssertFalse(viewSources.contains { $0.lastPathComponent == "BlinkingCaret.swift" })
+    }
+
+    private func recentProofSession(
+        projectPath: String,
+        projectName: String,
+        branch: String,
+        source: String?,
+        terminal: TerminalInfo?,
+        endedAt: Date
+    ) -> Session {
+        Session(
+            sessionId: UUID().uuidString,
+            projectPath: projectPath,
+            projectName: projectName,
+            branch: branch,
+            status: .idle,
+            lastPrompt: nil,
+            lastActivity: endedAt,
+            startedAt: endedAt.addingTimeInterval(-600),
+            terminal: terminal,
+            pid: nil,
+            lastTool: nil,
+            lastToolDetail: nil,
+            notificationMessage: nil,
+            source: source,
+            endedAt: endedAt
+        )
     }
 }

--- a/menubar/CctopMenubarTests/SnapshotTests.swift
+++ b/menubar/CctopMenubarTests/SnapshotTests.swift
@@ -378,6 +378,83 @@ final class SnapshotTests: XCTestCase {
         )
     }
 
+    func testGenerateRecentDesktopResumePrototypeProof() throws {
+        let home = NSHomeDirectory()
+        let now = Date()
+        let targets: [RecentResumeTarget] = [
+            .desktopThread(.init(
+                sessionId: "019ee566-93a1-7d00-8384-822ae67c77de",
+                title: "Can you use product design skills for cctop logo redesign",
+                projectPath: "\(home)/projects/cctop",
+                projectName: "cctop",
+                sourceApp: .codexDesktop,
+                lastActiveAt: now.addingTimeInterval(-120)
+            )),
+            .project(RecentProject(
+                projectPath: "\(home)/projects/irb",
+                projectName: "irb",
+                lastBranch: "master",
+                lastSessionAt: now.addingTimeInterval(-480),
+                sessionCount: 3,
+                lastEditor: "Ghostty",
+                lastAgent: "Claude Code",
+                workspaceFile: nil
+            )),
+            .desktopThread(.init(
+                sessionId: "9f4a3d84-6360-4fb3-8fa7-656d283babac",
+                title: "Test case refactor",
+                projectPath: "\(home)/projects/cctop",
+                projectName: "cctop",
+                sourceApp: .claudeDesktop,
+                lastActiveAt: now.addingTimeInterval(-900)
+            )),
+            .project(RecentProject(
+                projectPath: "\(home)/projects/rdoc",
+                projectName: "rdoc",
+                lastBranch: "unknown",
+                lastSessionAt: now.addingTimeInterval(-1_200),
+                sessionCount: 1,
+                lastEditor: "Codex",
+                lastAgent: "Codex",
+                workspaceFile: nil
+            )),
+            .project(RecentProject(
+                projectPath: "\(home)/projects/memories",
+                projectName: "memories",
+                lastBranch: "main",
+                lastSessionAt: now.addingTimeInterval(-1_800),
+                sessionCount: 2,
+                lastEditor: "Cursor",
+                lastAgent: "Codex",
+                workspaceFile: "\(home)/projects/memories/memories.code-workspace"
+            )),
+        ]
+
+        XCTAssertEqual(targets.map(\.openActionLabel), [
+            "Open Codex Desktop",
+            "Open in Ghostty",
+            "Open Claude Desktop",
+            "Open Project Folder",
+            "Open in Cursor",
+        ])
+        XCTAssertFalse(targets.contains { $0.openActionLabel.contains("Thread") || ($0.inlineActionLabel?.contains("Thread") ?? false) })
+
+        let view = PopupView(
+            sessions: [],
+            recentResumeTargets: targets,
+            updater: DisabledUpdater(),
+            pluginManager: inertPluginManager(),
+            initialTab: .recent
+        )
+        let size = try renderPanelScreenshot(
+            view: view,
+            colorScheme: .dark,
+            directoryName: "cctop-recent-desktop-resume-proof",
+            filename: "recent-desktop-resume-prototype.png"
+        )
+        XCTAssertLessThanOrEqual(size.width, 320)
+    }
+
     func testGenerateCleanupScreenshot() throws {
         let view = PopupView(
             sessions: Session.qaShowcase,

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1065,10 +1065,10 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertFalse(WorktreeCleanupCandidate.State.ignored(["main checkout"]).isActionable)
     }
 
-    func testPopupTabAvailabilityAlwaysIncludesCleanupForExplicitScan() {
+    func testPopupTabAvailabilityAlwaysIncludesRecentAndCleanupForExplicitScan() {
         XCTAssertEqual(
             PopupTab.availableTabs(hasIdleSessions: false, hasRecentProjects: false, hasCleanupCandidates: false),
-            [.active, .cleanup]
+            [.active, .recent, .cleanup]
         )
         XCTAssertEqual(
             PopupTab.availableTabs(hasIdleSessions: true, hasRecentProjects: true, hasCleanupCandidates: true),


### PR DESCRIPTION
## Problem

Recent was mostly useful for CLI/project-folder sessions. Desktop-hosted sessions could disappear from the active list after archiving, but cctop did not offer a useful, truthful way to find them again. The first pass also risked overclaiming Codex support by labeling archived rows as direct thread opens even though archived Codex thread URLs can land on a loading screen, and neither Codex nor Claude exposes a verified archive-list route.

## Solution

- Build Recent from resumable project targets plus archived desktop session targets, using the shared session classification state so the tab reflects the same lifecycle model as the rest of the app.
- Keep project rows focused on reopening folders, editors, and terminals, while archived desktop rows show session title, app, compact project path, and last activity.
- Use truthful desktop actions: `Open Codex` and `Open Claude` activate the host app only, with no Finder/path fallback or unverified thread/archive/settings deep link.
- Update Recent navigation, empty-state copy, and visual proof coverage for mixed project and archived desktop rows.
