### PR TITLE
Clarify tab discoverability copy

### DIFF
--- a/menubar/CctopMenubar/Models/RecentResumeTarget.swift
+++ b/menubar/CctopMenubar/Models/RecentResumeTarget.swift
@@ -112,7 +112,7 @@ enum RecentResumeTarget: Identifiable, Equatable {
         case .project(let project):
             return project.openHelpText
         case .desktopThread(let thread):
-            return "Open \(thread.sourceApp.displayName) to find this archived session"
+            return "Open \(thread.sourceApp.displayName); archived sessions may need manual lookup"
         }
     }
 

--- a/menubar/CctopMenubar/Views/PopupNavigation.swift
+++ b/menubar/CctopMenubar/Views/PopupNavigation.swift
@@ -3,6 +3,37 @@ import Foundation
 enum PopupTab {
     case active, idle, recent, cleanup
 
+    var helpText: String {
+        let staleIdleDuration = Self.staleIdleDurationText
+        switch self {
+        case .active:
+            return "Current sessions; idle moves after \(staleIdleDuration)."
+        case .idle:
+            return "Dormant sessions and idle sessions over \(staleIdleDuration)."
+        case .recent:
+            return "Finished work and archived desktop sessions. Rows open the project or app."
+        case .cleanup:
+            return "Ended-session worktrees checked before removal."
+        }
+    }
+
+    var emptyStateDetail: String {
+        switch self {
+        case .active:
+            return "Current and recently idle sessions appear here."
+        case .idle:
+            return "Dormant and long-idle sessions appear here."
+        case .recent:
+            return "Finished work and archived desktop sessions appear here."
+        case .cleanup:
+            return "Ended-session worktrees appear here after checks."
+        }
+    }
+
+    static var cleanupScanningDetail: String {
+        "Checking ended-session worktrees."
+    }
+
     static func availableTabs(
         hasIdleSessions: Bool,
         hasRecentProjects _: Bool,
@@ -31,6 +62,11 @@ enum PopupTab {
         default:
             return current
         }
+    }
+
+    private static var staleIdleDurationText: String {
+        let hours = Int(SessionDisplayPolicy.staleIdleInterval / 3_600)
+        return "\(hours) hours"
     }
 }
 

--- a/menubar/CctopMenubar/Views/PopupNavigation.swift
+++ b/menubar/CctopMenubar/Views/PopupNavigation.swift
@@ -11,7 +11,7 @@ enum PopupTab {
         case .idle:
             return "Dormant sessions and idle sessions over \(staleIdleDuration)."
         case .recent:
-            return "Finished work and archived desktop sessions. Rows open the project or app."
+            return "Finished work and archived desktop sessions. Rows open the project or app when possible."
         case .cleanup:
             return "Ended-session worktrees checked before removal."
         }

