### PR TITLE
Codify the launch social clip as a named timeline cut

### DIFF
--- a/video/DELIVERABLES.md
+++ b/video/DELIVERABLES.md
@@ -7,7 +7,7 @@ to the non-latest `media-assets` GitHub Release through the repo-local `$video-a
 | project | published assets | source commit | notes |
 |---------|------------------|---------------|-------|
 | launch  | [`preview.avif`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-preview.avif), [`720p.mp4`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-720p.mp4), [`1080p.mp4`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch.mp4) | _pending source commit_ | 30s launch video; AVIF is the README inline preview |
-| launch social clip | [`clip.mp4`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-clip.mp4), [`clip-720p.mp4`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-clip-720p.mp4) | _pending source commit_ | 12.5s timeline cut of the launch project (see below); for feed posts, release announcements, and replies |
+| launch social clip | [`clip.mp4`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-clip.mp4), [`clip-720p.mp4`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-clip-720p.mp4) | 16c50bac | 12.5s timeline cut of the launch project (see below); for feed posts, release announcements, and replies |
 
 ## Social clip (timeline cut)
 

--- a/video/DELIVERABLES.md
+++ b/video/DELIVERABLES.md
@@ -6,7 +6,44 @@ to the non-latest `media-assets` GitHub Release through the repo-local `$video-a
 
 | project | published assets | source commit | notes |
 |---------|------------------|---------------|-------|
-| launch  | [`preview.avif`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-preview.avif), [`720p.mp4`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-720p.mp4), [`1080p.mp4`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch.mp4) | _pending source commit_ | ~28s launch video; AVIF is the README inline preview |
+| launch  | [`preview.avif`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-preview.avif), [`720p.mp4`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-720p.mp4), [`1080p.mp4`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch.mp4) | _pending source commit_ | 30s launch video; AVIF is the README inline preview |
+| launch social clip | [`clip.mp4`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-clip.mp4), [`clip-720p.mp4`](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-clip-720p.mp4) | _pending source commit_ | 12.5s timeline cut of the launch project (see below); for feed posts, release announcements, and replies |
+
+## Social clip (timeline cut)
+
+The social clip is a named cut of the launch project. There is no separate source
+file; it renders the same `projects/launch/body.html` over a sub-range of the
+timeline:
+
+```bash
+CUT=clip ./build.sh launch     # -> .video-build/launch-clip.mp4 (and -720p)
+```
+
+The cut's boundaries are defined once, in `projects/launch/body.html` as
+`window.__cuts.clip`, right next to the `TL` beat table and derived from it, so
+retiming beats moves the cut automatically:
+
+- **In**: end of the morph beat plus a short settle, the first moment the panel is
+  fully readable. Earlier frames are mostly empty (hook text fading, dots still
+  converging), which reads as a blank first frame in feeds.
+- **Out**: end of the payoff beat minus a margin, while it is still fully lit, so
+  the encoder's 0.6s fade-out lands on bright content instead of fading a fade.
+
+The build log prints the resolved boundaries (`cut 'clip': t=[...] -> frames ...`);
+sanity-check them after any substantial beat or copy change, e.g. by sampling the
+boundary frames with `render.mjs --times`.
+
+Upload with the `$video-assets` one-off helper, keeping the stable asset names:
+
+```bash
+.agents/skills/video-assets/scripts/upload-video-asset.sh \
+  --file video/projects/launch/.video-build/launch-clip.mp4 --name cctop-launch-clip.mp4 --clobber
+.agents/skills/video-assets/scripts/upload-video-asset.sh \
+  --file video/projects/launch/.video-build/launch-clip-720p.mp4 --name cctop-launch-clip-720p.mp4 --clobber
+```
+
+**Keep the clip matching the launch video**: when the launch video is re-rendered
+and republished, re-cut the clip from the same checkout and re-upload it too.
 
 ## Publishing a cut
 

