### PR TITLE
Capture Codex local shell command details

### DIFF
--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -692,7 +692,7 @@ func extractToolDetail(toolName: String, toolInput: [String: String]?) -> String
 
     let field: String
     switch toolName.lowercased() {
-    case "bash": field = "command"
+    case "bash", "local_shell": field = "command"
     case "edit", "write", "read": field = "file_path"
     case "grep", "glob": field = "pattern"
     case "webfetch": field = "url"

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -418,6 +418,39 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertEqual(session.lastToolDetail, "npm test")
     }
 
+    func testCodexLocalShellPreToolUseSetsCommandDetail() throws {
+        try handleHook(
+            """
+            {
+              "session_id": "local-shell-session",
+              "cwd": "/tmp/test-project",
+              "hook_event_name": "SessionStart",
+              "harness_name": "codex"
+            }
+            """,
+            hookName: "SessionStart"
+        )
+        try handleHook(
+            """
+            {
+              "session_id": "local-shell-session",
+              "cwd": "/tmp/test-project",
+              "hook_event_name": "PreToolUse",
+              "harness_name": "codex",
+              "tool_name": "local_shell",
+              "tool_input": {"command": "echo hello"}
+            }
+            """,
+            hookName: "PreToolUse"
+        )
+
+        let session = try loadSession("codex-local-shell-session.json")
+        XCTAssertEqual(session.status, .working)
+        XCTAssertEqual(session.lastTool, "local_shell")
+        XCTAssertEqual(session.lastToolDetail, "echo hello")
+        XCTAssertEqual(session.contextLine, "Running: echo hello")
+    }
+
     // MARK: - PostToolUse stays working
 
     func testPostToolUseStaysWorking() throws {


### PR DESCRIPTION
## Problem

Codex `local_shell` sessions already format stored command details like Bash, but the hook detail extractor only read `command` for Bash. When Codex sent a `local_shell` tool input with a command string, the session could persist no detail and the card fell back to less useful raw tool text.

## Solution

- Extract `command` details for `local_shell` the same way as `bash`.
- Add a hook-handler regression test that stores a Codex `local_shell` command detail and verifies the visible context line renders as `Running: ...`.

Note: tool input decoding still only preserves string-valued fields, so non-string command payloads remain outside this narrow fix.