### PR TITLE
Centralize panel position persistence

### DIFF
--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -341,13 +341,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     /// The screen key for the screen the panel is currently on.
     @MainActor private func panelScreenKey() -> String? {
-        guard let panelScreen = panel.screen ?? NSScreen.main else { return nil }
-        return panelScreen.screenKey
+        PanelPositioning.screenKey(forPanelFrame: panel.frame, in: screenLayouts)
     }
 
     /// The screen key for the screen containing a point.
     private func screenKey(at point: NSPoint) -> String? {
-        NSScreen.screens.first { NSMouseInRect(point, $0.frame, false) }?.screenKey
+        PanelPositioning.screenKey(containing: point, in: screenLayouts)
     }
 
     /// Migrate legacy single-position UserDefaults to per-screen dictionary.
@@ -355,9 +354,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         let ud = UserDefaults.standard
         guard let originX = ud.object(forKey: PanelPositionKeys.legacyOriginX) as? Double else { return }
         let topY = ud.double(forKey: PanelPositionKeys.legacyTopY)
-        let point = NSPoint(x: originX, y: topY)
-        let key = screenKey(at: point) ?? NSScreen.main?.screenKey ?? "builtin"
-        panelGeometry.saveCustomPosition(originX: CGFloat(originX), topY: CGFloat(topY), forScreenKey: key)
+        panelGeometry.saveLegacyPosition(
+            originX: CGFloat(originX), topY: CGFloat(topY),
+            screens: screenLayouts,
+            fallbackScreenKey: NSScreen.main?.screenKey
+        )
         ud.removeObject(forKey: PanelPositionKeys.legacyOriginX)
         ud.removeObject(forKey: PanelPositionKeys.legacyTopY)
     }
