### PR TITLE
Suppress Codex machine-only notifications

### DIFF
--- a/menubar/CctopMenubar/Hook/HookDependencies.swift
+++ b/menubar/CctopMenubar/Hook/HookDependencies.swift
@@ -107,3 +107,35 @@ func withSessionLock(
     defer { flock(fd, LOCK_UN) }
     try body()
 }
+
+/// Try to acquire the per-session lock without waiting. Returns `false` when another
+/// process currently owns the lock, so UI-side maintenance can skip this pass instead
+/// of blocking the main actor behind a hook process.
+@discardableResult
+func withSessionLockIfAvailable(
+    sessionPath: String,
+    onError: (String) -> Void = { HookLogger().logError($0) },
+    body: () throws -> Void
+) throws -> Bool {
+    let lockPath = sessionPath + ".lock"
+    let fd = open(lockPath, O_CREAT | O_WRONLY, 0o600)
+    guard fd >= 0 else {
+        let err = errno
+        onError("withSessionLockIfAvailable: open(\(lockPath)) failed: \(err)")
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(err),
+                      userInfo: [NSLocalizedDescriptionKey: "Failed to open lock file: \(lockPath)"])
+    }
+    defer { close(fd) }
+    guard flock(fd, LOCK_EX | LOCK_NB) == 0 else {
+        let err = errno
+        if err == EWOULDBLOCK || err == EAGAIN {
+            return false
+        }
+        onError("withSessionLockIfAvailable: flock(\(lockPath)) failed: \(err)")
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(err),
+                      userInfo: [NSLocalizedDescriptionKey: "Failed to acquire lock: \(lockPath)"])
+    }
+    defer { flock(fd, LOCK_UN) }
+    try body()
+    return true
+}

--- a/menubar/CctopMenubar/Hook/HookLogger.swift
+++ b/menubar/CctopMenubar/Hook/HookLogger.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 /// Writes per-session hook logs and the error log under `logsDir`
@@ -66,12 +67,24 @@ struct HookLogger {
             attributes: [.posixPermissions: 0o700]
         )
 
-        if let handle = FileHandle(forWritingAtPath: path) {
-            handle.seekToEndOfFile()
-            handle.write(Data(line.utf8))
-            handle.closeFile()
-        } else {
-            fm.createFile(atPath: path, contents: Data(line.utf8), attributes: [.posixPermissions: 0o600])
+        let fd = open(path, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC | O_NONBLOCK, 0o600)
+        guard fd >= 0 else { return }
+        defer { close(fd) }
+
+        let data = Data(line.utf8)
+        data.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+            var offset = 0
+            while offset < buffer.count {
+                let written = write(fd, baseAddress.advanced(by: offset), buffer.count - offset)
+                if written > 0 {
+                    offset += written
+                } else if written == -1 && errno == EINTR {
+                    continue
+                } else {
+                    return
+                }
+            }
         }
     }
 }