--- a/video/build.sh
+++ b/video/build.sh
@@ -2,9 +2,14 @@
 # Build one video end-to-end:  ./build.sh <project>   (default: launch)
 # Renders projects/<project>/body.html headlessly and encodes the mp4. Everything the build
 # touches (staged screenshots, frames, mp4, poster) lives in projects/<project>/.video-build/ (gitignored).
+#
+# Timeline cuts:  CUT=clip ./build.sh launch  renders the named cut that the project's body.html
+# defines in window.__cuts (next to its beat table), into <project>-<cut>.mp4 alongside the full
+# render. Cut boundaries live only in body.html so beat retimes move them automatically.
 set -euo pipefail
 cd "$(dirname "$0")"
 PROJECT="${1:-launch}"; PORT="${PORT:-8123}"; SCALE="${SCALE:-2}"; FPS=30; DUR="${DUR:-30.0}"; W="${W:-1920}"; H="${H:-1080}"
+CUT="${CUT:-}"; OUT_NAME="${OUT_NAME:-$PROJECT${CUT:+-$CUT}}"
 REPO="$(cd .. && pwd)"                 # <repo> root: needs <repo>/docs/*.png (relocate-friendly: override REPO=)
 PDIR="projects/$PROJECT"
 [ -f "$PDIR/body.html" ] || { echo "no such project: $PDIR/body.html"; exit 1; }
@@ -34,7 +39,8 @@ SRV_PID=$!
 sleep 0.6
 kill -0 "$SRV_PID" 2>/dev/null || { echo "preview server failed to start on port $PORT"; cat /tmp/cctop-video-http.log; exit 1; }
 node engine/render.mjs --url="http://127.0.0.1:$PORT/$PDIR/body.html" \
-  --out="$BUILD/frames" --duration="$DUR" --fps="$FPS" --scale="$SCALE" --width="$W" --height="$H"
-OW="$W" OH="$H" bash engine/encode.sh "$BUILD/frames" "$BUILD/$PROJECT.mp4"
-bash engine/check.sh "$BUILD/$PROJECT.mp4"     # set -e: a failed check fails the build (don't print "Built")
-echo "Built $BUILD/$PROJECT.mp4  (and ${PROJECT}-720p.mp4)"
+  --out="$BUILD/frames" --duration="$DUR" --fps="$FPS" --scale="$SCALE" --width="$W" --height="$H" \
+  ${CUT:+--cut="$CUT"}
+OW="$W" OH="$H" bash engine/encode.sh "$BUILD/frames" "$BUILD/$OUT_NAME.mp4"
+bash engine/check.sh "$BUILD/$OUT_NAME.mp4"    # set -e: a failed check fails the build (don't print "Built")
+echo "Built $BUILD/$OUT_NAME.mp4  (and ${OUT_NAME}-720p.mp4)"

--- a/video/engine/encode.sh
+++ b/video/engine/encode.sh
@@ -16,13 +16,19 @@ FPS=30
 OW="${OW:-1920}"; OH="${OH:-1080}"     # output resolution (frames are supersampled above this)
 TAGS=(-color_primaries bt709 -color_trc bt709 -colorspace bt709 -color_range tv)
 