--- a/menubar/CctopMenubar/Views/PopupView+EmptyState.swift
+++ b/menubar/CctopMenubar/Views/PopupView+EmptyState.swift
@@ -2,22 +2,40 @@ import SwiftUI
 
 extension PopupView {
     var noActiveSessionsContent: some View {
-        emptyPlaceholder(systemImage: "circle.dotted", title: "No active sessions")
+        emptyPlaceholder(
+            systemImage: "circle.dotted",
+            title: "No active sessions",
+            detail: PopupTab.active.emptyStateDetail
+        )
     }
 
     var noIdleSessionsContent: some View {
-        emptyPlaceholder(systemImage: "moon", title: "No idle sessions")
+        emptyPlaceholder(
+            systemImage: "moon",
+            title: "No idle sessions",
+            detail: PopupTab.idle.emptyStateDetail
+        )
     }
 
-    func emptyPlaceholder(systemImage: String, title: String) -> some View {
+    func emptyPlaceholder(systemImage: String, title: String, detail: String? = nil) -> some View {
         VStack(spacing: 8) {
             Image(systemName: systemImage)
                 .font(.system(size: 20))
                 .foregroundStyle(Color.textMuted)
-            Text(title)
-                .font(.system(size: 12))
-                .foregroundStyle(Color.textMuted)
-                .multilineTextAlignment(.center)
+            VStack(spacing: 2) {
+                Text(title)
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color.textMuted)
+                    .multilineTextAlignment(.center)
+                if let detail {
+                    Text(detail)
+                        .font(.system(size: 10))
+                        .foregroundStyle(Color.textSecondary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 24)

--- a/menubar/CctopMenubar/Views/PopupView+Recent.swift
+++ b/menubar/CctopMenubar/Views/PopupView+Recent.swift
@@ -4,7 +4,11 @@ extension PopupView {
     @ViewBuilder
     var recentContent: some View {
         if recentTargets.isEmpty {
-            emptyPlaceholder(systemImage: "clock", title: "No recent items yet\nFinished projects and archived sessions appear here")
+            emptyPlaceholder(
+                systemImage: "clock",
+                title: "No recent items yet",
+                detail: PopupTab.recent.emptyStateDetail
+            )
         } else {
             panelList(recentTargets, tab: .recent) { _, target, isSelected in
                 recentCard(target, isSelected: isSelected)

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -155,6 +155,7 @@ struct PopupView: View {
             withAnimation(.easeInOut(duration: 0.15)) { selectedTab = tab }
             notifyLayoutChanged()
         }
+        .help(tab.helpText)
     }
     // MARK: - Active tab
     private var activeContent: some View {

--- a/menubar/CctopMenubar/Views/WorktreeCleanupTabView.swift
+++ b/menubar/CctopMenubar/Views/WorktreeCleanupTabView.swift
@@ -58,6 +58,12 @@ struct WorktreeCleanupTabView: View {
                     .font(.system(size: 12))
                     .foregroundStyle(Color.textMuted)
                     .multilineTextAlignment(.center)
+                Text(isScanning ? PopupTab.cleanupScanningDetail : PopupTab.cleanup.emptyStateDetail)
+                    .font(.system(size: 10))
+                    .foregroundStyle(Color.textSecondary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 24)

--- a/menubar/CctopMenubarTests/SessionLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/SessionLifecycleTests.swift
@@ -782,6 +782,24 @@ final class SessionLifecycleTests: XCTestCase {
         )
     }
 
+    func testRecentResumeTargetDesktopThreadOpenHelpTextUsesCautiousArchiveLanguage() {
+        let target = RecentResumeTarget.desktopThread(.init(
+            sessionId: "019e1eff-3374-74b0-8d3d-6fba94e7d75f",
+            title: "Can you use product design skills for the cctop logo",
+            projectPath: "/Users/dev/projects/cctop",
+            projectName: "cctop",
+            sourceApp: .codexDesktop,
+            lastActiveAt: Date()
+        ))
+
+        XCTAssertEqual(
+            target.openHelpText,
+            "Open Codex Desktop; archived sessions may need manual lookup"
+        )
+        XCTAssertFalse(target.openHelpText.localizedCaseInsensitiveContains("return"))
+        XCTAssertFalse(target.openHelpText.localizedCaseInsensitiveContains("resume"))
+    }
+
     func testClassificationSnapshotDoesNotEmitCleanupSourceForArchivedDesktopWithoutKnownPath() {
         var session = Session(
             sessionId: "archived-root",

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1076,6 +1076,53 @@ final class WorktreeCleanupTests: XCTestCase {
         )
     }
 
+    func testPopupTabHelpTextDescribesCurrentBuckets() {
+        let staleIdleHours = Int(SessionDisplayPolicy.staleIdleInterval / 3_600)
+
+        XCTAssertEqual(
+            PopupTab.active.helpText,
+            "Current sessions; idle moves after \(staleIdleHours) hours."
+        )
+        XCTAssertEqual(
+            PopupTab.idle.helpText,
+            "Dormant sessions and idle sessions over \(staleIdleHours) hours."
+        )
+        let recentHelpText = PopupTab.recent.helpText
+        XCTAssertTrue(recentHelpText.contains("Finished work"))
+        XCTAssertTrue(recentHelpText.contains("archived desktop sessions"))
+        XCTAssertTrue(recentHelpText.contains("Rows open"))
+        XCTAssertFalse(recentHelpText.localizedCaseInsensitiveContains("return"))
+        XCTAssertFalse(recentHelpText.localizedCaseInsensitiveContains("resume"))
+        XCTAssertEqual(
+            PopupTab.cleanup.helpText,
+            "Ended-session worktrees checked before removal."
+        )
+    }
+
+    func testPopupTabEmptyStateDetailsTeachBuckets() {
+        XCTAssertEqual(
+            PopupTab.active.emptyStateDetail,
+            "Current and recently idle sessions appear here."
+        )
+        XCTAssertEqual(
+            PopupTab.idle.emptyStateDetail,
+            "Dormant and long-idle sessions appear here."
+        )
+        let recentEmptyStateDetail = PopupTab.recent.emptyStateDetail
+        XCTAssertTrue(recentEmptyStateDetail.contains("Finished work"))
+        XCTAssertTrue(recentEmptyStateDetail.contains("archived desktop sessions"))
+        XCTAssertFalse(recentEmptyStateDetail.localizedCaseInsensitiveContains("return"))
+        XCTAssertFalse(recentEmptyStateDetail.localizedCaseInsensitiveContains("resume"))
+        XCTAssertEqual(
+            PopupTab.cleanup.emptyStateDetail,
+            "Ended-session worktrees appear here after checks."
+        )
+        XCTAssertEqual(
+            PopupTab.cleanupScanningDetail,
+            "Checking ended-session worktrees."
+        )
+    }
+
     func testKeyboardTabSwitchingIncludesCleanup() {
         let tabs: [PopupTab] = [.active, .recent, .cleanup]
 

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1091,6 +1091,7 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertTrue(recentHelpText.contains("Finished work"))
         XCTAssertTrue(recentHelpText.contains("archived desktop sessions"))
         XCTAssertTrue(recentHelpText.contains("Rows open"))
+        XCTAssertTrue(recentHelpText.contains("when possible"))
         XCTAssertFalse(recentHelpText.localizedCaseInsensitiveContains("return"))
         XCTAssertFalse(recentHelpText.localizedCaseInsensitiveContains("resume"))
         XCTAssertEqual(


### PR DESCRIPTION
## Problem

The menubar tabs expose useful product concepts, but the UI did not explain those buckets at the point where users encounter them. Recent also risked overpromising by implying archived or finished work could always be returned to directly.

## Solution

- Add concise hover help for Active, Idle, Recent, and Cleanup so users can learn each tab without leaving the panel.
- Add compact empty-state details for the same buckets, including cleanup scanning copy that makes in-progress checking clear.
- Keep Recent copy accurate by describing finished work and archived desktop sessions without promising direct resume behavior.