### PR TITLE
Preserve opencode session identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,7 @@ The script uses Chrome headless (auto-detected on macOS, override with `CHROME_B
 | Claude Desktop | Yes | Same Claude plugin hook path, hosted by the Claude Desktop app | `source: "cc"` plus trusted bundle ID `com.anthropic.claudefordesktop`; PID-keyed file; title/archive metadata read from `~/Library/Application Support/Claude/claude-code-sessions` | Desktop app liveness applies unless `ended_at` is set or the session has been idle past the retention window (anchored on `last_activity`), which finishes it even while the app runs; within retention, disconnected sessions stay dormant; archived/orphaned metadata filters visibility; no deep link, so jump-to-session activates the app |
 | Codex CLI | Yes | `~/.codex/hooks.json` → `~/.codex/cctop-shim.sh` → `cctop-hook --harness codex` | `source: "codex"`; session-id-keyed `codex-<session_id>.json` because one host PID can emit multiple conversations | Uses session ID for display/dedup; structured Codex `threads.source` hides `SubAgent`/`Internal` helpers while preserving interactive `cli`/`vscode` tasks; spawn edges only corroborate topology |
 | Codex Desktop | Yes | Same Codex hook shim path, hosted by the Codex Desktop app | `source: "codex"` plus trusted bundle ID `com.openai.codex`; session-id-keyed `codex-<session_id>.json`; titles read from `~/.codex/session_index.jsonl` | Desktop app liveness/recency applies unless `ended_at` is set or the session has been idle past the retention window (anchored on `last_activity`), which finishes it even while the app runs; within retention, disconnected sessions stay dormant; archived threads and structured `SubAgent`/`Internal` helpers filter visibility, while `cli`/`vscode` tasks remain visible; archive placement is checked against rollout files when available; memory/title helper sessions auto-hide; deep links use `codex://threads/<uuid>` |
-| opencode | Yes | JS plugin → `cctop-hook` CLI via `execFileSync` | `source: "opencode"`; PID-keyed `<pid>.json`; installed at `~/.config/opencode/plugins/cctop.js`; explicit source wins over inherited Claude/Codex Desktop bundle IDs | Plugin load and `session.created` start tracking; PID liveness decides finished state |
+| opencode | Yes | JS plugin → `cctop-hook` CLI via `execFileSync` | `source: "opencode"`; real conversations use `opencode-<pid>-<session_id>.json`; plugin-load and legacy/no-id fallback events remain PID-keyed; installed at `~/.config/opencode/plugins/cctop.js`; explicit source wins over inherited Claude/Codex Desktop bundle IDs | `session.deleted` ends a real-ID conversation; sessions with `parentID` are marked as helpers and hidden; PID liveness handles fallback/no-end cleanup |
 | pi | Yes | TS extension → `cctop-hook` CLI via `execFileSync` | `source: "pi"`; PID-keyed `<pid>.json`; installed at `~/.pi/agent/extensions/cctop.ts`; explicit source wins over inherited Claude/Codex Desktop bundle IDs | Skips non-interactive sessions (`ctx.hasUI === false`); `session_shutdown` sends `SessionEnd`; PID liveness decides finished state |
 | Aider | No | — | — | — |
 | Goose | No | — | — | — |
@@ -271,7 +271,7 @@ All supported clients use `cctop-hook` as the single entry point for session sta
 2. `cctop-shim.sh` dispatches to `cctop-hook <Event> --harness codex`
 3. `cctop-hook` writes session files to `~/.cctop/sessions/`
 
-**All paths converge:** The menubar app (SessionManager file watcher) reads `~/.cctop/sessions/*.json` and displays live status regardless of source. Sessions include a `source` field identifying the harness (`"cc"` for Claude Code, `"opencode"` for opencode, `"pi"`, `"codex"`). Most integrations write PID-keyed files (`<pid>.json`); Codex writes `codex-<session_id>.json` because multiple conversations can share one host PID.
+**All paths converge:** The menubar app (SessionManager file watcher) reads `~/.cctop/sessions/*.json` and displays live status regardless of source. Sessions include a `source` field identifying the harness (`"cc"` for Claude Code, `"opencode"` for opencode, `"pi"`, `"codex"`). Claude Code, pi, and legacy/no-id opencode fallback events write PID-keyed files (`<pid>.json`). Codex writes `codex-<session_id>.json`, and real opencode conversations write `opencode-<pid>-<session_id>.json`, so one host PID can emit multiple conversations without changing OpenCode's record-local reopen contract.
 
 **Stream Deck is downstream of the app:** The app publishes its resolved,
 ordered display projection to `~/.cctop/display-state.json`. The Stream Deck
@@ -346,7 +346,7 @@ echo '{"session_id":"test123","cwd":"/tmp","hook_event_name":"SessionStart"}' | 
 # Or use the debug build
 echo '{"session_id":"test123","cwd":"/tmp","hook_event_name":"SessionStart"}' | menubar/build/Build/Products/Debug/cctop-hook SessionStart
 
-# Check if session was created. Non-Codex files are usually PID-keyed.
+# Check if session was created. Some harnesses use session-id-keyed files.
 cat ~/.cctop/sessions/*.json | jq 'select(.session_id=="test123")'
 
 # Clean up test session
@@ -472,7 +472,8 @@ The opencode plugin (`plugin.js`) translates opencode events to cctop-hook calls
 | experimental.session.compacting | PreCompact |
 | session.compacted | PostCompact |
 | session.updated | (stores session_name locally, passed in subsequent calls) |
-| session.deleted / permission.replied | (skipped — handled by liveness check / next event) |
+| session.deleted | SessionEnd when the deleted session id is present |
+| permission.replied | (skipped — PreToolUse follows permission) |
 
 ### pi Extension Event Mapping
 
@@ -492,7 +493,7 @@ The pi extension (`cctop.ts`) translates pi events to cctop-hook calls. Non-inte
 
 ### Session File Format
 
-Non-Codex session files are keyed by PID (`{pid}.json`). Codex files are keyed by session ID (`codex-<session_id>.json`) because multiple conversations can share one host PID. Each file stores `pid_start_time` (from `sysctl`) to detect PID reuse where PID identity applies. Hooks also stamp `harness_session_id`, the exact unsanitized reference supplied to the hook, as lookup evidence. Each observed record receives a cctop-owned permanent `cctop_session_id`; external surfaces use that ID and cctop separately resolves it to the current live focus target. Same-machine resume continuity is guaranteed only for the client contracts listed in [`docs/session-files.md`](docs/session-files.md). Desktop-hosted sessions use desktop lifecycle rules, app liveness/recency, and archive visibility checks. Each session includes `"source": "<harness>"` (`"cc"`, `"opencode"`, `"pi"`, `"codex"`). Legacy sessions without the field are treated as Claude Code.
+Claude Code, pi, and legacy/no-id opencode fallback session files are keyed by PID (`{pid}.json`). Codex files use `codex-<session_id>.json`, and real opencode conversations use `opencode-<pid>-<session_id>.json`, because those hosts can emit multiple conversations from one PID. Each file stores `pid_start_time` (from `sysctl`) to detect PID reuse where PID identity applies. Hooks also stamp `harness_session_id`, the exact unsanitized reference supplied to the hook, as lookup evidence. Each observed record receives a cctop-owned permanent `cctop_session_id`; external surfaces use that ID and cctop separately resolves it to the current live focus target. Same-machine resume continuity is guaranteed only for the client contracts listed in [`docs/session-files.md`](docs/session-files.md). Desktop-hosted sessions use desktop lifecycle rules, app liveness/recency, and archive visibility checks. Each session includes `"source": "<harness>"` (`"cc"`, `"opencode"`, `"pi"`, `"codex"`). Legacy sessions without the field are treated as Claude Code.
 
 The `active_subagents` field tracks currently running subagents (Agent tool). It's `nil` for sessions that haven't reported subagent events (old plugin), `[]` when no subagents are active, or an array of `{agent_id, agent_type, started_at}` objects. The menubar app shows an agent-count label (e.g. "2 agents") when the count is > 0.
 

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -47,10 +47,10 @@ Type: `string`
 Default: `null` when omitted.
 
 The exact unsanitized session reference supplied to `cctop-hook`, byte-for-byte.
-For integrations that expose a real conversation reference, this preserves it;
-OpenCode intentionally continues to supply its process-scoped synthetic reference
-until all of its per-session event payloads can be routed consistently. `session_id` is
-sanitized to a restricted character set and truncated to 64 characters so it can
+For integrations that expose a real conversation reference, this preserves it.
+OpenCode supplies real per-conversation references on routable events; its plugin-load
+and legacy/no-id fallback record remains process-scoped. `session_id` is sanitized to
+a restricted character set and truncated to 64 characters so it can
 safely appear in file names and logs, which makes it a lossy projection of the
 hook reference; `harness_session_id` preserves the original value for resume
 lookup. It is evidence, not cctop identity. The hook stamps it after a matching event loads the record,
@@ -64,7 +64,7 @@ may replace a PID-keyed record only through `SessionStart`-driven rotation.
 | Codex CLI/Desktop | Yes | The client supplies the same UUID conversation reference across process generations. |
 | Claude Code/Desktop | Yes when a UUID session reference is available | Claude session/transcript state preserves that UUID across resume. |
 | pi | Yes only when `getSessionId()` supplies a real UUID | Synthetic `pi-<pid>` fallback observations remain record-local. |
-| OpenCode | Not yet | The plugin intentionally uses a process-scoped synthetic reference until per-event session routing is reliable. |
+| OpenCode | Not yet | Per-conversation capture is supported, but reopened observations remain record-local after their prior session file is cleaned up. |
 
 Every newly observed record still receives a `cctop_session_id`; “not yet” means
 cctop cannot promise that a later reopened observation will recover the same

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -96,7 +96,7 @@ CLI sessions do not need `disconnected_at` because disconnected CLI sessions bec
 
 ## Dedup and Cleanup
 
-Session files are deduplicated by a stable identity key before publishing. `SessionIdentityPolicy` owns that grouping rule. Codex sessions use `session_id` across both old PID-keyed files and newer `codex-<session_id>` files. Known desktop sessions also use `session_id`; other terminal or ambiguous sessions keep PID identity.
+Session files are deduplicated by a stable identity key before publishing. `SessionIdentityPolicy` owns that grouping rule. Codex sessions use `session_id` across both old PID-keyed files and newer `codex-<session_id>` files. Real opencode conversations use process-scoped `session_id` keys across `opencode-<pid>-<session_id>` files so one host PID can retain multiple rows without changing the record-local reopen contract; plugin-load and legacy/no-id fallback records remain process-scoped. Known desktop sessions also use `session_id`; other terminal or ambiguous sessions keep PID identity.
 
 Archived desktop sessions are filtered from the active/dormant list before display dedup. cctop does not persist `hidden = true` for this case and does not remove the `.json`, so a later app-level unarchive can make the same session file visible again. Archived desktop sessions are not archived into Recent Projects. If the same classified cctop JSON record has a known project path, the classification snapshot can emit an explicit worktree cleanup source for that path; this does not delete the session JSON. If host metadata is missing, unreadable, or lacks enough path evidence, cleanup fails safe by emitting no source.
 

--- a/fixtures/PermissionRequest-opencode-question.json
+++ b/fixtures/PermissionRequest-opencode-question.json
@@ -1,5 +1,5 @@
 {
-  "session_id": "opencode-12345",
+  "session_id": "opencode-4242",
   "cwd": "/tmp/test-project",
   "hook_event_name": "PermissionRequest",
   "title": "Which direction should I take?",

--- a/fixtures/SessionStart-opencode.json
+++ b/fixtures/SessionStart-opencode.json
@@ -1,5 +1,5 @@
 {
-  "session_id": "opencode-12345",
+  "session_id": "opencode-4242",
   "cwd": "/tmp/test-project",
   "hook_event_name": "SessionStart",
   "harness_name": "opencode",

--- a/fixtures/UserPromptSubmit-opencode.json
+++ b/fixtures/UserPromptSubmit-opencode.json
@@ -1,5 +1,5 @@
 {
-  "session_id": "opencode-12345",
+  "session_id": "opencode-4242",
   "cwd": "/tmp/test-project",
   "hook_event_name": "UserPromptSubmit",
   "harness_name": "opencode",

--- a/hook-input.schema.json
+++ b/hook-input.schema.json
@@ -86,6 +86,7 @@
       ],
       "opencode": [
         "SessionStart",
+        "SessionEnd",
         "UserPromptSubmit",
         "PreToolUse",
         "PostToolUse",

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -67,6 +67,11 @@ enum HookHandler {
             let (oldStatus, newStatus) = applyTransition(&session, event: event, input: input, branch: branch, terminal: terminal)
             applySessionName(&session, event: event, input: input, names: deps.names)
             applySideEffects(event: event, session: &session, input: input, sessionsDir: sessionsDir, safeId: safeId)
+            if isRealOpencodeSession(input: input, pid: pid, safeSessionId: safeId),
+               isNewSessionFile, event != .sessionStart {
+                session.activeSubagents = []
+                session.workspaceFile = Session.findWorkspaceFile(in: input.cwd)
+            }
             if input.isSubagentSession == true { session.isSubagentSession = true }
             if session.shouldAutoHide { session.hidden = true }
             session.markWrittenByHook(version: Config.hookVersion, isNewSessionFile: isNewSessionFile)
@@ -401,6 +406,10 @@ extension HookHandler {
         let label = HookLogger.sessionLabel(cwd: input.cwd, sessionId: safeId)
         let source = input.resolvedHarnessName ?? Session.ccSource
 
+        defer {
+            runProjectCleanupIfNeeded(event: .sessionEnd, sessionsDir: sessionsDir, input: input, pid: pid, deps: deps)
+        }
+
         // The end-time parent walk can resolve a different PID than at start (ancestors
         // exit during teardown), so the PID-derived path may miss the session's file or
         // hold a different conversation. Key the stamp to session_id (issue #155 P3).
@@ -566,6 +575,19 @@ extension HookHandler {
             }
         }
 
+        if source == Session.opencodeSource {
+            if exact.contains(where: { $0.path == primaryPath }) {
+                return SessionEndTarget(path: primaryPath, match: .exact)
+            }
+            if exact.isEmpty, legacyPaths.count == 1, legacyPaths.first == primaryPath {
+                return SessionEndTarget(path: primaryPath, match: .legacy)
+            }
+            // OpenCode observations are record-local across host processes. A delete
+            // without the current process-qualified record must not end an older
+            // process's same-named conversation.
+            return nil
+        }
+
         if !exact.isEmpty {
             if exact.contains(where: { $0.path == primaryPath }) {
                 return SessionEndTarget(path: primaryPath, match: .exact)
@@ -623,6 +645,28 @@ extension HookHandler {
             if isStale {
                 removeSession(at: path, sessionId: session.sessionId, logger: logger)
             }
+        }
+    }
+
+    static func cleanupOpencodeProcessFallbackSession(
+        sessionsDir: String,
+        projectPath: String,
+        incomingSafeId: String,
+        currentPid: UInt32,
+        logger: HookLogger
+    ) {
+        guard !isOpencodeProcessFallbackSessionId(incomingSafeId, pid: currentPid) else { return }
+
+        let fallbackPath = (sessionsDir as NSString).appendingPathComponent("\(currentPid).json")
+        try? withSessionLock(sessionPath: fallbackPath, onError: logger.logError) {
+            guard let session = try? Session.fromFile(path: fallbackPath),
+                  session.source == Session.opencodeSource,
+                  session.projectPath == projectPath,
+                  session.pid == currentPid,
+                  isOpencodeProcessFallbackSessionId(session.sessionId, pid: currentPid) else {
+                return
+            }
+            removeSession(at: fallbackPath, sessionId: session.sessionId, logger: logger)
         }
     }
 
@@ -691,6 +735,15 @@ private func runProjectCleanupIfNeeded(
     deps: HookDependencies
 ) {
     // Cleanup runs outside the lock: it scans all session files and makes sysctl calls per file.
+    if input.resolvedHarnessName == Session.opencodeSource {
+        HookHandler.cleanupOpencodeProcessFallbackSession(
+            sessionsDir: sessionsDir,
+            projectPath: input.cwd,
+            incomingSafeId: Session.sanitizeSessionId(raw: input.sessionId),
+            currentPid: pid,
+            logger: deps.logger
+        )
+    }
     guard event == .sessionStart else { return }
     HookHandler.cleanupSessionsForProject(
         sessionsDir: sessionsDir, projectPath: input.cwd, currentPid: pid,
@@ -809,14 +862,26 @@ private func canReplaceDecodedSessionFile(existing: Session, fresh: Session, eve
 // MARK: - Session File Naming
 
 /// The single writer-side source of truth for session file naming. Files are keyed by
-/// PID, except Codex where one host process can emit hooks for multiple conversations.
-/// The `codex-` prefix also keeps Codex files out of the reader-side legacy UUID-file
+/// PID, except harnesses where one host process can emit hooks for multiple conversations.
+/// Harness prefixes also keep per-conversation files out of the reader-side legacy UUID-file
 /// sweep (`SessionManager.isLegacyUUIDFilename`) — keep both sides in sync.
 func sessionFileName(input: HookInput, pid: UInt32, safeSessionId: String) -> String {
     if input.resolvedHarnessName == Session.codexSource {
         return "codex-\(safeSessionId).json"
     }
+    if isRealOpencodeSession(input: input, pid: pid, safeSessionId: safeSessionId) {
+        return "opencode-\(pid)-\(safeSessionId).json"
+    }
     return "\(pid).json"
+}
+
+private func isRealOpencodeSession(input: HookInput, pid: UInt32, safeSessionId: String) -> Bool {
+    input.resolvedHarnessName == Session.opencodeSource
+        && !isOpencodeProcessFallbackSessionId(safeSessionId, pid: pid)
+}
+
+private func isOpencodeProcessFallbackSessionId(_ sessionId: String, pid: UInt32) -> Bool {
+    sessionId == "opencode-\(pid)"
 }
 
 // MARK: - Git Branch

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -20,6 +20,14 @@ enum SessionIdentityPolicy {
         if session.isCodex {
             return "codex:\(session.sessionId)"
         }
+        // OpenCode can publish multiple per-conversation files from one host PID. Keep
+        // them distinct during the pre-identity winner pass; permanent cctop identity
+        // remains the authority for the final panel projection and user actions.
+        if session.source == Session.opencodeSource,
+           let pid = session.pid,
+           session.sessionId != "opencode-\(pid)" {
+            return "opencode:\(pid):\(session.sessionId)"
+        }
         if session.hostClass == .desktop {
             return "desktop:\(session.sessionId)"
         }

--- a/menubar/CctopMenubar/Services/SessionManager+Loading.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Loading.swift
@@ -232,7 +232,7 @@ extension SessionManager {
     }
 
     /// A pre-PID session file was keyed by a bare session UUID. Today's files are either
-    /// numeric (PID) or `codex-<uuid>`, so only genuinely old files match.
+    /// numeric (PID) or harness-prefixed, so only genuinely old files match.
     nonisolated static func isLegacyUUIDFilename(_ stem: String) -> Bool {
         HostApp.isUUID(stem)
     }

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -200,13 +200,65 @@ final class HookHandlerTests: XCTestCase {
         {"session_id": "ses_same", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart", "harness_name": "opencode"}
         """
         try handleHook(input, hookName: "SessionStart", deps: makeDeps(pid: 4242, startTime: 1_000))
-        let firstCctopSessionID = try loadSession("4242.json").cctopSessionId
-        try handleHook(input, hookName: "SessionStart", deps: makeDeps(pid: 5002, startTime: 2_000))
+        let firstPath = "opencode-4242-ses_same.json"
+        let secondPath = "opencode-5002-ses_same.json"
+        let firstCctopSessionID = try loadSession(firstPath).cctopSessionId
+        try handleHook(input, hookName: "SessionStart", deps: makeDeps(pid: 5002, startTime: 1_000))
 
         XCTAssertNotEqual(
             firstCctopSessionID,
-            try loadSession("5002.json").cctopSessionId
+            try loadSession(secondPath).cctopSessionId
         )
+
+        try handleHook("""
+        {"session_id": "ses_same", "cwd": "/tmp/test-project", "hook_event_name": "SessionEnd", "harness_name": "opencode"}
+        """, hookName: "SessionEnd", deps: makeDeps(pid: 5002, startTime: 1_000))
+
+        XCTAssertNil(try loadSession(firstPath).endedAt)
+        XCTAssertNotNil(try loadSession(secondPath).endedAt)
+    }
+
+    func testOpenCodeSessionEndWithoutCurrentProcessRecordFailsClosed() throws {
+        let input = """
+        {"session_id": "ses_same", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart", "harness_name": "opencode"}
+        """
+        try handleHook(input, hookName: "SessionStart", deps: makeDeps(pid: 4242, startTime: 1_000))
+        try handleHook(input, hookName: "SessionStart", deps: makeDeps(pid: 5002, startTime: 1_000))
+
+        try handleHook("""
+        {"session_id": "ses_same", "cwd": "/tmp/test-project", "hook_event_name": "SessionEnd", "harness_name": "opencode"}
+        """, hookName: "SessionEnd", deps: makeDeps(pid: 6003, startTime: 1_000))
+
+        XCTAssertNil(try loadSession("opencode-4242-ses_same.json").endedAt)
+        XCTAssertNil(try loadSession("opencode-5002-ses_same.json").endedAt)
+    }
+
+    func testOpenCodeSessionEndDoesNotUseAnotherProcessLegacyFallback() throws {
+        var legacy = Session.mock(id: "ses_same", pid: 4242, source: Session.opencodeSource)
+        legacy.harnessSessionId = nil
+        try legacy.writeToFile(path: sessionFilePath())
+
+        try handleHook("""
+        {"session_id": "ses_same", "cwd": "/tmp/test-project", "hook_event_name": "SessionEnd", "harness_name": "opencode"}
+        """, hookName: "SessionEnd", deps: makeDeps(pid: 5002, startTime: 1_000))
+
+        XCTAssertNil(try loadSession().endedAt)
+    }
+
+    func testOpenCodeSessionEndDoesNotUseAmbiguousCurrentProcessLegacyFallback() throws {
+        var current = Session.mock(id: "ses_same", pid: 4242, source: Session.opencodeSource)
+        current.harnessSessionId = nil
+        try current.writeToFile(path: sessionFilePath("opencode-4242-ses_same.json"))
+        var other = Session.mock(id: "ses_same", pid: 5002, source: Session.opencodeSource)
+        other.harnessSessionId = nil
+        try other.writeToFile(path: sessionFilePath("opencode-5002-ses_same.json"))
+
+        try handleHook("""
+        {"session_id": "ses_same", "cwd": "/tmp/test-project", "hook_event_name": "SessionEnd", "harness_name": "opencode"}
+        """, hookName: "SessionEnd")
+
+        XCTAssertNil(try loadSession("opencode-4242-ses_same.json").endedAt)
+        XCTAssertNil(try loadSession("opencode-5002-ses_same.json").endedAt)
     }
 
     func testCodexSanitizedCollisionStillFailsClosed() throws {
@@ -843,7 +895,7 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertNil(try loadSession().disconnectedAt)
 
         try handleHook("""
-        {"session_id":"opencode-12345","cwd":"/tmp/test-project","hook_event_name":"SessionEnd","harness_name":"opencode"}
+        {"session_id":"opencode-4242","cwd":"/tmp/test-project","hook_event_name":"SessionEnd","harness_name":"opencode"}
         """, hookName: "SessionEnd", deps: deps)
 
         let session = try loadSession()
@@ -1057,7 +1109,7 @@ final class HookHandlerTests: XCTestCase {
     func testSessionIdChange_inSamePID_resetsConversationState() throws {
         try handleFixture("SessionStart-opencode")
         let first = try loadSession()
-        XCTAssertEqual(first.sessionId, "opencode-12345")
+        XCTAssertEqual(first.sessionId, "opencode-4242")
         XCTAssertEqual(first.sessionName, "Fix login bug")
         XCTAssertEqual(first.projectName, "test-project")
 
@@ -1255,6 +1307,16 @@ final class HookHandlerTests: XCTestCase {
     func testHookInputMarkedSubagentWritesHiddenSession() throws {
         try handleHook("""
         {
+          "session_id": "opencode-4242",
+          "cwd": "/tmp/p",
+          "hook_event_name": "SessionStart",
+          "harness_name": "opencode"
+        }
+        """, hookName: "SessionStart")
+        XCTAssertTrue(sessionFileExists("4242.json"))
+
+        try handleHook("""
+        {
           "session_id": "delegated-agent-session",
           "cwd": "/tmp/p",
           "hook_event_name": "SessionStart",
@@ -1263,7 +1325,8 @@ final class HookHandlerTests: XCTestCase {
         }
         """, hookName: "SessionStart")
 
-        XCTAssertTrue(try loadSession().hidden)
+        XCTAssertFalse(sessionFileExists("4242.json"))
+        XCTAssertTrue(try loadSession("opencode-4242-delegated-agent-session.json").hidden)
     }
 
     // MARK: - Project cleanup (stale-PID GC)
@@ -1286,7 +1349,7 @@ final class HookHandlerTests: XCTestCase {
             process: FakeProcessProber(alive: false), logger: HookLogger(logsDir: logsDir)
         )
 
-        XCTAssertTrue(sessionFileExists())
+        XCTAssertTrue(sessionFileExists("opencode-4242-delegated-agent-session.json"))
     }
 
     func testProjectCleanupRemovesStaleOpencodeWithLeakedCodexDesktopBundle() throws {
@@ -1309,7 +1372,7 @@ final class HookHandlerTests: XCTestCase {
             process: FakeProcessProber(alive: false), logger: HookLogger(logsDir: logsDir)
         )
 
-        XCTAssertFalse(sessionFileExists())
+        XCTAssertFalse(sessionFileExists("opencode-4242-opencode-stale.json"))
     }
 
     func testProjectCleanupRemovesSessionWhosePIDIsDead() throws {
@@ -1479,12 +1542,68 @@ final class HookHandlerTests: XCTestCase {
         ])
     }
 
+    func testOpencodeKeepsSeparateRealSessionsForSameHostPID() throws {
+        try handleHook("""
+        {"session_id":"ses_main","cwd":"/tmp/p","hook_event_name":"SessionStart","harness_name":"opencode","session_name":"Main"}
+        """, hookName: "SessionStart")
+        try handleHook("""
+        {"session_id":"ses_other","cwd":"/tmp/p","hook_event_name":"SessionStart","harness_name":"opencode","session_name":"Other"}
+        """, hookName: "SessionStart")
+
+        let main = try loadSession("opencode-4242-ses_main.json")
+        let other = try loadSession("opencode-4242-ses_other.json")
+        XCTAssertEqual(main.sessionName, "Main")
+        XCTAssertEqual(other.sessionName, "Other")
+        XCTAssertNotEqual(main.cctopSessionId, other.cctopSessionId)
+    }
+
+    func testOpencodeRealActivityPreservesIdentityAndInitializesWorkspaceFile() throws {
+        let project = NSTemporaryDirectory() + "cctop-opencode-resume-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: project, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: project) }
+        let workspace = (project as NSString).appendingPathComponent("project.code-workspace")
+        FileManager.default.createFile(atPath: workspace, contents: Data())
+
+        let prompt = """
+        {"session_id":"ses_main","cwd":\(try jsonString(project)),"hook_event_name":"UserPromptSubmit","harness_name":"opencode","prompt":"continue"}
+        """
+        try handleHook(prompt, hookName: "UserPromptSubmit")
+        let fileName = "opencode-4242-ses_main.json"
+        let first = try loadSession(fileName)
+        try handleHook(prompt, hookName: "UserPromptSubmit")
+        let updated = try loadSession(fileName)
+
+        XCTAssertEqual(updated.cctopSessionId, first.cctopSessionId)
+        XCTAssertEqual(updated.workspaceFile, workspace)
+        XCTAssertEqual(updated.lastPrompt, "continue")
+    }
+
+    func testOpencodeProjectCleanupKeepsCurrentPIDSiblingsAndRemovesDeadOldPID() throws {
+        let project = "/tmp/cctop-opencode-siblings-\(UUID().uuidString)"
+        let main = """
+        {"session_id":"ses_main","cwd":"\(project)","hook_event_name":"SessionStart","harness_name":"opencode"}
+        """
+        let other = """
+        {"session_id":"ses_other","cwd":"\(project)","hook_event_name":"SessionStart","harness_name":"opencode"}
+        """
+        try handleHook(main, hookName: "SessionStart", deps: makeDeps(pid: 4242, startTime: 1_000))
+        try handleHook(other, hookName: "SessionStart", deps: makeDeps(pid: 4242, startTime: 1_000))
+        try handleHook(main, hookName: "SessionStart", deps: makeDeps(pid: 5002, startTime: 1_000))
+
+        HookHandler.cleanupSessionsForProject(
+            sessionsDir: sessionsDir, projectPath: project, currentPid: 4242,
+            process: FakeProcessProber(alive: false), logger: HookLogger(logsDir: logsDir)
+        )
+
+        XCTAssertTrue(sessionFileExists("opencode-4242-ses_main.json"))
+        XCTAssertTrue(sessionFileExists("opencode-4242-ses_other.json"))
+        XCTAssertFalse(sessionFileExists("opencode-5002-ses_main.json"))
+    }
+
     // MARK: - Session file naming contract
 
-    /// Pins the writer-side naming rule directly: Codex files are keyed by session id
-    /// (one host PID serves many conversations), everything else by PID. The codex-
-    /// prefix must also keep matching what SessionManager.isLegacyUUIDFilename skips.
-    func testSessionFileNameKeysCodexBySessionIdAndOthersByPID() throws {
+    /// Pins multiplexed writer keys while preserving process fallbacks and PID-only clients.
+    func testSessionFileNameKeysMultiplexedHarnessesAndFallbacks() throws {
         func input(_ json: String) throws -> HookInput {
             try JSONDecoder().decode(HookInput.self, from: Data(json.utf8))
         }
@@ -1494,11 +1613,29 @@ final class HookHandlerTests: XCTestCase {
         let claude = try input("""
         {"session_id":"thread-1","cwd":"/tmp/p","hook_event_name":"SessionStart","harness_name":"cc"}
         """)
+        let opencode = try input("""
+        {"session_id":"ses_abc","cwd":"/tmp/p","hook_event_name":"SessionStart","harness_name":"opencode"}
+        """)
+        let opencodeFallback = try input("""
+        {"session_id":"opencode-4242","cwd":"/tmp/p","hook_event_name":"SessionStart","harness_name":"opencode"}
+        """)
+        let numericRealOpencode = try input("""
+        {"session_id":"opencode-12345","cwd":"/tmp/p","hook_event_name":"SessionStart","harness_name":"opencode"}
+        """)
         let legacy = try input("""
         {"session_id":"thread-1","cwd":"/tmp/p","hook_event_name":"SessionStart"}
         """)
 
         XCTAssertEqual(sessionFileName(input: codex, pid: 4242, safeSessionId: "thread-1"), "codex-thread-1.json")
+        XCTAssertEqual(
+            sessionFileName(input: opencode, pid: 4242, safeSessionId: "ses_abc"),
+            "opencode-4242-ses_abc.json"
+        )
+        XCTAssertEqual(sessionFileName(input: opencodeFallback, pid: 4242, safeSessionId: "opencode-4242"), "4242.json")
+        XCTAssertEqual(
+            sessionFileName(input: numericRealOpencode, pid: 4242, safeSessionId: "opencode-12345"),
+            "opencode-4242-opencode-12345.json"
+        )
         XCTAssertEqual(sessionFileName(input: claude, pid: 4242, safeSessionId: "thread-1"), "4242.json")
         XCTAssertEqual(sessionFileName(input: legacy, pid: 4242, safeSessionId: "thread-1"), "4242.json")
     }

--- a/menubar/CctopMenubarTests/HookInputTests.swift
+++ b/menubar/CctopMenubarTests/HookInputTests.swift
@@ -152,7 +152,7 @@ final class HookInputTests: XCTestCase {
 
     func testDecodeSessionStartOpencode() throws {
         let input = try JSONDecoder().decode(HookInput.self, from: loadFixture("SessionStart-opencode"))
-        XCTAssertEqual(input.sessionId, "opencode-12345")
+        XCTAssertEqual(input.sessionId, "opencode-4242")
         XCTAssertEqual(input.hookEventName, "SessionStart")
         XCTAssertEqual(input.source, "opencode")
         XCTAssertEqual(input.harnessName, "opencode")

--- a/menubar/CctopMenubarTests/SessionDedupTests.swift
+++ b/menubar/CctopMenubarTests/SessionDedupTests.swift
@@ -149,6 +149,29 @@ final class SessionDedupTests: XCTestCase {
         XCTAssertEqual(result.compactMap(\.pid).sorted(), [100, 200])
     }
 
+    func testDedupOpencodeKeepsSamePIDConversationsAndCrossPIDObservationsSeparate() {
+        let main = candidate(
+            sessionId: "ses-main", pid: 100, bundleId: nil, lifecycleRank: 0,
+            source: Session.opencodeSource, path: "/opencode-100-ses-main.json"
+        )
+        let other = candidate(
+            sessionId: "ses-other", pid: 100, bundleId: nil, lifecycleRank: 0,
+            source: Session.opencodeSource, path: "/opencode-100-ses-other.json"
+        )
+        let resumedElsewhere = candidate(
+            sessionId: "ses-main", pid: 200, bundleId: nil, lifecycleRank: 0,
+            source: Session.opencodeSource, path: "/opencode-200-ses-main.json"
+        )
+
+        let result = deduped([main, other, resumedElsewhere])
+
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(
+            Set(result.map { "\($0.pid ?? 0):\($0.sessionId)" }),
+            ["100:ses-main", "100:ses-other", "200:ses-main"]
+        )
+    }
+
     func testDedupMigratedCodexSessionUsesStableConversationIdAcrossHostClass() {
         let oldPidKeyed = candidate(
             sessionId: "conv-a", pid: 100, bundleId: nil, lifecycleRank: 2,

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -9,6 +9,8 @@ final class SessionFileFormatTests: XCTestCase {
         XCTAssertFalse(SessionManager.isLegacyUUIDFilename("31349"))
         // Codex per-conversation files -> keep.
         XCTAssertFalse(SessionManager.isLegacyUUIDFilename("codex-019e4b0c-9473-7a33-a4b9-749fd2c83a9e"))
+        // OpenCode process-and-conversation files -> keep.
+        XCTAssertFalse(SessionManager.isLegacyUUIDFilename("opencode-31349-ses_main"))
     }
 
     @MainActor

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -2263,7 +2263,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         defer { try? FileManager.default.removeItem(atPath: root) }
 
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("4242.json")
-        var legacy = Session.mock(id: "legacy", pid: 4242, source: Session.opencodeSource)
+        var legacy = Session.mock(id: "opencode-4242", pid: 4242, source: Session.opencodeSource)
         legacy.cctopSessionId = nil
         try legacy.writeToFile(path: sessionPath)
 
@@ -2286,7 +2286,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         terminateProcess(lockHolder)
         let hookInput = try JSONDecoder().decode(HookInput.self, from: Data("""
-        {"session_id":"legacy","cwd":"/tmp/project","hook_event_name":"PreToolUse","harness_name":"opencode"}
+        {"session_id":"opencode-4242","cwd":"/tmp/project","hook_event_name":"PreToolUse","harness_name":"opencode"}
         """.utf8))
         let hookDeps = HookDependencies(
             sessionsDir: { sessionsDir },

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -2444,9 +2444,9 @@ final class SessionTests: XCTestCase {
     }
 
     func testLogicalFocusResolverKeepsLegacyFallbackUniqueAndFailsClosedWhenAmbiguous() {
-        var first = Session.mock(id: "first", pid: 111, source: Session.opencodeSource)
+        var first = Session.mock(id: "first", pid: 111, source: Session.ccSource)
         first.cctopSessionId = nil
-        var duplicate = Session.mock(id: "duplicate", pid: 111, source: Session.opencodeSource)
+        var duplicate = Session.mock(id: "duplicate", pid: 111, source: Session.ccSource)
         duplicate.cctopSessionId = nil
         let identity = SessionIdentityPolicy.logicalIdentity(for: first)
 

--- a/plugins/opencode/plugin.js
+++ b/plugins/opencode/plugin.js
@@ -80,19 +80,38 @@ export const cctop = async ({ directory }) => {
   const hookBin = findHookBinary();
   if (!hookBin) return {};
 
-  // Keep one process-scoped identity until every callback can route its own opencode
-  // session payload safely. Adopting only session.created/updated would let child and
-  // background events mutate whichever conversation happened to be current in memory.
-  const sessionId = `opencode-${process.pid}`;
-  let sessionName = null;
+  const fallbackSessionId = `opencode-${process.pid}`;
+  const sessionNames = new Map();
+  const childSessionIds = new Set();
 
-  function basePayload() {
+  function normalizeSessionId(value) {
+    return typeof value === "string" && value.trim() ? value.trim() : null;
+  }
+
+  function rememberSessionInfo(info, fallbackId = null) {
+    const id = normalizeSessionId(info?.id) || fallbackId;
+    const title = typeof info?.title === "string" ? info.title.trim() : "";
+    if (!id) return null;
+
+    if (title) sessionNames.set(id, title);
+    if (normalizeSessionId(info?.parentID)) childSessionIds.add(id);
+    return id;
+  }
+
+  function sessionIdFromEvent(event) {
+    const explicitId = normalizeSessionId(event?.properties?.sessionID);
+    return rememberSessionInfo(event?.properties?.info, explicitId) || explicitId;
+  }
+
+  function basePayload(sessionId = fallbackSessionId) {
+    const sessionName = sessionNames.get(sessionId);
     return {
       session_id: sessionId,
       cwd: directory,
       harness_name: "opencode",
       source: "opencode",  // MIGRATION(harness_name): Keep for older cctop-hook binaries
       ...(sessionName && { session_name: sessionName }),
+      ...(childSessionIds.has(sessionId) && { is_subagent: true }),
     };
   }
 
@@ -106,28 +125,29 @@ export const cctop = async ({ directory }) => {
       switch (event.type) {
         case "question.asked":
           callHook(hookBin, "PermissionRequest", {
-            ...basePayload(),
+            ...basePayload(sessionIdFromEvent(event) || undefined),
             title: questionMessage(event.properties),
           });
           break;
 
         case "question.replied":
         case "question.rejected":
-          callHook(hookBin, "PostToolUse", basePayload());
+          callHook(hookBin, "PostToolUse", basePayload(sessionIdFromEvent(event) || undefined));
           break;
 
         case "session.created":
-          callHook(hookBin, "SessionStart", basePayload());
+          callHook(hookBin, "SessionStart", basePayload(sessionIdFromEvent(event) || undefined));
           break;
 
         case "session.idle":
-          callHook(hookBin, "Stop", basePayload());
+          callHook(hookBin, "Stop", basePayload(sessionIdFromEvent(event) || undefined));
           break;
 
         case "session.error": {
-          const errMsg = event.error?.message || event.message || null;
+          const error = event.properties?.error || event.error;
+          const errMsg = error?.message || event.message || null;
           callHook(hookBin, "SessionError", {
-            ...basePayload(),
+            ...basePayload(sessionIdFromEvent(event) || undefined),
             ...(errMsg && { error: errMsg }),
             ...(event.message && { message: event.message }),
           });
@@ -141,7 +161,7 @@ export const cctop = async ({ directory }) => {
             event.status?.type;
           if (type === "retry") {
             callHook(hookBin, "SessionError", {
-              ...basePayload(),
+              ...basePayload(sessionIdFromEvent(event) || undefined),
               error: "Retry",
             });
           }
@@ -151,60 +171,68 @@ export const cctop = async ({ directory }) => {
         }
 
         case "session.updated": {
-          const title = event.properties?.info?.title;
-          if (title) sessionName = title;
+          rememberSessionInfo(event.properties?.info);
           break;
         }
 
         case "session.compacted":
-          callHook(hookBin, "PostCompact", basePayload());
+          callHook(hookBin, "PostCompact", basePayload(sessionIdFromEvent(event) || undefined));
           break;
 
-        case "session.deleted":
+        case "session.deleted": {
+          const sessionId = sessionIdFromEvent(event);
+          if (sessionId) {
+            callHook(hookBin, "SessionEnd", basePayload(sessionId));
+            sessionNames.delete(sessionId);
+            childSessionIds.delete(sessionId);
+          }
+          break;
+        }
+
         case "permission.replied":
-          // skip — liveness handles deletion, PreToolUse follows permission
+          // skip — PreToolUse follows permission
           break;
       }
     },
 
-    "chat.message": async (_input, output) => {
+    "chat.message": async (input, output) => {
       const prompt =
         output?.message?.content ||
         output?.content ||
         (typeof output?.text === "string" ? output.text : null);
       callHook(hookBin, "UserPromptSubmit", {
-        ...basePayload(),
+        ...basePayload(normalizeSessionId(input?.sessionID) || undefined),
         ...(prompt && { prompt }),
       });
     },
 
-    "tool.execute.before": async (_input, output) => {
-      const tool = normalizeTool(output?.tool || _input?.tool);
-      const args = output?.args || _input?.args;
+    "tool.execute.before": async (input, output) => {
+      const tool = normalizeTool(output?.tool || input?.tool);
+      const args = output?.args || input?.args;
       callHook(hookBin, "PreToolUse", {
-        ...basePayload(),
+        ...basePayload(normalizeSessionId(input?.sessionID) || undefined),
         ...(tool && { tool_name: tool }),
         ...(args && { tool_input: normalizeToolInput(args) }),
       });
     },
 
-    "tool.execute.after": async () => {
-      callHook(hookBin, "PostToolUse", basePayload());
+    "tool.execute.after": async (input) => {
+      callHook(hookBin, "PostToolUse", basePayload(normalizeSessionId(input?.sessionID) || undefined));
     },
 
     "permission.ask": async (input) => {
       const tool = normalizeTool(input?.tool);
       const args = input?.args;
       callHook(hookBin, "PermissionRequest", {
-        ...basePayload(),
+        ...basePayload(normalizeSessionId(input?.sessionID) || undefined),
         ...(tool && { tool_name: tool }),
         ...(input?.title && { title: input.title }),
         ...(args && { tool_input: normalizeToolInput(args) }),
       });
     },
 
-    "experimental.session.compacting": async () => {
-      callHook(hookBin, "PreCompact", basePayload());
+    "experimental.session.compacting": async (input) => {
+      callHook(hookBin, "PreCompact", basePayload(normalizeSessionId(input?.sessionID) || undefined));
     },
   };
 };

--- a/plugins/opencode/test/plugin.test.mjs
+++ b/plugins/opencode/test/plugin.test.mjs
@@ -127,66 +127,110 @@ test("maps opencode plugin callbacks to cctop prompt and tool hooks", async () =
   }
 });
 
+test("routes every callback-provided opencode session id", async () => {
+  const plugin = await loadPlugin();
+
+  try {
+    await plugin.hooks["chat.message"]({ sessionID: "ses_chat" }, { text: "hello" });
+    await plugin.hooks["tool.execute.before"]({ sessionID: "ses_before", tool: "read" }, {});
+    await plugin.hooks["tool.execute.after"]({ sessionID: "ses_after" });
+    await plugin.hooks["permission.ask"]({ sessionID: "ses_permission", tool: "bash" });
+    await plugin.hooks["experimental.session.compacting"]({ sessionID: "ses_compact" });
+
+    assert.deepEqual(
+      plugin.readCalls().slice(1).map((call) => call.payload.session_id),
+      ["ses_chat", "ses_before", "ses_after", "ses_permission", "ses_compact"],
+    );
+  } finally {
+    plugin.restore();
+  }
+});
+
 test("maps opencode session events to cctop lifecycle hooks", async () => {
   const plugin = await loadPlugin();
 
   try {
     await plugin.hooks.event({
-      event: { type: "session.updated", properties: { info: { title: "opencode session" } } },
+      event: { type: "session.updated", properties: { info: { id: "ses_top", title: "opencode session" } } },
     });
     await plugin.hooks.event({
       event: { type: "session.created", properties: { info: { id: "ses_top" } } },
     });
-    await plugin.hooks.event({ event: { type: "session.idle" } });
-    await plugin.hooks.event({ event: { type: "session.compacted" } });
-    await plugin.hooks.event({ event: { type: "session.status", properties: { status: { type: "retry" } } } });
-    await plugin.hooks.event({ event: { type: "session.status", properties: { status: { type: "busy" } } } });
-    await plugin.hooks.event({ event: { type: "session.error", error: { message: "boom" } } });
-    await plugin.hooks.event({ event: { type: "session.deleted" } });
+    await plugin.hooks.event({ event: { type: "session.idle", properties: { sessionID: "ses_top" } } });
+    await plugin.hooks.event({ event: { type: "session.compacted", properties: { sessionID: "ses_top" } } });
+    await plugin.hooks.event({
+      event: { type: "session.status", properties: { sessionID: "ses_top", status: { type: "retry" } } },
+    });
+    await plugin.hooks.event({
+      event: { type: "session.status", properties: { sessionID: "ses_top", status: { type: "busy" } } },
+    });
+    await plugin.hooks.event({
+      event: { type: "session.error", properties: { sessionID: "ses_top", error: { message: "boom" } } },
+    });
+    await plugin.hooks.event({
+      event: { type: "session.deleted", properties: { info: { id: "ses_top", title: "opencode session" } } },
+    });
     await plugin.hooks.event({ event: { type: "permission.replied" } });
 
     const calls = plugin.readCalls();
 
     assert.deepEqual(
       eventNames(calls),
-      ["SessionStart", "SessionStart", "Stop", "PostCompact", "SessionError", "SessionError"],
+      ["SessionStart", "SessionStart", "Stop", "PostCompact", "SessionError", "SessionError", "SessionEnd"],
     );
     assert.equal(calls[1].payload.session_name, "opencode session");
-    assert.equal(calls[1].payload.session_id, `opencode-${process.pid}`);
+    assert.equal(calls[1].payload.session_id, "ses_top");
     assert.equal(calls[4].payload.error, "Retry");
     assert.equal(calls[5].payload.error, "boom");
+    assert.equal(calls[6].payload.session_id, "ses_top");
   } finally {
     plugin.restore();
   }
 });
 
-test("keeps process identity when session events carry conversation ids", async () => {
+test("keeps concurrent opencode identities, titles, and child ownership separate", async () => {
   const plugin = await loadPlugin();
 
   try {
     await plugin.hooks.event({
-      event: { type: "session.created", properties: { info: { id: "ses_top", title: "top work" } } },
+      event: { type: "session.created", properties: { info: { id: "ses_top", title: "Top work" } } },
     });
     await plugin.hooks.event({
-      event: { type: "session.created", properties: { info: { id: "ses_child", parentID: "ses_top" } } },
+      event: {
+        type: "session.created",
+        properties: { info: { id: "ses_child", parentID: "ses_top", title: "Child work" } },
+      },
     });
     await plugin.hooks.event({
-      event: { type: "session.updated", properties: { info: { id: "ses_child", parentID: "ses_top", title: "child" } } },
+      event: { type: "session.updated", properties: { info: { id: "ses_top", title: "Top work renamed" } } },
     });
-    await plugin.hooks["tool.execute.after"]();
+    await plugin.hooks["tool.execute.before"](
+      { tool: "bash", sessionID: "ses_top" },
+      { args: { command: "make test" } },
+    );
     await plugin.hooks.event({
-      event: { type: "session.updated", properties: { info: { id: "ses_resumed", title: "older work" } } },
+      event: { type: "session.idle", properties: { sessionID: "ses_child" } },
     });
-    await plugin.hooks["tool.execute.after"]();
+    await plugin.hooks["tool.execute.after"]({ sessionID: "ses_top" });
 
     const calls = plugin.readCalls();
     assert.deepEqual(
-      eventNames(calls),
-      ["SessionStart", "SessionStart", "SessionStart", "PostToolUse", "PostToolUse"],
+      calls.slice(1).map((call) => [
+        call.eventName,
+        call.payload.session_id,
+        call.payload.session_name,
+        call.payload.is_subagent,
+      ]),
+      [
+        ["SessionStart", "ses_top", "Top work", undefined],
+        ["SessionStart", "ses_child", "Child work", true],
+        ["PreToolUse", "ses_top", "Top work renamed", undefined],
+        ["Stop", "ses_child", "Child work", true],
+        ["PostToolUse", "ses_top", "Top work renamed", undefined],
+      ],
     );
-    for (const call of calls) {
-      assert.equal(call.payload.session_id, `opencode-${process.pid}`);
-    }
+    assert.equal(calls[3].payload.tool_name, "Bash");
+    assert.deepEqual(calls[3].payload.tool_input, { command: "make test" });
   } finally {
     plugin.restore();
   }
@@ -200,6 +244,7 @@ test("maps opencode question events to cctop permission wait hooks", async () =>
       event: {
         type: "question.asked",
         properties: {
+          sessionID: "ses_question",
           questions: [
             {
               header: "Direction",
@@ -232,10 +277,12 @@ test("maps opencode question events to cctop permission wait hooks", async () =>
     );
 
     assert.equal(calls[1].payload.title, "Which direction should I take?");
+    assert.equal(calls[1].payload.session_id, "ses_question");
     assert.equal(calls[1].payload.harness_name, "opencode");
     assert.equal(calls[1].payload.source, "opencode");
     assert.equal(calls[1].payload.notification_type, undefined);
     assert.equal(calls[2].payload.title, "Fallback");
+    assert.equal(calls[2].payload.session_id, `opencode-${process.pid}`);
     assert.equal(calls[3].payload.notification_type, undefined);
     assert.equal(calls[4].payload.notification_type, undefined);
   } finally {


### PR DESCRIPTION
## Problem

opencode can emit events for multiple conversations from one host process. A single process-derived session id therefore collapses concurrent conversations into one cctop record, allowing their titles and lifecycle state to overwrite each other. Child sessions also need to remain classified as internal across every later callback rather than briefly appearing as normal user sessions.

## Solution

- Route opencode callbacks and lifecycle events by their conversation id, writing real conversations as process-qualified `opencode-<pid>-<session-id>.json` records. The exact `opencode-<pid>` fallback remains PID-keyed only for plugin-load and older/no-id events.
- Keep opencode's pre-identity record-local to `(process, conversation)` while the permanent `cctop_session_id` remains the canonical display and focus identity. Reusing an opencode id in a later process does not join the records.
- Remove a same-process/project fallback record after real conversation activity begins, and fail closed when real and legacy filenames or session-end targets are ambiguous.
- Preserve `parentID` child ownership across later callbacks so delegated/internal conversations stay hidden from normal user-openable rows.
- Align the hook contract, fixtures, lifecycle documentation, and regression coverage with the permanent-session-identity architecture.
