### PR TITLE
Show update prompt in footer

### DIFF
--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -99,6 +99,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             updater: updater,
             pluginManager: pluginManager,
             navigate: navigateController,
+            onOpenUpdater: { [weak self] in
+                Task { @MainActor in self?.openUpdaterFromPanel() }
+            },
             onSelectCleanupRemovalAction: { [weak self] candidate in
                 await self?.selectCleanupRemovalAction(candidate) ?? .blocked(candidate, "Cleanup is unavailable right now.")
             },
@@ -541,12 +544,7 @@ extension AppDelegate {
                     self?.focusLocation = nil
                 }
             case .dismissPanel:
-                panel.orderOut(nil)
-                updateCleanupPanelVisibility()
-                focusLocation = nil
-                previousApp = nil
-                stopNavKeyMonitor()
-                updateNotchVisibility(immediate: true)
+                dismissPanel()
             case .navigatePanel:
                 panel.makeKeyAndOrderFront(nil)
                 updateCleanupPanelVisibility()
@@ -580,6 +578,25 @@ extension AppDelegate {
         }
     }
 
+    @MainActor private func dismissPanel() {
+        panel.orderOut(nil)
+        updateCleanupPanelVisibility()
+        focusLocation = nil
+        previousApp = nil
+        stopNavKeyMonitor()
+        updateNotchVisibility(immediate: true)
+    }
+
+    @MainActor private func openUpdaterFromPanel() {
+        if navigateController.isActive {
+            navigateController.deactivate()
+            postNavAction(.reset)
+        }
+        panelMode = .hidden
+        dismissPanel()
+        updater.checkForUpdates()
+    }
+
     @MainActor private func jumpToSession(index: Int) {
         guard index < navigateController.frozenSessions.count else { return }
         focusTerminal(session: navigateController.frozenSessions[index])
@@ -594,7 +611,8 @@ extension AppDelegate {
             // Navigate: digit keys jump to session (use keyCode for IME compatibility)
             if self.navigateController.isActive,
                let digit = digitKeyCodeMap[event.keyCode] {
-                DispatchQueue.main.async { self.jumpToSession(index: digit - 1) }
+                let index = digit - 1
+                DispatchQueue.main.async { self.jumpToSession(index: index) }
                 return nil
             }
 

--- a/menubar/CctopMenubar/Info.plist
+++ b/menubar/CctopMenubar/Info.plist
@@ -4,6 +4,12 @@
 <dict>
 	<key>SUFeedURL</key>
 	<string>https://raw.githubusercontent.com/st0012/cctop/master/appcast.xml</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUAutomaticallyUpdate</key>
+	<true/>
+	<key>SUScheduledCheckInterval</key>
+	<integer>3600</integer>
 	<key>SUPublicEDKey</key>
 	<string>7Ts0HFX10tBXROh8uS9x2Gvuy+K5g3WT48FFYSIR51g=</string>
 	<key>CFBundleURLTypes</key>

--- a/menubar/CctopMenubar/Services/SparkleUpdater.swift
+++ b/menubar/CctopMenubar/Services/SparkleUpdater.swift
@@ -56,16 +56,21 @@ final class SparkleUpdater: UpdaterBase, @preconcurrency SPUUpdaterDelegate {
 
     override init() {
         super.init()
-        let updater = controller.updater
-        updater.automaticallyChecksForUpdates = true
-        updater.automaticallyDownloadsUpdates = true
         controller.startUpdater()
+        checkForUpdatesInBackgroundAtLaunch()
     }
 
     override var canCheckForUpdates: Bool { true }
 
     override func checkForUpdates() {
         controller.checkForUpdates(nil)
+    }
+
+    private func checkForUpdatesInBackgroundAtLaunch() {
+        let updater = controller.updater
+        guard updater.automaticallyChecksForUpdates else { return }
+        // Sparkle recommends forcing launch checks only immediately after startup.
+        updater.checkForUpdatesInBackground()
     }
 
     // MARK: - SPUUpdaterDelegate

--- a/menubar/CctopMenubar/Views/PopupView+EmptyState.swift
+++ b/menubar/CctopMenubar/Views/PopupView+EmptyState.swift
@@ -1,6 +1,25 @@
 import SwiftUI
 
 extension PopupView {
+    func overlayPanel<Content: View>(
+        verticalPadding: CGFloat = AppChrome.overlayContentVerticalPadding,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        content()
+            .padding(.vertical, verticalPadding)
+            .frame(maxWidth: .infinity, minHeight: AppChrome.overlayMinimumContentHeight, alignment: .top)
+            .background {
+                PanelSurfaceBackground(usesMaterial: false)
+            }
+            .transition(.asymmetric(
+                insertion: .move(edge: .top),
+                removal: .modifier(
+                    active: RollUpEffect(progress: 0),
+                    identity: RollUpEffect(progress: 1)
+                )
+            ))
+    }
+
     var noActiveSessionsContent: some View {
         emptyPlaceholder(
             systemImage: "circle.dotted",

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -18,6 +18,7 @@ struct PopupView: View {
     @ObservedObject var overlayController: OverlayController = OverlayController()
     var initialTab: PopupTab = .active
     var initialCleanupCandidate: WorktreeCleanupCandidate?
+    var onOpenUpdater: (() -> Void)?
     var onSelectCleanupRemovalAction: ((WorktreeCleanupCandidate) async -> WorktreeRemovalService.RemovalAction)?
     var onExecuteCleanupRemovalAction: ((WorktreeRemovalService.RemovalAction) async -> WorktreeRemovalService.RemovalResult)?
     var onCleanupTabVisible: () -> Void = {}
@@ -76,7 +77,11 @@ struct PopupView: View {
                     switch overlay {
                     case .settings:
                         overlayPanel(verticalPadding: AppChrome.settingsOverlayVerticalPadding) {
-                            SettingsSection(updater: updater, pluginManager: pluginManager)
+                            SettingsSection(
+                                updater: updater,
+                                pluginManager: pluginManager,
+                                onOpenUpdater: onOpenUpdater
+                            )
                         }
                     case .about:
                         overlayPanel {
@@ -107,12 +112,8 @@ struct PopupView: View {
         .onChange(of: recentTargets.map(\.id)) { _ in ensureSelectedTabAvailable() }
         .onChange(of: actionableCleanupCandidates) { _ in handleCleanupCandidatesChanged() }
         .onChange(of: cleanupIsScanning) { _ in handleCleanupScanningChanged() }
-        .onChange(of: selectedCleanupCandidate?.id) { _ in
-            notifyLayoutChanged()
-        }
-        .alert(item: $pendingRemovalConfirmation) { confirmation in
-            removalAlert(for: confirmation)
-        }
+        .onChange(of: selectedCleanupCandidate?.id) { _ in notifyLayoutChanged() }
+        .alert(item: $pendingRemovalConfirmation) { removalAlert(for: $0) }
         .onAppear {
             selectedTab = availableTabs.contains(initialTab) ? initialTab : .active
             if selectedTab == .cleanup,
@@ -272,31 +273,13 @@ struct PopupView: View {
 // MARK: - Overlay & Footer
 
 extension PopupView {
-    func overlayPanel<Content: View>(
-        verticalPadding: CGFloat = AppChrome.overlayContentVerticalPadding,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        content()
-            .padding(.vertical, verticalPadding)
-            .frame(maxWidth: .infinity, minHeight: AppChrome.overlayMinimumContentHeight, alignment: .top)
-            .background {
-                PanelSurfaceBackground(usesMaterial: false)
-            }
-            .transition(.asymmetric(
-                insertion: .move(edge: .top),
-                removal: .modifier(
-                    active: RollUpEffect(progress: 0),
-                    identity: RollUpEffect(progress: 1)
-                )
-            ))
-    }
-
     var footerBar: some View {
-        HStack {
+        HStack(spacing: 8) {
             QuitButton()
             versionButton
             footerShortcutHints
             Spacer()
+            footerUpdateStatus
             settingsGearButton
         }
         .padding(.horizontal, 16)
@@ -326,14 +309,28 @@ extension PopupView {
                     RoundedRectangle(cornerRadius: AppChrome.controlCornerRadius, style: .continuous)
                         .fill(gearHovered ? Color.panelSelectionBackground : Color.clear)
                 )
-                .overlay(alignment: .topTrailing) {
-                    if updater.pendingUpdateVersion != nil && overlayController.active != .settings {
-                        Circle().fill(Color.amber).frame(width: 7, height: 7).offset(x: 2, y: -2)
-                    }
-                }
         }
         .buttonStyle(.plain)
         .onHover { gearHovered = $0 }
+    }
+
+    @ViewBuilder
+    private var footerUpdateStatus: some View {
+        if let version = updater.downloadingUpdateVersion {
+            FooterUpdateStatusView(state: .downloading(version: version)) {}
+        } else if let version = updater.pendingUpdateVersion {
+            FooterUpdateStatusView(state: .available(version: version)) {
+                openUpdater()
+            }
+        }
+    }
+
+    private func openUpdater() {
+        if let onOpenUpdater {
+            onOpenUpdater()
+        } else {
+            updater.checkForUpdates()
+        }
     }
 
     // MARK: - Helpers
@@ -346,9 +343,11 @@ extension PopupView {
                     .foregroundStyle(shortcutHovered ? Color.textPrimary : Color.textSecondary)
                     .underline(shortcutHovered)
                     .lineLimit(1)
+                    .truncationMode(.tail)
             }
             .buttonStyle(.plain)
             .onHover { shortcutHovered = $0 }
+            .layoutPriority(-1)
         } else { EmptyView() }
     }
     private var isNavigateActive: Bool { navigate?.isActive ?? false }
@@ -365,7 +364,6 @@ extension PopupView {
     var actionableCleanupCandidates: [WorktreeCleanupCandidate] {
         cleanupCandidates.filter(\.state.isActionable)
     }
-
     private func syncSelectedCleanupCandidate() {
         selectedCleanupCandidate = Self.syncedCleanupCandidate(
             selectedCleanupCandidate,
@@ -486,5 +484,4 @@ extension PopupView {
         cleanupRemovalNotice = nil
         selectedCleanupCandidate = candidate
     }
-
 }

--- a/menubar/CctopMenubar/Views/PopupViewHelpers.swift
+++ b/menubar/CctopMenubar/Views/PopupViewHelpers.swift
@@ -232,6 +232,63 @@ struct TabButtonView: View {
     }
 }
 
+// MARK: - Footer update status
+
+enum FooterUpdateStatusState: Equatable {
+    case available(version: String)
+    case downloading(version: String)
+
+    var version: String {
+        switch self {
+        case .available(let version), .downloading(let version):
+            return version
+        }
+    }
+}
+
+struct FooterUpdateStatusView: View {
+    let state: FooterUpdateStatusState
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        switch state {
+        case .available:
+            Button(action: action) {
+                Text("Update")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Color.accentButtonText)
+                    .lineLimit(1)
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 4)
+                    .background(Color.amber.opacity(isHovered ? 0.90 : 1.0))
+                    .clipShape(RoundedRectangle(cornerRadius: AppChrome.controlCornerRadius, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .onHover { isHovered = $0 }
+            .help("Open updater for v\(state.version)")
+            .accessibilityLabel("Open cctop updater")
+            .accessibilityHint("Opens the updater for cctop v\(state.version).")
+        case .downloading:
+            HStack(spacing: 4) {
+                ProgressView()
+                    .controlSize(.mini)
+                    .frame(width: 10, height: 10)
+                    .accessibilityHidden(true)
+                Text("Downloading")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(Color.textSecondary)
+                    .lineLimit(1)
+            }
+            .fixedSize(horizontal: true, vertical: false)
+            .help("Downloading cctop v\(state.version)")
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Downloading cctop update")
+            .accessibilityHint("cctop v\(state.version) is downloading.")
+        }
+    }
+}
+
 // MARK: - Panel content wrapper (used by AppDelegate)
 
 struct PanelContentView: View {
@@ -242,6 +299,7 @@ struct PanelContentView: View {
     @ObservedObject var updater: UpdaterBase
     @ObservedObject var pluginManager: PluginManager
     @ObservedObject var navigate: NavigateController
+    var onOpenUpdater: (() -> Void)?
     var onSelectCleanupRemovalAction: ((WorktreeCleanupCandidate) async -> WorktreeRemovalService.RemovalAction)?
     var onExecuteCleanupRemovalAction: ((WorktreeRemovalService.RemovalAction) async -> WorktreeRemovalService.RemovalResult)?
     var onCleanupTabVisible: () -> Void = {}
@@ -263,6 +321,7 @@ struct PanelContentView: View {
             pluginManager: pluginManager,
             navigate: navigate,
             overlayController: overlayController,
+            onOpenUpdater: onOpenUpdater,
             onSelectCleanupRemovalAction: onSelectCleanupRemovalAction,
             onExecuteCleanupRemovalAction: onExecuteCleanupRemovalAction,
             onCleanupTabVisible: onCleanupTabVisible,

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct SettingsSection: View {
     @ObservedObject var updater: UpdaterBase
     @ObservedObject var pluginManager: PluginManager
+    var onOpenUpdater: (() -> Void)?
     @ObservedObject private var themeManager = ThemeManager.shared
     @StateObject private var notificationPermission: NotificationPermissionController
     @AppStorage("appearanceMode") private var appearanceMode = "system"
@@ -14,10 +15,12 @@ struct SettingsSection: View {
     init(
         updater: UpdaterBase,
         pluginManager: PluginManager,
+        onOpenUpdater: (() -> Void)? = nil,
         notificationPermission: NotificationPermissionController = NotificationPermissionController()
     ) {
         self.updater = updater
         self.pluginManager = pluginManager
+        self.onOpenUpdater = onOpenUpdater
         _notificationPermission = StateObject(wrappedValue: notificationPermission)
     }
 
@@ -197,7 +200,7 @@ struct SettingsSection: View {
         } else if let version = updater.pendingUpdateVersion {
             settingsGroup {
                 Button {
-                    updater.checkForUpdates()
+                    openUpdater()
                 } label: {
                     HStack {
                         Text("v\(version) available")
@@ -216,6 +219,9 @@ struct SettingsSection: View {
                     .padding(.vertical, 10)
                 }
                 .buttonStyle(.plain)
+                .help("Open updater for v\(version)")
+                .accessibilityLabel("Open cctop updater")
+                .accessibilityHint("Opens the updater for cctop v\(version).")
             }
         } else if let reason = updater.disabledReason {
             settingsGroup {
@@ -280,6 +286,14 @@ struct SettingsSection: View {
             return
         }
         NSWorkspace.shared.open(FileAccessSettings.privacySecurityURL)
+    }
+
+    private func openUpdater() {
+        if let onOpenUpdater {
+            onOpenUpdater()
+        } else {
+            updater.checkForUpdates()
+        }
     }
 }
 

--- a/menubar/CctopMenubarTests/AppSettingsTests.swift
+++ b/menubar/CctopMenubarTests/AppSettingsTests.swift
@@ -44,6 +44,19 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertTrue(source.contains(".popover(isPresented: $showFileAccessHelp)"))
     }
 
+    func testSparkleChecksHourlyByDefaultWithAutomaticChecksEnabled() throws {
+        let root = try repoRoot()
+        let plistURL = root.appendingPathComponent("menubar/CctopMenubar/Info.plist")
+        let data = try Data(contentsOf: plistURL)
+        let plist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        )
+
+        XCTAssertEqual(plist["SUScheduledCheckInterval"] as? Int, 60 * 60)
+        XCTAssertEqual(plist["SUEnableAutomaticChecks"] as? Bool, true)
+        XCTAssertEqual(plist["SUAutomaticallyUpdate"] as? Bool, true)
+    }
+
     private func repoRoot() throws -> URL {
         var url = URL(fileURLWithPath: #filePath)
         while url.path != "/" {

--- a/menubar/CctopMenubarTests/QASnapshotTests.swift
+++ b/menubar/CctopMenubarTests/QASnapshotTests.swift
@@ -78,6 +78,18 @@ final class QASnapshotTests: XCTestCase {
 
     // MARK: - Update UI scenarios
 
+    func testFooterUpdateAvailable() throws {
+        let updater = DisabledUpdater()
+        updater.pendingUpdateVersion = "0.7.0"
+        try renderSnapshot(sessions: Session.qaShowcase, updater: updater, name: "11b-footer-update-available")
+    }
+
+    func testFooterUpdateDownloading() throws {
+        let updater = DisabledUpdater()
+        updater.downloadingUpdateVersion = "0.7.0"
+        try renderSnapshot(sessions: Session.qaShowcase, updater: updater, name: "11c-footer-update-downloading")
+    }
+
     func testSettingsUpdateAvailable() throws {
         let updater = DisabledUpdater()
         updater.pendingUpdateVersion = "0.7.0"
@@ -227,10 +239,11 @@ final class QASnapshotTests: XCTestCase {
 
     private func renderSnapshot(
         sessions: [Session],
+        updater: UpdaterBase? = nil,
         name: String,
         colorScheme: ColorScheme = .light
     ) throws {
-        let view = PopupView(sessions: sessions, updater: DisabledUpdater(), pluginManager: inertPluginManager())
+        let view = PopupView(sessions: sessions, updater: updater ?? DisabledUpdater(), pluginManager: inertPluginManager())
             .frame(width: 320)
             .panelSnapshotChrome()
             .environment(\.colorScheme, colorScheme)


### PR DESCRIPTION
## Problem

When cctop detects an available update, the footer only hinted at it through the settings gear. Users had to know to open Settings before seeing an explicit update action, and adding a separate cctop confirmation would duplicate Sparkle's own updater UI.

Sparkle also used its default daily scheduled check interval, so a newly published release could take up to a day to surface unless the user manually checked for updates.

## Solution

- Add a compact footer update state that shows an explicit `Update` pill when an update is pending and a subdued `Downloading` state while Sparkle is downloading.
- Have both footer and Settings update actions open or resume Sparkle's standard updater flow directly.
- Keep help and accessibility copy honest about that handoff, so cctop surfaces the opportunity and Sparkle owns progress, confirmation, install, and relaunch.
- Configure Sparkle to check hourly by default and kick off one background check at app startup when automatic checks are enabled, so new releases are discovered sooner without panel-open polling or promising push-style updates.