--- a/menubar/CctopMenubar/Models/Session+NotificationContent.swift
+++ b/menubar/CctopMenubar/Models/Session+NotificationContent.swift
@@ -187,7 +187,11 @@ extension Session {
     }
 
     private static func isCodexScaffoldText(_ text: String) -> Bool {
-        let lowercased = text.lowercased()
+        isCodexScaffoldHeadingLine(text)
+    }
+
+    private static func isCodexScaffoldHeadingLine(_ line: String) -> Bool {
+        let lowercased = line.lowercased()
         let prefixes = [
             "# in app browser:",
             "# in browser:",
@@ -212,7 +216,8 @@ extension Session {
             ? String(line.dropFirst(2)).trimmingCharacters(in: .whitespacesAndNewlines)
             : line
         let lowercased = content.lowercased()
-        return content.hasPrefix("/")
+        return isCodexScaffoldHeadingLine(content)
+            || content.hasPrefix("/")
             || content.hasPrefix("~/")
             || lowercased.hasPrefix("file://")
             || lowercased.hasPrefix("http://")

--- a/menubar/CctopMenubar/Models/Session+NotificationContent.swift
+++ b/menubar/CctopMenubar/Models/Session+NotificationContent.swift
@@ -9,6 +9,14 @@ struct SessionNotificationContent: Equatable {
 extension Session {
     private static let notificationBodyLimit = 72
 
+    var shouldPostAttentionNotification: Bool {
+        guard status.needsAttention else { return false }
+        guard usesCodexPromptFallbackPolicy, status == .waitingInput else { return true }
+        guard Self.cleanOptionalNotificationBodyText(notificationMessage) == nil else { return true }
+        guard let lastPrompt else { return true }
+        return Self.userFacingCodexPromptFallbackText(from: lastPrompt) != nil
+    }
+
     var notificationContent: SessionNotificationContent {
         let sender = notificationSenderName
         return SessionNotificationContent(
@@ -71,7 +79,10 @@ extension Session {
             detail = Self.cleanOptionalNotificationBodyText(notificationMessage) ?? "Permission needed"
         case .waitingInput:
             detail = Self.cleanOptionalNotificationBodyText(notificationMessage)
-                ?? Self.cleanOptionalNotificationBodyText(lastPrompt)
+                ?? Self.cleanOptionalPromptFallbackText(
+                    lastPrompt,
+                    usesCodexPromptFallbackPolicy: usesCodexPromptFallbackPolicy
+                )
                 ?? "Waiting for input"
         default:
             detail = Self.cleanOptionalNotificationBodyText(notificationMessage) ?? "Needs attention"
@@ -83,6 +94,12 @@ extension Session {
         let title = title.lowercased()
         let project = project.lowercased()
         return title == project || title.hasPrefix("[\(project)] ")
+    }
+
+    private var usesCodexPromptFallbackPolicy: Bool {
+        source == Self.codexSource
+            || (terminal?.bundleId == HostAppBundleID.codexDesktop
+                && Self.trustsDesktopBundle(source: source, bundleId: terminal?.bundleId))
     }
 
     private static func cleanOptionalNotificationTitleText(_ text: String?) -> String? {
@@ -97,6 +114,24 @@ extension Session {
         return cleaned.isEmpty ? nil : cleaned
     }
 
+    private static func cleanOptionalPromptFallbackText(
+        _ text: String?,
+        usesCodexPromptFallbackPolicy: Bool
+    ) -> String? {
+        guard let text else { return nil }
+        let userFacingText: String?
+        if usesCodexPromptFallbackPolicy {
+            userFacingText = userFacingCodexPromptFallbackText(from: text)
+        } else {
+            userFacingText = text
+        }
+        guard let userFacingText else {
+            return nil
+        }
+        let cleaned = cleanNotificationBodyText(userFacingText)
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
     private static func cleanNotificationTitleText(_ text: String) -> String {
         cleanNotificationBodyText(text)
             .replacingOccurrences(of: "CCTOP", with: "cctop")
@@ -106,6 +141,86 @@ extension Session {
         text.components(separatedBy: .whitespacesAndNewlines)
             .filter { !$0.isEmpty }
             .joined(separator: " ")
+    }
+
+    private static func userFacingCodexPromptFallbackText(from text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if isMachineWrapperText(trimmed) {
+            return nil
+        }
+        if let userRequest = extractCodexUserRequestFromScaffold(trimmed) {
+            return userRequest
+        }
+        if isMachineOnlyCodexScaffoldText(trimmed) {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func extractCodexUserRequestFromScaffold(_ text: String) -> String? {
+        guard isCodexScaffoldText(text),
+              let marker = text.range(of: "## My request for Codex:") else {
+            return nil
+        }
+        let request = String(text[marker.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !request.isEmpty, !isMachineWrapperText(request) else {
+            return nil
+        }
+        return request
+    }
+
+    private static func isMachineWrapperText(_ text: String) -> Bool {
+        let lowercased = text.lowercased()
+        let prefixes = [
+            "<codex_delegation",
+            "&lt;codex_delegation",
+            "<heartbeat",
+            "&lt;heartbeat",
+            "<environment_context",
+            "&lt;environment_context",
+            "<skill",
+            "&lt;skill"
+        ]
+        return prefixes.contains { lowercased.hasPrefix($0) }
+    }
+
+    private static func isCodexScaffoldText(_ text: String) -> Bool {
+        let lowercased = text.lowercased()
+        let prefixes = [
+            "# in app browser:",
+            "# in browser:",
+            "# open files:",
+            "# files:"
+        ]
+        return prefixes.contains { lowercased.hasPrefix($0) }
+    }
+
+    private static func isMachineOnlyCodexScaffoldText(_ text: String) -> Bool {
+        guard isCodexScaffoldText(text) else { return false }
+        let lines = text.components(separatedBy: .newlines)
+            .dropFirst()
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !lines.isEmpty else { return false }
+        return lines.allSatisfy(isGeneratedCodexScaffoldContextLine)
+    }
+
+    private static func isGeneratedCodexScaffoldContextLine(_ line: String) -> Bool {
+        let content = line.hasPrefix("- ")
+            ? String(line.dropFirst(2)).trimmingCharacters(in: .whitespacesAndNewlines)
+            : line
+        let lowercased = content.lowercased()
+        return content.hasPrefix("/")
+            || content.hasPrefix("~/")
+            || lowercased.hasPrefix("file://")
+            || lowercased.hasPrefix("http://")
+            || lowercased.hasPrefix("https://")
+            || lowercased.hasPrefix("current url:")
+            || lowercased.hasPrefix("page:")
+            || lowercased.hasPrefix("url:")
+            || lowercased.hasPrefix("the user has ")
     }
 
     private static func truncateNotificationBody(_ text: String) -> String {

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -492,24 +492,21 @@ extension SessionManager {
 
     func hideCodexSubagentSessions(_ candidates: [DedupCandidate]) {
         for candidate in candidates {
-            sessionManagerLogger.info(
-                "hiding Codex subagent session \(candidate.session.sessionId, privacy: .public)"
-            )
-            do {
-                try withSessionLock(sessionPath: candidate.path) {
-                    guard let hiddenSession = try Self.codexSubagentHiddenSessionSnapshot(
-                        path: candidate.path,
-                        codexThreads: dataSources.codexThreads
-                    ) else {
-                        return
-                    }
-                    try hiddenSession.writeToFile(path: candidate.path)
+            withSessionLockForMaintenance(
+                sessionPath: candidate.path,
+                sessionId: candidate.session.sessionId,
+                action: "Codex subagent hide"
+            ) {
+                guard let hiddenSession = try Self.codexSubagentHiddenSessionSnapshot(
+                    path: candidate.path,
+                    codexThreads: dataSources.codexThreads
+                ) else {
+                    return
                 }
-            } catch {
-                let sessionId = candidate.session.sessionId
-                sessionManagerLogger.warning(
-                    "skipping Codex subagent hide for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                sessionManagerLogger.info(
+                    "hiding Codex subagent session \(candidate.session.sessionId, privacy: .public)"
                 )
+                try hiddenSession.writeToFile(path: candidate.path)
             }
         }
     }

--- a/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
@@ -56,19 +56,19 @@ extension SessionManager {
         )
 
         var actions: [SessionNotificationAction] = []
-        for (key, oldSession) in oldByStableKey where oldSession.status.needsAttention {
+        for (key, oldSession) in oldByStableKey where oldSession.shouldPostAttentionNotification {
             guard let newSession = newByStableKey[key],
                   newSession.lifecycle == .active,
-                  newSession.status.needsAttention else {
+                  newSession.shouldPostAttentionNotification else {
                 actions.append(.remove(identifier: SessionIdentityPolicy.notificationRequestIdentifier(for: oldSession)))
                 continue
             }
         }
 
         guard notificationsEnabled else { return actions }
-        for (key, newSession) in newByStableKey where newSession.lifecycle == .active && newSession.status.needsAttention {
+        for (key, newSession) in newByStableKey where newSession.lifecycle == .active && newSession.shouldPostAttentionNotification {
             guard let oldSession = oldByStableKey[key],
-                  !oldSession.status.needsAttention else { continue }
+                  !oldSession.shouldPostAttentionNotification else { continue }
             actions.append(.post(session: newSession))
         }
         return actions

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -130,6 +130,30 @@ class SessionManager: ObservableObject {
         }
     }
 
+    func withSessionLockForMaintenance(
+        sessionPath: String,
+        sessionId: String,
+        action: String,
+        body: () throws -> Void
+    ) {
+        do {
+            let didAcquire = try withSessionLockIfAvailable(
+                sessionPath: sessionPath,
+                onError: { sessionManagerLogger.warning("\($0, privacy: .public)") },
+                body: body
+            )
+            if !didAcquire {
+                sessionManagerLogger.info(
+                    "skipping \(action, privacy: .public) for \(sessionId, privacy: .public): session lock is busy"
+                )
+            }
+        } catch {
+            sessionManagerLogger.warning(
+                "skipping \(action, privacy: .public) for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
     func cleanupSnapshotForRemoval() -> WorktreeCleanupSessionSnapshot {
         loadSessions()
         return WorktreeCleanupSessionSnapshot(
@@ -140,18 +164,12 @@ class SessionManager: ObservableObject {
 
     private func hideAutoHiddenSessions(_ sessions: [(URL, Session)]) {
         for (url, session) in sessions {
-            sessionManagerLogger.info(
-                "hiding \(self.autoHideReason(for: session), privacy: .public) session \(session.sessionId, privacy: .public)"
-            )
-            do {
-                try withSessionLock(sessionPath: url.path) {
-                    guard let hiddenSession = try Self.autoHiddenSessionSnapshot(path: url.path) else { return }
-                    try hiddenSession.writeToFile(path: url.path)
-                }
-            } catch {
-                sessionManagerLogger.warning(
-                    "skipping auto-hide update for \(session.sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            withSessionLockForMaintenance(sessionPath: url.path, sessionId: session.sessionId, action: "auto-hide update") {
+                guard let hiddenSession = try Self.autoHiddenSessionSnapshot(path: url.path) else { return }
+                sessionManagerLogger.info(
+                    "hiding \(self.autoHideReason(for: session), privacy: .public) session \(session.sessionId, privacy: .public)"
                 )
+                try hiddenSession.writeToFile(path: url.path)
             }
         }
     }
@@ -198,7 +216,11 @@ class SessionManager: ObservableObject {
             guard candidate.session.hostClass == .desktop,
                   candidate.session.lifecycle == .active,
                   candidate.session.disconnectedAt != nil else { continue }
-            try? withSessionLock(sessionPath: candidate.path) {
+            withSessionLockForMaintenance(
+                sessionPath: candidate.path,
+                sessionId: candidate.session.sessionId,
+                action: "desktop reconnect update"
+            ) {
                 guard var session = try? Session.fromFile(path: candidate.path),
                       session.hostClass == .desktop,
                       session.disconnectedAt != nil else {
@@ -224,7 +246,11 @@ class SessionManager: ObservableObject {
             guard candidate.session.hostClass == .desktop,
                   candidate.session.lifecycle == .dormant,
                   candidate.session.disconnectedAt == nil else { continue }
-            try? withSessionLock(sessionPath: candidate.path) {
+            withSessionLockForMaintenance(
+                sessionPath: candidate.path,
+                sessionId: candidate.session.sessionId,
+                action: "desktop disconnect update"
+            ) {
                 guard var session = try? Session.fromFile(path: candidate.path),
                       session.hostClass == .desktop,
                       session.disconnectedAt == nil else {
@@ -260,7 +286,11 @@ class SessionManager: ObservableObject {
                 try? fm.removeItem(at: url)   // pre-PID legacy file; no live writer to race
                 continue
             }
-            try? withSessionLock(sessionPath: url.path) {
+            withSessionLockForMaintenance(
+                sessionPath: url.path,
+                sessionId: url.deletingPathExtension().lastPathComponent,
+                action: "desktop GC"
+            ) {
                 guard let data = try? Data(contentsOf: url),
                       let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data) else {
                     return   // decode failure → never treat as finished

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -394,6 +394,46 @@ final class SessionManagerVisibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testGarbageCollectSkipsBusySessionLockWithoutBlockingMainActor() throws {
+        let root = NSTemporaryDirectory() + "cctop-gc-busy-lock-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let old = Date(timeIntervalSinceNow: -SessionManager.lifecycleWindows.retention - 86_400)
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-busy-finished-thread.json")
+        var session = codexDesktopSession(sessionId: "busy-finished-thread", projectPath: "/tmp/p")
+        session.lastActivity = old
+        session.disconnectedAt = old
+        try session.writeToFile(path: sessionPath)
+
+        let readyPath = (root as NSString).appendingPathComponent("lock-ready")
+        let lockHolder = try startSessionLockHolder(lockPath: sessionPath + ".lock", readyPath: readyPath, holdSeconds: 1.5)
+        defer { terminateProcess(lockHolder) }
+
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
+        sources.codexThreads = StubCodexThreadState(existing: ["busy-finished-thread"], archived: [])
+        sources.claudeDesktopSessions = StubClaudeDesktopState(snapshot: ClaudeDesktopSessionMetadataSnapshot())
+        sources.desktopAppConnection = DesktopAppConnectionLookup { _ in false }
+        sources.processAlive = { _ in false }
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        let start = Date()
+        manager.garbageCollectFinished()
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertLessThan(elapsed, 0.75)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
+    }
+
+    @MainActor
     func testSessionManagerHidesGenericSubagentSessionFilesWithoutArchivingOrRemovingThem() throws {
         let root = NSTemporaryDirectory() + "cctop-generic-subagent-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")
@@ -1327,6 +1367,55 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.garbageCollectFinished()
         XCTAssertFalse(FileManager.default.fileExists(atPath: sessionPath))
     }
+}
+
+private func startSessionLockHolder(lockPath: String, readyPath: String, holdSeconds: TimeInterval) throws -> Process {
+    let script = """
+    import fcntl
+    import pathlib
+    import sys
+    import time
+
+    lock_path, ready_path, hold_seconds = sys.argv[1], sys.argv[2], float(sys.argv[3])
+    with open(lock_path, "a") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        pathlib.Path(ready_path).write_text("ready")
+        time.sleep(hold_seconds)
+    """
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+    process.arguments = ["-c", script, lockPath, readyPath, String(holdSeconds)]
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    try process.run()
+    try waitForFile(path: readyPath, process: process)
+    return process
+}
+
+private func waitForFile(path: String, process: Process, timeout: TimeInterval = 2) throws {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if FileManager.default.fileExists(atPath: path) { return }
+        if !process.isRunning {
+            throw NSError(
+                domain: "CctopMenubarTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "lock holder exited before acquiring the lock"]
+            )
+        }
+        Thread.sleep(forTimeInterval: 0.02)
+    }
+    throw NSError(
+        domain: "CctopMenubarTests",
+        code: 2,
+        userInfo: [NSLocalizedDescriptionKey: "timed out waiting for lock holder"]
+    )
+}
+
+private func terminateProcess(_ process: Process) {
+    guard process.isRunning else { return }
+    process.terminate()
+    process.waitUntilExit()
 }
 
 private final class CountingClaudeDesktopState: ClaudeDesktopSessionStateProviding {

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -1392,7 +1392,7 @@ private func startSessionLockHolder(lockPath: String, readyPath: String, holdSec
     return process
 }
 
-private func waitForFile(path: String, process: Process, timeout: TimeInterval = 2) throws {
+private func waitForFile(path: String, process: Process, timeout: TimeInterval = 10) throws {
     let deadline = Date().addingTimeInterval(timeout)
     while Date() < deadline {
         if FileManager.default.fileExists(atPath: path) { return }

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -285,6 +285,24 @@ final class SessionTests: XCTestCase {
         )
     }
 
+    func testNotificationBodyFallsBackForMachineOnlyCodexScaffoldWithMultipleSections() {
+        let session = Session.mock(
+            project: "cctop",
+            sessionName: "Generated context",
+            status: .waitingInput,
+            lastPrompt: """
+            # Files:
+            - /Users/test/project/App.swift
+
+            # In app browser:
+            - Current URL: http://localhost:3000
+            """,
+            source: "codex"
+        )
+
+        XCTAssertEqual(session.notificationContent.body, "Waiting for input")
+    }
+
     func testNotificationBodyFallsBackForMachineWrapperPrompts() {
         let heartbeat = Session.mock(
             project: "cctop",
@@ -809,6 +827,18 @@ final class SessionTests: XCTestCase {
             """,
             source: "codex"
         )
+        let multiSectionScaffoldSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: """
+            # Files:
+            - /Users/test/project/App.swift
+
+            # In app browser:
+            - Current URL: http://localhost:3000
+            """,
+            source: "codex"
+        )
 
         XCTAssertEqual(
             notificationActions(newSession: browserScaffoldSession, oldSession: oldSession),
@@ -816,6 +846,10 @@ final class SessionTests: XCTestCase {
         )
         XCTAssertEqual(
             notificationActions(newSession: fileScaffoldSession, oldSession: oldSession),
+            []
+        )
+        XCTAssertEqual(
+            notificationActions(newSession: multiSectionScaffoldSession, oldSession: oldSession),
             []
         )
     }

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -215,6 +215,19 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.notificationContent.body, "Which option should I choose?")
     }
 
+    func testNotificationBodyPreservesMachineLikeNotificationMessage() {
+        let session = Session.mock(
+            project: "cctop",
+            sessionName: "Elicitation dialog",
+            status: .waitingInput,
+            lastPrompt: "<heartbeat><automation_id>watchdog</automation_id></heartbeat>",
+            notificationMessage: "# Files: choose the changelog section",
+            source: "codex"
+        )
+
+        XCTAssertEqual(session.notificationContent.body, "# Files: choose the changelog section")
+    }
+
     func testNotificationBodyFallsBackToLastPromptForWaitingInput() {
         let session = Session.mock(
             project: "cctop",
@@ -225,6 +238,133 @@ final class SessionTests: XCTestCase {
         )
 
         XCTAssertEqual(session.notificationContent.body, "Actual user prompt")
+    }
+
+    func testNotificationBodyPreservesNonCodexPromptFallback() {
+        let session = Session.mock(
+            project: "cctop",
+            sessionName: "Generic idle prompt",
+            status: .waitingInput,
+            lastPrompt: "# Files: draft a changelog",
+            source: "cc"
+        )
+
+        XCTAssertEqual(session.notificationContent.body, "# Files: draft a changelog")
+    }
+
+    func testNotificationBodyPreservesCodexPromptFallbackStartingWithScaffoldHeading() {
+        let session = Session.mock(
+            project: "cctop",
+            sessionName: "Generic idle prompt",
+            status: .waitingInput,
+            lastPrompt: "# Files: draft a changelog",
+            source: "codex"
+        )
+
+        XCTAssertEqual(session.notificationContent.body, "# Files: draft a changelog")
+    }
+
+    func testNotificationBodyExtractsUserRequestFromCodexScaffold() {
+        let session = Session.mock(
+            project: "cctop",
+            sessionName: "Chief driver",
+            status: .waitingInput,
+            lastPrompt: """
+            # In app browser:
+            - Current URL: file:///tmp/codex-explainers/example.html
+
+            ## My request for Codex:
+            This is a separate thing, not related to the current PR.
+            """,
+            source: "codex"
+        )
+
+        XCTAssertEqual(
+            session.notificationContent.body,
+            "This is a separate thing, not related to the current PR."
+        )
+    }
+
+    func testNotificationBodyFallsBackForMachineWrapperPrompts() {
+        let heartbeat = Session.mock(
+            project: "cctop",
+            sessionName: "Chief watchdog",
+            status: .waitingInput,
+            lastPrompt: """
+            <heartbeat>
+              <automation_id>cctop-chief-workflow-watchdog</automation_id>
+            </heartbeat>
+            """,
+            source: "codex"
+        )
+        let delegation = Session.mock(
+            project: "cctop",
+            sessionName: "Driver task",
+            status: .waitingInput,
+            lastPrompt: """
+            &lt;codex_delegation&gt;
+              &lt;source_thread_id&gt;019f3cfa&lt;/source_thread_id&gt;
+            &lt;/codex_delegation&gt;
+            """,
+            source: "codex"
+        )
+
+        XCTAssertEqual(heartbeat.notificationContent.body, "Waiting for input")
+        XCTAssertEqual(delegation.notificationContent.body, "Waiting for input")
+    }
+
+    func testNotificationBodyFallsBackForLegacyCodexDesktopMachineWrapperPrompts() {
+        let session = Session.mock(
+            project: "cctop",
+            sessionName: "Chief watchdog",
+            status: .waitingInput,
+            lastPrompt: """
+            <heartbeat>
+              <automation_id>cctop-chief-workflow-watchdog</automation_id>
+            </heartbeat>
+            """,
+            terminal: TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
+        )
+
+        XCTAssertEqual(session.notificationContent.body, "Waiting for input")
+    }
+
+    func testNotificationBodyRejectsMachineWrapperBeforeExtractingCodexMarker() {
+        let session = Session.mock(
+            project: "cctop",
+            sessionName: "Driver task",
+            status: .waitingInput,
+            lastPrompt: """
+            <codex_delegation>
+              <input>
+            ## My request for Codex:
+            Please fix notification text.
+              </input>
+            </codex_delegation>
+            """,
+            source: "codex"
+        )
+
+        XCTAssertEqual(session.notificationContent.body, "Waiting for input")
+    }
+
+    func testNotificationBodyDoesNotExtractCodexMarkerFromOrdinaryPrompt() {
+        let session = Session.mock(
+            project: "cctop",
+            sessionName: "Docs edit",
+            status: .waitingInput,
+            lastPrompt: """
+            Please edit this template section:
+            ## My request for Codex:
+            Keep the heading visible.
+            """,
+            source: "codex"
+        )
+
+        XCTAssertEqual(
+            session.notificationContent.body,
+            "Please edit this template section: ## My request for Codex: Keep the..."
+        )
     }
 
     func testDecodesSessionName() throws {
@@ -570,6 +710,271 @@ final class SessionTests: XCTestCase {
                 notificationsEnabled: true
             ),
             [.post(session: waitingSession)]
+        )
+    }
+
+    private func notificationActions(
+        newSession: Session,
+        oldSession: Session,
+        notificationsEnabled: Bool = true
+    ) -> [SessionNotificationAction] {
+        SessionManager.notificationActions(
+            newSessions: [newSession],
+            oldSessions: [oldSession],
+            notificationsEnabled: notificationsEnabled
+        )
+    }
+
+    func testNotificationActionsSuppressMachineOnlyCodexEnvelopeWaitingInput() {
+        let oldSession = Session.mock(
+            id: "codex-thread-1",
+            status: .working,
+            source: "codex"
+        )
+        let heartbeatSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: """
+            <heartbeat>
+              <automation_id>cctop-chief-workflow-watchdog</automation_id>
+            </heartbeat>
+            """,
+            source: "codex"
+        )
+        let delegationSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: """
+            <codex_delegation>
+              <source_thread_id>019f3cfa</source_thread_id>
+            </codex_delegation>
+            """,
+            source: "codex"
+        )
+
+        XCTAssertEqual(
+            notificationActions(newSession: heartbeatSession, oldSession: oldSession),
+            []
+        )
+        XCTAssertEqual(
+            notificationActions(newSession: delegationSession, oldSession: oldSession),
+            []
+        )
+    }
+
+    func testNotificationActionsSuppressLegacyCodexDesktopMachineOnlyWaitingInput() {
+        let oldSession = Session.mock(
+            id: "codex-thread-1",
+            status: .working,
+            terminal: TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
+        )
+        let heartbeatSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: """
+            <heartbeat>
+              <automation_id>cctop-chief-workflow-watchdog</automation_id>
+            </heartbeat>
+            """,
+            terminal: TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
+        )
+
+        XCTAssertEqual(
+            notificationActions(newSession: heartbeatSession, oldSession: oldSession),
+            []
+        )
+    }
+
+    func testNotificationActionsSuppressCodexScaffoldWithoutUserRequest() {
+        let oldSession = Session.mock(
+            id: "codex-thread-1",
+            status: .working,
+            source: "codex"
+        )
+        let browserScaffoldSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: """
+            # In app browser:
+            - page: http://localhost:3000
+            """,
+            source: "codex"
+        )
+        let fileScaffoldSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: """
+            # Files:
+            - /Users/test/project/App.swift
+            """,
+            source: "codex"
+        )
+
+        XCTAssertEqual(
+            notificationActions(newSession: browserScaffoldSession, oldSession: oldSession),
+            []
+        )
+        XCTAssertEqual(
+            notificationActions(newSession: fileScaffoldSession, oldSession: oldSession),
+            []
+        )
+    }
+
+    func testNotificationActionsDoNotApplyCodexSuppressionToLeakedDesktopBundle() {
+        let oldSession = Session.mock(
+            id: "cc-thread-1",
+            status: .working,
+            terminal: TerminalInfo(bundleId: HostAppBundleID.codexDesktop),
+            source: "cc",
+        )
+        let waitingSession = Session.mock(
+            id: "cc-thread-1",
+            status: .waitingInput,
+            lastPrompt: """
+            # Files:
+            - /Users/test/project/App.swift
+            """,
+            terminal: TerminalInfo(bundleId: HostAppBundleID.codexDesktop),
+            source: "cc",
+        )
+
+        XCTAssertEqual(
+            notificationActions(newSession: waitingSession, oldSession: oldSession),
+            [.post(session: waitingSession)]
+        )
+    }
+
+    func testNotificationActionsPostUserFacingCodexWaitingInput() {
+        let oldSession = Session.mock(
+            id: "codex-thread-1",
+            status: .working,
+            source: "codex"
+        )
+        let explicitMessageSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: """
+            <heartbeat>
+              <automation_id>cctop-chief-workflow-watchdog</automation_id>
+            </heartbeat>
+            """,
+            notificationMessage: "Which option should I choose?",
+            source: "codex"
+        )
+        let scaffoldWithRequestSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: """
+            # In app browser:
+            - page: http://localhost:3000
+
+            ## My request for Codex:
+            Click the export button and tell me what happens.
+            """,
+            source: "codex"
+        )
+        let promptStartingWithScaffoldHeading = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: "# Files: draft a changelog entry",
+            source: "codex"
+        )
+        let multilinePromptStartingWithScaffoldHeading = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: """
+            # Files:
+            Draft a changelog entry for PR 213.
+            """,
+            source: "codex"
+        )
+
+        XCTAssertEqual(
+            notificationActions(newSession: explicitMessageSession, oldSession: oldSession),
+            [.post(session: explicitMessageSession)]
+        )
+        XCTAssertEqual(
+            notificationActions(newSession: scaffoldWithRequestSession, oldSession: oldSession),
+            [.post(session: scaffoldWithRequestSession)]
+        )
+        XCTAssertEqual(
+            notificationActions(newSession: promptStartingWithScaffoldHeading, oldSession: oldSession),
+            [.post(session: promptStartingWithScaffoldHeading)]
+        )
+        XCTAssertEqual(
+            notificationActions(newSession: multilinePromptStartingWithScaffoldHeading, oldSession: oldSession),
+            [.post(session: multilinePromptStartingWithScaffoldHeading)]
+        )
+    }
+
+    func testNotificationActionsPostCodexPermissionAndErrorAttention() {
+        let oldSession = Session.mock(
+            id: "codex-thread-1",
+            status: .working,
+            source: "codex"
+        )
+        let permissionSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingPermission,
+            lastPrompt: "<heartbeat></heartbeat>",
+            notificationMessage: "Allow Bash: make all",
+            source: "codex"
+        )
+        let errorSession = Session.mock(
+            id: "codex-thread-1",
+            status: .needsAttention,
+            lastPrompt: "<codex_delegation></codex_delegation>",
+            notificationMessage: "Command failed",
+            source: "codex"
+        )
+
+        XCTAssertEqual(
+            notificationActions(newSession: permissionSession, oldSession: oldSession),
+            [.post(session: permissionSession)]
+        )
+        XCTAssertEqual(
+            notificationActions(newSession: errorSession, oldSession: oldSession),
+            [.post(session: errorSession)]
+        )
+    }
+
+    func testNotificationActionsPostWhenSuppressedCodexWaitingInputBecomesUserFacing() {
+        let oldMachineOnlySession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: "<heartbeat></heartbeat>",
+            source: "codex"
+        )
+        let userFacingSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: "yo",
+            source: "codex"
+        )
+
+        XCTAssertEqual(
+            notificationActions(newSession: userFacingSession, oldSession: oldMachineOnlySession),
+            [.post(session: userFacingSession)]
+        )
+    }
+
+    func testNotificationActionsRemoveWhenUserFacingCodexWaitingInputBecomesMachineOnly() {
+        let oldUserFacingSession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: "Can you check this?",
+            source: "codex"
+        )
+        let machineOnlySession = Session.mock(
+            id: "codex-thread-1",
+            status: .waitingInput,
+            lastPrompt: "<heartbeat></heartbeat>",
+            source: "codex"
+        )
+
+        XCTAssertEqual(
+            notificationActions(newSession: machineOnlySession, oldSession: oldUserFacingSession),
+            [.remove(identifier: "session-codex:codex-thread-1")]
         )
     }
 


### PR DESCRIPTION
## Problem

cctop could post notifications for Codex sessions that were technically in `waiting_input` even when the content was machine transport rather than something a human needed to act on. Chief/driver/watchdog traffic such as delegation envelopes, heartbeats, or generated browser/file scaffolding could therefore leak into macOS notifications or create noisy alerts with nothing useful to click.

A separate runtime issue surfaced while testing that notification flow: app-side maintenance writes and desktop garbage collection could wait on a hook-owned session lock on the main actor. If a hook process wedged while holding that lock, main-actor interactions such as notification clicks or status-item interaction could sit behind the maintenance pass.

## Solution

- Filter notification posting for Codex-style waiting-input sessions so machine-only transport does not create a macOS notification.
- Preserve human-actionable Codex attention: ordinary user prompts, including prompts that only start with scaffold-like headings, explicit notification messages, permission and elicitation prompts, error states, and generated scaffolds that contain a real `## My request for Codex:` request.
- Keep notification-body cleanup as defense-in-depth for text that still reaches formatting, rather than relying on sanitization as the primary filter.
- Apply the same Codex notification policy to trusted legacy Codex Desktop session files without trusting leaked bundle IDs from other sources.
- Make app-side session maintenance skip busy session locks and retry later instead of blocking the main actor.