-N=$(ls "$FRAMES_DIR"/frame_*.png 2>/dev/null | wc -l | tr -d ' ')
+# glob (sorted), not `ls | head`: head's early exit SIGPIPEs ls, which pipefail turns fatal
+frames=( "$FRAMES_DIR"/frame_*.png )
+[ -e "${frames[0]}" ] || { echo "no frames in $FRAMES_DIR"; exit 1; }
+N=${#frames[@]}
+# frame numbering is absolute timeline position; derive the sequence start so cuts encode correctly
+START_NUMBER=$((10#$(basename "${frames[0]}" .png | cut -d_ -f2)))
 DUR=$(echo "scale=3; $N / $FPS" | bc)
-FOUT_ST=$(echo "scale=3; $DUR - 0.6" | bc)
+# printf: bc emits sub-1s values without a leading zero (".400"), which ffmpeg rejects
+FOUT_ST=$(printf '%.3f' "$(echo "scale=3; $DUR - 0.6" | bc)")
 echo "Encoding $N frames (${DUR}s) -> $OUT  (${OW}x${OH})"
 
 ffmpeg -y -hide_banner -loglevel error \
-  -framerate "$FPS" -i "$FRAMES_DIR/frame_%05d.png" \
+  -framerate "$FPS" -start_number "$START_NUMBER" -i "$FRAMES_DIR/frame_%05d.png" \
   -vf "scale=${OW}:${OH}:flags=lanczos:out_color_matrix=bt709:out_range=tv,fade=t=out:st=${FOUT_ST}:d=0.6,format=yuv420p,setparams=range=tv:colorspace=bt709:color_primaries=bt709:color_trc=bt709" \
   -c:v libx264 -preset slow -crf 18 -pix_fmt yuv420p "${TAGS[@]}" -movflags +faststart -r "$FPS" \
   "$OUT"
@@ -34,7 +40,7 @@ ffmpeg -y -hide_banner -loglevel error -i "$OUT" \
   -movflags +faststart "${OUT%.mp4}-720p.mp4"
 
 # poster frame: a CTA-region frame near the end (2s before fade-out)
-POSTER_N=$(printf "%05d" "$(( N > 60 ? N - 60 : N ))")
+POSTER_N=$(printf "%05d" "$(( START_NUMBER + (N > 60 ? N - 60 : 0) ))")
 cp "$FRAMES_DIR/frame_${POSTER_N}.png" "${OUT%.mp4}-poster.png" 2>/dev/null || true
 
 echo "Done:"

--- a/video/engine/render.mjs
+++ b/video/engine/render.mjs
@@ -127,6 +127,21 @@ process.stdout.write('\n');
 const renderErr = await evalJS('window.__error || null').catch(() => null);
 if (renderErr) { console.error('render aborted:', renderErr); ws.close(); cleanup(); process.exit(1); }
 
+// --cut=<name>: resolve a named timeline cut from the page (window.__cuts, defined next to the
+// beat table), so cut boundaries live in one place and follow beat retimes automatically.
+let firstFrame = START;
+let endFrame = Math.round(DURATION * FPS);
+if (args.cut) {
+  const cut = await evalJS(`(window.__cuts && window.__cuts[${JSON.stringify(String(args.cut))}]) || null`);
+  if (!cut || typeof cut.start !== 'number' || typeof cut.end !== 'number' || cut.end <= cut.start) {
+    console.error(`unknown cut '${args.cut}': the page must define window.__cuts['${args.cut}'] = {start, end} (seconds)`);
+    ws.close(); cleanup(); process.exit(1);
+  }
+  firstFrame = Math.round(cut.start * FPS);
+  endFrame = Math.round(cut.end * FPS);
+  console.log(`cut '${args.cut}': t=[${cut.start.toFixed(2)}, ${cut.end.toFixed(2)}) -> frames ${firstFrame}..${endFrame - 1}`);
+}
+
 const t0 = Date.now();
 if (args.times) {
   // keyframe sampling mode: render specific timestamps to keyframe_<t>.png
@@ -140,17 +155,16 @@ if (args.times) {
   console.log(`Keyframes done in ${((Date.now() - t0) / 1000).toFixed(1)}s -> ${OUT}`);
   ws.close(); cleanup(); process.exit(0);
 }
-const totalFrames = Math.round(DURATION * FPS);
-console.log(`Rendering ${totalFrames} frames @ ${FPS}fps (${WIDTH}x${HEIGHT} x${SCALE}) from frame ${START}`);
-for (let f = START; f < totalFrames; f++) {
+console.log(`Rendering frames ${firstFrame}..${endFrame - 1} @ ${FPS}fps (${WIDTH}x${HEIGHT} x${SCALE})`);
+for (let f = firstFrame; f < endFrame; f++) {
   const t = f / FPS;
   await evalJS(`window.__seek(${t})`, true);
   const shot = await send('Page.captureScreenshot', { format: 'png', captureBeyondViewport: false, fromSurface: true });
   writeFileSync(`${OUT}/frame_${String(f).padStart(5, '0')}.png`, Buffer.from(shot.data, 'base64'));
   if (f % 30 === 0) {
-    const pct = ((f - START) / (totalFrames - START) * 100).toFixed(0);
-    const eta = ((Date.now() - t0) / Math.max(1, f - START + 1) * (totalFrames - f) / 1000).toFixed(0);
-    process.stdout.write(`\r  frame ${f}/${totalFrames} (${pct}%) eta ${eta}s   `);
+    const pct = ((f - firstFrame) / (endFrame - firstFrame) * 100).toFixed(0);
+    const eta = ((Date.now() - t0) / Math.max(1, f - firstFrame + 1) * (endFrame - f) / 1000).toFixed(0);
+    process.stdout.write(`\r  frame ${f}/${endFrame} (${pct}%) eta ${eta}s   `);
   }
 }
 console.log(`\nDone in ${((Date.now() - t0) / 1000).toFixed(1)}s -> ${OUT}`);

--- a/video/projects/launch/body.html
+++ b/video/projects/launch/body.html
@@ -289,6 +289,11 @@ const TL={
   jump:[10.6,13.8], payoff:[13.7,17.4], cleanup:[17.3,22.2], stack:[22.25,25.3], cta:[25.1,30.0]
 };
 const TOTAL=30.0;
+// Named timeline cuts, derived from TL so retiming beats moves them too (render.mjs --cut).
+// clip: the social/feed cut. In after the morph settles (panel readable; earlier frames read
+// as blank in feeds). Out while the payoff is still fully lit, leaving room for the encoder's
+// 0.6s fade-out before the beat's own dim.
+window.__cuts={ clip:{ start:TL.morph[1]+0.4, end:TL.payoff[1]-0.5 } };
 const PANEL={x:905,y:176,w:680,h:781};
 const PILL={x:1630,y:30};                       // pill centre — bloom origin + dot convergence
 const DOTC=[868,914,960,1006,1052], DOTY=538;   // hook dot centres at rest


### PR DESCRIPTION
## Summary

The social clip published to the media-assets release ([cctop-launch-clip.mp4](https://github.com/st0012/cctop/releases/download/media-assets/cctop-launch-clip.mp4)) previously existed only as an ad-hoc render command with hardcoded cut times, which would silently break whenever the launch timeline's beats are retimed. This defines the cut once, in the project source, derived from the beats:

- `projects/launch/body.html` defines `window.__cuts.clip` directly below its `TL` beat table: start = end of the morph beat plus a settle, end = end of the payoff beat minus room for the encoder's fade-out. Retiming beats moves the cut automatically; no literal seconds exist anywhere else.
- `render.mjs` gains `--cut=<name>`: it resolves the named cut from the live page and logs the resolved range (`cut 'clip': t=[4.40, 16.90) -> frames 132..506`).
- `CUT=clip ./build.sh launch` builds `launch-clip.mp4` (and the 720p variant) alongside the full render; the output name derives from the cut name so the full render is never clobbered.
- `encode.sh` now reads the frame-sequence start from the frame filenames, so timeline sub-ranges encode correctly regardless of caller. Also: a guard for an empty frames directory, a fix for the fade offset ffmpeg rejects when `bc` emits sub-1s values without a leading zero, and a poster-frame index fix for cuts and sub-2s renders.
- `video/DELIVERABLES.md` records the published clip assets and source commit, the cut's beat-anchored rationale, the upload commands, and the practice of re-cutting the clip from the same checkout whenever the launch video is republished.

The clip renders identically through the new path (deterministic pipeline; `engine/check.sh` green: BT.709 tags, non-black first frame, 720p sibling).