### PR TITLE
Surface cleanup opportunity nudges

### DIFF
--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -95,6 +95,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             sessionManager: sessionManager,
             historyManager: historyManager,
             cleanupManager: cleanupManager,
+            cleanupRefreshGate: cleanupRefreshGate,
             updater: updater,
             pluginManager: pluginManager,
             navigate: navigateController,
@@ -105,10 +106,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
                 await self?.executeCleanupRemovalAction(action) ?? .refused(action.candidate)
             },
             onCleanupTabVisible: { [weak self] in
-                Task { @MainActor in self?.setCleanupVisible(true) }
+                Task { @MainActor in self?.setCleanupTabSelected(true) }
             },
             onCleanupTabHidden: { [weak self] in
-                Task { @MainActor in self?.setCleanupVisible(false) }
+                Task { @MainActor in self?.setCleanupTabSelected(false) }
             },
             onLayoutChanged: { [weak self] in
                 Task { @MainActor in self?.resizePanel(animate: true) }
@@ -158,8 +159,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         return result
     }
 
-    @MainActor private func setCleanupVisible(_ visible: Bool) {
-        cleanupRefreshGate.setCleanupVisible(visible)
+    @MainActor private func setCleanupTabSelected(_ selected: Bool) {
+        cleanupRefreshGate.setCleanupTabSelected(selected)
+    }
+
+    @MainActor private func updateCleanupPanelVisibility() {
+        cleanupRefreshGate.setPanelVisible(panel?.isVisible == true)
     }
 
     @MainActor private func registerShortcuts() {
@@ -539,6 +544,7 @@ extension AppDelegate {
                 // Codex hooks in Codex itself) — re-read it on every open.
                 pluginManager.refresh()
                 panel.makeKeyAndOrderFront(nil)
+                updateCleanupPanelVisibility()
                 // Re-position after SwiftUI layout settles
                 DispatchQueue.main.async { [weak self] in
                     self?.positionPanel()
@@ -546,12 +552,14 @@ extension AppDelegate {
                 }
             case .dismissPanel:
                 panel.orderOut(nil)
+                updateCleanupPanelVisibility()
                 focusLocation = nil
                 previousApp = nil
                 stopNavKeyMonitor()
                 updateNotchVisibility(immediate: true)
             case .navigatePanel:
                 panel.makeKeyAndOrderFront(nil)
+                updateCleanupPanelVisibility()
             case .positionPanel:
                 positionPanel()
                 // If panel didn't land on target screen, clear stale position and retry

--- a/menubar/CctopMenubar/Models/Config.swift
+++ b/menubar/CctopMenubar/Models/Config.swift
@@ -100,8 +100,15 @@ enum Config {
 
     static func isLikelyPrivacyProtectedUserPath(_ path: String) -> Bool {
         let pathComponents = URL(fileURLWithPath: standardizedPath(path)).pathComponents
-        guard pathComponents.count > 3, pathComponents[1] == "Users" else { return false }
-        return ["Desktop", "Documents", "Downloads"].contains(pathComponents[3])
+        guard let userDirectoryIndex = userDirectoryComponentIndex(in: pathComponents) else { return false }
+        let protectedFolderIndex = userDirectoryIndex + 2
+        guard pathComponents.indices.contains(protectedFolderIndex) else { return false }
+        if ["Desktop", "Documents", "Downloads"].contains(pathComponents[protectedFolderIndex]) {
+            return true
+        }
+        return pathComponents[protectedFolderIndex] == "Library"
+            && pathComponents.indices.contains(protectedFolderIndex + 1)
+            && pathComponents[protectedFolderIndex + 1] == "Mobile Documents"
     }
 
     private static func ensureDirectoryExists(_ path: String) {
@@ -112,6 +119,20 @@ enum Config {
                 attributes: [.posixPermissions: 0o700]
             )
         }
+    }
+
+    private static func userDirectoryComponentIndex(in pathComponents: [String]) -> Int? {
+        if pathComponents.count > 2, pathComponents[1] == "Users" {
+            return 1
+        }
+        if pathComponents.count > 5,
+           pathComponents[1] == "System",
+           pathComponents[2] == "Volumes",
+           pathComponents[3] == "Data",
+           pathComponents[4] == "Users" {
+            return 4
+        }
+        return nil
     }
 
     private static func codexHome() -> String {

--- a/menubar/CctopMenubar/Models/Config.swift
+++ b/menubar/CctopMenubar/Models/Config.swift
@@ -98,6 +98,12 @@ enum Config {
         NSString(string: NSString(string: path).expandingTildeInPath).standardizingPath
     }
 
+    static func isLikelyPrivacyProtectedUserPath(_ path: String) -> Bool {
+        let pathComponents = URL(fileURLWithPath: standardizedPath(path)).pathComponents
+        guard pathComponents.count > 3, pathComponents[1] == "Users" else { return false }
+        return ["Desktop", "Documents", "Downloads"].contains(pathComponents[3])
+    }
+
     private static func ensureDirectoryExists(_ path: String) {
         let fm = FileManager.default
         if !fm.fileExists(atPath: path) {

--- a/menubar/CctopMenubar/Models/WorktreeCleanupCandidate.swift
+++ b/menubar/CctopMenubar/Models/WorktreeCleanupCandidate.swift
@@ -11,6 +11,7 @@ struct WorktreeCleanupCandidate: Identifiable, Equatable {
     static let branchUnknownReason = "Branch is unknown or detached"
     static let mainWorktreePathUnverifiedReason = "Main checkout path could not be verified"
     static let commitSafetyUnknownReason = "Branch upstream or commit safety could not be verified"
+    static let protectedFolderAccessReason = "File access is needed to inspect this protected worktree"
     private static let localFileReasons = [untrackedFilesReason, ignoredFilesReason]
 
     enum State: Equatable {

--- a/menubar/CctopMenubar/Services/GitWorktreeInspector.swift
+++ b/menubar/CctopMenubar/Services/GitWorktreeInspector.swift
@@ -27,6 +27,21 @@ struct GitWorktreeInspector {
             .max { lhs, rhs in lhs.count < rhs.count }
     }
 
+    func linkedWorktreeRoot(containing path: String) -> String? {
+        guard let entries = listWorktrees(from: path) else { return nil }
+        let comparablePath = Self.comparablePath(path)
+        return entries
+            .enumerated()
+            .compactMap { index, entry in
+                guard index > 0,
+                      Self.path(comparablePath, isSameAsOrDescendantOf: Self.comparablePath(entry.path)) else {
+                    return nil
+                }
+                return entry.path
+            }
+            .max { lhs, rhs in lhs.count < rhs.count }
+    }
+
     func inspect(path: String) -> GitWorktreeInspection {
         var failures: [String] = []
 

--- a/menubar/CctopMenubar/Services/GitWorktreeInspector.swift
+++ b/menubar/CctopMenubar/Services/GitWorktreeInspector.swift
@@ -11,6 +11,7 @@ struct GitWorktreeInspector {
     var runGitWithInput: (String, [String], String) -> GitCommandResult = GitCommand.run
     var worktreeFileMode: (String) -> String? = Self.gitWorktreeFileMode
     var symlinkDestination: (String) -> String? = Self.symlinkDestination
+    var canonicalizePath: (String) -> String = Self.resolvingSymlinksInPath
 
     func listWorktrees(from path: String) -> [GitWorktreeListEntry]? {
         let list = runGit(path, ["worktree", "list", "--porcelain", "-z"])
@@ -20,21 +21,21 @@ struct GitWorktreeInspector {
 
     func worktreeRoot(containing path: String) -> String? {
         guard let entries = listWorktrees(from: path) else { return nil }
-        let comparablePath = Self.comparablePath(path)
+        let needlePath = comparablePath(path)
         return entries
             .map(\.path)
-            .filter { Self.path(comparablePath, isSameAsOrDescendantOf: Self.comparablePath($0)) }
+            .filter { Self.path(needlePath, isSameAsOrDescendantOf: comparablePath($0)) }
             .max { lhs, rhs in lhs.count < rhs.count }
     }
 
     func linkedWorktreeRoot(containing path: String) -> String? {
         guard let entries = listWorktrees(from: path) else { return nil }
-        let comparablePath = Self.comparablePath(path)
+        let needlePath = comparablePath(path)
         return entries
             .enumerated()
             .compactMap { index, entry in
                 guard index > 0,
-                      Self.path(comparablePath, isSameAsOrDescendantOf: Self.comparablePath(entry.path)) else {
+                      Self.path(needlePath, isSameAsOrDescendantOf: comparablePath(entry.path)) else {
                     return nil
                 }
                 return entry.path
@@ -58,9 +59,9 @@ struct GitWorktreeInspector {
             )
         }
 
-        let comparablePath = Self.comparablePath(path)
+        let needlePath = comparablePath(path)
         let mainWorktreePath = entries.first?.path
-        guard let matchIndex = entries.firstIndex(where: { Self.comparablePath($0.path) == comparablePath }) else {
+        guard let matchIndex = entries.firstIndex(where: { comparablePath($0.path) == needlePath }) else {
             return GitWorktreeInspection(
                 isRegisteredWorktree: false,
                 isLinkedWorktree: false,
@@ -300,8 +301,16 @@ struct GitWorktreeInspector {
         path == root || path.hasPrefix(root.hasSuffix("/") ? root : "\(root)/")
     }
 
-    private static func comparablePath(_ path: String) -> String {
-        Config.standardizedPath((path as NSString).resolvingSymlinksInPath)
+    private func comparablePath(_ path: String) -> String {
+        let standardizedPath = Config.standardizedPath(path)
+        guard !Config.isLikelyPrivacyProtectedUserPath(standardizedPath) else {
+            return standardizedPath
+        }
+        return Config.standardizedPath(canonicalizePath(path))
+    }
+
+    private static func resolvingSymlinksInPath(_ path: String) -> String {
+        (path as NSString).resolvingSymlinksInPath
     }
 }
 

--- a/menubar/CctopMenubar/Services/HistoryManager.swift
+++ b/menubar/CctopMenubar/Services/HistoryManager.swift
@@ -93,10 +93,10 @@ class HistoryManager: ObservableObject {
         for session in sessions {
             if session.isHostedByDesktopApp { continue }
             let canonicalProjectPath = canonicalRecentProjectPath(session.projectPath)
+            if activeProjectPaths.contains(canonicalProjectPath) { continue }
             guard isDurableRecentProjectPath(canonicalProjectPath, projectPathExists: projectPathExists) else {
                 continue
             }
-            if activeProjectPaths.contains(canonicalProjectPath) { continue }
             if let existing = grouped[canonicalProjectPath] {
                 let newer = session.effectiveEndDate > existing.latest.effectiveEndDate
                 grouped[canonicalProjectPath] = (
@@ -131,8 +131,9 @@ class HistoryManager: ObservableObject {
         projectPathExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
     ) -> Bool {
         let canonicalPath = canonicalRecentProjectPath(path)
-        guard projectPathExists(canonicalPath) else { return false }
-        return !isExcludedRecentProjectPath(canonicalPath)
+        guard !isExcludedRecentProjectPath(canonicalPath) else { return false }
+        guard !Config.isLikelyPrivacyProtectedUserPath(canonicalPath) else { return true }
+        return projectPathExists(canonicalPath)
     }
 
     private static func isExcludedRecentProjectPath(_ canonicalPath: String) -> Bool {
@@ -143,7 +144,9 @@ class HistoryManager: ObservableObject {
     }
 
     static func canonicalRecentProjectPath(_ path: String) -> String {
-        URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath().path
+        let path = Config.standardizedPath(path)
+        guard !Config.isLikelyPrivacyProtectedUserPath(path) else { return path }
+        return URL(fileURLWithPath: path).resolvingSymlinksInPath().path
     }
 
     private static var nonDurableRecentProjectRootPaths: [String] {
@@ -230,7 +233,7 @@ class HistoryManager: ObservableObject {
                 toRemove.append(entry.url)
             } else {
                 seenProjects.insert(canonicalPath)
-                if projectPathExists(canonicalPath) {
+                if Config.isLikelyPrivacyProtectedUserPath(canonicalPath) || projectPathExists(canonicalPath) {
                     capEligibleKeep.append(entry)
                 }
             }

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -124,28 +124,10 @@ struct SessionClassificationSnapshot {
         }
     }
 
-    /// Cleanup sources are only emitted from cctop JSON records classified in this pass.
-    /// External host metadata may hide or enrich those records, but it never creates cleanup rows
-    /// without a session file because the scanner needs cctop's project path and recency context.
-    /// Missing/deleted desktop conversations stay hidden and preserved, but do not become cleanup
-    /// sources unless the host metadata explicitly marks the conversation archived.
+    /// Archived desktop conversations stay hidden and resumable in Recent, but are preserved
+    /// files rather than cleanup opportunities. Non-desktop cleanup rows come from history.
     var cleanupSources: [SessionCleanupSource] {
-        records.compactMap { record in
-            guard case .hidden(let reason) = record.disposition,
-                  Self.emitsCleanupSource(for: reason),
-                  Self.hasKnownCleanupPath(record.candidate.session.projectPath) else {
-                return nil
-            }
-            return SessionCleanupSource(session: record.candidate.session)
-        }
-    }
-
-    private static func hasKnownCleanupPath(_ path: String) -> Bool {
-        !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && path != "/"
-    }
-
-    private static func emitsCleanupSource(for reason: SessionHiddenReason) -> Bool {
-        reason == .archivedCodexDesktop || reason == .archivedClaudeDesktop
+        []
     }
 
     var archivedCodexThreadIDs: Set<String> { evidence.archivedCodexThreadIDs }

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -124,10 +124,18 @@ struct SessionClassificationSnapshot {
         }
     }
 
-    /// Archived desktop conversations stay hidden and resumable in Recent, but are preserved
-    /// files rather than cleanup opportunities. Non-desktop cleanup rows come from history.
+    /// Archived desktop conversations stay hidden and resumable in Recent, but a known
+    /// project path can still seed worktree cleanup while preserving the session file.
+    /// Non-desktop cleanup rows come from history.
     var cleanupSources: [SessionCleanupSource] {
-        []
+        records.compactMap { record in
+            guard case .hidden(let reason) = record.disposition,
+                  reason.emitsCleanupSource,
+                  record.candidate.session.hasCleanupSourcePath else {
+                return nil
+            }
+            return SessionCleanupSource(session: record.candidate.session)
+        }
     }
 
     var archivedCodexThreadIDs: Set<String> { evidence.archivedCodexThreadIDs }
@@ -135,6 +143,25 @@ struct SessionClassificationSnapshot {
     var codexSubagentThreadIDs: Set<String> { evidence.codexSubagentThreadIDs }
     var codexExecHelperThreadIDs: Set<String> { evidence.codexExecHelperThreadIDs }
     var archivedClaudeSessionIDs: Set<String> { evidence.archivedClaudeSessionIDs }
+}
+
+private extension SessionHiddenReason {
+    var emitsCleanupSource: Bool {
+        switch self {
+        case .archivedCodexDesktop, .archivedClaudeDesktop:
+            return true
+        case .persistedHidden, .autoHidden, .missingCodexDesktopThread, .codexSubagent,
+             .codexExecHelper, .orphanedEndedClaudeDesktop, .claudeDesktopStartupPlaceholder:
+            return false
+        }
+    }
+}
+
+private extension Session {
+    var hasCleanupSourcePath: Bool {
+        let path = WorktreeCleanupScanner.standardizedPath(projectPath)
+        return !path.isEmpty && path != "/"
+    }
 }
 
 extension SessionManager {

--- a/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
@@ -158,9 +158,11 @@ struct WorktreeCleanupRefreshSignature: Equatable {
 
     init(cleanupSources: [SessionCleanupSource], activeProjectPaths: Set<String>) {
         self.cleanupSources = cleanupSources
-            .map {
-                CleanupSourceFingerprint(
-                    path: WorktreeCleanupScanner.standardizedPath($0.projectPath),
+            .compactMap {
+                let path = WorktreeCleanupScanner.standardizedPath($0.projectPath)
+                guard WorktreeCleanupScanner.shouldScanCleanupSourcePath(path) else { return nil }
+                return CleanupSourceFingerprint(
+                    path: path,
                     sessionId: $0.sessionId,
                     lastActiveAt: $0.lastActiveAt,
                     displayName: $0.sessionName,

--- a/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
@@ -62,6 +62,9 @@ final class WorktreeCleanupRefreshGate: ObservableObject {
     private var isPanelVisible = false
     private var isCleanupVisible = false
     private var seenCleanupSourceIDs: Set<WorktreeCleanupSourceIdentity> = []
+    private var hiddenLinkedWorktreeIdentityPaths: [String: String] = [:]
+    private var hiddenNonLinkedWorktreePaths: Set<String> = []
+    private var pendingHiddenLinkedWorktreePaths: Set<String> = []
 
     init(manager: WorktreeCleanupManager) {
         self.manager = manager
@@ -109,6 +112,7 @@ final class WorktreeCleanupRefreshGate: ObservableObject {
     }
 
     private func updateHiddenNudgeFromSourceIdentities() {
+        resolveHiddenLinkedWorktreeIdentitiesIfNeeded()
         let sourceIDs = currentSourceIDs()
         if sourceIDs.isEmpty {
             hasHiddenCleanupNudge = false
@@ -119,6 +123,7 @@ final class WorktreeCleanupRefreshGate: ObservableObject {
     }
 
     private func markCurrentSourcesSeen() {
+        resolveHiddenLinkedWorktreeIdentitiesIfNeeded()
         seenCleanupSourceIDs = currentSourceIDs()
         hasHiddenCleanupNudge = false
     }
@@ -126,7 +131,62 @@ final class WorktreeCleanupRefreshGate: ObservableObject {
     private func currentSourceIDs() -> Set<WorktreeCleanupSourceIdentity> {
         let activePaths = Set(activeProjectPaths.map(WorktreeCleanupScanner.standardizedPath))
         return Set(cleanupSources.compactMap { source in
-            WorktreeCleanupSourceIdentity(source: source, activeProjectPaths: activePaths, scanner: manager.scanner)
+            let sourcePath = WorktreeCleanupScanner.standardizedPath(source.projectPath)
+            let identityPath = WorktreeCleanupScanner.hiddenCleanupSourceIdentityPath(for: sourcePath)
+                ?? hiddenLinkedWorktreeIdentityPaths[sourcePath]
+            guard let identityPath else { return nil }
+            return WorktreeCleanupSourceIdentity(source: source, identityPath: identityPath, activeProjectPaths: activePaths)
+        })
+    }
+
+    private func resolveHiddenLinkedWorktreeIdentitiesIfNeeded() {
+        let sourcePaths = hiddenLinkedWorktreeSourcePaths()
+        hiddenLinkedWorktreeIdentityPaths = hiddenLinkedWorktreeIdentityPaths.filter { sourcePaths.contains($0.key) }
+        hiddenNonLinkedWorktreePaths = hiddenNonLinkedWorktreePaths.intersection(sourcePaths)
+        pendingHiddenLinkedWorktreePaths = pendingHiddenLinkedWorktreePaths.intersection(sourcePaths)
+
+        let unresolvedPaths = sourcePaths
+            .subtracting(hiddenLinkedWorktreeIdentityPaths.keys)
+            .subtracting(hiddenNonLinkedWorktreePaths)
+            .subtracting(pendingHiddenLinkedWorktreePaths)
+        guard !unresolvedPaths.isEmpty else { return }
+
+        pendingHiddenLinkedWorktreePaths.formUnion(unresolvedPaths)
+        let scanner = manager.scanner
+        DispatchQueue.global(qos: .utility).async {
+            let resolvedPaths = unresolvedPaths.map { sourcePath in
+                (sourcePath, scanner.hiddenLinkedWorktreeIdentityPath(for: sourcePath))
+            }
+            DispatchQueue.main.async {
+                self.finishResolvingHiddenLinkedWorktreeIdentities(resolvedPaths)
+            }
+        }
+    }
+
+    private func finishResolvingHiddenLinkedWorktreeIdentities(_ resolvedPaths: [(String, String?)]) {
+        let currentSourcePaths = hiddenLinkedWorktreeSourcePaths()
+        for (sourcePath, identityPath) in resolvedPaths {
+            pendingHiddenLinkedWorktreePaths.remove(sourcePath)
+            guard currentSourcePaths.contains(sourcePath) else { continue }
+            if let identityPath {
+                hiddenLinkedWorktreeIdentityPaths[sourcePath] = identityPath
+                hiddenNonLinkedWorktreePaths.remove(sourcePath)
+            } else {
+                hiddenLinkedWorktreeIdentityPaths.removeValue(forKey: sourcePath)
+                hiddenNonLinkedWorktreePaths.insert(sourcePath)
+            }
+        }
+        if isCleanupVisible {
+            markCurrentSourcesSeen()
+        } else {
+            updateHiddenNudgeFromSourceIdentities()
+        }
+    }
+
+    private func hiddenLinkedWorktreeSourcePaths() -> Set<String> {
+        Set(cleanupSources.compactMap { source in
+            let sourcePath = WorktreeCleanupScanner.standardizedPath(source.projectPath)
+            return WorktreeCleanupScanner.shouldResolveHiddenLinkedWorktreeRoot(for: sourcePath) ? sourcePath : nil
         })
     }
 }
@@ -135,10 +195,10 @@ private struct WorktreeCleanupSourceIdentity: Hashable {
     let path: String
     let sessionId: String
 
-    init?(source: SessionCleanupSource, activeProjectPaths: Set<String>, scanner: WorktreeCleanupScanner) {
-        guard let path = scanner.hiddenCleanupSourceIdentityPath(for: source.projectPath) else { return nil }
-        guard !Self.isActive(path, activeProjectPaths: activeProjectPaths) else { return nil }
-        self.path = path
+    init?(source: SessionCleanupSource, identityPath: String, activeProjectPaths: Set<String>) {
+        let identityPath = WorktreeCleanupScanner.standardizedPath(identityPath)
+        guard !Self.isActive(identityPath, activeProjectPaths: activeProjectPaths) else { return nil }
+        path = identityPath
         sessionId = source.sessionId
     }
 

--- a/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
@@ -99,8 +99,7 @@ final class WorktreeCleanupRefreshGate: ObservableObject {
         guard isCleanupVisible else { return }
         markCurrentCandidatesSeen()
         manager.refresh(from: cleanupSources, activeProjectPaths: activeProjectPaths, force: force) { [weak self] candidates in
-            guard let self, self.isCleanupVisible else { return }
-            self.markCandidatesSeen(candidates)
+            self?.handleRefreshCompletion(candidates)
         }
     }
 
@@ -115,12 +114,15 @@ final class WorktreeCleanupRefreshGate: ObservableObject {
 
     private func refreshWhileHidden() {
         manager.refresh(from: cleanupSources, activeProjectPaths: activeProjectPaths) { [weak self] candidates in
-            guard let self else { return }
-            if self.isCleanupVisible {
-                self.markCandidatesSeen(candidates)
-            } else {
-                self.updateHiddenNudge(from: candidates)
-            }
+            self?.handleRefreshCompletion(candidates)
+        }
+    }
+
+    private func handleRefreshCompletion(_ candidates: [WorktreeCleanupCandidate]) {
+        if isCleanupVisible {
+            markCandidatesSeen(candidates)
+        } else {
+            updateHiddenNudge(from: candidates)
         }
     }
 

--- a/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
@@ -19,7 +19,11 @@ class WorktreeCleanupManager: ObservableObject {
         self.scanner = scanner
     }
 
-    func refresh(from cleanupSources: [SessionCleanupSource], activeProjectPaths: Set<String>, force: Bool = false) {
+    func refresh(
+        from cleanupSources: [SessionCleanupSource],
+        activeProjectPaths: Set<String>,
+        force: Bool = false
+    ) {
         let signature = WorktreeCleanupRefreshSignature(
             cleanupSources: cleanupSources,
             activeProjectPaths: activeProjectPaths
@@ -48,11 +52,16 @@ class WorktreeCleanupManager: ObservableObject {
 }
 
 @MainActor
-final class WorktreeCleanupRefreshGate {
+final class WorktreeCleanupRefreshGate: ObservableObject {
+    @Published private(set) var hasHiddenCleanupNudge = false
+
     private let manager: WorktreeCleanupManager
     private var cleanupSources: [SessionCleanupSource] = []
     private var activeProjectPaths: Set<String> = []
+    private var isCleanupTabSelected = false
+    private var isPanelVisible = false
     private var isCleanupVisible = false
+    private var seenCleanupSourceIDs: Set<WorktreeCleanupSourceIdentity> = []
 
     init(manager: WorktreeCleanupManager) {
         self.manager = manager
@@ -61,19 +70,77 @@ final class WorktreeCleanupRefreshGate {
     func updateSources(_ cleanupSources: [SessionCleanupSource], activeProjectPaths: Set<String>) {
         self.cleanupSources = cleanupSources
         self.activeProjectPaths = activeProjectPaths
-        refreshIfVisible()
+        if isCleanupVisible {
+            refreshIfVisible()
+        } else {
+            updateHiddenNudgeFromSourceIdentities()
+        }
     }
 
     func setCleanupVisible(_ visible: Bool) {
+        isCleanupTabSelected = visible
+        isPanelVisible = visible
+        updateCleanupVisibility(forceRefreshWhenVisible: visible)
+    }
+
+    func setCleanupTabSelected(_ selected: Bool) {
+        isCleanupTabSelected = selected
+        updateCleanupVisibility()
+    }
+
+    func setPanelVisible(_ visible: Bool) {
+        isPanelVisible = visible
+        updateCleanupVisibility()
+    }
+
+    func refreshIfVisible(force: Bool = false) {
+        guard isCleanupVisible else { return }
+        markCurrentSourcesSeen()
+        manager.refresh(from: cleanupSources, activeProjectPaths: activeProjectPaths, force: force)
+    }
+
+    private func updateCleanupVisibility(forceRefreshWhenVisible: Bool = false) {
+        let visible = isCleanupTabSelected && isPanelVisible
+        guard visible != isCleanupVisible || (visible && forceRefreshWhenVisible) else { return }
         isCleanupVisible = visible
         if visible {
             refreshIfVisible(force: true)
         }
     }
 
-    func refreshIfVisible(force: Bool = false) {
-        guard isCleanupVisible else { return }
-        manager.refresh(from: cleanupSources, activeProjectPaths: activeProjectPaths, force: force)
+    private func updateHiddenNudgeFromSourceIdentities() {
+        let sourceIDs = currentSourceIDs()
+        if sourceIDs.isEmpty {
+            hasHiddenCleanupNudge = false
+            seenCleanupSourceIDs = []
+        } else {
+            hasHiddenCleanupNudge = !sourceIDs.subtracting(seenCleanupSourceIDs).isEmpty
+        }
+    }
+
+    private func markCurrentSourcesSeen() {
+        seenCleanupSourceIDs = currentSourceIDs()
+        hasHiddenCleanupNudge = false
+    }
+
+    private func currentSourceIDs() -> Set<WorktreeCleanupSourceIdentity> {
+        let activePaths = Set(activeProjectPaths.map(WorktreeCleanupScanner.standardizedPath))
+        return Set(cleanupSources.compactMap { source in
+            WorktreeCleanupSourceIdentity(source: source, activeProjectPaths: activePaths)
+        })
+    }
+}
+
+private struct WorktreeCleanupSourceIdentity: Hashable {
+    let path: String
+    let sessionId: String
+
+    init?(source: SessionCleanupSource, activeProjectPaths: Set<String>) {
+        let path = WorktreeCleanupScanner.standardizedPath(source.projectPath)
+        guard WorktreeCleanupScanner.shouldScanCleanupSourcePath(path) else { return nil }
+        guard !WorktreeCleanupScanner.isCleanupSourcePathActive(path, activeProjectPaths: activeProjectPaths) else { return nil }
+        self.path = path
+        sessionId = source.sessionId
     }
 }
 

--- a/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
@@ -22,7 +22,8 @@ class WorktreeCleanupManager: ObservableObject {
     func refresh(
         from cleanupSources: [SessionCleanupSource],
         activeProjectPaths: Set<String>,
-        force: Bool = false
+        force: Bool = false,
+        onCompletion: (([WorktreeCleanupCandidate]) -> Void)? = nil
     ) {
         let signature = WorktreeCleanupRefreshSignature(
             cleanupSources: cleanupSources,
@@ -46,6 +47,7 @@ class WorktreeCleanupManager: ObservableObject {
                     worktreeCleanupLogger.info("cleanup candidates \(self.candidates.count) -> \(next.count)")
                     self.candidates = next
                 }
+                onCompletion?(next)
             }
         }
     }
@@ -61,10 +63,7 @@ final class WorktreeCleanupRefreshGate: ObservableObject {
     private var isCleanupTabSelected = false
     private var isPanelVisible = false
     private var isCleanupVisible = false
-    private var seenCleanupSourceIDs: Set<WorktreeCleanupSourceIdentity> = []
-    private var hiddenLinkedWorktreeIdentityPaths: [String: String] = [:]
-    private var hiddenNonLinkedWorktreePaths: Set<String> = []
-    private var pendingHiddenLinkedWorktreePaths: Set<String> = []
+    private var seenCleanupCandidateIDs: Set<String> = []
 
     init(manager: WorktreeCleanupManager) {
         self.manager = manager
@@ -76,7 +75,7 @@ final class WorktreeCleanupRefreshGate: ObservableObject {
         if isCleanupVisible {
             refreshIfVisible()
         } else {
-            updateHiddenNudgeFromSourceIdentities()
+            refreshWhileHidden()
         }
     }
 
@@ -98,8 +97,11 @@ final class WorktreeCleanupRefreshGate: ObservableObject {
 
     func refreshIfVisible(force: Bool = false) {
         guard isCleanupVisible else { return }
-        markCurrentSourcesSeen()
-        manager.refresh(from: cleanupSources, activeProjectPaths: activeProjectPaths, force: force)
+        markCurrentCandidatesSeen()
+        manager.refresh(from: cleanupSources, activeProjectPaths: activeProjectPaths, force: force) { [weak self] candidates in
+            guard let self, self.isCleanupVisible else { return }
+            self.markCandidatesSeen(candidates)
+        }
     }
 
     private func updateCleanupVisibility(forceRefreshWhenVisible: Bool = false) {
@@ -111,127 +113,34 @@ final class WorktreeCleanupRefreshGate: ObservableObject {
         }
     }
 
-    private func updateHiddenNudgeFromSourceIdentities() {
-        resolveHiddenLinkedWorktreeIdentitiesIfNeeded()
-        let sourceIDs = currentSourceIDs()
-        if sourceIDs.isEmpty {
-            hasHiddenCleanupNudge = false
-            seenCleanupSourceIDs = []
-        } else {
-            hasHiddenCleanupNudge = !sourceIDs.subtracting(seenCleanupSourceIDs).isEmpty
-        }
-    }
-
-    private func markCurrentSourcesSeen() {
-        resolveHiddenLinkedWorktreeIdentitiesIfNeeded()
-        seenCleanupSourceIDs = currentSourceIDs()
-        hasHiddenCleanupNudge = false
-    }
-
-    private func currentSourceIDs() -> Set<WorktreeCleanupSourceIdentity> {
-        let activePaths = Set(activeProjectPaths.map(WorktreeCleanupScanner.standardizedPath))
-        return Set(cleanupSources.compactMap { source in
-            let sourcePath = WorktreeCleanupScanner.standardizedPath(source.projectPath)
-            let identityPath = WorktreeCleanupScanner.hiddenCleanupSourceIdentityPath(for: sourcePath)
-                ?? hiddenLinkedWorktreeIdentityPaths[sourcePath]
-            guard let identityPath else { return nil }
-            return WorktreeCleanupSourceIdentity(source: source, identityPath: identityPath, activeProjectPaths: activePaths)
-        })
-    }
-
-    private func resolveHiddenLinkedWorktreeIdentitiesIfNeeded() {
-        let sourcePaths = hiddenLinkedWorktreeSourcePaths()
-        hiddenLinkedWorktreeIdentityPaths = hiddenLinkedWorktreeIdentityPaths.filter { sourcePaths.contains($0.key) }
-        hiddenNonLinkedWorktreePaths = hiddenNonLinkedWorktreePaths.intersection(sourcePaths)
-        pendingHiddenLinkedWorktreePaths = pendingHiddenLinkedWorktreePaths.intersection(sourcePaths)
-
-        let unresolvedPaths = sourcePaths
-            .subtracting(hiddenLinkedWorktreeIdentityPaths.keys)
-            .subtracting(hiddenNonLinkedWorktreePaths)
-            .subtracting(pendingHiddenLinkedWorktreePaths)
-        guard !unresolvedPaths.isEmpty else { return }
-
-        pendingHiddenLinkedWorktreePaths.formUnion(unresolvedPaths)
-        let scanner = manager.scanner
-        DispatchQueue.global(qos: .utility).async {
-            let resolvedPaths = unresolvedPaths.map { sourcePath in
-                (sourcePath, scanner.hiddenLinkedWorktreeIdentityPath(for: sourcePath))
-            }
-            DispatchQueue.main.async {
-                self.finishResolvingHiddenLinkedWorktreeIdentities(resolvedPaths)
-            }
-        }
-    }
-
-    private func finishResolvingHiddenLinkedWorktreeIdentities(_ resolvedPaths: [(String, String?)]) {
-        let currentSourcePaths = hiddenLinkedWorktreeSourcePaths()
-        for (sourcePath, identityPath) in resolvedPaths {
-            pendingHiddenLinkedWorktreePaths.remove(sourcePath)
-            guard currentSourcePaths.contains(sourcePath) else { continue }
-            if let identityPath {
-                hiddenLinkedWorktreeIdentityPaths[sourcePath] = identityPath
-                hiddenNonLinkedWorktreePaths.remove(sourcePath)
+    private func refreshWhileHidden() {
+        manager.refresh(from: cleanupSources, activeProjectPaths: activeProjectPaths) { [weak self] candidates in
+            guard let self else { return }
+            if self.isCleanupVisible {
+                self.markCandidatesSeen(candidates)
             } else {
-                hiddenLinkedWorktreeIdentityPaths.removeValue(forKey: sourcePath)
-                hiddenNonLinkedWorktreePaths.insert(sourcePath)
+                self.updateHiddenNudge(from: candidates)
             }
         }
-        if isCleanupVisible {
-            markCurrentSourcesSeen()
+    }
+
+    private func updateHiddenNudge(from candidates: [WorktreeCleanupCandidate]) {
+        let candidateIDs = Set(candidates.map(\.id))
+        if candidateIDs.isEmpty {
+            hasHiddenCleanupNudge = false
+            seenCleanupCandidateIDs = []
         } else {
-            updateHiddenNudgeFromSourceIdentities()
+            hasHiddenCleanupNudge = !candidateIDs.subtracting(seenCleanupCandidateIDs).isEmpty
         }
     }
 
-    private func hiddenLinkedWorktreeSourcePaths() -> Set<String> {
-        Set(cleanupSources.compactMap { source in
-            let sourcePath = WorktreeCleanupScanner.standardizedPath(source.projectPath)
-            return WorktreeCleanupScanner.shouldResolveHiddenLinkedWorktreeRoot(for: sourcePath) ? sourcePath : nil
-        })
-    }
-}
-
-private struct WorktreeCleanupSourceIdentity: Hashable {
-    let path: String
-    let sessionId: String
-
-    init?(source: SessionCleanupSource, identityPath: String, activeProjectPaths: Set<String>) {
-        let identityPath = WorktreeCleanupScanner.standardizedPath(identityPath)
-        guard !Self.isActive(identityPath, activeProjectPaths: activeProjectPaths) else { return nil }
-        path = identityPath
-        sessionId = source.sessionId
+    private func markCurrentCandidatesSeen() {
+        markCandidatesSeen(manager.candidates)
     }
 
-    private static func isActive(_ path: String, activeProjectPaths: Set<String>) -> Bool {
-        if WorktreeCleanupScanner.isCleanupSourcePathActive(path, activeProjectPaths: activeProjectPaths) {
-            return true
-        }
-        guard let cleanupRoot = cleanupWorktreePrefix(for: path) else { return false }
-        return activeProjectPaths.contains { activePath in
-            cleanupWorktreePrefix(for: activePath) == cleanupRoot
-        }
-    }
-
-    private static func cleanupWorktreePrefix(for path: String) -> String? {
-        let components = URL(fileURLWithPath: WorktreeCleanupScanner.standardizedPath(path)).pathComponents
-        guard components.count >= 3 else { return nil }
-        for index in 0..<(components.count - 2) {
-            let marker = components[index]
-            guard marker == ".claude" || marker == ".codex",
-                  components[index + 1] == "worktrees",
-                  !components[index + 2].isEmpty else {
-                continue
-            }
-            return prefixPath(from: components.prefix(index + 3))
-        }
-        return nil
-    }
-
-    private static func prefixPath(from components: ArraySlice<String>) -> String {
-        if components.first == "/" {
-            return "/" + components.dropFirst().joined(separator: "/")
-        }
-        return components.joined(separator: "/")
+    private func markCandidatesSeen(_ candidates: [WorktreeCleanupCandidate]) {
+        seenCleanupCandidateIDs = Set(candidates.map(\.id))
+        hasHiddenCleanupNudge = false
     }
 }
 

--- a/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
@@ -138,9 +138,41 @@ private struct WorktreeCleanupSourceIdentity: Hashable {
     init?(source: SessionCleanupSource, activeProjectPaths: Set<String>) {
         let path = WorktreeCleanupScanner.standardizedPath(source.projectPath)
         guard WorktreeCleanupScanner.shouldScanCleanupSourcePath(path) else { return nil }
-        guard !WorktreeCleanupScanner.isCleanupSourcePathActive(path, activeProjectPaths: activeProjectPaths) else { return nil }
+        guard !Self.isActive(path, activeProjectPaths: activeProjectPaths) else { return nil }
         self.path = path
         sessionId = source.sessionId
+    }
+
+    private static func isActive(_ path: String, activeProjectPaths: Set<String>) -> Bool {
+        if WorktreeCleanupScanner.isCleanupSourcePathActive(path, activeProjectPaths: activeProjectPaths) {
+            return true
+        }
+        guard let cleanupRoot = cleanupWorktreePrefix(for: path) else { return false }
+        return activeProjectPaths.contains { activePath in
+            cleanupWorktreePrefix(for: activePath) == cleanupRoot
+        }
+    }
+
+    private static func cleanupWorktreePrefix(for path: String) -> String? {
+        let components = URL(fileURLWithPath: WorktreeCleanupScanner.standardizedPath(path)).pathComponents
+        guard components.count >= 3 else { return nil }
+        for index in 0..<(components.count - 2) {
+            let marker = components[index]
+            guard marker == ".claude" || marker == ".codex",
+                  components[index + 1] == "worktrees",
+                  !components[index + 2].isEmpty else {
+                continue
+            }
+            return prefixPath(from: components.prefix(index + 3))
+        }
+        return nil
+    }
+
+    private static func prefixPath(from components: ArraySlice<String>) -> String {
+        if components.first == "/" {
+            return "/" + components.dropFirst().joined(separator: "/")
+        }
+        return components.joined(separator: "/")
     }
 }
 

--- a/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
@@ -11,7 +11,7 @@ class WorktreeCleanupManager: ObservableObject {
     @Published var candidates: [WorktreeCleanupCandidate] = []
     @Published private(set) var isScanning = false
 
-    private let scanner: WorktreeCleanupScanner
+    fileprivate let scanner: WorktreeCleanupScanner
     private var refreshGeneration = 0
     private var lastRefreshSignature: WorktreeCleanupRefreshSignature?
 
@@ -126,7 +126,7 @@ final class WorktreeCleanupRefreshGate: ObservableObject {
     private func currentSourceIDs() -> Set<WorktreeCleanupSourceIdentity> {
         let activePaths = Set(activeProjectPaths.map(WorktreeCleanupScanner.standardizedPath))
         return Set(cleanupSources.compactMap { source in
-            WorktreeCleanupSourceIdentity(source: source, activeProjectPaths: activePaths)
+            WorktreeCleanupSourceIdentity(source: source, activeProjectPaths: activePaths, scanner: manager.scanner)
         })
     }
 }
@@ -135,10 +135,8 @@ private struct WorktreeCleanupSourceIdentity: Hashable {
     let path: String
     let sessionId: String
 
-    init?(source: SessionCleanupSource, activeProjectPaths: Set<String>) {
-        let path = WorktreeCleanupScanner.standardizedPath(source.projectPath)
-        guard WorktreeCleanupScanner.shouldScanCleanupSourcePath(path) else { return nil }
-        guard Self.cleanupWorktreePrefix(for: path) != nil else { return nil }
+    init?(source: SessionCleanupSource, activeProjectPaths: Set<String>, scanner: WorktreeCleanupScanner) {
+        guard let path = scanner.hiddenCleanupSourceIdentityPath(for: source.projectPath) else { return nil }
         guard !Self.isActive(path, activeProjectPaths: activeProjectPaths) else { return nil }
         self.path = path
         sessionId = source.sessionId

--- a/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
@@ -138,6 +138,7 @@ private struct WorktreeCleanupSourceIdentity: Hashable {
     init?(source: SessionCleanupSource, activeProjectPaths: Set<String>) {
         let path = WorktreeCleanupScanner.standardizedPath(source.projectPath)
         guard WorktreeCleanupScanner.shouldScanCleanupSourcePath(path) else { return nil }
+        guard Self.cleanupWorktreePrefix(for: path) != nil else { return nil }
         guard !Self.isActive(path, activeProjectPaths: activeProjectPaths) else { return nil }
         self.path = path
         sessionId = source.sessionId

--- a/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
@@ -397,41 +397,6 @@ extension WorktreeCleanupScanner {
         guard Config.isLikelyPrivacyProtectedUserPath(path) else { return true }
         return isPlausibleCleanupWorktreePath(path)
     }
-
-    func hiddenCleanupSourceIdentityPath(for path: String) -> String? {
-        let path = Self.standardizedPath(path)
-        if let path = Self.hiddenCleanupSourceIdentityPath(for: path) { return path }
-        guard Self.shouldResolveHiddenLinkedWorktreeRoot(for: path) else { return nil }
-        return resolveLinkedWorktreeRoot(path).map(Self.standardizedPath)
-    }
-
-    static func hiddenCleanupSourceIdentityPath(for path: String) -> String? {
-        let path = Self.standardizedPath(path)
-        guard shouldScanCleanupSourcePath(path) else { return nil }
-        return cleanupWorktreeRootPath(for: path)
-    }
-
-    static func shouldResolveHiddenLinkedWorktreeRoot(for path: String) -> Bool {
-        let path = Self.standardizedPath(path)
-        guard shouldScanCleanupSourcePath(path) else { return false }
-        return !isPlausibleCleanupWorktreePath(path)
-    }
-
-    func hiddenLinkedWorktreeIdentityPath(for path: String) -> String? {
-        let path = Self.standardizedPath(path)
-        guard Self.shouldResolveHiddenLinkedWorktreeRoot(for: path) else { return nil }
-        return resolveLinkedWorktreeRoot(path).map(Self.standardizedPath)
-    }
-
-    static func isCleanupSourcePathActive(_ path: String, activeProjectPaths: Set<String>) -> Bool {
-        activeProjectPaths.contains { activePath in
-            isPath(activePath, sameAsOrDescendantOf: path)
-        }
-    }
-
-    static func isPath(_ path: String, sameAsOrDescendantOf parentPath: String) -> Bool {
-        path == parentPath || path.hasPrefix(parentPath.hasSuffix("/") ? parentPath : "\(parentPath)/")
-    }
 }
 
 private extension WorktreeCleanupScanner {

--- a/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
@@ -76,11 +76,12 @@ struct WorktreeCleanupScanner {
         for source in cleanupSources {
             let rawPath = Self.standardizedPath(source.projectPath)
             guard Self.shouldScanCleanupSourcePath(rawPath) else { continue }
-            let path = resolvedPaths[rawPath] ?? {
+            let needsProtectedFolderAccess = Self.needsProtectedFolderAccessReview(rawPath)
+            let path = needsProtectedFolderAccess ? rawPath : (resolvedPaths[rawPath] ?? {
                 let path = resolvedCandidatePath(for: rawPath)
                 resolvedPaths[rawPath] = path
                 return path
-            }()
+            }())
             guard let existing = result[path] else {
                 result[path] = CandidateContext(source: source, path: path)
                 continue
@@ -123,6 +124,14 @@ struct WorktreeCleanupScanner {
                 context: context,
                 state: .ignored(["Active cctop session is using this path"]),
                 checks: [WorktreeCleanupCheck(label: "No active cctop sessions here", status: .ignored)]
+            )
+        }
+
+        guard !Self.needsProtectedFolderAccessReview(context.path) else {
+            return ignoredCandidate(
+                context: context,
+                state: .review([WorktreeCleanupCandidate.protectedFolderAccessReason]),
+                checks: [WorktreeCleanupCheck(label: "Protected folder access", status: .review)]
             )
         }
 
@@ -343,9 +352,7 @@ struct WorktreeCleanupScanner {
         ]
     }
 
-    static func standardizedPath(_ path: String) -> String {
-        Config.standardizedPath(path)
-    }
+    static func standardizedPath(_ path: String) -> String { Config.standardizedPath(path) }
 }
 
 extension WorktreeCleanupScanner {
@@ -366,11 +373,12 @@ extension WorktreeCleanupScanner {
         for source in cleanupSources {
             let rawPath = Self.standardizedPath(source.projectPath)
             guard Self.shouldScanCleanupSourcePath(rawPath) else { continue }
-            let path = resolvedPaths[rawPath] ?? {
+            let needsProtectedFolderAccess = Self.needsProtectedFolderAccessReview(rawPath)
+            let path = needsProtectedFolderAccess ? rawPath : (resolvedPaths[rawPath] ?? {
                 let path = resolvedCandidatePath(for: rawPath)
                 resolvedPaths[rawPath] = path
                 return path
-            }()
+            }())
             guard path == id else { continue }
             guard let existing = result else {
                 result = CandidateContext(source: source, path: path)
@@ -386,7 +394,7 @@ extension WorktreeCleanupScanner {
 
 extension WorktreeCleanupScanner {
     static func shouldScanCleanupSourcePath(_ path: String) -> Bool {
-        guard isLikelyPrivacyProtectedUserPath(path) else { return true }
+        guard Config.isLikelyPrivacyProtectedUserPath(path) else { return true }
         return isPlausibleCleanupWorktreePath(path)
     }
 
@@ -428,13 +436,11 @@ extension WorktreeCleanupScanner {
 
 private extension WorktreeCleanupScanner {
     func shouldResolveActiveProjectPath(_ activePath: String, candidatePaths _: Set<String>) -> Bool {
-        !Self.isLikelyPrivacyProtectedUserPath(activePath)
+        !Config.isLikelyPrivacyProtectedUserPath(activePath)
     }
 
-    static func isLikelyPrivacyProtectedUserPath(_ path: String) -> Bool {
-        let pathComponents = URL(fileURLWithPath: path).pathComponents
-        guard pathComponents.count > 3, pathComponents[1] == "Users" else { return false }
-        return ["Desktop", "Documents", "Downloads"].contains(pathComponents[3])
+    static func needsProtectedFolderAccessReview(_ path: String) -> Bool {
+        Config.isLikelyPrivacyProtectedUserPath(path) && isPlausibleCleanupWorktreePath(path)
     }
 
     static func isPlausibleCleanupWorktreePath(_ path: String) -> Bool {

--- a/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
@@ -392,8 +392,26 @@ extension WorktreeCleanupScanner {
 
     func hiddenCleanupSourceIdentityPath(for path: String) -> String? {
         let path = Self.standardizedPath(path)
-        guard Self.shouldScanCleanupSourcePath(path) else { return nil }
-        if Self.isPlausibleCleanupWorktreePath(path) { return path }
+        if let path = Self.hiddenCleanupSourceIdentityPath(for: path) { return path }
+        guard Self.shouldResolveHiddenLinkedWorktreeRoot(for: path) else { return nil }
+        return resolveLinkedWorktreeRoot(path).map(Self.standardizedPath)
+    }
+
+    static func hiddenCleanupSourceIdentityPath(for path: String) -> String? {
+        let path = Self.standardizedPath(path)
+        guard shouldScanCleanupSourcePath(path) else { return nil }
+        return isPlausibleCleanupWorktreePath(path) ? path : nil
+    }
+
+    static func shouldResolveHiddenLinkedWorktreeRoot(for path: String) -> Bool {
+        let path = Self.standardizedPath(path)
+        guard shouldScanCleanupSourcePath(path) else { return false }
+        return !isPlausibleCleanupWorktreePath(path)
+    }
+
+    func hiddenLinkedWorktreeIdentityPath(for path: String) -> String? {
+        let path = Self.standardizedPath(path)
+        guard Self.shouldResolveHiddenLinkedWorktreeRoot(for: path) else { return nil }
         return resolveLinkedWorktreeRoot(path).map(Self.standardizedPath)
     }
 

--- a/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
@@ -73,7 +73,7 @@ struct WorktreeCleanupScanner {
         var resolvedPaths: [String: String] = [:]
         for source in cleanupSources {
             let rawPath = Self.standardizedPath(source.projectPath)
-            guard shouldScanCleanupSourcePath(rawPath) else { continue }
+            guard Self.shouldScanCleanupSourcePath(rawPath) else { continue }
             let path = resolvedPaths[rawPath] ?? {
                 let path = resolvedCandidatePath(for: rawPath)
                 resolvedPaths[rawPath] = path
@@ -363,7 +363,7 @@ extension WorktreeCleanupScanner {
         var resolvedPaths: [String: String] = [:]
         for source in cleanupSources {
             let rawPath = Self.standardizedPath(source.projectPath)
-            guard shouldScanCleanupSourcePath(rawPath) else { continue }
+            guard Self.shouldScanCleanupSourcePath(rawPath) else { continue }
             let path = resolvedPaths[rawPath] ?? {
                 let path = resolvedCandidatePath(for: rawPath)
                 resolvedPaths[rawPath] = path
@@ -382,12 +382,24 @@ extension WorktreeCleanupScanner {
     }
 }
 
-private extension WorktreeCleanupScanner {
-    func shouldScanCleanupSourcePath(_ path: String) -> Bool {
-        guard Self.isLikelyPrivacyProtectedUserPath(path) else { return true }
-        return Self.isPlausibleCleanupWorktreePath(path)
+extension WorktreeCleanupScanner {
+    static func shouldScanCleanupSourcePath(_ path: String) -> Bool {
+        guard isLikelyPrivacyProtectedUserPath(path) else { return true }
+        return isPlausibleCleanupWorktreePath(path)
     }
 
+    static func isCleanupSourcePathActive(_ path: String, activeProjectPaths: Set<String>) -> Bool {
+        activeProjectPaths.contains { activePath in
+            isPath(activePath, sameAsOrDescendantOf: path)
+        }
+    }
+
+    static func isPath(_ path: String, sameAsOrDescendantOf parentPath: String) -> Bool {
+        path == parentPath || path.hasPrefix(parentPath.hasSuffix("/") ? parentPath : "\(parentPath)/")
+    }
+}
+
+private extension WorktreeCleanupScanner {
     func shouldResolveActiveProjectPath(_ activePath: String, candidatePaths: Set<String>) -> Bool {
         if candidatePaths.contains(where: { candidatePath in
             Self.isPath(activePath, sameAsOrDescendantOf: candidatePath)
@@ -396,10 +408,6 @@ private extension WorktreeCleanupScanner {
             return true
         }
         return !Self.isLikelyPrivacyProtectedUserPath(activePath)
-    }
-
-    static func isPath(_ path: String, sameAsOrDescendantOf parentPath: String) -> Bool {
-        path == parentPath || path.hasPrefix(parentPath.hasSuffix("/") ? parentPath : "\(parentPath)/")
     }
 
     static func isLikelyPrivacyProtectedUserPath(_ path: String) -> Bool {

--- a/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
@@ -77,7 +77,7 @@ struct WorktreeCleanupScanner {
             let rawPath = Self.standardizedPath(source.projectPath)
             guard Self.shouldScanCleanupSourcePath(rawPath) else { continue }
             let needsProtectedFolderAccess = Self.needsProtectedFolderAccessReview(rawPath)
-            let path = needsProtectedFolderAccess ? rawPath : (resolvedPaths[rawPath] ?? {
+            let path = needsProtectedFolderAccess ? Self.cleanupWorktreeRootPath(for: rawPath) ?? rawPath : (resolvedPaths[rawPath] ?? {
                 let path = resolvedCandidatePath(for: rawPath)
                 resolvedPaths[rawPath] = path
                 return path
@@ -374,7 +374,7 @@ extension WorktreeCleanupScanner {
             let rawPath = Self.standardizedPath(source.projectPath)
             guard Self.shouldScanCleanupSourcePath(rawPath) else { continue }
             let needsProtectedFolderAccess = Self.needsProtectedFolderAccessReview(rawPath)
-            let path = needsProtectedFolderAccess ? rawPath : (resolvedPaths[rawPath] ?? {
+            let path = needsProtectedFolderAccess ? Self.cleanupWorktreeRootPath(for: rawPath) ?? rawPath : (resolvedPaths[rawPath] ?? {
                 let path = resolvedCandidatePath(for: rawPath)
                 resolvedPaths[rawPath] = path
                 return path
@@ -408,7 +408,7 @@ extension WorktreeCleanupScanner {
     static func hiddenCleanupSourceIdentityPath(for path: String) -> String? {
         let path = Self.standardizedPath(path)
         guard shouldScanCleanupSourcePath(path) else { return nil }
-        return isPlausibleCleanupWorktreePath(path) ? path : nil
+        return cleanupWorktreeRootPath(for: path)
     }
 
     static func shouldResolveHiddenLinkedWorktreeRoot(for path: String) -> Bool {
@@ -443,17 +443,18 @@ private extension WorktreeCleanupScanner {
         Config.isLikelyPrivacyProtectedUserPath(path) && isPlausibleCleanupWorktreePath(path)
     }
 
-    static func isPlausibleCleanupWorktreePath(_ path: String) -> Bool {
+    static func isPlausibleCleanupWorktreePath(_ path: String) -> Bool { cleanupWorktreeRootPath(for: path) != nil }
+    static func cleanupWorktreeRootPath(for path: String) -> String? {
         let pathComponents = URL(fileURLWithPath: path).pathComponents
-        guard pathComponents.count >= 3 else { return false }
+        guard pathComponents.count >= 3 else { return nil }
         for index in 0..<(pathComponents.count - 2) {
             let marker = pathComponents[index]
             guard marker == ".claude" || marker == ".codex" else { continue }
             if pathComponents[index + 1] == "worktrees", !pathComponents[index + 2].isEmpty {
-                return true
+                return NSString.path(withComponents: Array(pathComponents[0...(index + 2)]))
             }
         }
-        return false
+        return nil
     }
 }
 
@@ -489,9 +490,7 @@ private extension WorktreeCleanupCandidate.State {
 }
 
 private extension Array where Element == String {
-    func nonEmptyOr(_ fallback: [String]) -> [String] {
-        isEmpty ? fallback : self
-    }
+    func nonEmptyOr(_ fallback: [String]) -> [String] { isEmpty ? fallback : self }
 
     mutating func appendUnique(_ reason: String) {
         guard !contains(reason) else { return }

--- a/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
@@ -40,6 +40,7 @@ struct WorktreeCleanupScanner {
     var resolveWorktreeRoot: (String) -> String?
     var inspectGit: (String) -> GitWorktreeInspection
     var measureSize: (String) -> Int64?
+    var resolveLinkedWorktreeRoot: (String) -> String? = { _ in nil }
 
     static func live() -> WorktreeCleanupScanner {
         let inspector = GitWorktreeInspector()
@@ -47,7 +48,8 @@ struct WorktreeCleanupScanner {
             fileExists: { FileManager.default.fileExists(atPath: $0) },
             resolveWorktreeRoot: { inspector.worktreeRoot(containing: $0) },
             inspectGit: { inspector.inspect(path: $0) },
-            measureSize: { DirectorySizeScanner.sizeOfDirectory(atPath: $0) }
+            measureSize: { DirectorySizeScanner.sizeOfDirectory(atPath: $0) },
+            resolveLinkedWorktreeRoot: { inspector.linkedWorktreeRoot(containing: $0) }
         )
     }
 
@@ -386,6 +388,13 @@ extension WorktreeCleanupScanner {
     static func shouldScanCleanupSourcePath(_ path: String) -> Bool {
         guard isLikelyPrivacyProtectedUserPath(path) else { return true }
         return isPlausibleCleanupWorktreePath(path)
+    }
+
+    func hiddenCleanupSourceIdentityPath(for path: String) -> String? {
+        let path = Self.standardizedPath(path)
+        guard Self.shouldScanCleanupSourcePath(path) else { return nil }
+        if Self.isPlausibleCleanupWorktreePath(path) { return path }
+        return resolveLinkedWorktreeRoot(path).map(Self.standardizedPath)
     }
 
     static func isCleanupSourcePathActive(_ path: String, activeProjectPaths: Set<String>) -> Bool {

--- a/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
@@ -427,14 +427,8 @@ extension WorktreeCleanupScanner {
 }
 
 private extension WorktreeCleanupScanner {
-    func shouldResolveActiveProjectPath(_ activePath: String, candidatePaths: Set<String>) -> Bool {
-        if candidatePaths.contains(where: { candidatePath in
-            Self.isPath(activePath, sameAsOrDescendantOf: candidatePath)
-                || Self.isPath(candidatePath, sameAsOrDescendantOf: activePath)
-        }) {
-            return true
-        }
-        return !Self.isLikelyPrivacyProtectedUserPath(activePath)
+    func shouldResolveActiveProjectPath(_ activePath: String, candidatePaths _: Set<String>) -> Bool {
+        !Self.isLikelyPrivacyProtectedUserPath(activePath)
     }
 
     static func isLikelyPrivacyProtectedUserPath(_ path: String) -> Bool {

--- a/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
+++ b/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
@@ -200,7 +200,8 @@ private extension WorktreeCleanupCandidate {
         }
         if state.reasons.contains(WorktreeCleanupCandidate.initializedSubmodulesReason)
             || state.reasons.contains(WorktreeCleanupCandidate.indexHiddenTrackedFilesReason)
-            || state.reasons.contains(WorktreeCleanupCandidate.statusUnreadableReason) {
+            || state.reasons.contains(WorktreeCleanupCandidate.statusUnreadableReason)
+            || state.reasons.contains(WorktreeCleanupCandidate.protectedFolderAccessReason) {
             return self
         }
         return nil
@@ -256,6 +257,9 @@ private extension WorktreeCleanupCandidate {
     }
 
     var blockedRemovalReason: String {
+        if state.reasons.contains(Self.protectedFolderAccessReason) {
+            return "Grant file access in Settings before removing this protected worktree."
+        }
         if state.reasons.contains(Self.statusUnreadableReason) {
             return "Git status could not be read, so cctop cannot verify what removal would delete."
         }

--- a/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
+++ b/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
@@ -137,10 +137,13 @@ struct WorktreeRemovalService {
             return .refused(preflightCandidate)
         }
 
-        if let refusal = preflightCandidate.refusalCandidate(
-            comparedTo: candidate,
-            refuseCleanDowngrade: candidate.state.isClean
-        ) {
+        let preflightNeedsProtectedFolderInspection =
+            preflightCandidate.state.reasons.contains(WorktreeCleanupCandidate.protectedFolderAccessReason)
+        if !preflightNeedsProtectedFolderInspection,
+           let refusal = preflightCandidate.refusalCandidate(
+               comparedTo: candidate,
+               refuseCleanDowngrade: candidate.state.isClean
+           ) {
             return .refused(refusal)
         }
 
@@ -195,13 +198,15 @@ private extension WorktreeCleanupCandidate {
         if refuseCleanDowngrade && !state.isClean {
             return self
         }
-        if changesWorktreeIdentity(comparedTo: candidate) || changesLocalFileReviewEvidence(comparedTo: candidate) {
+        if candidate.state.reasons.contains(WorktreeCleanupCandidate.protectedFolderAccessReason) {
+            // Passive protected-folder rows intentionally skip identity and file-evidence probes.
+            guard worktreePath == candidate.worktreePath else { return self }
+        } else if changesWorktreeIdentity(comparedTo: candidate) || changesLocalFileReviewEvidence(comparedTo: candidate) {
             return self
         }
         if state.reasons.contains(WorktreeCleanupCandidate.initializedSubmodulesReason)
             || state.reasons.contains(WorktreeCleanupCandidate.indexHiddenTrackedFilesReason)
-            || state.reasons.contains(WorktreeCleanupCandidate.statusUnreadableReason)
-            || state.reasons.contains(WorktreeCleanupCandidate.protectedFolderAccessReason) {
+            || state.reasons.contains(WorktreeCleanupCandidate.statusUnreadableReason) {
             return self
         }
         return nil

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -11,6 +11,7 @@ struct PopupView: View {
     var recentResumeTargets: [RecentResumeTarget]?
     var cleanupCandidates: [WorktreeCleanupCandidate] = []
     var cleanupIsScanning = false
+    var cleanupHasUnseenCandidates = false
     @ObservedObject var updater: UpdaterBase
     let pluginManager: PluginManager
     var navigate: NavigateController?
@@ -142,15 +143,33 @@ struct PopupView: View {
                 tabButton("Idle", count: sortedIdleSessions.count, tab: .idle)
             }
             tabButton("Recent", count: recentTargets.count, tab: .recent)
-            tabButton("Cleanup", count: actionableCleanupCandidates.count, tab: .cleanup, isScanning: cleanupIsScanning)
+            tabButton(
+                "Cleanup",
+                count: actionableCleanupCandidates.count,
+                tab: .cleanup,
+                isScanning: cleanupIsScanning,
+                hasAttention: cleanupHasUnseenCandidates
+            )
             Spacer()
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
     }
 
-    private func tabButton(_ label: String, count: Int, tab: PopupTab, isScanning: Bool = false) -> some View {
-        TabButtonView(label: label, count: count, isScanning: isScanning, isSelected: selectedTab == tab) {
+    private func tabButton(
+        _ label: String,
+        count: Int,
+        tab: PopupTab,
+        isScanning: Bool = false,
+        hasAttention: Bool = false
+    ) -> some View {
+        TabButtonView(
+            label: label,
+            count: count,
+            isScanning: isScanning,
+            hasAttention: hasAttention && selectedTab != tab,
+            isSelected: selectedTab == tab
+        ) {
             if overlayController.active != nil { closeOverlay(animated: false) }
             withAnimation(.easeInOut(duration: 0.15)) { selectedTab = tab }
             notifyLayoutChanged()

--- a/menubar/CctopMenubar/Views/PopupViewHelpers.swift
+++ b/menubar/CctopMenubar/Views/PopupViewHelpers.swift
@@ -171,6 +171,7 @@ struct TabButtonView: View {
     let label: String
     let count: Int
     var isScanning = false
+    var hasAttention = false
     let isSelected: Bool
     let action: () -> Void
     @State private var isHovered = false
@@ -183,7 +184,7 @@ struct TabButtonView: View {
                     .foregroundStyle(isSelected ? Color.textPrimary : Color.textMuted)
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
-                if isScanning {
+                if isScanning && count == 0 {
                     ProgressView()
                         .controlSize(.mini)
                         .frame(width: 10, height: 10)
@@ -191,9 +192,20 @@ struct TabButtonView: View {
                 } else {
                     Text("\(count)")
                         .font(.system(size: 9, weight: .medium))
-                        .foregroundStyle(isSelected ? Color.textPrimary : Color.textMuted)
+                        .foregroundStyle(hasAttention ? Color.statusAttention : (isSelected ? Color.textPrimary : Color.textMuted))
                         .lineLimit(1)
                         .fixedSize(horizontal: true, vertical: false)
+                    if isScanning {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .frame(width: 10, height: 10)
+                            .accessibilityLabel("\(label) scanning")
+                    } else if hasAttention {
+                        Circle()
+                            .fill(Color.statusAttention)
+                            .frame(width: 5, height: 5)
+                            .accessibilityHidden(true)
+                    }
                 }
             }
             .padding(.horizontal, 10)
@@ -226,6 +238,7 @@ struct PanelContentView: View {
     @ObservedObject var sessionManager: SessionManager
     @ObservedObject var historyManager: HistoryManager
     @ObservedObject var cleanupManager: WorktreeCleanupManager
+    @ObservedObject var cleanupRefreshGate: WorktreeCleanupRefreshGate
     @ObservedObject var updater: UpdaterBase
     @ObservedObject var pluginManager: PluginManager
     @ObservedObject var navigate: NavigateController
@@ -245,6 +258,7 @@ struct PanelContentView: View {
             recentResumeTargets: sessionManager.recentResumeTargets,
             cleanupCandidates: cleanupManager.candidates,
             cleanupIsScanning: cleanupManager.isScanning,
+            cleanupHasUnseenCandidates: cleanupRefreshGate.hasHiddenCleanupNudge,
             updater: updater,
             pluginManager: pluginManager,
             navigate: navigate,

--- a/menubar/CctopMenubarTests/HistoryManagerTests.swift
+++ b/menubar/CctopMenubarTests/HistoryManagerTests.swift
@@ -250,6 +250,27 @@ final class HistoryManagerTests: XCTestCase {
         XCTAssertEqual(result[0].projectName, "inactive")
     }
 
+    func testBuildRecentProjectsDoesNotProbeProtectedActiveProjectPathBeforeExcludingIt() {
+        let now = Date()
+        let protectedActivePath = "/Users/dev/Documents/Codex/live-session"
+        let sessions = [
+            mockSession(project: "active", projectPath: protectedActivePath, endedAt: now),
+        ]
+        var probedPaths: [String] = []
+
+        let result = HistoryManager.buildRecentProjects(
+            from: sessions,
+            excludingActive: [protectedActivePath],
+            projectPathExists: { path in
+                probedPaths.append(path)
+                return true
+            }
+        )
+
+        XCTAssertEqual(result, [])
+        XCTAssertEqual(probedPaths, [])
+    }
+
     func testBuildRecentProjectsSortsByRecent() {
         let now = Date()
         let sessions = [

--- a/menubar/CctopMenubarTests/SessionLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/SessionLifecycleTests.swift
@@ -512,7 +512,7 @@ final class SessionLifecycleTests: XCTestCase {
         XCTAssertEqual(classification.archivedClaudeSessionIDs, ["archived-claude"])
     }
 
-    func testClassificationSnapshotDoesNotEmitCleanupSourcesForArchivedDesktopSessions() {
+    func testClassificationSnapshotEmitsCleanupSourcesForArchivedDesktopSessions() {
         let archived = candidate(sessionId: "archived-thread", pid: 1, bundleId: HostAppBundleID.codexDesktop,
                                  lifecycleRank: 0, source: Session.codexSource, path: "/archived.json") { session in
             session.sessionName = "Archived desktop work"
@@ -532,7 +532,9 @@ final class SessionLifecycleTests: XCTestCase {
         )
 
         XCTAssertEqual(state.displayCandidates.map(\.session.sessionId), ["visible-thread"])
-        XCTAssertEqual(state.cleanupSources.map(\.sessionId), [])
+        XCTAssertEqual(state.cleanupSources.map(\.sessionId), ["archived-thread"])
+        XCTAssertEqual(state.cleanupSources.map(\.projectPath), ["/tmp/p"])
+        XCTAssertEqual(state.cleanupSources.map(\.sessionName), ["Archived desktop work"])
         XCTAssertEqual(state.codexSubagentCandidates.map(\.session.sessionId), ["subagent-thread"])
     }
 
@@ -586,7 +588,10 @@ final class SessionLifecycleTests: XCTestCase {
             ["terminal-finished", "visible-thread"]
         )
         XCTAssertEqual(state.finishedNonDesktopCandidates.map(\.session.sessionId), ["terminal-finished"])
-        XCTAssertEqual(state.cleanupSources.map(\.sessionId), [])
+        XCTAssertEqual(
+            state.cleanupSources.map(\.sessionId).sorted(),
+            ["archived-claude", "archived-thread"]
+        )
         XCTAssertEqual(state.autoHiddenSessions.map(\.1.sessionId), ["auto-hidden"])
         XCTAssertEqual(state.codexSubagentCandidates.map(\.session.sessionId), ["subagent-thread"])
         XCTAssertEqual(state.protectedProjectPathsForCleanup, ["/tmp/p"])

--- a/menubar/CctopMenubarTests/SessionLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/SessionLifecycleTests.swift
@@ -512,7 +512,7 @@ final class SessionLifecycleTests: XCTestCase {
         XCTAssertEqual(classification.archivedClaudeSessionIDs, ["archived-claude"])
     }
 
-    func testClassificationSnapshotUsesSameClassificationForDisplayAndCleanupSources() {
+    func testClassificationSnapshotDoesNotEmitCleanupSourcesForArchivedDesktopSessions() {
         let archived = candidate(sessionId: "archived-thread", pid: 1, bundleId: HostAppBundleID.codexDesktop,
                                  lifecycleRank: 0, source: Session.codexSource, path: "/archived.json") { session in
             session.sessionName = "Archived desktop work"
@@ -532,8 +532,7 @@ final class SessionLifecycleTests: XCTestCase {
         )
 
         XCTAssertEqual(state.displayCandidates.map(\.session.sessionId), ["visible-thread"])
-        XCTAssertEqual(state.cleanupSources.map(\.sessionId), ["archived-thread"])
-        XCTAssertEqual(state.cleanupSources.map(\.projectPath), ["/tmp/p"])
+        XCTAssertEqual(state.cleanupSources.map(\.sessionId), [])
         XCTAssertEqual(state.codexSubagentCandidates.map(\.session.sessionId), ["subagent-thread"])
     }
 
@@ -587,7 +586,7 @@ final class SessionLifecycleTests: XCTestCase {
             ["terminal-finished", "visible-thread"]
         )
         XCTAssertEqual(state.finishedNonDesktopCandidates.map(\.session.sessionId), ["terminal-finished"])
-        XCTAssertEqual(state.cleanupSources.map(\.sessionId).sorted(), ["archived-claude", "archived-thread"])
+        XCTAssertEqual(state.cleanupSources.map(\.sessionId), [])
         XCTAssertEqual(state.autoHiddenSessions.map(\.1.sessionId), ["auto-hidden"])
         XCTAssertEqual(state.codexSubagentCandidates.map(\.session.sessionId), ["subagent-thread"])
         XCTAssertEqual(state.protectedProjectPathsForCleanup, ["/tmp/p"])

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -792,7 +792,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), [])
-        XCTAssertEqual(manager.cleanupSources.map(\.sessionId), [])
+        XCTAssertEqual(manager.cleanupSources.map(\.sessionId), ["archived-thread"])
+        XCTAssertEqual(manager.cleanupSources.map(\.projectPath), ["/tmp/p"])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
@@ -833,7 +834,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), [])
-        XCTAssertEqual(manager.cleanupSources.map(\.sessionId), [])
+        XCTAssertEqual(manager.cleanupSources.map(\.sessionId), ["archived-without-source"])
+        XCTAssertEqual(manager.cleanupSources.map(\.projectPath), ["/tmp/p"])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
@@ -877,7 +879,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), [])
-        XCTAssertEqual(manager.cleanupSources.map(\.sessionId), [])
+        XCTAssertEqual(manager.cleanupSources.map(\.sessionId), ["archived-claude-session"])
+        XCTAssertEqual(manager.cleanupSources.map(\.projectPath), ["/tmp/p"])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
@@ -927,6 +930,9 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), [])
+        XCTAssertEqual(manager.cleanupSources.map(\.sessionId), ["archived-claude-without-source"])
+        XCTAssertEqual(manager.cleanupSources.map(\.projectPath), ["/tmp/p"])
+        XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -792,7 +792,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), [])
-        XCTAssertEqual(manager.cleanupSources.map(\.sessionId), ["archived-thread"])
+        XCTAssertEqual(manager.cleanupSources.map(\.sessionId), [])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
@@ -833,7 +833,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), [])
-        XCTAssertEqual(manager.cleanupSources.map(\.sessionId), ["archived-without-source"])
+        XCTAssertEqual(manager.cleanupSources.map(\.sessionId), [])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
@@ -877,7 +877,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), [])
-        XCTAssertEqual(manager.cleanupSources.map(\.sessionId), ["archived-claude-session"])
+        XCTAssertEqual(manager.cleanupSources.map(\.sessionId), [])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)

--- a/menubar/CctopMenubarTests/SnapshotTests.swift
+++ b/menubar/CctopMenubarTests/SnapshotTests.swift
@@ -467,6 +467,60 @@ final class SnapshotTests: XCTestCase {
         try renderScreenshot(view: view, colorScheme: .dark, filename: "menubar-cleanup.png")
     }
 
+    func testGenerateCleanupDiscoverabilityScreenshots() throws {
+        let candidates = WorktreeCleanupCandidate.mockCandidates.filter(\.state.isActionable)
+        let directoryName = "cctop-cleanup-discoverability-proof-\(Int(Date().timeIntervalSince1970))"
+        let normalView = PopupView(
+            sessions: Session.qaShowcase,
+            recentProjects: RecentProject.mockRecents,
+            cleanupCandidates: candidates,
+            updater: DisabledUpdater(),
+            pluginManager: inertPluginManager(),
+            initialTab: .cleanup
+        )
+        let scanningView = PopupView(
+            sessions: Session.qaShowcase,
+            recentProjects: RecentProject.mockRecents,
+            cleanupCandidates: candidates,
+            cleanupIsScanning: true,
+            updater: DisabledUpdater(),
+            pluginManager: inertPluginManager(),
+            initialTab: .cleanup
+        )
+        let nudgedView = PopupView(
+            sessions: Session.qaShowcase,
+            recentProjects: RecentProject.mockRecents,
+            cleanupCandidates: candidates,
+            cleanupHasUnseenCandidates: true,
+            updater: DisabledUpdater(),
+            pluginManager: inertPluginManager(),
+            initialTab: .active
+        )
+
+        let normalSize = try renderPanelScreenshot(
+            view: normalView,
+            colorScheme: .dark,
+            directoryName: directoryName,
+            filename: "cleanup-tab-normal.png"
+        )
+        let scanningSize = try renderPanelScreenshot(
+            view: scanningView,
+            colorScheme: .dark,
+            directoryName: directoryName,
+            filename: "cleanup-tab-scanning.png"
+        )
+        let nudgedSize = try renderPanelScreenshot(
+            view: nudgedView,
+            colorScheme: .dark,
+            directoryName: directoryName,
+            filename: "cleanup-tab-nudged.png"
+        )
+
+        XCTAssertLessThanOrEqual(normalSize.width, 320)
+        XCTAssertLessThanOrEqual(scanningSize.width, 320)
+        XCTAssertLessThanOrEqual(nudgedSize.width, 320)
+    }
+
     func testGenerateCleanupDetailScreenshots() throws {
         let clean = WorktreeCleanupCandidate.mock(
             path: "/Users/dev/projects/rdoc/.claude/worktrees/stupefied-panini-cface5",

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -2447,6 +2447,71 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(selectedCandidate.state, .clean)
     }
 
+    func testRemovalServiceCanRemoveProtectedCandidateAfterExplicitInspection() {
+        let worktreePath = "/Users/dev/Documents/app/.claude/worktrees/feature-x"
+        let mainPath = "/Users/dev/projects/billing-api"
+        let session = historySession(path: worktreePath, branch: "claude/feature-x")
+        var inspectedPaths: [String] = []
+        var gitArguments: [[String]] = []
+        let success = GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")
+        let scanner = WorktreeCleanupScanner(
+            fileExists: { _ in
+                XCTFail("Protected cleanup action should not preflight with fileExists")
+                return false
+            },
+            resolveWorktreeRoot: { _ in
+                XCTFail("Protected cleanup action should not resolve the worktree root before explicit Git inspection")
+                return nil
+            },
+            inspectGit: { path in
+                inspectedPaths.append(path)
+                return self.cleanInspection(branch: "claude/feature-x")
+            },
+            measureSize: { _ in
+                XCTFail("Protected cleanup action should not measure size before removal")
+                return nil
+            },
+            resolveLinkedWorktreeRoot: { _ in
+                XCTFail("Protected cleanup action should not resolve linked roots")
+                return nil
+            }
+        )
+        let service = WorktreeRemovalService(
+            scanner: scanner,
+            runGit: { arguments in
+                gitArguments.append(arguments)
+                return success
+            }
+        )
+
+        let passiveCandidates = scanner.candidates(from: [session], activeProjectPaths: [])
+
+        XCTAssertEqual(passiveCandidates.map(\.id), [worktreePath])
+        XCTAssertEqual(passiveCandidates[0].state, .review([WorktreeCleanupCandidate.protectedFolderAccessReason]))
+        XCTAssertEqual(inspectedPaths, [])
+
+        let selectedAction = service.selectedAction(
+            for: passiveCandidates[0],
+            cleanupSources: [session],
+            activeProjectPaths: []
+        )
+
+        guard case .normalRemove(let selectedCandidate) = selectedAction else {
+            return XCTFail("Expected normal removal after explicit inspection, got \(selectedAction)")
+        }
+        XCTAssertEqual(selectedCandidate.worktreePath, worktreePath)
+        XCTAssertEqual(selectedCandidate.mainWorktreePath, mainPath)
+        XCTAssertEqual(selectedCandidate.branchName, "claude/feature-x")
+        XCTAssertEqual(selectedCandidate.state, .clean)
+        XCTAssertEqual(inspectedPaths, [worktreePath])
+
+        let result = service.executeConfirmed(selectedAction, cleanupSources: [session], activeProjectPaths: [])
+
+        XCTAssertEqual(result, .removed(success))
+        XCTAssertEqual(gitArguments, [["-C", mainPath, "worktree", "remove", worktreePath]])
+        XCTAssertEqual(inspectedPaths, [worktreePath, worktreePath])
+    }
+
     func testRemovalServiceSelectsNormalActionForUniqueLocalCommitsOnly() {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
         let session = historySession(path: worktreePath)

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -131,17 +131,23 @@ final class WorktreeCleanupTests: XCTestCase {
     func testScannerDoesNotResolveUnrelatedActiveProjectPaths() {
         let candidatePath = "/Users/dev/.codex/worktrees/billing-api"
         let activeDocumentsPath = "/Users/dev/Documents/Codex/unrelated-active"
+        var probedPaths: [String] = []
         var resolvedPaths: [String] = []
+        var inspectedPaths: [String] = []
+        var measuredPaths: [String] = []
+        var linkedRootPaths: [String] = []
         let scanner = WorktreeCleanupScanner(
             fileExists: { path in
-                path == candidatePath || path == activeDocumentsPath
+                probedPaths.append(path)
+                return path == candidatePath || path == activeDocumentsPath
             },
             resolveWorktreeRoot: { path in
                 resolvedPaths.append(path)
                 return path == candidatePath ? candidatePath : nil
             },
             inspectGit: { path in
-                path == candidatePath ? self.cleanInspection() : GitWorktreeInspection(
+                inspectedPaths.append(path)
+                return path == candidatePath ? self.cleanInspection() : GitWorktreeInspection(
                     isRegisteredWorktree: false,
                     isLinkedWorktree: false,
                     isLocked: false,
@@ -153,7 +159,12 @@ final class WorktreeCleanupTests: XCTestCase {
                 )
             },
             measureSize: { path in
-                path == candidatePath ? 1_024 : nil
+                measuredPaths.append(path)
+                return path == candidatePath ? 1_024 : nil
+            },
+            resolveLinkedWorktreeRoot: { path in
+                linkedRootPaths.append(path)
+                return nil
             }
         )
 
@@ -164,7 +175,75 @@ final class WorktreeCleanupTests: XCTestCase {
 
         XCTAssertEqual(candidates.map(\.id), [candidatePath])
         XCTAssertEqual(candidates[0].state, .clean)
+        XCTAssertEqual(probedPaths, [candidatePath, candidatePath])
         XCTAssertEqual(resolvedPaths, [candidatePath])
+        XCTAssertEqual(inspectedPaths, [candidatePath])
+        XCTAssertEqual(measuredPaths, [candidatePath])
+        XCTAssertEqual(linkedRootPaths, [])
+        XCTAssertFalse(probedPaths.contains(activeDocumentsPath))
+        XCTAssertFalse(resolvedPaths.contains(activeDocumentsPath))
+        XCTAssertFalse(inspectedPaths.contains(activeDocumentsPath))
+        XCTAssertFalse(measuredPaths.contains(activeDocumentsPath))
+        XCTAssertFalse(linkedRootPaths.contains(activeDocumentsPath))
+    }
+
+    func testScannerDoesNotProbeProtectedActiveParentProjectPath() {
+        let activeDocumentsPath = "/Users/dev/Documents/app"
+        let candidatePath = "\(activeDocumentsPath)/.claude/worktrees/feature-x"
+        var probedPaths: [String] = []
+        var resolvedPaths: [String] = []
+        var inspectedPaths: [String] = []
+        var measuredPaths: [String] = []
+        var linkedRootPaths: [String] = []
+        let scanner = WorktreeCleanupScanner(
+            fileExists: { path in
+                probedPaths.append(path)
+                return path == candidatePath
+            },
+            resolveWorktreeRoot: { path in
+                resolvedPaths.append(path)
+                return path == candidatePath ? candidatePath : nil
+            },
+            inspectGit: { path in
+                inspectedPaths.append(path)
+                return path == candidatePath ? self.cleanInspection(branch: "claude/feature-x") : GitWorktreeInspection(
+                    isRegisteredWorktree: false,
+                    isLinkedWorktree: false,
+                    isLocked: false,
+                    mainWorktreePath: nil,
+                    branchName: nil,
+                    statusEntries: nil,
+                    uniqueCommitCount: nil,
+                    failureReasons: ["unexpected inspection"]
+                )
+            },
+            measureSize: { path in
+                measuredPaths.append(path)
+                return path == candidatePath ? 1_024 : nil
+            },
+            resolveLinkedWorktreeRoot: { path in
+                linkedRootPaths.append(path)
+                return nil
+            }
+        )
+
+        let candidates = scanner.candidates(
+            from: [historySession(path: candidatePath)],
+            activeProjectPaths: [activeDocumentsPath]
+        )
+
+        XCTAssertEqual(candidates.map(\.id), [candidatePath])
+        XCTAssertEqual(candidates[0].state, .clean)
+        XCTAssertEqual(probedPaths, [candidatePath, candidatePath])
+        XCTAssertEqual(resolvedPaths, [candidatePath])
+        XCTAssertEqual(inspectedPaths, [candidatePath])
+        XCTAssertEqual(measuredPaths, [candidatePath])
+        XCTAssertEqual(linkedRootPaths, [])
+        XCTAssertFalse(probedPaths.contains(activeDocumentsPath))
+        XCTAssertFalse(resolvedPaths.contains(activeDocumentsPath))
+        XCTAssertFalse(inspectedPaths.contains(activeDocumentsPath))
+        XCTAssertFalse(measuredPaths.contains(activeDocumentsPath))
+        XCTAssertFalse(linkedRootPaths.contains(activeDocumentsPath))
     }
 
     func testScannerSkipsProtectedEndedProjectPathWithoutFileProbes() {
@@ -205,6 +284,8 @@ final class WorktreeCleanupTests: XCTestCase {
         var probedPaths: [String] = []
         var resolvedPaths: [String] = []
         var inspectedPaths: [String] = []
+        var measuredPaths: [String] = []
+        var linkedRootPaths: [String] = []
 
         let scanner = WorktreeCleanupScanner(
             fileExists: { path in
@@ -219,7 +300,14 @@ final class WorktreeCleanupTests: XCTestCase {
                 inspectedPaths.append(path)
                 return self.cleanInspection(branch: "claude/feature-x")
             },
-            measureSize: { _ in 1_024 }
+            measureSize: { path in
+                measuredPaths.append(path)
+                return 1_024
+            },
+            resolveLinkedWorktreeRoot: { path in
+                linkedRootPaths.append(path)
+                return nil
+            }
         )
 
         let candidates = scanner.candidates(
@@ -232,6 +320,8 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertFalse(probedPaths.isEmpty)
         XCTAssertEqual(resolvedPaths, [documentsWorktreePath])
         XCTAssertEqual(inspectedPaths, [documentsWorktreePath])
+        XCTAssertEqual(measuredPaths, [documentsWorktreePath])
+        XCTAssertEqual(linkedRootPaths, [])
     }
 
     func testActiveProjectPathPrefixSiblingDoesNotProtectCandidate() {
@@ -1645,7 +1735,7 @@ final class WorktreeCleanupTests: XCTestCase {
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [])
-        try await waitForCondition { linkedRootCount == 1 }
+        try await waitForCondition { linkedRootCount == 1 && gate.hasHiddenCleanupNudge }
 
         XCTAssertTrue(gate.hasHiddenCleanupNudge)
         XCTAssertEqual(manager.candidates, [])

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -387,6 +387,60 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(linkedRootPaths, [])
     }
 
+    func testScannerUsesProtectedCleanupWorktreeRootForSubdirectorySourceWithoutProbes() {
+        let documentsWorktreePath = "/Users/dev/Documents/app/.claude/worktrees/feature-x"
+        let sessionPath = "\(documentsWorktreePath)/Sources"
+        var probedPaths: [String] = []
+        var resolvedPaths: [String] = []
+        var inspectedPaths: [String] = []
+        var measuredPaths: [String] = []
+        var linkedRootPaths: [String] = []
+
+        let scanner = WorktreeCleanupScanner(
+            fileExists: { path in
+                probedPaths.append(path)
+                return false
+            },
+            resolveWorktreeRoot: { path in
+                resolvedPaths.append(path)
+                return nil
+            },
+            inspectGit: { path in
+                inspectedPaths.append(path)
+                return GitWorktreeInspection(
+                    isRegisteredWorktree: false,
+                    isLinkedWorktree: false,
+                    isLocked: false,
+                    mainWorktreePath: nil,
+                    branchName: nil,
+                    statusEntries: nil,
+                    uniqueCommitCount: nil,
+                    failureReasons: ["unexpected inspection: \(path)"]
+                )
+            },
+            measureSize: { path in
+                measuredPaths.append(path)
+                return nil
+            },
+            resolveLinkedWorktreeRoot: { path in
+                linkedRootPaths.append(path)
+                return nil
+            }
+        )
+
+        let candidates = scanner.candidates(from: [historySession(path: sessionPath)], activeProjectPaths: [])
+
+        XCTAssertEqual(candidates.map(\.id), [documentsWorktreePath])
+        XCTAssertEqual(candidates[0].worktreePath, documentsWorktreePath)
+        XCTAssertEqual(candidates[0].worktreeName, "feature-x")
+        XCTAssertEqual(candidates[0].state, .review([WorktreeCleanupCandidate.protectedFolderAccessReason]))
+        XCTAssertEqual(probedPaths, [])
+        XCTAssertEqual(resolvedPaths, [])
+        XCTAssertEqual(inspectedPaths, [])
+        XCTAssertEqual(measuredPaths, [])
+        XCTAssertEqual(linkedRootPaths, [])
+    }
+
     func testActiveProjectPathPrefixSiblingDoesNotProtectCandidate() {
         let path = "/Users/dev/.codex/worktrees/billing-api"
 
@@ -2449,8 +2503,9 @@ final class WorktreeCleanupTests: XCTestCase {
 
     func testRemovalServiceCanRemoveProtectedCandidateAfterExplicitInspection() {
         let worktreePath = "/Users/dev/Documents/app/.claude/worktrees/feature-x"
+        let sessionPath = "\(worktreePath)/Sources"
         let mainPath = "/Users/dev/projects/billing-api"
-        let session = historySession(path: worktreePath, branch: "claude/feature-x")
+        let session = historySession(path: sessionPath, branch: "claude/feature-x")
         var inspectedPaths: [String] = []
         var gitArguments: [[String]] = []
         let success = GitCommandResult(exitCode: 0, stdout: "removed\n", stderr: "")

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1539,6 +1539,80 @@ final class WorktreeCleanupTests: XCTestCase {
     }
 
     @MainActor
+    func testCleanupRefreshGateDoesNotNudgeForHiddenOrdinaryCheckoutPath() async throws {
+        let projectPath = "/Users/dev/projects/app"
+        let session = historySession(path: projectPath)
+        var probeCount = 0
+        var inspectionCount = 0
+        var sizeCount = 0
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in
+                    probeCount += 1
+                    return true
+                },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { _ in
+                    inspectionCount += 1
+                    return self.cleanInspection()
+                },
+                measureSize: { _ in
+                    sizeCount += 1
+                    return 1_024
+                }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([session], activeProjectPaths: [])
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
+        XCTAssertEqual(manager.candidates, [])
+        XCTAssertFalse(manager.isScanning)
+        XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(inspectionCount, 0)
+        XCTAssertEqual(sizeCount, 0)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateNudgesForHiddenCleanupWorktreeOutsideProtectedFolders() async throws {
+        let worktreePath = "/Users/dev/projects/app/.claude/worktrees/feature-x"
+        let session = historySession(path: worktreePath)
+        var probeCount = 0
+        var inspectionCount = 0
+        var sizeCount = 0
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in
+                    probeCount += 1
+                    return true
+                },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { _ in
+                    inspectionCount += 1
+                    return self.cleanInspection()
+                },
+                measureSize: { _ in
+                    sizeCount += 1
+                    return 1_024
+                }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([session], activeProjectPaths: [])
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
+        XCTAssertEqual(manager.candidates, [])
+        XCTAssertFalse(manager.isScanning)
+        XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(inspectionCount, 0)
+        XCTAssertEqual(sizeCount, 0)
+    }
+
+    @MainActor
     func testCleanupRefreshGateDoesNotNudgeForHiddenActiveCleanupSource() async throws {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
         let session = historySession(path: worktreePath)

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -233,11 +233,15 @@ final class WorktreeCleanupTests: XCTestCase {
         )
 
         XCTAssertEqual(candidates.map(\.id), [candidatePath])
-        XCTAssertEqual(candidates[0].state, .clean)
-        XCTAssertEqual(probedPaths, [candidatePath, candidatePath])
-        XCTAssertEqual(resolvedPaths, [candidatePath])
-        XCTAssertEqual(inspectedPaths, [candidatePath])
-        XCTAssertEqual(measuredPaths, [candidatePath])
+        XCTAssertEqual(candidates[0].state, .review([WorktreeCleanupCandidate.protectedFolderAccessReason]))
+        XCTAssertEqual(
+            candidates[0].checks,
+            [WorktreeCleanupCheck(label: "Protected folder access", status: .review)]
+        )
+        XCTAssertEqual(probedPaths, [])
+        XCTAssertEqual(resolvedPaths, [])
+        XCTAssertEqual(inspectedPaths, [])
+        XCTAssertEqual(measuredPaths, [])
         XCTAssertEqual(linkedRootPaths, [])
         XCTAssertFalse(probedPaths.contains(activeDocumentsPath))
         XCTAssertFalse(resolvedPaths.contains(activeDocumentsPath))
@@ -279,8 +283,8 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(inspectedPaths, [])
     }
 
-    func testScannerStillScansProtectedEndedWorktreePath() {
-        let documentsWorktreePath = "/Users/dev/Documents/app/.claude/worktrees/feature-x"
+    func testScannerStillScansUnprotectedEndedWorktreePath() {
+        let worktreePath = "/Users/dev/projects/app/.claude/worktrees/feature-x"
         var probedPaths: [String] = []
         var resolvedPaths: [String] = []
         var inspectedPaths: [String] = []
@@ -290,11 +294,11 @@ final class WorktreeCleanupTests: XCTestCase {
         let scanner = WorktreeCleanupScanner(
             fileExists: { path in
                 probedPaths.append(path)
-                return path == documentsWorktreePath
+                return path == worktreePath
             },
             resolveWorktreeRoot: { path in
                 resolvedPaths.append(path)
-                return path == documentsWorktreePath ? documentsWorktreePath : nil
+                return path == worktreePath ? worktreePath : nil
             },
             inspectGit: { path in
                 inspectedPaths.append(path)
@@ -311,16 +315,75 @@ final class WorktreeCleanupTests: XCTestCase {
         )
 
         let candidates = scanner.candidates(
-            from: [historySession(path: documentsWorktreePath)],
+            from: [historySession(path: worktreePath)],
             activeProjectPaths: []
         )
 
-        XCTAssertEqual(candidates.map(\.id), [documentsWorktreePath])
+        XCTAssertEqual(candidates.map(\.id), [worktreePath])
         XCTAssertEqual(candidates[0].branchName, "claude/feature-x")
         XCTAssertFalse(probedPaths.isEmpty)
-        XCTAssertEqual(resolvedPaths, [documentsWorktreePath])
-        XCTAssertEqual(inspectedPaths, [documentsWorktreePath])
-        XCTAssertEqual(measuredPaths, [documentsWorktreePath])
+        XCTAssertEqual(resolvedPaths, [worktreePath])
+        XCTAssertEqual(inspectedPaths, [worktreePath])
+        XCTAssertEqual(measuredPaths, [worktreePath])
+        XCTAssertEqual(linkedRootPaths, [])
+    }
+
+    func testScannerReportsProtectedCleanupCandidateNeedsFileAccessWithoutRepeatedProbes() {
+        let documentsWorktreePath = "/Users/dev/Documents/app/.claude/worktrees/feature-x"
+        var probedPaths: [String] = []
+        var resolvedPaths: [String] = []
+        var inspectedPaths: [String] = []
+        var measuredPaths: [String] = []
+        var linkedRootPaths: [String] = []
+
+        let scanner = WorktreeCleanupScanner(
+            fileExists: { path in
+                probedPaths.append(path)
+                return false
+            },
+            resolveWorktreeRoot: { path in
+                resolvedPaths.append(path)
+                return nil
+            },
+            inspectGit: { path in
+                inspectedPaths.append(path)
+                return GitWorktreeInspection(
+                    isRegisteredWorktree: false,
+                    isLinkedWorktree: false,
+                    isLocked: false,
+                    mainWorktreePath: nil,
+                    branchName: nil,
+                    statusEntries: nil,
+                    uniqueCommitCount: nil,
+                    failureReasons: ["unexpected inspection: \(path)"]
+                )
+            },
+            measureSize: { path in
+                measuredPaths.append(path)
+                return nil
+            },
+            resolveLinkedWorktreeRoot: { path in
+                linkedRootPaths.append(path)
+                return nil
+            }
+        )
+
+        let firstScan = scanner.candidates(from: [historySession(path: documentsWorktreePath)], activeProjectPaths: [])
+        let secondScan = scanner.candidates(from: [historySession(path: documentsWorktreePath)], activeProjectPaths: [])
+
+        for candidates in [firstScan, secondScan] {
+            XCTAssertEqual(candidates.map(\.id), [documentsWorktreePath])
+            XCTAssertEqual(candidates[0].state, .review([WorktreeCleanupCandidate.protectedFolderAccessReason]))
+            XCTAssertEqual(candidates[0].storageBytes, nil)
+            XCTAssertEqual(
+                candidates[0].checks,
+                [WorktreeCleanupCheck(label: "Protected folder access", status: .review)]
+            )
+        }
+        XCTAssertEqual(probedPaths, [])
+        XCTAssertEqual(resolvedPaths, [])
+        XCTAssertEqual(inspectedPaths, [])
+        XCTAssertEqual(measuredPaths, [])
         XCTAssertEqual(linkedRootPaths, [])
     }
 

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1571,6 +1571,7 @@ final class WorktreeCleanupTests: XCTestCase {
         let session = historySession(path: projectPath)
         var probeCount = 0
         var linkedRootCount = 0
+        var linkedRootRanOnMainThread: Bool?
         var inspectionCount = 0
         var sizeCount = 0
         let manager = WorktreeCleanupManager(
@@ -1590,6 +1591,7 @@ final class WorktreeCleanupTests: XCTestCase {
                 },
                 resolveLinkedWorktreeRoot: { _ in
                     linkedRootCount += 1
+                    linkedRootRanOnMainThread = Thread.isMainThread
                     return nil
                 }
             )
@@ -1597,13 +1599,14 @@ final class WorktreeCleanupTests: XCTestCase {
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [])
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitForCondition { linkedRootCount == 1 }
 
         XCTAssertFalse(gate.hasHiddenCleanupNudge)
         XCTAssertEqual(manager.candidates, [])
         XCTAssertFalse(manager.isScanning)
         XCTAssertEqual(probeCount, 0)
         XCTAssertEqual(linkedRootCount, 1)
+        XCTAssertEqual(linkedRootRanOnMainThread, false)
         XCTAssertEqual(inspectionCount, 0)
         XCTAssertEqual(sizeCount, 0)
     }
@@ -1614,6 +1617,7 @@ final class WorktreeCleanupTests: XCTestCase {
         let session = historySession(path: worktreePath)
         var probeCount = 0
         var linkedRootCount = 0
+        var linkedRootRanOnMainThread: Bool?
         var inspectionCount = 0
         var sizeCount = 0
         let manager = WorktreeCleanupManager(
@@ -1633,6 +1637,7 @@ final class WorktreeCleanupTests: XCTestCase {
                 },
                 resolveLinkedWorktreeRoot: { _ in
                     linkedRootCount += 1
+                    linkedRootRanOnMainThread = Thread.isMainThread
                     return worktreePath
                 }
             )
@@ -1640,13 +1645,14 @@ final class WorktreeCleanupTests: XCTestCase {
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [])
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitForCondition { linkedRootCount == 1 }
 
         XCTAssertTrue(gate.hasHiddenCleanupNudge)
         XCTAssertEqual(manager.candidates, [])
         XCTAssertFalse(manager.isScanning)
         XCTAssertEqual(probeCount, 0)
         XCTAssertEqual(linkedRootCount, 1)
+        XCTAssertEqual(linkedRootRanOnMainThread, false)
         XCTAssertEqual(inspectionCount, 0)
         XCTAssertEqual(sizeCount, 0)
     }
@@ -4256,6 +4262,19 @@ final class WorktreeCleanupTests: XCTestCase {
             try await Task.sleep(nanoseconds: 20_000_000)
         }
         XCTFail("Timed out waiting for cleanup candidates", file: file, line: line)
+    }
+
+    @MainActor
+    private func waitForCondition(
+        _ predicate: @escaping () -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        for _ in 0..<50 {
+            if predicate() { return }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        XCTFail("Timed out waiting for condition", file: file, line: line)
     }
 
     @MainActor

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1302,6 +1302,27 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertNotEqual(lhs, rhs)
     }
 
+    func testRefreshSignatureIgnoresScannerSkippedProtectedProjectPaths() {
+        let skippedProtectedProject = historySession(
+            id: "documents-project",
+            path: "/Users/dev/Documents/Codex/old-session"
+        )
+        let plausibleProtectedWorktree = historySession(
+            id: "documents-worktree",
+            path: "/Users/dev/Documents/app/.claude/worktrees/feature-x"
+        )
+        let empty = WorktreeCleanupRefreshSignature(cleanupSources: [], activeProjectPaths: [])
+
+        XCTAssertEqual(
+            WorktreeCleanupRefreshSignature(cleanupSources: [skippedProtectedProject], activeProjectPaths: []),
+            empty
+        )
+        XCTAssertNotEqual(
+            WorktreeCleanupRefreshSignature(cleanupSources: [plausibleProtectedWorktree], activeProjectPaths: []),
+            empty
+        )
+    }
+
     @MainActor
     func testNonForcedRefreshRunsWhenLatestEndedSessionForPathChanges() async throws {
         let path = "/Users/dev/.codex/worktrees/billing-api"

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1450,10 +1450,11 @@ final class WorktreeCleanupTests: XCTestCase {
     }
 
     @MainActor
-    func testCleanupRefreshGateDoesNotScanWhileCleanupIsHidden() async throws {
+    func testCleanupRefreshGateDoesNotScanWhileHiddenSourcesChange() async throws {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
         let session = historySession(path: worktreePath)
         var inspectionCount = 0
+        var sizeCount = 0
         let manager = WorktreeCleanupManager(
             scanner: WorktreeCleanupScanner(
                 fileExists: { _ in true },
@@ -1462,7 +1463,10 @@ final class WorktreeCleanupTests: XCTestCase {
                     inspectionCount += 1
                     return self.cleanInspection()
                 },
-                measureSize: { _ in 1_024 }
+                measureSize: { _ in
+                    sizeCount += 1
+                    return 1_024
+                }
             )
         )
         let gate = WorktreeCleanupRefreshGate(manager: manager)
@@ -1470,8 +1474,172 @@ final class WorktreeCleanupTests: XCTestCase {
         gate.updateSources([session], activeProjectPaths: [])
         try await Task.sleep(nanoseconds: 100_000_000)
 
-        XCTAssertEqual(inspectionCount, 0)
         XCTAssertEqual(manager.candidates, [])
+        XCTAssertFalse(manager.isScanning)
+        XCTAssertEqual(inspectionCount, 0)
+        XCTAssertEqual(sizeCount, 0)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateDoesNotNudgeForHiddenNonPlausibleCleanupPath() async throws {
+        let projectPath = "/Users/dev/Documents/Codex/old-session"
+        let session = historySession(path: projectPath)
+        var probeCount = 0
+        var inspectionCount = 0
+        var sizeCount = 0
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in
+                    probeCount += 1
+                    return true
+                },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { _ in
+                    inspectionCount += 1
+                    return self.cleanInspection()
+                },
+                measureSize: { _ in
+                    sizeCount += 1
+                    return 1_024
+                }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([session], activeProjectPaths: [])
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
+        XCTAssertEqual(manager.candidates, [])
+        XCTAssertFalse(manager.isScanning)
+        XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(inspectionCount, 0)
+        XCTAssertEqual(sizeCount, 0)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateDoesNotNudgeForHiddenActiveCleanupSource() async throws {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        var probeCount = 0
+        var inspectionCount = 0
+        var sizeCount = 0
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in
+                    probeCount += 1
+                    return true
+                },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { _ in
+                    inspectionCount += 1
+                    return self.cleanInspection()
+                },
+                measureSize: { _ in
+                    sizeCount += 1
+                    return 1_024
+                }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([session], activeProjectPaths: [worktreePath])
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
+        XCTAssertEqual(manager.candidates, [])
+        XCTAssertFalse(manager.isScanning)
+        XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(inspectionCount, 0)
+        XCTAssertEqual(sizeCount, 0)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateNudgesForHiddenCleanupWorktreeInsideActiveParentCheckout() async throws {
+        let checkoutPath = "/Users/dev/projects/app"
+        let worktreePath = "/Users/dev/projects/app/.claude/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        var probeCount = 0
+        var inspectionCount = 0
+        var sizeCount = 0
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in
+                    probeCount += 1
+                    return true
+                },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { _ in
+                    inspectionCount += 1
+                    return self.cleanInspection()
+                },
+                measureSize: { _ in
+                    sizeCount += 1
+                    return 1_024
+                }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([session], activeProjectPaths: [checkoutPath])
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
+        XCTAssertEqual(manager.candidates, [])
+        XCTAssertFalse(manager.isScanning)
+        XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(inspectionCount, 0)
+        XCTAssertEqual(sizeCount, 0)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateNudgesForNewHiddenSourceIdentity() async throws {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        var inspectionCount = 0
+        var sizeCount = 0
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in true },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { _ in
+                    inspectionCount += 1
+                    return self.cleanInspection()
+                },
+                measureSize: { _ in
+                    sizeCount += 1
+                    return 1_024
+                }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([session], activeProjectPaths: [])
+
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
+        XCTAssertEqual(inspectionCount, 0)
+        XCTAssertEqual(sizeCount, 0)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateDoesNotRenudgeUnchangedHiddenSourcesAfterOpeningCleanup() async throws {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let manager = WorktreeCleanupManager(
+            scanner: scanner(existingPaths: [worktreePath], inspections: [worktreePath: cleanInspection()])
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([session], activeProjectPaths: [])
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
+
+        gate.setCleanupVisible(true)
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
+
+        gate.setCleanupVisible(false)
+        gate.updateSources([session], activeProjectPaths: [])
+
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
     }
 
     @MainActor
@@ -1492,20 +1660,19 @@ final class WorktreeCleanupTests: XCTestCase {
         )
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
-        gate.updateSources([session], activeProjectPaths: [])
         gate.setCleanupVisible(true)
+        gate.updateSources([session], activeProjectPaths: [])
 
         try await waitForCleanupCandidates(manager) { candidates in
             candidates.first?.worktreePath == worktreePath
         }
         XCTAssertEqual(inspectionCount, 1)
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
     }
 
     @MainActor
-    func testCleanupRefreshGateStopsScanningAfterCleanupIsHidden() async throws {
+    func testCleanupRefreshGateDoesNotNudgeWhenVisibleSourcesChange() async throws {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
-        let session = historySession(path: worktreePath)
-        var inspection = cleanInspection()
         var inspectionCount = 0
         let manager = WorktreeCleanupManager(
             scanner: WorktreeCleanupScanner(
@@ -1513,21 +1680,60 @@ final class WorktreeCleanupTests: XCTestCase {
                 resolveWorktreeRoot: { _ in nil },
                 inspectGit: { _ in
                     inspectionCount += 1
-                    return inspection
+                    return self.cleanInspection()
                 },
                 measureSize: { _ in 1_024 }
             )
         )
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
-        gate.updateSources([session], activeProjectPaths: [])
         gate.setCleanupVisible(true)
+        gate.updateSources([historySession(path: worktreePath)], activeProjectPaths: [])
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.worktreePath == worktreePath
+        }
+        gate.updateSources(
+            [historySession(id: "new", path: worktreePath, endedAt: now.addingTimeInterval(1))],
+            activeProjectPaths: []
+        )
+        try await waitForCleanupCandidates(manager) { _ in
+            inspectionCount == 2
+        }
+
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateDoesNotScanAfterCleanupIsHiddenAgain() async throws {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        var inspectionCount = 0
+        var sizeCount = 0
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in true },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { _ in
+                    inspectionCount += 1
+                    return self.cleanInspection()
+                },
+                measureSize: { _ in
+                    sizeCount += 1
+                    return 1_024
+                }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.setCleanupVisible(true)
+        gate.updateSources([session], activeProjectPaths: [])
         try await waitForCleanupCandidates(manager) { candidates in
             candidates.first?.state == .clean
         }
+        XCTAssertEqual(inspectionCount, 1)
+        XCTAssertEqual(sizeCount, 1)
 
         gate.setCleanupVisible(false)
-        inspection = cleanInspection(statusEntries: ["?? scratch.txt"])
         gate.updateSources(
             [historySession(id: "new", path: worktreePath, endedAt: now.addingTimeInterval(1))],
             activeProjectPaths: []
@@ -1535,7 +1741,129 @@ final class WorktreeCleanupTests: XCTestCase {
         try await Task.sleep(nanoseconds: 100_000_000)
 
         XCTAssertEqual(inspectionCount, 1)
-        XCTAssertEqual(manager.candidates.first?.state, .clean)
+        XCTAssertEqual(sizeCount, 1)
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateNudgesWhenPanelHidesWithCleanupTabSelected() async throws {
+        let firstPath = "/Users/dev/.codex/worktrees/billing-api"
+        let secondPath = "/Users/dev/.codex/worktrees/reporting-api"
+        var inspectionCount = 0
+        var sizeCount = 0
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in true },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { path in
+                    inspectionCount += 1
+                    return self.cleanInspection(branch: path == firstPath ? "feature/invoices" : "feature/reports")
+                },
+                measureSize: { _ in
+                    sizeCount += 1
+                    return 1_024
+                }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.setPanelVisible(true)
+        gate.setCleanupTabSelected(true)
+        gate.updateSources([historySession(id: "first", path: firstPath)], activeProjectPaths: [])
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.worktreePath == firstPath
+        }
+        XCTAssertEqual(inspectionCount, 1)
+        XCTAssertEqual(sizeCount, 1)
+
+        gate.setPanelVisible(false)
+        gate.updateSources(
+            [historySession(id: "second", path: secondPath, endedAt: now.addingTimeInterval(1))],
+            activeProjectPaths: []
+        )
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
+        XCTAssertEqual(inspectionCount, 1)
+        XCTAssertEqual(sizeCount, 1)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateDoesNotNudgeWhenHiddenSourceSetShrinksAfterSeen() async throws {
+        let firstPath = "/Users/dev/.codex/worktrees/billing-api"
+        let secondPath = "/Users/dev/.codex/worktrees/reporting-api"
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { [firstPath, secondPath].contains($0) },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { path in
+                    self.cleanInspection(branch: path == firstPath ? "feature/invoices" : "feature/reports")
+                },
+                measureSize: { _ in 1_024 }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+        let first = historySession(id: "first", path: firstPath, endedAt: now)
+        let second = historySession(id: "second", path: secondPath, endedAt: now.addingTimeInterval(1))
+
+        gate.setCleanupVisible(true)
+        gate.updateSources([first, second], activeProjectPaths: [])
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
+
+        gate.setCleanupVisible(false)
+        gate.updateSources([first], activeProjectPaths: [])
+
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateClearsNudgeWhenHiddenSourcesShrinkBackToSeenSet() {
+        let firstPath = "/Users/dev/.codex/worktrees/billing-api"
+        let secondPath = "/Users/dev/.codex/worktrees/reporting-api"
+        let manager = WorktreeCleanupManager(scanner: scanner(existingPaths: [firstPath, secondPath]))
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+        let first = historySession(id: "first", path: firstPath, endedAt: now)
+        let second = historySession(id: "second", path: secondPath, endedAt: now.addingTimeInterval(1))
+
+        gate.setCleanupVisible(true)
+        gate.updateSources([first], activeProjectPaths: [])
+        gate.setCleanupVisible(false)
+
+        gate.updateSources([first, second], activeProjectPaths: [])
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
+
+        gate.updateSources([first], activeProjectPaths: [])
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateClearsHiddenNudgeWhenCleanupOpens() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let manager = WorktreeCleanupManager(scanner: scanner(existingPaths: [worktreePath]))
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([session], activeProjectPaths: [])
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
+
+        gate.setCleanupVisible(true)
+
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateClearsHiddenNudgeWhenSourceIdentitySetBecomesEmpty() {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let manager = WorktreeCleanupManager(scanner: scanner(existingPaths: [worktreePath]))
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([session], activeProjectPaths: [])
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
+
+        gate.updateSources([], activeProjectPaths: [])
+
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
     }
 
     func testRemovalServiceRunsGitWorktreeRemoveWithArgumentArrayForCleanCandidate() {

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -187,6 +187,22 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertFalse(linkedRootPaths.contains(activeDocumentsPath))
     }
 
+    func testProtectedPathDetectionIncludesDataVolumeAndICloudShapes() {
+        XCTAssertTrue(Config.isLikelyPrivacyProtectedUserPath("/Users/dev/Documents/app"))
+        XCTAssertTrue(Config.isLikelyPrivacyProtectedUserPath("/Users/dev/Desktop/app"))
+        XCTAssertTrue(Config.isLikelyPrivacyProtectedUserPath("/Users/dev/Downloads/app"))
+        XCTAssertTrue(Config.isLikelyPrivacyProtectedUserPath("/System/Volumes/Data/Users/dev/Documents/app"))
+        XCTAssertTrue(Config.isLikelyPrivacyProtectedUserPath("/System/Volumes/Data/Users/dev/Desktop/app"))
+        XCTAssertTrue(Config.isLikelyPrivacyProtectedUserPath("/System/Volumes/Data/Users/dev/Downloads/app"))
+        XCTAssertTrue(Config.isLikelyPrivacyProtectedUserPath("/Users/dev/Library/Mobile Documents/com~apple~CloudDocs/app"))
+        XCTAssertTrue(
+            Config.isLikelyPrivacyProtectedUserPath(
+                "/System/Volumes/Data/Users/dev/Library/Mobile Documents/com~apple~CloudDocs/app"
+            )
+        )
+        XCTAssertFalse(Config.isLikelyPrivacyProtectedUserPath("/Users/dev/projects/app"))
+    }
+
     func testScannerDoesNotProbeProtectedActiveParentProjectPath() {
         let activeDocumentsPath = "/Users/dev/Documents/app"
         let candidatePath = "\(activeDocumentsPath)/.claude/worktrees/feature-x"
@@ -1135,6 +1151,63 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(inspector.linkedWorktreeRoot(containing: "\(worktreePath)/pkg"), worktreePath)
         XCTAssertNil(inspector.linkedWorktreeRoot(containing: "\(repo)/pkg"))
         XCTAssertNil(inspector.linkedWorktreeRoot(containing: "/Users/dev/projects/other"))
+    }
+
+    func testInspectorDoesNotCanonicalizeProtectedWorktreeListEntriesWhileInspectingUnprotectedWorktree() {
+        let repo = "/Users/dev/projects/billing-api"
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let protectedSibling = "/Users/dev/Documents/app/.codex/worktrees/protected-feature"
+        let output = [
+            "worktree \(repo)",
+            "branch refs/heads/master",
+            "",
+            "worktree \(worktreePath)",
+            "branch refs/heads/feature/invoices",
+            "",
+            "worktree \(protectedSibling)",
+            "branch refs/heads/protected-feature",
+            "",
+        ].joined(separator: "\u{0}")
+        var canonicalizedPaths: [String] = []
+        let inspector = GitWorktreeInspector(
+            runGit: { _, arguments in
+                switch arguments {
+                case ["worktree", "list", "--porcelain", "-z"]:
+                    return GitCommandResult(exitCode: 0, stdout: output, stderr: "")
+                case ["branch", "--show-current"]:
+                    return GitCommandResult(exitCode: 0, stdout: "feature/invoices\n", stderr: "")
+                case ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--ignored=traditional"]:
+                    return GitCommandResult(exitCode: 0, stdout: "", stderr: "")
+                case ["ls-files", "-s", "-v", "-z"]:
+                    return GitCommandResult(exitCode: 0, stdout: "", stderr: "")
+                case ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]:
+                    return GitCommandResult(exitCode: 0, stdout: "origin/feature/invoices\n", stderr: "")
+                case ["rev-list", "--count", "@{u}..HEAD"]:
+                    return GitCommandResult(exitCode: 0, stdout: "0\n", stderr: "")
+                case ["submodule", "status", "--recursive"]:
+                    return GitCommandResult(exitCode: 0, stdout: "", stderr: "")
+                default:
+                    return GitCommandResult(exitCode: 1, stdout: "", stderr: "unexpected \(arguments)")
+                }
+            },
+            canonicalizePath: { path in
+                canonicalizedPaths.append(path)
+                return path
+            }
+        )
+
+        XCTAssertEqual(inspector.worktreeRoot(containing: "\(worktreePath)/pkg"), worktreePath)
+
+        XCTAssertTrue(canonicalizedPaths.contains(worktreePath))
+        XCTAssertFalse(canonicalizedPaths.contains(protectedSibling))
+
+        canonicalizedPaths.removeAll()
+        let inspection = inspector.inspect(path: worktreePath)
+
+        XCTAssertTrue(inspection.isRegisteredWorktree)
+        XCTAssertTrue(inspection.isLinkedWorktree)
+        XCTAssertTrue(canonicalizedPaths.contains(worktreePath))
+        XCTAssertFalse(canonicalizedPaths.contains(protectedSibling))
     }
 
     func testInspectorResolvesSymlinkedPathToContainingWorktreeRoot() throws {
@@ -2132,6 +2205,57 @@ final class WorktreeCleanupTests: XCTestCase {
         }
         XCTAssertEqual(inspectionCount, 1)
         XCTAssertFalse(gate.hasHiddenCleanupNudge)
+    }
+
+    @MainActor
+    func testCleanupVisibleRefreshDoesNotProbeProtectedActiveProjectPathWithUnprotectedHistorySource() async throws {
+        let historyWorktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let protectedActivePath = "/Users/dev/Documents/Codex/2026-07-04/can-you-check-my-email-and"
+        let session = historySession(path: historyWorktreePath)
+        var probedPaths: [String] = []
+        var resolvedPaths: [String] = []
+        var inspectedPaths: [String] = []
+        var measuredPaths: [String] = []
+        var linkedRootPaths: [String] = []
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { path in
+                    probedPaths.append(path)
+                    return path == historyWorktreePath
+                },
+                resolveWorktreeRoot: { path in
+                    resolvedPaths.append(path)
+                    return path == historyWorktreePath ? historyWorktreePath : nil
+                },
+                inspectGit: { path in
+                    inspectedPaths.append(path)
+                    return self.cleanInspection()
+                },
+                measureSize: { path in
+                    measuredPaths.append(path)
+                    return 1_024
+                },
+                resolveLinkedWorktreeRoot: { path in
+                    linkedRootPaths.append(path)
+                    return nil
+                }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.setPanelVisible(true)
+        gate.setCleanupTabSelected(true)
+        gate.updateSources([session], activeProjectPaths: [protectedActivePath])
+
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.worktreePath == historyWorktreePath
+        }
+
+        XCTAssertFalse(probedPaths.contains(protectedActivePath))
+        XCTAssertFalse(resolvedPaths.contains(protectedActivePath))
+        XCTAssertFalse(inspectedPaths.contains(protectedActivePath))
+        XCTAssertFalse(measuredPaths.contains(protectedActivePath))
+        XCTAssertFalse(linkedRootPaths.contains(protectedActivePath))
     }
 
     @MainActor

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 final class WorktreeCleanupTests: XCTestCase {
     private let now = Date(timeIntervalSince1970: 1_800_000_000)
+    private let layoutNotificationTimeout: TimeInterval = 5
 
     func testCandidateGroupingChoosesLatestEndedSessionPerPath() {
         let path = "/Users/dev/.codex/worktrees/billing-api"
@@ -1180,7 +1181,7 @@ final class WorktreeCleanupTests: XCTestCase {
 
         view.handleCleanupCandidatesChanged()
 
-        await fulfillment(of: [layoutChanged], timeout: 1)
+        await fulfillment(of: [layoutChanged], timeout: layoutNotificationTimeout)
     }
 
     @MainActor
@@ -1218,7 +1219,7 @@ final class WorktreeCleanupTests: XCTestCase {
 
         view.handleCleanupScanningChanged()
 
-        await fulfillment(of: [layoutChanged], timeout: 1)
+        await fulfillment(of: [layoutChanged], timeout: layoutNotificationTimeout)
     }
 
     @MainActor

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1772,7 +1772,7 @@ final class WorktreeCleanupTests: XCTestCase {
     }
 
     @MainActor
-    func testCleanupRefreshGateDoesNotScanWhileHiddenSourcesChange() async throws {
+    func testCleanupRefreshGateScansWhileHiddenSourcesChange() async throws {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
         let session = historySession(path: worktreePath)
         var inspectionCount = 0
@@ -1794,11 +1794,59 @@ final class WorktreeCleanupTests: XCTestCase {
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [])
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.worktreePath == worktreePath
+        }
+
+        XCTAssertEqual(manager.candidates.count, 1)
+        XCTAssertFalse(manager.isScanning)
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
+        XCTAssertEqual(inspectionCount, 1)
+        XCTAssertEqual(sizeCount, 1)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateDoesNotNudgeWhenHiddenScanFindsNoActionableCandidates() async throws {
+        let projectPath = "/Users/dev/projects/deleted-api"
+        let session = historySession(path: projectPath)
+        var probeCount = 0
+        var inspectionCount = 0
+        var sizeCount = 0
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in
+                    probeCount += 1
+                    return true
+                },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { _ in
+                    inspectionCount += 1
+                    return GitWorktreeInspection(
+                        isRegisteredWorktree: false,
+                        isLinkedWorktree: false,
+                        isLocked: false,
+                        mainWorktreePath: nil,
+                        branchName: nil,
+                        statusEntries: nil,
+                        uniqueCommitCount: nil,
+                        failureReasons: []
+                    )
+                },
+                measureSize: { _ in
+                    sizeCount += 1
+                    return 1_024
+                }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([session], activeProjectPaths: [])
+        try await waitForCondition { !manager.isScanning && inspectionCount == 1 }
 
         XCTAssertEqual(manager.candidates, [])
-        XCTAssertFalse(manager.isScanning)
-        XCTAssertEqual(inspectionCount, 0)
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
+        XCTAssertEqual(probeCount, 2)
+        XCTAssertEqual(inspectionCount, 1)
         XCTAssertEqual(sizeCount, 0)
     }
 
@@ -1834,7 +1882,7 @@ final class WorktreeCleanupTests: XCTestCase {
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [])
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitForCondition { !manager.isScanning }
 
         XCTAssertFalse(gate.hasHiddenCleanupNudge)
         XCTAssertEqual(manager.candidates, [])
@@ -1851,7 +1899,6 @@ final class WorktreeCleanupTests: XCTestCase {
         let session = historySession(path: projectPath)
         var probeCount = 0
         var linkedRootCount = 0
-        var linkedRootRanOnMainThread: Bool?
         var inspectionCount = 0
         var sizeCount = 0
         let manager = WorktreeCleanupManager(
@@ -1863,7 +1910,16 @@ final class WorktreeCleanupTests: XCTestCase {
                 resolveWorktreeRoot: { _ in nil },
                 inspectGit: { _ in
                     inspectionCount += 1
-                    return self.cleanInspection()
+                    return GitWorktreeInspection(
+                        isRegisteredWorktree: true,
+                        isLinkedWorktree: false,
+                        isLocked: false,
+                        mainWorktreePath: projectPath,
+                        branchName: "master",
+                        statusEntries: [],
+                        uniqueCommitCount: 0,
+                        failureReasons: []
+                    )
                 },
                 measureSize: { _ in
                     sizeCount += 1
@@ -1871,7 +1927,6 @@ final class WorktreeCleanupTests: XCTestCase {
                 },
                 resolveLinkedWorktreeRoot: { _ in
                     linkedRootCount += 1
-                    linkedRootRanOnMainThread = Thread.isMainThread
                     return nil
                 }
             )
@@ -1879,15 +1934,14 @@ final class WorktreeCleanupTests: XCTestCase {
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [])
-        try await waitForCondition { linkedRootCount == 1 }
+        try await waitForCondition { !manager.isScanning && inspectionCount == 1 }
 
         XCTAssertFalse(gate.hasHiddenCleanupNudge)
         XCTAssertEqual(manager.candidates, [])
         XCTAssertFalse(manager.isScanning)
-        XCTAssertEqual(probeCount, 0)
-        XCTAssertEqual(linkedRootCount, 1)
-        XCTAssertEqual(linkedRootRanOnMainThread, false)
-        XCTAssertEqual(inspectionCount, 0)
+        XCTAssertEqual(probeCount, 2)
+        XCTAssertEqual(linkedRootCount, 0)
+        XCTAssertEqual(inspectionCount, 1)
         XCTAssertEqual(sizeCount, 0)
     }
 
@@ -1897,7 +1951,6 @@ final class WorktreeCleanupTests: XCTestCase {
         let session = historySession(path: worktreePath)
         var probeCount = 0
         var linkedRootCount = 0
-        var linkedRootRanOnMainThread: Bool?
         var inspectionCount = 0
         var sizeCount = 0
         let manager = WorktreeCleanupManager(
@@ -1917,7 +1970,6 @@ final class WorktreeCleanupTests: XCTestCase {
                 },
                 resolveLinkedWorktreeRoot: { _ in
                     linkedRootCount += 1
-                    linkedRootRanOnMainThread = Thread.isMainThread
                     return worktreePath
                 }
             )
@@ -1925,16 +1977,17 @@ final class WorktreeCleanupTests: XCTestCase {
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [])
-        try await waitForCondition { linkedRootCount == 1 && gate.hasHiddenCleanupNudge }
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.worktreePath == worktreePath
+        }
 
         XCTAssertTrue(gate.hasHiddenCleanupNudge)
-        XCTAssertEqual(manager.candidates, [])
+        XCTAssertEqual(manager.candidates.count, 1)
         XCTAssertFalse(manager.isScanning)
-        XCTAssertEqual(probeCount, 0)
-        XCTAssertEqual(linkedRootCount, 1)
-        XCTAssertEqual(linkedRootRanOnMainThread, false)
-        XCTAssertEqual(inspectionCount, 0)
-        XCTAssertEqual(sizeCount, 0)
+        XCTAssertEqual(probeCount, 2)
+        XCTAssertEqual(linkedRootCount, 0)
+        XCTAssertEqual(inspectionCount, 1)
+        XCTAssertEqual(sizeCount, 1)
     }
 
     @MainActor
@@ -1969,15 +2022,17 @@ final class WorktreeCleanupTests: XCTestCase {
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [])
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.worktreePath == worktreePath
+        }
 
         XCTAssertTrue(gate.hasHiddenCleanupNudge)
-        XCTAssertEqual(manager.candidates, [])
+        XCTAssertEqual(manager.candidates.count, 1)
         XCTAssertFalse(manager.isScanning)
-        XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(probeCount, 2)
         XCTAssertEqual(linkedRootCount, 0)
-        XCTAssertEqual(inspectionCount, 0)
-        XCTAssertEqual(sizeCount, 0)
+        XCTAssertEqual(inspectionCount, 1)
+        XCTAssertEqual(sizeCount, 1)
     }
 
     @MainActor
@@ -2007,12 +2062,12 @@ final class WorktreeCleanupTests: XCTestCase {
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [worktreePath])
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitForCondition { !manager.isScanning && probeCount == 2 }
 
         XCTAssertFalse(gate.hasHiddenCleanupNudge)
         XCTAssertEqual(manager.candidates, [])
         XCTAssertFalse(manager.isScanning)
-        XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(probeCount, 2)
         XCTAssertEqual(inspectionCount, 0)
         XCTAssertEqual(sizeCount, 0)
     }
@@ -2030,7 +2085,7 @@ final class WorktreeCleanupTests: XCTestCase {
                     probeCount += 1
                     return true
                 },
-                resolveWorktreeRoot: { _ in nil },
+                resolveWorktreeRoot: { _ in worktreePath },
                 inspectGit: { _ in
                     inspectionCount += 1
                     return self.cleanInspection()
@@ -2044,12 +2099,12 @@ final class WorktreeCleanupTests: XCTestCase {
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [worktreePath])
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitForCondition { !manager.isScanning && probeCount == 2 }
 
         XCTAssertFalse(gate.hasHiddenCleanupNudge)
         XCTAssertEqual(manager.candidates, [])
         XCTAssertFalse(manager.isScanning)
-        XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(probeCount, 2)
         XCTAssertEqual(inspectionCount, 0)
         XCTAssertEqual(sizeCount, 0)
     }
@@ -2067,7 +2122,7 @@ final class WorktreeCleanupTests: XCTestCase {
                     probeCount += 1
                     return true
                 },
-                resolveWorktreeRoot: { _ in nil },
+                resolveWorktreeRoot: { _ in worktreePath },
                 inspectGit: { _ in
                     inspectionCount += 1
                     return self.cleanInspection()
@@ -2081,12 +2136,12 @@ final class WorktreeCleanupTests: XCTestCase {
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: ["\(worktreePath)/Tests/BillingTests"])
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitForCondition { !manager.isScanning && probeCount == 2 }
 
         XCTAssertFalse(gate.hasHiddenCleanupNudge)
         XCTAssertEqual(manager.candidates, [])
         XCTAssertFalse(manager.isScanning)
-        XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(probeCount, 2)
         XCTAssertEqual(inspectionCount, 0)
         XCTAssertEqual(sizeCount, 0)
     }
@@ -2119,14 +2174,16 @@ final class WorktreeCleanupTests: XCTestCase {
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [checkoutPath])
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.worktreePath == worktreePath
+        }
 
         XCTAssertTrue(gate.hasHiddenCleanupNudge)
-        XCTAssertEqual(manager.candidates, [])
+        XCTAssertEqual(manager.candidates.count, 1)
         XCTAssertFalse(manager.isScanning)
-        XCTAssertEqual(probeCount, 0)
-        XCTAssertEqual(inspectionCount, 0)
-        XCTAssertEqual(sizeCount, 0)
+        XCTAssertEqual(probeCount, 3)
+        XCTAssertEqual(inspectionCount, 1)
+        XCTAssertEqual(sizeCount, 1)
     }
 
     @MainActor
@@ -2152,10 +2209,13 @@ final class WorktreeCleanupTests: XCTestCase {
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [])
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.worktreePath == worktreePath
+        }
 
         XCTAssertTrue(gate.hasHiddenCleanupNudge)
-        XCTAssertEqual(inspectionCount, 0)
-        XCTAssertEqual(sizeCount, 0)
+        XCTAssertEqual(inspectionCount, 1)
+        XCTAssertEqual(sizeCount, 1)
     }
 
     @MainActor
@@ -2168,15 +2228,106 @@ final class WorktreeCleanupTests: XCTestCase {
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [])
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.worktreePath == worktreePath
+        }
         XCTAssertTrue(gate.hasHiddenCleanupNudge)
 
         gate.setCleanupVisible(true)
+        try await waitForCondition { !gate.hasHiddenCleanupNudge }
         XCTAssertFalse(gate.hasHiddenCleanupNudge)
 
         gate.setCleanupVisible(false)
         gate.updateSources([session], activeProjectPaths: [])
+        try await Task.sleep(nanoseconds: 100_000_000)
 
         XCTAssertFalse(gate.hasHiddenCleanupNudge)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateDoesNotRescanUnchangedHiddenRefreshSignature() async throws {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        var inspectionCount = 0
+        var sizeCount = 0
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in true },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { _ in
+                    inspectionCount += 1
+                    return self.cleanInspection()
+                },
+                measureSize: { _ in
+                    sizeCount += 1
+                    return 1_024
+                }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([session], activeProjectPaths: [])
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.worktreePath == worktreePath
+        }
+
+        gate.updateSources([session], activeProjectPaths: [])
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(inspectionCount, 1)
+        XCTAssertEqual(sizeCount, 1)
+        XCTAssertEqual(manager.candidates.map(\.id), [worktreePath])
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateIgnoresStaleHiddenScanResultWhenNewerSourcesArrive() async throws {
+        let firstPath = "/Users/dev/.codex/worktrees/billing-api"
+        let secondPath = "/Users/dev/.codex/worktrees/reporting-api"
+        let firstStarted = expectation(description: "first scan started")
+        let secondStarted = expectation(description: "second scan started")
+        let releaseFirst = DispatchSemaphore(value: 0)
+        let releaseSecond = DispatchSemaphore(value: 0)
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in true },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { path in
+                    switch path {
+                    case firstPath:
+                        firstStarted.fulfill()
+                        releaseFirst.wait()
+                        return self.cleanInspection(branch: "feature/invoices")
+                    case secondPath:
+                        secondStarted.fulfill()
+                        releaseSecond.wait()
+                        return self.cleanInspection(branch: "feature/reports")
+                    default:
+                        return self.cleanInspection()
+                    }
+                },
+                measureSize: { _ in 1_024 }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([historySession(id: "first", path: firstPath)], activeProjectPaths: [])
+        await fulfillment(of: [firstStarted], timeout: 1)
+
+        gate.updateSources([historySession(id: "second", path: secondPath)], activeProjectPaths: [])
+        await fulfillment(of: [secondStarted], timeout: 1)
+
+        releaseSecond.signal()
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.map(\.id) == [secondPath]
+        }
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
+
+        releaseFirst.signal()
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(manager.candidates.map(\.id), [secondPath])
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
     }
 
     @MainActor
@@ -2292,18 +2443,19 @@ final class WorktreeCleanupTests: XCTestCase {
     }
 
     @MainActor
-    func testCleanupRefreshGateDoesNotScanAfterCleanupIsHiddenAgain() async throws {
-        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
-        let session = historySession(path: worktreePath)
+    func testCleanupRefreshGateScansAfterCleanupIsHiddenAgain() async throws {
+        let firstPath = "/Users/dev/.codex/worktrees/billing-api"
+        let secondPath = "/Users/dev/.codex/worktrees/reporting-api"
+        let session = historySession(id: "first", path: firstPath)
         var inspectionCount = 0
         var sizeCount = 0
         let manager = WorktreeCleanupManager(
             scanner: WorktreeCleanupScanner(
                 fileExists: { _ in true },
                 resolveWorktreeRoot: { _ in nil },
-                inspectGit: { _ in
+                inspectGit: { path in
                     inspectionCount += 1
-                    return self.cleanInspection()
+                    return self.cleanInspection(branch: path == firstPath ? "feature/invoices" : "feature/reports")
                 },
                 measureSize: { _ in
                     sizeCount += 1
@@ -2316,20 +2468,22 @@ final class WorktreeCleanupTests: XCTestCase {
         gate.setCleanupVisible(true)
         gate.updateSources([session], activeProjectPaths: [])
         try await waitForCleanupCandidates(manager) { candidates in
-            candidates.first?.state == .clean
+            candidates.first?.worktreePath == firstPath
         }
         XCTAssertEqual(inspectionCount, 1)
         XCTAssertEqual(sizeCount, 1)
 
         gate.setCleanupVisible(false)
         gate.updateSources(
-            [historySession(id: "new", path: worktreePath, endedAt: now.addingTimeInterval(1))],
+            [historySession(id: "second", path: secondPath, endedAt: now.addingTimeInterval(1))],
             activeProjectPaths: []
         )
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.worktreePath == secondPath
+        }
 
-        XCTAssertEqual(inspectionCount, 1)
-        XCTAssertEqual(sizeCount, 1)
+        XCTAssertEqual(inspectionCount, 2)
+        XCTAssertEqual(sizeCount, 2)
         XCTAssertTrue(gate.hasHiddenCleanupNudge)
     }
 
@@ -2369,11 +2523,13 @@ final class WorktreeCleanupTests: XCTestCase {
             [historySession(id: "second", path: secondPath, endedAt: now.addingTimeInterval(1))],
             activeProjectPaths: []
         )
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.worktreePath == secondPath
+        }
 
         XCTAssertTrue(gate.hasHiddenCleanupNudge)
-        XCTAssertEqual(inspectionCount, 1)
-        XCTAssertEqual(sizeCount, 1)
+        XCTAssertEqual(inspectionCount, 2)
+        XCTAssertEqual(sizeCount, 2)
     }
 
     @MainActor
@@ -2396,60 +2552,99 @@ final class WorktreeCleanupTests: XCTestCase {
 
         gate.setCleanupVisible(true)
         gate.updateSources([first, second], activeProjectPaths: [])
+        try await waitForCleanupCandidates(manager) { candidates in
+            Set(candidates.map(\.id)) == Set([firstPath, secondPath])
+        }
         XCTAssertFalse(gate.hasHiddenCleanupNudge)
 
         gate.setCleanupVisible(false)
         gate.updateSources([first], activeProjectPaths: [])
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.map(\.id) == [firstPath]
+        }
 
         XCTAssertFalse(gate.hasHiddenCleanupNudge)
     }
 
     @MainActor
-    func testCleanupRefreshGateClearsNudgeWhenHiddenSourcesShrinkBackToSeenSet() {
+    func testCleanupRefreshGateClearsNudgeWhenHiddenSourcesShrinkBackToSeenSet() async throws {
         let firstPath = "/Users/dev/.codex/worktrees/billing-api"
         let secondPath = "/Users/dev/.codex/worktrees/reporting-api"
-        let manager = WorktreeCleanupManager(scanner: scanner(existingPaths: [firstPath, secondPath]))
+        let manager = WorktreeCleanupManager(
+            scanner: scanner(
+                existingPaths: [firstPath, secondPath],
+                inspections: [
+                    firstPath: cleanInspection(branch: "feature/invoices"),
+                    secondPath: cleanInspection(branch: "feature/reports")
+                ],
+                sizes: [
+                    firstPath: 1_024,
+                    secondPath: 1_024
+                ]
+            )
+        )
         let gate = WorktreeCleanupRefreshGate(manager: manager)
         let first = historySession(id: "first", path: firstPath, endedAt: now)
         let second = historySession(id: "second", path: secondPath, endedAt: now.addingTimeInterval(1))
 
         gate.setCleanupVisible(true)
         gate.updateSources([first], activeProjectPaths: [])
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.map(\.id) == [firstPath]
+        }
         gate.setCleanupVisible(false)
 
         gate.updateSources([first, second], activeProjectPaths: [])
+        try await waitForCleanupCandidates(manager) { candidates in
+            Set(candidates.map(\.id)) == Set([firstPath, secondPath])
+        }
         XCTAssertTrue(gate.hasHiddenCleanupNudge)
 
         gate.updateSources([first], activeProjectPaths: [])
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.map(\.id) == [firstPath]
+        }
         XCTAssertFalse(gate.hasHiddenCleanupNudge)
     }
 
     @MainActor
-    func testCleanupRefreshGateClearsHiddenNudgeWhenCleanupOpens() {
+    func testCleanupRefreshGateClearsHiddenNudgeWhenCleanupOpens() async throws {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
         let session = historySession(path: worktreePath)
-        let manager = WorktreeCleanupManager(scanner: scanner(existingPaths: [worktreePath]))
+        let manager = WorktreeCleanupManager(
+            scanner: scanner(existingPaths: [worktreePath], inspections: [worktreePath: cleanInspection()])
+        )
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [])
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.id == worktreePath
+        }
         XCTAssertTrue(gate.hasHiddenCleanupNudge)
 
         gate.setCleanupVisible(true)
+        try await waitForCondition { !gate.hasHiddenCleanupNudge }
 
         XCTAssertFalse(gate.hasHiddenCleanupNudge)
     }
 
     @MainActor
-    func testCleanupRefreshGateClearsHiddenNudgeWhenSourceIdentitySetBecomesEmpty() {
+    func testCleanupRefreshGateClearsHiddenNudgeWhenCandidateSetBecomesEmpty() async throws {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
         let session = historySession(path: worktreePath)
-        let manager = WorktreeCleanupManager(scanner: scanner(existingPaths: [worktreePath]))
+        let manager = WorktreeCleanupManager(
+            scanner: scanner(existingPaths: [worktreePath], inspections: [worktreePath: cleanInspection()])
+        )
         let gate = WorktreeCleanupRefreshGate(manager: manager)
 
         gate.updateSources([session], activeProjectPaths: [])
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.id == worktreePath
+        }
         XCTAssertTrue(gate.hasHiddenCleanupNudge)
 
         gate.updateSources([], activeProjectPaths: [])
+        try await waitForCondition { !manager.isScanning && manager.candidates.isEmpty }
 
         XCTAssertFalse(gate.hasHiddenCleanupNudge)
     }

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -909,6 +909,26 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(arguments, [sessionPath, "worktree", "list", "--porcelain", "-z"])
     }
 
+    func testInspectorResolvesLinkedWorktreeRootOnlyForLinkedEntries() {
+        let repo = "/Users/dev/projects/billing-api"
+        let worktreePath = "/Users/dev/projects/billing-api-feature"
+        let output = [
+            "worktree \(repo)",
+            "branch refs/heads/master",
+            "",
+            "worktree \(worktreePath)",
+            "branch refs/heads/feature/invoices",
+            "",
+        ].joined(separator: "\u{0}")
+        let inspector = GitWorktreeInspector(runGit: { _, _ in
+            GitCommandResult(exitCode: 0, stdout: output, stderr: "")
+        })
+
+        XCTAssertEqual(inspector.linkedWorktreeRoot(containing: "\(worktreePath)/pkg"), worktreePath)
+        XCTAssertNil(inspector.linkedWorktreeRoot(containing: "\(repo)/pkg"))
+        XCTAssertNil(inspector.linkedWorktreeRoot(containing: "/Users/dev/projects/other"))
+    }
+
     func testInspectorResolvesSymlinkedPathToContainingWorktreeRoot() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("cctop-worktree-inspector-\(UUID().uuidString)")
@@ -1506,6 +1526,7 @@ final class WorktreeCleanupTests: XCTestCase {
         let projectPath = "/Users/dev/Documents/Codex/old-session"
         let session = historySession(path: projectPath)
         var probeCount = 0
+        var linkedRootCount = 0
         var inspectionCount = 0
         var sizeCount = 0
         let manager = WorktreeCleanupManager(
@@ -1522,6 +1543,10 @@ final class WorktreeCleanupTests: XCTestCase {
                 measureSize: { _ in
                     sizeCount += 1
                     return 1_024
+                },
+                resolveLinkedWorktreeRoot: { _ in
+                    linkedRootCount += 1
+                    return projectPath
                 }
             )
         )
@@ -1534,6 +1559,7 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(manager.candidates, [])
         XCTAssertFalse(manager.isScanning)
         XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(linkedRootCount, 0)
         XCTAssertEqual(inspectionCount, 0)
         XCTAssertEqual(sizeCount, 0)
     }
@@ -1543,6 +1569,7 @@ final class WorktreeCleanupTests: XCTestCase {
         let projectPath = "/Users/dev/projects/app"
         let session = historySession(path: projectPath)
         var probeCount = 0
+        var linkedRootCount = 0
         var inspectionCount = 0
         var sizeCount = 0
         let manager = WorktreeCleanupManager(
@@ -1559,6 +1586,10 @@ final class WorktreeCleanupTests: XCTestCase {
                 measureSize: { _ in
                     sizeCount += 1
                     return 1_024
+                },
+                resolveLinkedWorktreeRoot: { _ in
+                    linkedRootCount += 1
+                    return nil
                 }
             )
         )
@@ -1571,15 +1602,17 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(manager.candidates, [])
         XCTAssertFalse(manager.isScanning)
         XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(linkedRootCount, 1)
         XCTAssertEqual(inspectionCount, 0)
         XCTAssertEqual(sizeCount, 0)
     }
 
     @MainActor
-    func testCleanupRefreshGateNudgesForHiddenCleanupWorktreeOutsideProtectedFolders() async throws {
-        let worktreePath = "/Users/dev/projects/app/.claude/worktrees/feature-x"
+    func testCleanupRefreshGateNudgesForHiddenManualLinkedWorktreeOutsideProtectedFolders() async throws {
+        let worktreePath = "/Users/dev/projects/app-feature"
         let session = historySession(path: worktreePath)
         var probeCount = 0
+        var linkedRootCount = 0
         var inspectionCount = 0
         var sizeCount = 0
         let manager = WorktreeCleanupManager(
@@ -1588,7 +1621,7 @@ final class WorktreeCleanupTests: XCTestCase {
                     probeCount += 1
                     return true
                 },
-                resolveWorktreeRoot: { _ in nil },
+                resolveWorktreeRoot: { _ in worktreePath },
                 inspectGit: { _ in
                     inspectionCount += 1
                     return self.cleanInspection()
@@ -1596,6 +1629,10 @@ final class WorktreeCleanupTests: XCTestCase {
                 measureSize: { _ in
                     sizeCount += 1
                     return 1_024
+                },
+                resolveLinkedWorktreeRoot: { _ in
+                    linkedRootCount += 1
+                    return worktreePath
                 }
             )
         )
@@ -1608,6 +1645,50 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(manager.candidates, [])
         XCTAssertFalse(manager.isScanning)
         XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(linkedRootCount, 1)
+        XCTAssertEqual(inspectionCount, 0)
+        XCTAssertEqual(sizeCount, 0)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateNudgesForHiddenCleanupWorktreeOutsideProtectedFolders() async throws {
+        let worktreePath = "/Users/dev/projects/app/.claude/worktrees/feature-x"
+        let session = historySession(path: worktreePath)
+        var probeCount = 0
+        var linkedRootCount = 0
+        var inspectionCount = 0
+        var sizeCount = 0
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in
+                    probeCount += 1
+                    return true
+                },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { _ in
+                    inspectionCount += 1
+                    return self.cleanInspection()
+                },
+                measureSize: { _ in
+                    sizeCount += 1
+                    return 1_024
+                },
+                resolveLinkedWorktreeRoot: { _ in
+                    linkedRootCount += 1
+                    return nil
+                }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([session], activeProjectPaths: [])
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
+        XCTAssertEqual(manager.candidates, [])
+        XCTAssertFalse(manager.isScanning)
+        XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(linkedRootCount, 0)
         XCTAssertEqual(inspectionCount, 0)
         XCTAssertEqual(sizeCount, 0)
     }

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -2359,6 +2359,39 @@ final class WorktreeCleanupTests: XCTestCase {
     }
 
     @MainActor
+    func testCleanupRefreshGateNudgesIfVisibleScanCompletesAfterCleanupHides() async throws {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath)
+        let scanStarted = expectation(description: "visible cleanup scan started")
+        let releaseScan = DispatchSemaphore(value: 0)
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in true },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { _ in
+                    scanStarted.fulfill()
+                    releaseScan.wait()
+                    return self.cleanInspection()
+                },
+                measureSize: { _ in 1_024 }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.setCleanupVisible(true)
+        gate.updateSources([session], activeProjectPaths: [])
+        await fulfillment(of: [scanStarted], timeout: 1)
+
+        gate.setCleanupVisible(false)
+        releaseScan.signal()
+
+        try await waitForCleanupCandidates(manager) { candidates in
+            candidates.first?.worktreePath == worktreePath
+        }
+        XCTAssertTrue(gate.hasHiddenCleanupNudge)
+    }
+
+    @MainActor
     func testCleanupVisibleRefreshDoesNotProbeProtectedActiveProjectPathWithUnprotectedHistorySource() async throws {
         let historyWorktreePath = "/Users/dev/.codex/worktrees/billing-api"
         let protectedActivePath = "/Users/dev/Documents/Codex/2026-07-04/can-you-check-my-email-and"

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1576,6 +1576,80 @@ final class WorktreeCleanupTests: XCTestCase {
     }
 
     @MainActor
+    func testCleanupRefreshGateDoesNotNudgeWhenHiddenSourceIsInsideActiveWorktreeRoot() async throws {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: "\(worktreePath)/Sources/Billing")
+        var probeCount = 0
+        var inspectionCount = 0
+        var sizeCount = 0
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in
+                    probeCount += 1
+                    return true
+                },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { _ in
+                    inspectionCount += 1
+                    return self.cleanInspection()
+                },
+                measureSize: { _ in
+                    sizeCount += 1
+                    return 1_024
+                }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([session], activeProjectPaths: [worktreePath])
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
+        XCTAssertEqual(manager.candidates, [])
+        XCTAssertFalse(manager.isScanning)
+        XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(inspectionCount, 0)
+        XCTAssertEqual(sizeCount, 0)
+    }
+
+    @MainActor
+    func testCleanupRefreshGateDoesNotNudgeWhenHiddenSourceAndActivePathShareCleanupWorktreeRoot() async throws {
+        let worktreePath = "/Users/dev/.claude/worktrees/billing-api"
+        let session = historySession(path: "\(worktreePath)/Sources/Billing")
+        var probeCount = 0
+        var inspectionCount = 0
+        var sizeCount = 0
+        let manager = WorktreeCleanupManager(
+            scanner: WorktreeCleanupScanner(
+                fileExists: { _ in
+                    probeCount += 1
+                    return true
+                },
+                resolveWorktreeRoot: { _ in nil },
+                inspectGit: { _ in
+                    inspectionCount += 1
+                    return self.cleanInspection()
+                },
+                measureSize: { _ in
+                    sizeCount += 1
+                    return 1_024
+                }
+            )
+        )
+        let gate = WorktreeCleanupRefreshGate(manager: manager)
+
+        gate.updateSources([session], activeProjectPaths: ["\(worktreePath)/Tests/BillingTests"])
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertFalse(gate.hasHiddenCleanupNudge)
+        XCTAssertEqual(manager.candidates, [])
+        XCTAssertFalse(manager.isScanning)
+        XCTAssertEqual(probeCount, 0)
+        XCTAssertEqual(inspectionCount, 0)
+        XCTAssertEqual(sizeCount, 0)
+    }
+
+    @MainActor
     func testCleanupRefreshGateNudgesForHiddenCleanupWorktreeInsideActiveParentCheckout() async throws {
         let checkoutPath = "/Users/dev/projects/app"
         let worktreePath = "/Users/dev/projects/app/.claude/worktrees/billing-api"


### PR DESCRIPTION
## Problem

Cleanup opportunities can appear after ended or archived sessions are classified, but users who stay on Active or Recent have no quiet tab-level signal that there may be cleanup follow-up work to check.

## Solution

- Track unseen cleanup source identities while Cleanup is hidden without running the worktree cleanup scanner.
- Add a subtle Cleanup tab attention state and preserve visible scanning/count behavior when users open Cleanup.