@@ -426,10 +427,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     @MainActor private func resetPanelToCurrentScreen(animate: Bool = false) {
         guard let size = panelFittingSize() else { return }
         let layouts = screenLayouts
-        let panelIdx = (panel.screen ?? NSScreen.main).flatMap { screen in
-            layouts.firstIndex { $0.frame == ScreenLayout(screen).frame }
-        }
-        if let frame = panelGeometry.resetFrame(
+        let panelIdx = PanelPositioning.screenIndex(forPanelFrame: panel.frame, in: layouts)
+        if let frame = PanelPositioning.resolveResetPosition(
             anchorRect: anchorRect(),
             menubarIconRect: menubarIconRect(),
             panelScreenIndex: panelIdx,
@@ -453,15 +452,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             // screen-change repositioning; clearing it keeps the key below
             // and positionPanel's internal key identical.
             self.focusLocation = nil
-            // Capture the key before repositioning: positionPanel may snap the
-            // panel home to the anchor screen, and resaving under that screen's
-            // key would overwrite a user-dragged position with the anchor frame.
-            let key = self.panelScreenKey()
             self.positionPanel(animate: false)
-            // Update saved position if it was clamped to new screen bounds
-            self.panelGeometry.resaveAfterScreenChange(
-                panelScreenKey: key, panelFrame: self.panel.frame
-            )
         }
         screenChangeWork = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: work)
@@ -534,7 +525,6 @@ extension AppDelegate {
         return result.eventConsumed
     }
 
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
     @MainActor private func execute(_ actions: [PanelAction]) {
         for action in actions {
             switch action {
@@ -562,13 +552,6 @@ extension AppDelegate {
                 updateCleanupPanelVisibility()
             case .positionPanel:
                 positionPanel()
-                // If panel didn't land on target screen, clear stale position and retry
-                if let click = focusLocation,
-                   let clickKey = screenKey(at: click),
-                   panelScreenKey() != clickKey {
-                    panelGeometry.clearCustomPosition(forScreenKey: clickKey)
-                    positionPanel()
-                }
             case .activateApp:
                 NSApp.activate(ignoringOtherApps: true)
             case .deactivateApp:
@@ -652,14 +635,16 @@ extension AppDelegate {
 // MARK: - FloatingPanelDelegate
 extension AppDelegate: FloatingPanelDelegate {
     @MainActor func panelDidDrag(originX: CGFloat, topY: CGFloat) {
-        guard let key = panelScreenKey() else { return }
-        panelGeometry.saveCustomPosition(originX: originX, topY: topY, forScreenKey: key)
+        panelGeometry.saveUserDraggedPosition(
+            originX: originX,
+            topY: topY,
+            panelSize: panel.frame.size,
+            screens: screenLayouts
+        )
     }
 
     @MainActor func panelDidRequestReset() {
-        if let key = panelScreenKey() {
-            panelGeometry.clearCustomPosition(forScreenKey: key)
-        }
+        panelGeometry.clearUserPosition(forPanelFrame: panel.frame, screens: screenLayouts)
         resetPanelToCurrentScreen(animate: true)
     }
 }

--- a/menubar/CctopMenubar/Models/PanelPositioning.swift
+++ b/menubar/CctopMenubar/Models/PanelPositioning.swift
@@ -63,23 +63,42 @@ struct PanelGeometryModel {
         }
     }
 
-    /// Save a custom position for a screen.
-    func saveCustomPosition(originX: CGFloat, topY: CGFloat, forScreenKey key: String) {
+    /// Persist a user drag-end as the desired panel position.
+    func saveUserDraggedPosition(
+        originX: CGFloat,
+        topY: CGFloat,
+        panelSize: NSSize,
+        screens: [ScreenLayout]
+    ) {
+        let frame = NSRect(x: originX, y: topY - panelSize.height, width: panelSize.width, height: panelSize.height)
+        guard let key = PanelPositioning.screenKey(forPanelFrame: frame, in: screens) else { return }
+        saveCustomPosition(originX: originX, topY: topY, forScreenKey: key)
+    }
+
+    /// Clear the desired panel position for the screen the panel is currently assigned to.
+    func clearUserPosition(forPanelFrame frame: NSRect, screens: [ScreenLayout]) {
+        guard let key = PanelPositioning.screenKey(forPanelFrame: frame, in: screens) else { return }
+        clearCustomPosition(forScreenKey: key)
+    }
+
+    /// Migrate the legacy single-position keys to the established per-screen store.
+    func saveLegacyPosition(originX: CGFloat, topY: CGFloat, screens: [ScreenLayout], fallbackScreenKey: String?) {
+        let key = PanelPositioning.screenKey(containing: NSPoint(x: originX, y: topY), in: screens)
+            ?? fallbackScreenKey
+            ?? "builtin"
+        saveCustomPosition(originX: originX, topY: topY, forScreenKey: key)
+    }
+
+    private func saveCustomPosition(originX: CGFloat, topY: CGFloat, forScreenKey key: String) {
         var dict = store.positionsDict
         dict[key] = ["originX": originX, "topY": topY]
         store.positionsDict = dict
     }
 
-    /// Remove the custom position for a screen.
-    func clearCustomPosition(forScreenKey key: String) {
+    private func clearCustomPosition(forScreenKey key: String) {
         var dict = store.positionsDict
         dict.removeValue(forKey: key)
         store.positionsDict = dict
-    }
-
-    /// Whether a custom position is saved for a screen.
-    func hasCustomPosition(forScreenKey key: String) -> Bool {
-        savedPositions()[key] != nil
     }
 
     // MARK: - Geometry decisions
@@ -122,33 +141,6 @@ struct PanelGeometryModel {
         )
     }
 
-    /// Resolve where the panel lands on double-click reset.
-    func resetFrame(
-        anchorRect: NSRect?,
-        menubarIconRect: NSRect? = nil,
-        panelScreenIndex: Int?,
-        panelSize: NSSize,
-        screens: [ScreenLayout]
-    ) -> NSRect? {
-        PanelPositioning.resolveResetPosition(
-            anchorRect: anchorRect,
-            menubarIconRect: menubarIconRect,
-            panelScreenIndex: panelScreenIndex,
-            panelSize: panelSize,
-            screens: screens
-        )
-    }
-
-    /// After a screen-parameter change, overwrite the saved position for the
-    /// panel's screen with the panel's current (possibly clamped) frame — but
-    /// only if a custom position already exists for that screen key. The key
-    /// must be captured before repositioning: if the change snapped the panel
-    /// to another screen, resaving under the landing screen's key would
-    /// overwrite that screen's user-dragged position with the new frame.
-    func resaveAfterScreenChange(panelScreenKey: String?, panelFrame: NSRect) {
-        guard let key = panelScreenKey, savedPositions()[key] != nil else { return }
-        saveCustomPosition(originX: panelFrame.origin.x, topY: panelFrame.maxY, forScreenKey: key)
-    }
 }
 
 /// Pure positioning math for the floating panel.
@@ -164,18 +156,58 @@ enum PanelPositioning {
         screens.firstIndex { NSMouseInRect(point, $0.frame, false) }
     }
 
+    static func screenKey(containing point: NSPoint, in screens: [ScreenLayout]) -> String? {
+        guard let idx = screenIndex(containing: point, in: screens) else { return nil }
+        return screens[idx].key
+    }
+
+    static func screenKey(forPanelFrame frame: NSRect, in screens: [ScreenLayout]) -> String? {
+        guard let idx = screenIndex(forPanelFrame: frame, in: screens) else { return nil }
+        return screens[idx].key
+    }
+
+    static func screenIndex(forPanelFrame frame: NSRect, in screens: [ScreenLayout]) -> Int? {
+        screenIndex(containing: NSPoint(x: frame.origin.x, y: frame.maxY), in: screens)
+            ?? screenIndex(intersecting: frame, in: screens)
+    }
+
+    static func screenIndex(intersecting panelFrame: NSRect, in screens: [ScreenLayout]) -> Int? {
+        var best: (index: Int, area: CGFloat)?
+        for (idx, screen) in screens.enumerated() {
+            let area = intersectionArea(panelFrame, screen.visibleFrame)
+            guard area > 0 else { continue }
+            if best == nil || area > best!.area {
+                best = (idx, area)
+            }
+        }
+        return best?.index
+    }
+
+    private static func intersectionArea(_ lhs: NSRect, _ rhs: NSRect) -> CGFloat {
+        let width = min(lhs.maxX, rhs.maxX) - max(lhs.minX, rhs.minX)
+        let height = min(lhs.maxY, rhs.maxY) - max(lhs.minY, rhs.minY)
+        guard width > 0, height > 0 else { return 0 }
+        return width * height
+    }
+
     /// Clamp a saved panel position to stay within screen bounds.
     static func clampToScreen(
         originX: CGFloat, topY: CGFloat,
         size: NSSize,
         screens: [ScreenLayout]
     ) -> (originX: CGFloat, topY: CGFloat) {
-        let point = NSPoint(x: originX, y: topY)
         let panelRect = NSRect(x: originX, y: topY - size.height, width: size.width, height: size.height)
-        let idx = screens.firstIndex { NSMouseInRect(point, $0.frame, false) }
-                  ?? screens.firstIndex { $0.visibleFrame.intersects(panelRect) }
+        let idx = screenIndex(forPanelFrame: panelRect, in: screens)
         guard let idx, idx < screens.count else { return (originX, topY) }
-        let vf = screens[idx].visibleFrame
+        return clampToScreen(originX: originX, topY: topY, size: size, screen: screens[idx])
+    }
+
+    static func clampToScreen(
+        originX: CGFloat, topY: CGFloat,
+        size: NSSize,
+        screen: ScreenLayout
+    ) -> (originX: CGFloat, topY: CGFloat) {
+        let vf = screen.visibleFrame
         let clampedX = max(vf.minX + margin, min(originX, vf.maxX - size.width - margin))
         let clampedTopY = max(vf.minY + size.height + margin, min(topY, vf.maxY - margin))
         return (clampedX, clampedTopY)
@@ -191,15 +223,19 @@ enum PanelPositioning {
         screens: [ScreenLayout]
     ) -> NSRect? {
         if let key = clickScreenKey, let saved = savedPositions[key] {
-            // Find the target screen by key
-            let targetScreen = screens.first { $0.key == key }
-            let savedPoint = NSPoint(x: saved.originX, y: saved.topY)
+            let savedFrame = NSRect(
+                x: saved.originX,
+                y: saved.topY - panelSize.height,
+                width: panelSize.width,
+                height: panelSize.height
+            )
 
-            // Validate saved position is on the target screen (not stale from a different layout)
-            if let target = targetScreen, target.frame.contains(savedPoint) {
+            // Validate saved position belongs to the same screen key used when persisting.
+            if let screenIdx = screenIndex(forPanelFrame: savedFrame, in: screens),
+               screens[screenIdx].key == key {
                 let clamped = clampToScreen(
                     originX: saved.originX, topY: saved.topY,
-                    size: panelSize, screens: screens
+                    size: panelSize, screen: screens[screenIdx]
                 )
                 return NSRect(
                     x: clamped.originX, y: clamped.topY - panelSize.height,

--- a/menubar/CctopMenubarTests/PanelLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/PanelLifecycleTests.swift
@@ -22,7 +22,7 @@ private struct PanelLifecycleDriver {
     var isVisible: Bool = false
 
     var screens: [ScreenLayout]
-    let anchorRect: NSRect
+    let anchorRect: NSRect?
     let panelSize: NSSize
 
     var savedPositions: [String: (originX: CGFloat, topY: CGFloat)] { model.savedPositions() }
@@ -32,14 +32,16 @@ private struct PanelLifecycleDriver {
         panelFrame: NSRect? = nil,
         isVisible: Bool = false,
         screens: [ScreenLayout],
-        anchorRect: NSRect,
+        anchorRect: NSRect?,
         panelSize: NSSize,
         store: PanelPositionStoring = InMemoryPanelPositionStore()
     ) {
-        self.model = PanelGeometryModel(store: store)
+        var dict = store.positionsDict
         for (key, position) in savedPositions {
-            model.saveCustomPosition(originX: position.originX, topY: position.topY, forScreenKey: key)
+            dict[key] = ["originX": position.originX, "topY": position.topY]
         }
+        store.positionsDict = dict
+        self.model = PanelGeometryModel(store: store)
         self.panelFrame = panelFrame
         self.isVisible = isVisible
         self.screens = screens
@@ -58,7 +60,7 @@ private struct PanelLifecycleDriver {
     /// The screen key the panel is currently on (mirrors AppDelegate.panelScreenKey()).
     private var panelScreenKey: String? {
         guard let frame = panelFrame else { return nil }
-        return screenKey(for: NSPoint(x: frame.midX, y: frame.midY))
+        return PanelPositioning.screenKey(forPanelFrame: frame, in: screens)
     }
 
     /// togglePanel() when hidden → show.
@@ -97,6 +99,25 @@ private struct PanelLifecycleDriver {
         isVisible = true
     }
 
+    /// Menubar click on a different screen while the panel is already visible.
+    /// Mirrors AppDelegate's transient .positionPanel path.
+    mutating func repositionWhileVisible(clickAt clickLocation: NSPoint) {
+        precondition(isVisible, "Panel must be visible to reposition")
+        let clickKey = screenKey(for: clickLocation)
+
+        if let frame = model.showFrame(
+            clickScreenKey: clickKey,
+            clickLocation: clickLocation,
+            anchorRect: anchorRect,
+            panelSize: panelSize,
+            screens: screens
+        ) {
+            panelFrame = frame
+        }
+
+        // A transient miss may move the live frame, but it must not mutate saved intent.
+    }
+
     /// Header drag to a new position.
     /// Mirrors: FloatingPanel.handleHeaderDrag → AppDelegate.panelDidDrag.
     mutating func drag(toOriginX originX: CGFloat, topY: CGFloat) {
@@ -105,10 +126,7 @@ private struct PanelLifecycleDriver {
             x: originX, y: topY - panelSize.height,
             width: panelSize.width, height: panelSize.height
         )
-        // Save under the screen key the panel is now on
-        if let key = panelScreenKey {
-            model.saveCustomPosition(originX: originX, topY: topY, forScreenKey: key)
-        }
+        model.saveUserDraggedPosition(originX: originX, topY: topY, panelSize: panelSize, screens: screens)
     }
 
     /// togglePanel() when visible → dismiss.
@@ -120,12 +138,12 @@ private struct PanelLifecycleDriver {
     }
 
     /// Screen-parameter change while panel is visible.
-    /// Mirrors: AppDelegate.handleScreenChange → positionPanel + resave if custom.
+    /// Mirrors: AppDelegate.handleScreenChange → transient positionPanel only.
     mutating func handleScreenChange() {
         guard isVisible else { return }
 
         // Capture the key before repositioning (mirrors AppDelegate): the
-        // resave must key off the screen the panel was on, not where it lands
+        // transient move should be based on where the panel started.
         let key = panelScreenKey
 
         // positionPanel with focusLocation = nil (explicitly cleared at the
@@ -140,10 +158,7 @@ private struct PanelLifecycleDriver {
             panelFrame = frame
         }
 
-        // Overwrite the saved position with the possibly clamped frame, if one exists
-        if let frame = panelFrame {
-            model.resaveAfterScreenChange(panelScreenKey: key, panelFrame: frame)
-        }
+        // Screen changes adjust only the live frame; saved intent is unchanged.
     }
 
     /// Screen-parameter change with a new screen layout.
@@ -168,20 +183,17 @@ private struct PanelLifecycleDriver {
     mutating func resetPosition() {
         precondition(isVisible, "Panel must be visible to reset")
 
-        // Clear only the current screen's saved position
-        if let key = panelScreenKey {
-            model.clearCustomPosition(forScreenKey: key)
+        if let frame = panelFrame {
+            model.clearUserPosition(forPanelFrame: frame, screens: screens)
         }
 
         let panelIdx = panelFrame.flatMap { frame in
-            PanelPositioning.screenIndex(
-                containing: NSPoint(x: frame.midX, y: frame.midY), in: screens
-            )
+            PanelPositioning.screenIndex(forPanelFrame: frame, in: screens)
         }
 
         // Models the no-pill case only: menubarIconRect defaults to nil and
         // falls back to anchorRect (the pill case is covered by unit tests)
-        if let frame = model.resetFrame(
+        if let frame = PanelPositioning.resolveResetPosition(
             anchorRect: anchorRect,
             panelScreenIndex: panelIdx,
             panelSize: panelSize,
@@ -236,6 +248,22 @@ final class PanelLifecycleTests: XCTestCase {
         XCTAssertEqual(lc.panelFrame!.maxY, 700, accuracy: 1)
     }
 
+    func testDragPersistsUnderTopLeftScreenWhenPanelSpansDisplays() {
+        var lc = makeLifecycle()
+
+        lc.show(clickAt: clickOnPrimary)
+        lc.drag(toOriginX: 1800, topY: 700)
+
+        XCTAssertEqual(
+            lc.savedPositions["primary"]?.originX, 1800,
+            "A dragged panel belongs to the screen containing its top-left point"
+        )
+        XCTAssertNil(
+            lc.savedPositions["secondary"],
+            "Greatest-overlap or midpoint ownership must not choose the secondary display"
+        )
+    }
+
     func testNoDragShowsAtAnchor() {
         var lc = makeLifecycle()
 
@@ -277,10 +305,9 @@ final class PanelLifecycleTests: XCTestCase {
 
     // MARK: - Screen change while on different screen
 
-    /// The clamp-resave must key off the screen the panel was on BEFORE
-    /// repositioning. With no custom position on secondary, the screen change
-    /// snaps the panel back to the anchor on primary — but primary's
-    /// user-dragged entry must not be overwritten with the anchor frame.
+    /// With no custom position on secondary, the screen change snaps the panel
+    /// back to the anchor on primary — but primary's user-dragged entry must
+    /// not be overwritten with the anchor frame.
     func testScreenChangeWhileOnSecondaryPreservesPrimaryPosition() {
         var lc = makeLifecycle()
 
@@ -296,22 +323,22 @@ final class PanelLifecycleTests: XCTestCase {
         lc.handleScreenChange()
 
         // No custom position on secondary → the panel snaps back to the anchor
-        // on primary, but the resave keys off secondary and is a no-op
+        // on primary, without mutating stored primary intent.
         XCTAssertLessThan(
             lc.panelFrame!.maxX, primary.frame.maxX,
             "Panel should snap back to the anchor screen"
         )
         XCTAssertEqual(
             lc.savedPositions["primary"]!.originX, 200, accuracy: 0.5,
-            "Dragged primary position must survive the resave"
+            "Dragged primary position must survive the screen change"
         )
         XCTAssertEqual(
             lc.savedPositions["primary"]!.topY, 700, accuracy: 0.5,
-            "Dragged primary position must survive the resave"
+            "Dragged primary position must survive the screen change"
         )
         XCTAssertNil(
             lc.savedPositions["secondary"],
-            "The no-op resave must not invent an entry for secondary"
+            "Screen change must not invent an entry for secondary"
         )
 
         lc.dismiss()
@@ -330,7 +357,7 @@ final class PanelLifecycleTests: XCTestCase {
 
     // MARK: - Screen layout change (monitor disconnected/reconfigured)
 
-    func testScreenLayoutChangeRelocatesSavedPosition() {
+    func testScreenLayoutChangePreservesSavedPosition() {
         var lc = makeLifecycle()
 
         // Drag to position on primary
@@ -361,7 +388,7 @@ final class PanelLifecycleTests: XCTestCase {
         // Session update triggers resize
         lc.resize(newHeight: 500)
 
-        // Panel stays on secondary (top-left stable because hasCustomPosition)
+        // Panel stays on secondary; no saved position there, so resize keeps it centered.
         XCTAssertEqual(
             lc.panelFrame!.origin.x, secondaryOriginX, accuracy: 1,
             "Resize should keep panel on secondary"
@@ -412,6 +439,19 @@ final class PanelLifecycleTests: XCTestCase {
         XCTAssertNotEqual(
             lc.panelFrame!.origin.x, 200,
             "After reset, should use anchor not custom position"
+        )
+    }
+
+    func testResetClearsTopLeftScreenWhenPanelSpansDisplays() {
+        var lc = makeLifecycle()
+
+        lc.show(clickAt: clickOnPrimary)
+        lc.drag(toOriginX: 1800, topY: 700)
+        lc.resetPosition()
+
+        XCTAssertNil(
+            lc.savedPositions["primary"],
+            "Reset should clear the screen containing the panel's saved top-left point"
         )
     }
 
@@ -552,7 +592,7 @@ final class PanelLifecycleTests: XCTestCase {
 
     // MARK: - Screen change while visible on same screen
 
-    func testScreenChangeOnSameScreenClampsPosition() {
+    func testScreenChangeOnSameScreenMovesFrameWithoutOverwritingSavedIntent() {
         // Use a single-screen setup so the position can only clamp within it
         let screen = ScreenLayout(
             frame: NSRect(x: 0, y: 0, width: 1920, height: 1080),
@@ -577,12 +617,17 @@ final class PanelLifecycleTests: XCTestCase {
         )
         lc = lc.handleScreenChange(newScreens: [smaller])
 
-        // Saved position should be clamped to new screen bounds
+        // The live frame is clamped for the current layout.
         let margin = PanelPositioning.margin
         XCTAssertLessThanOrEqual(
-            lc.savedPositions["primary"]!.originX,
+            lc.panelFrame!.origin.x,
             smaller.visibleFrame.maxX - panelSize.width - margin,
-            "Saved position should be clamped to smaller screen"
+            "Screen change should keep the visible panel inside the smaller screen"
+        )
+        XCTAssertEqual(
+            lc.savedPositions["primary"]!.originX,
+            1200,
+            "Screen change is not a user gesture and must not overwrite saved intent"
         )
     }
 
@@ -613,6 +658,43 @@ final class PanelLifecycleTests: XCTestCase {
         XCTAssertTrue(FloatingPanel.shouldPersistDrag(sawDragEvents: true, originMoved: true))
         XCTAssertFalse(FloatingPanel.shouldPersistDrag(sawDragEvents: true, originMoved: false))
         XCTAssertFalse(FloatingPanel.shouldPersistDrag(sawDragEvents: false, originMoved: false))
+    }
+
+    func testVisibleOffscreenDragPersistsAndResetClearsSameScreen() {
+        let store = InMemoryPanelPositionStore()
+        var lc = PanelLifecycleDriver(
+            screens: [primary],
+            anchorRect: anchorOnPrimary,
+            panelSize: panelSize,
+            store: store
+        )
+
+        lc.show(clickAt: clickOnPrimary)
+        lc.drag(toOriginX: 200, topY: 700)
+        lc.drag(toOriginX: -20, topY: 700)
+
+        XCTAssertEqual(
+            store.positionsDict,
+            ["primary": ["originX": -20, "topY": 700]],
+            "Visible off-screen drag-end should update the user's saved intent"
+        )
+
+        lc.dismiss()
+        lc.show(clickAt: clickOnPrimary)
+
+        XCTAssertEqual(
+            lc.panelFrame!.origin.x, PanelPositioning.margin, accuracy: 0.5,
+            "Reopening should honor the saved off-screen intent by clamping it into view"
+        )
+        XCTAssertEqual(lc.panelFrame!.maxY, 700, accuracy: 0.5)
+
+        lc.resetPosition()
+
+        XCTAssertEqual(
+            store.positionsDict,
+            [:],
+            "Reset from that visible off-screen frame should not leave an older saved position behind"
+        )
     }
 
     func testFloatingPanelMovesToActiveSpaceWhenOrderedFront() {
@@ -696,9 +778,9 @@ final class PanelLifecycleTests: XCTestCase {
         XCTAssertEqual(lc.panelFrame!.height, 550, accuracy: 0.5)
     }
 
-    // MARK: - Screen change clamp-resave (what actually lands in the store)
+    // MARK: - Screen change store invariants
 
-    func testScreenChangeResaveWritesClampedPositionToStore() {
+    func testScreenChangeDoesNotWriteClampedPositionToStore() {
         let store = InMemoryPanelPositionStore()
         var lc = PanelLifecycleDriver(
             screens: [primary],
@@ -718,11 +800,10 @@ final class PanelLifecycleTests: XCTestCase {
         )
         lc = lc.handleScreenChange(newScreens: [smaller])
 
-        let expectedX = smaller.visibleFrame.maxX - panelSize.width - PanelPositioning.margin
         XCTAssertEqual(
             store.positionsDict,
-            ["primary": ["originX": expectedX, "topY": 700]],
-            "Screen change must resave the clamped position in the persisted format"
+            ["primary": ["originX": 1200, "topY": 700]],
+            "Screen change may move the live frame but must not rewrite persisted user intent"
         )
     }
 
@@ -741,7 +822,34 @@ final class PanelLifecycleTests: XCTestCase {
 
         XCTAssertEqual(
             store.positionsDict, [:],
-            "Resave must not invent a position for a screen that never had one"
+            "Screen change must not invent a position for a screen that never had one"
+        )
+    }
+
+    func testRepositionMissRecoveryDoesNotDeleteSavedIntent() {
+        let store = InMemoryPanelPositionStore()
+        store.positionsDict = ["primary": ["originX": 2500, "topY": 700]]
+        let originalFrame = NSRect(x: 2200, y: 300, width: panelSize.width, height: panelSize.height)
+        var lc = PanelLifecycleDriver(
+            panelFrame: originalFrame,
+            isVisible: true,
+            screens: screens,
+            anchorRect: nil,
+            panelSize: panelSize,
+            store: store
+        )
+
+        lc.repositionWhileVisible(clickAt: clickOnPrimary)
+
+        XCTAssertEqual(
+            store.positionsDict,
+            ["primary": ["originX": 2500, "topY": 700]],
+            "Recovery from a transient screen mismatch must not delete the user's saved position"
+        )
+        XCTAssertEqual(
+            lc.panelFrame!,
+            originalFrame,
+            "Without a usable target frame, recovery should leave the transient frame alone"
         )
     }
 }

--- a/menubar/CctopMenubarTests/PanelPositioningTests.swift
+++ b/menubar/CctopMenubarTests/PanelPositioningTests.swift
@@ -1,6 +1,10 @@
 import XCTest
 @testable import CctopMenubar
 
+private final class PanelPositioningMemoryStore: PanelPositionStoring {
+    var positionsDict: [String: [String: CGFloat]] = [:]
+}
+
 final class PanelPositioningTests: XCTestCase {
     // Two-screen setup: primary (left), secondary (right)
     let primary = ScreenLayout(
@@ -128,6 +132,35 @@ final class PanelPositioningTests: XCTestCase {
         )
         XCTAssertNotNil(result)
         XCTAssertEqual(result!.origin.x, 100, accuracy: 1)
+    }
+
+    func testSavedPositionWithOffscreenTopLeftUsesVisibleIntersectionOnShow() {
+        let result = PanelPositioning.resolveShowPosition(
+            savedPositions: ["primary": (originX: -20, topY: 700)],
+            clickScreenKey: "primary",
+            clickLocation: NSPoint(x: 500, y: 500),
+            anchorRect: anchorOnPrimary,
+            panelSize: panelSize, screens: screens
+        )
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.origin.x, margin, accuracy: 1)
+        XCTAssertEqual(result!.maxY, 700, accuracy: 1)
+    }
+
+    func testSavedPositionSpanningDisplaysClampsToValidatedScreen() {
+        let result = PanelPositioning.resolveShowPosition(
+            savedPositions: ["secondary": (originX: 1800, topY: 1100)],
+            clickScreenKey: "secondary",
+            clickLocation: NSPoint(x: 2500, y: 500),
+            anchorRect: anchorOnPrimary,
+            panelSize: panelSize, screens: screens
+        )
+
+        XCTAssertNotNil(result)
+        XCTAssertGreaterThanOrEqual(result!.origin.x, secondary.visibleFrame.minX)
+        XCTAssertLessThan(result!.maxX, secondary.visibleFrame.maxX)
+        XCTAssertEqual(result!.maxY, secondary.visibleFrame.maxY - margin, accuracy: 1)
     }
 
     func testSavedPositionOnWrongScreenFallsBackToAnchor() {
@@ -337,10 +370,10 @@ final class PanelPositioningTests: XCTestCase {
         let model = PanelGeometryModel(store: store)
         XCTAssertEqual(model.savedPositions()["primary"]?.originX, 200)
         XCTAssertEqual(model.savedPositions()["primary"]?.topY, 700)
-        XCTAssertTrue(model.hasCustomPosition(forScreenKey: "primary"))
-        XCTAssertFalse(model.hasCustomPosition(forScreenKey: "secondary"))
+        XCTAssertNotNil(model.savedPositions()["primary"])
+        XCTAssertNil(model.savedPositions()["secondary"])
 
-        model.saveCustomPosition(originX: 2200.5, topY: 901.25, forScreenKey: "secondary")
+        model.saveUserDraggedPosition(originX: 2200.5, topY: 901.25, panelSize: panelSize, screens: screens)
         XCTAssertEqual(
             defaults.dictionary(forKey: "panelPositions") as? [String: [String: CGFloat]],
             [
@@ -350,11 +383,46 @@ final class PanelPositioningTests: XCTestCase {
             "Saving must write the identical raw UserDefaults format"
         )
 
-        model.clearCustomPosition(forScreenKey: "primary")
+        let primaryFrame = NSRect(
+            x: 200, y: 700 - panelSize.height,
+            width: panelSize.width, height: panelSize.height
+        )
+        model.clearUserPosition(forPanelFrame: primaryFrame, screens: screens)
         XCTAssertEqual(
             defaults.dictionary(forKey: "panelPositions") as? [String: [String: CGFloat]],
             ["secondary": ["originX": 2200.5, "topY": 901.25]],
             "Clearing must remove only the given screen's entry, preserving the format"
+        )
+    }
+
+    func testUserDragWithOffscreenTopLeftFallsBackToVisibleIntersection() {
+        let store = PanelPositioningMemoryStore()
+        let model = PanelGeometryModel(store: store)
+
+        model.saveUserDraggedPosition(originX: -20, topY: 700, panelSize: panelSize, screens: screens)
+
+        XCTAssertEqual(
+            store.positionsDict,
+            ["primary": ["originX": -20, "topY": 700]],
+            "Visible off-screen drag-end should still persist the user's intended screen"
+        )
+    }
+
+    func testResetWithOffscreenTopLeftClearsVisibleIntersectionScreen() {
+        let store = PanelPositioningMemoryStore()
+        store.positionsDict = ["primary": ["originX": 200, "topY": 700]]
+        let model = PanelGeometryModel(store: store)
+        let offscreenFrame = NSRect(
+            x: -20, y: 700 - panelSize.height,
+            width: panelSize.width, height: panelSize.height
+        )
+
+        model.clearUserPosition(forPanelFrame: offscreenFrame, screens: screens)
+
+        XCTAssertEqual(
+            store.positionsDict,
+            [:],
+            "Reset from a visible off-screen frame should clear the screen it still occupies"
         )
     }
 


### PR DESCRIPTION
## Problem

Panel position persistence mixed live AppKit geometry with stored user intent. Drag, reset, screen-change, and miss-recovery paths could all mutate `panelPositions`, while screen ownership was derived in more than one way. That made non-user events capable of rewriting or deleting the saved position a user had explicitly dragged.

## Solution

- Route panel position ownership and persistence through `PanelGeometryModel` using one top-left screen-assignment rule.
- Persist desired panel position only from explicit user actions: drag-end and reset, plus the existing one-time legacy migration.
- Keep screen-change and reposition miss paths transient-only, and add tests that lock those store invariants.