### PR TITLE
Share session display identity source

### DIFF
--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -4,11 +4,6 @@ enum SessionIdentityPolicy {
     static let notificationSessionIDKey = "sessionID"
     static let notificationSessionPIDKey = "sessionPID"
 
-    /// UI identity shared with `Session.id`.
-    static func displayID(for session: Session) -> String {
-        session.id
-    }
-
     /// Stable grouping key shared by dedup and notification transition guards.
     static func stableKey(for session: Session) -> String {
         if session.isCodex {
@@ -17,7 +12,7 @@ enum SessionIdentityPolicy {
         if session.hostClass == .desktop {
             return "desktop:\(session.sessionId)"
         }
-        return "active:\(displayID(for: session))"
+        return "active:\(session.id)"
     }
 
     static func notificationRequestIdentifier(for session: Session) -> String {
@@ -39,12 +34,12 @@ enum SessionIdentityPolicy {
             if let match = sessions.first(where: { notificationSessionID(for: $0) == sessionID }) {
                 return match
             }
-            return sessions.first { displayID(for: $0) == sessionID }
+            return sessions.first { $0.id == sessionID }
         }
 
         guard let pid = nonEmptyString(userInfo[notificationSessionPIDKey]) else { return nil }
         return sessions.first {
-            displayID(for: $0) == pid || $0.pid.map(String.init) == pid
+            $0.id == pid || $0.pid.map(String.init) == pid
         }
     }
 
@@ -52,7 +47,7 @@ enum SessionIdentityPolicy {
         if session.isCodex || session.hostClass == .desktop {
             return session.sessionId
         }
-        return displayID(for: session)
+        return session.id
     }
 
     private static func nonEmptyString(_ value: Any?) -> String? {
@@ -64,13 +59,13 @@ enum SessionIdentityPolicy {
     static func dedupedByDisplayID(_ sessions: [Session]) -> [Session] {
         var byID: [String: Session] = [:]
         for session in sessions {
-            let id = displayID(for: session)
+            let id = session.id
             if let existing = byID[id], existing.lastActivity >= session.lastActivity {
                 continue
             }
             byID[id] = session
         }
-        return byID.values.sorted { displayID(for: $0) < displayID(for: $1) }
+        return byID.values.sorted { $0.id < $1.id }
     }
 
     /// Collapse multiple files for one conversation only for hosts with stable conversation identity.

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -4,11 +4,9 @@ enum SessionIdentityPolicy {
     static let notificationSessionIDKey = "sessionID"
     static let notificationSessionPIDKey = "sessionPID"
 
-    /// UI identity. Codex multiplexes many conversations onto one host process, so its PID is
-    /// not unique per conversation; every other source keeps the existing PID identity.
+    /// UI identity shared with `Session.id`.
     static func displayID(for session: Session) -> String {
-        if session.isCodex { return session.sessionId }
-        return session.pid.map { String($0) } ?? session.sessionId
+        session.id
     }
 
     /// Stable grouping key shared by dedup and notification transition guards.

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -306,6 +306,35 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.id, "abc-123")
     }
 
+    func testIdentityPolicyDisplayIDMirrorsSessionIdentifiableID() {
+        let cases: [(name: String, session: Session, expectedID: String)] = [
+            (
+                "codex conversations use session id even with a shared host pid",
+                Session.mock(id: "codex-thread-1", pid: 12345, source: Session.codexSource),
+                "codex-thread-1"
+            ),
+            (
+                "non-codex sessions use pid when available",
+                Session.mock(id: "claude-thread-1", pid: 12345, source: Session.ccSource),
+                "12345"
+            ),
+            (
+                "non-codex sessions fall back to session id when pid is missing",
+                Session.mock(id: "claude-thread-2", source: Session.ccSource),
+                "claude-thread-2"
+            ),
+        ]
+
+        for identityCase in cases {
+            XCTAssertEqual(identityCase.session.id, identityCase.expectedID, identityCase.name)
+            XCTAssertEqual(
+                SessionIdentityPolicy.displayID(for: identityCase.session),
+                identityCase.session.id,
+                identityCase.name
+            )
+        }
+    }
+
     // MARK: - Notification identity
 
     func testNotificationUserInfoStoresStableCodexSessionID() {

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -306,7 +306,7 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.id, "abc-123")
     }
 
-    func testIdentityPolicyDisplayIDMirrorsSessionIdentifiableID() {
+    func testIdentifiableIDUsesHarnessSpecificDisplayIdentity() {
         let cases: [(name: String, session: Session, expectedID: String)] = [
             (
                 "codex conversations use session id even with a shared host pid",
@@ -327,11 +327,6 @@ final class SessionTests: XCTestCase {
 
         for identityCase in cases {
             XCTAssertEqual(identityCase.session.id, identityCase.expectedID, identityCase.name)
-            XCTAssertEqual(
-                SessionIdentityPolicy.displayID(for: identityCase.session),
-                identityCase.session.id,
-                identityCase.name
-            )
         }
     }
 


### PR DESCRIPTION
## Problem

`Session.id` and `SessionIdentityPolicy.displayID(for:)` both encoded the same harness-specific display identity rule independently. Codex sessions need conversation identity because one host PID can multiplex threads, while non-Codex sessions keep PID identity with a session-id fallback. Keeping two implementations made future harness changes easy to drift between SwiftUI identity and display-policy identity.

## Solution

- Keep the harness-specific identity rule in `Session.id` and use it directly inside session identity policy code instead of preserving a pass-through display helper.
- Add a focused identity test covering Codex, non-Codex PID, and missing-PID fallback sessions so the model-level identity rule stays explicit.
