### PR TITLE
Batch Codex thread state during refresh

### DIFF
--- a/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
@@ -297,7 +297,7 @@ private extension CodexThreadArchiveLookup {
 
         for path in resolvedStateDatabasePaths() where !remainingThreadIDs.isEmpty {
             guard let snapshot = stateSnapshot(at: path, matching: remainingThreadIDs) else {
-                return nil
+                return foundReadableDatabase ? .available(mergedIndex) : nil
             }
             guard case .available(let index) = snapshot else {
                 continue

--- a/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
@@ -7,7 +7,7 @@ final class CodexThreadArchiveLookup {
     typealias StateDatabasePaths = () -> [String]
 
     private static let maxIndexCacheEntries = 8
-    private static let stateDatabasePathCacheDuration: TimeInterval = 30
+    private static let stateDatabasePathCacheDuration: TimeInterval = 5
 
     private let stateDatabasePaths: StateDatabasePaths
     private let rolloutOriginator: RolloutOriginator

--- a/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
@@ -74,6 +74,7 @@ final class CodexThreadArchiveLookup {
         case .missing:
             return []
         case .available(let index):
+            guard index.unknownThreadIDs.isDisjoint(with: threadIDs) else { return nil }
             return index.archivedThreadIDs.intersection(threadIDs)
         }
     }
@@ -287,7 +288,6 @@ final class CodexThreadArchiveLookup {
             index.projectNamesByThreadID[threadID] = name
         }
     }
-
 }
 
 private extension CodexThreadArchiveLookup {

--- a/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
@@ -58,6 +58,7 @@ final class CodexThreadArchiveLookup {
         case .missing:
             return nil
         case .available(let index):
+            guard index.unknownThreadIDs.isDisjoint(with: threadIDs) else { return nil }
             return index.existingThreadIDs.intersection(threadIDs)
         }
     }
@@ -297,6 +298,7 @@ private extension CodexThreadArchiveLookup {
 
         for path in resolvedStateDatabasePaths() where !remainingThreadIDs.isEmpty {
             guard let snapshot = stateSnapshot(at: path, matching: remainingThreadIDs) else {
+                mergedIndex.unknownThreadIDs.formUnion(remainingThreadIDs)
                 return foundReadableDatabase ? .available(mergedIndex) : nil
             }
             guard case .available(let index) = snapshot else {
@@ -495,5 +497,4 @@ private extension CodexThreadArchiveLookup {
         return value.isEmpty ? nil : value
     }
 }
-
 extension CodexThreadArchiveLookup: CodexThreadStateProviding {}

--- a/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
@@ -2,24 +2,12 @@ import Darwin
 import Foundation
 import SQLite3
 
-/// Read-side seam over Codex's local thread state. `CodexThreadArchiveLookup` is the live
-/// SQLite-backed implementation; tests substitute in-memory stubs so classification and archive
-/// logic can run without a database on disk. `nil` means the lookup could not prove an answer,
-/// either because the store was unreadable or because absence is intentionally treated as unknown.
-protocol CodexThreadStateProviding {
-    func existingThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
-    func archivedThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
-    func subagentThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
-    func execHelperThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
-    func projectNames(matching threadIDs: Set<String>) -> [String: String]?
-}
-
 final class CodexThreadArchiveLookup {
     typealias RolloutOriginator = (String) -> String?
     typealias StateDatabasePaths = () -> [String]
 
     private static let maxIndexCacheEntries = 8
-    private static let stateDatabasePathCacheDuration: TimeInterval = 1
+    private static let stateDatabasePathCacheDuration: TimeInterval = 30
 
     private let stateDatabasePaths: StateDatabasePaths
     private let rolloutOriginator: RolloutOriginator
@@ -45,6 +33,19 @@ final class CodexThreadArchiveLookup {
 
     private static func liveStateDatabasePaths() -> [String] {
         Config.codexStateDatabaseCandidates(desktopSQLiteHome: CodexDesktopRuntimeProbe().currentDesktopSQLiteHome())
+    }
+
+    /// Returns all Codex thread metadata cctop needs for `threadIDs` using one database pass.
+    /// Missing or unreadable state is unknown, so callers should fail OPEN when this returns `nil`.
+    func stateIndex(matching threadIDs: Set<String>) -> CodexThreadStateIndex? {
+        guard !threadIDs.isEmpty else { return CodexThreadStateIndex() }
+        guard let snapshot = stateSnapshot(matching: threadIDs) else { return nil }
+        switch snapshot {
+        case .missing:
+            return nil
+        case .available(let index):
+            return index
+        }
     }
 
     /// Returns the subset of `threadIDs` present in Codex's thread state. Unlike archive

--- a/menubar/CctopMenubar/Services/CodexThreadStateTypes.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadStateTypes.swift
@@ -41,6 +41,7 @@ struct CodexThreadStateIndex {
     var subagentThreadIDs: Set<String> = []
     var execHelperThreadIDs: Set<String> = []
     var projectNamesByThreadID: [String: String] = [:]
+    var unknownThreadIDs: Set<String> = []
 
     mutating func merge(_ other: CodexThreadStateIndex) {
         existingThreadIDs.formUnion(other.existingThreadIDs)
@@ -48,6 +49,7 @@ struct CodexThreadStateIndex {
         subagentThreadIDs.formUnion(other.subagentThreadIDs)
         execHelperThreadIDs.formUnion(other.execHelperThreadIDs)
         projectNamesByThreadID.merge(other.projectNamesByThreadID) { current, _ in current }
+        unknownThreadIDs.formUnion(other.unknownThreadIDs)
     }
 
     func filtered(to threadIDs: Set<String>) -> CodexThreadStateIndex {
@@ -56,7 +58,8 @@ struct CodexThreadStateIndex {
             archivedThreadIDs: archivedThreadIDs.intersection(threadIDs),
             subagentThreadIDs: subagentThreadIDs.intersection(threadIDs),
             execHelperThreadIDs: execHelperThreadIDs.intersection(threadIDs),
-            projectNamesByThreadID: projectNamesByThreadID.filter { threadIDs.contains($0.key) }
+            projectNamesByThreadID: projectNamesByThreadID.filter { threadIDs.contains($0.key) },
+            unknownThreadIDs: unknownThreadIDs.intersection(threadIDs)
         )
     }
 }

--- a/menubar/CctopMenubar/Services/CodexThreadStateTypes.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadStateTypes.swift
@@ -1,5 +1,18 @@
 import SQLite3
 
+/// Read-side seam over Codex's local thread state. `CodexThreadArchiveLookup` is the live
+/// SQLite-backed implementation; tests substitute in-memory stubs so classification and archive
+/// logic can run without a database on disk. `nil` means the lookup could not prove an answer,
+/// either because the store was unreadable or because absence is intentionally treated as unknown.
+protocol CodexThreadStateProviding {
+    func stateIndex(matching threadIDs: Set<String>) -> CodexThreadStateIndex?
+    func existingThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
+    func archivedThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
+    func subagentThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
+    func execHelperThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
+    func projectNames(matching threadIDs: Set<String>) -> [String: String]?
+}
+
 struct CodexThreadStateRequestKey: Hashable {
     let database: CodexThreadStateDatabaseFingerprint
     let threadIDs: Set<String>
@@ -36,6 +49,16 @@ struct CodexThreadStateIndex {
         execHelperThreadIDs.formUnion(other.execHelperThreadIDs)
         projectNamesByThreadID.merge(other.projectNamesByThreadID) { current, _ in current }
     }
+
+    func filtered(to threadIDs: Set<String>) -> CodexThreadStateIndex {
+        CodexThreadStateIndex(
+            existingThreadIDs: existingThreadIDs.intersection(threadIDs),
+            archivedThreadIDs: archivedThreadIDs.intersection(threadIDs),
+            subagentThreadIDs: subagentThreadIDs.intersection(threadIDs),
+            execHelperThreadIDs: execHelperThreadIDs.intersection(threadIDs),
+            projectNamesByThreadID: projectNamesByThreadID.filter { threadIDs.contains($0.key) }
+        )
+    }
 }
 
 struct CodexThreadStateRolloutTracker {
@@ -68,3 +91,18 @@ struct CodexThreadStateFileFingerprint: Equatable, Hashable {
 }
 
 let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+extension CodexThreadStateProviding {
+    func stateIndex(matching threadIDs: Set<String>) -> CodexThreadStateIndex? {
+        guard !threadIDs.isEmpty else { return CodexThreadStateIndex() }
+        guard let existingThreadIDs = existingThreadIDs(matching: threadIDs) else { return nil }
+
+        var index = CodexThreadStateIndex()
+        index.existingThreadIDs = existingThreadIDs
+        index.archivedThreadIDs = archivedThreadIDs(matching: threadIDs) ?? []
+        index.subagentThreadIDs = subagentThreadIDs(matching: threadIDs) ?? []
+        index.execHelperThreadIDs = execHelperThreadIDs(matching: threadIDs) ?? []
+        index.projectNamesByThreadID = projectNames(matching: threadIDs) ?? [:]
+        return index
+    }
+}

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -50,7 +50,10 @@ struct FrozenCodexThreadState: CodexThreadStateProviding {
     }
 
     func existingThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
-        index?.existingThreadIDs.intersection(threadIDs)
+        guard let index, index.unknownThreadIDs.isDisjoint(with: threadIDs) else {
+            return nil
+        }
+        return index.existingThreadIDs.intersection(threadIDs)
     }
 
     func archivedThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -41,6 +41,35 @@ struct SessionClassificationEvidence {
     let archivedClaudeSessionIDs: Set<String>
 }
 
+struct FrozenCodexThreadState: CodexThreadStateProviding {
+    let index: CodexThreadStateIndex?
+
+    func stateIndex(matching threadIDs: Set<String>) -> CodexThreadStateIndex? {
+        guard let index else { return nil }
+        return index.filtered(to: threadIDs)
+    }
+
+    func existingThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        index?.existingThreadIDs.intersection(threadIDs)
+    }
+
+    func archivedThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        index.map { $0.archivedThreadIDs.intersection(threadIDs) } ?? []
+    }
+
+    func subagentThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        index.map { $0.subagentThreadIDs.intersection(threadIDs) } ?? []
+    }
+
+    func execHelperThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        index.map { $0.execHelperThreadIDs.intersection(threadIDs) } ?? []
+    }
+
+    func projectNames(matching threadIDs: Set<String>) -> [String: String]? {
+        index.map { $0.projectNamesByThreadID.filter { threadIDs.contains($0.key) } }
+    }
+}
+
 enum SessionHiddenReason: Equatable {
     case persistedHidden
     case autoHidden
@@ -349,6 +378,10 @@ extension SessionManager {
         let classifiableSessions = decoded
             .map(\.session)
             .filter { !$0.hidden && !$0.shouldAutoHide }
+        let codexThreads = Self.batchedCodexThreadState(
+            in: classifiableSessions,
+            codexThreads: dataSources.codexThreads
+        )
         let claudeMetadata = Self.claudeDesktopMetadataSnapshot(
             in: classifiableSessions,
             claudeDesktopSessions: dataSources.claudeDesktopSessions
@@ -358,15 +391,34 @@ extension SessionManager {
             now: now,
             desktopAppConnectionLookup: dataSources.desktopAppConnection,
             claudeMetadata: claudeMetadata,
-            codexThreads: dataSources.codexThreads,
+            codexThreads: codexThreads,
             processAlive: dataSources.processAlive
         )
         return Self.sessionClassificationSnapshot(
             in: candidates,
             sessions: decoded.map(\.session),
             claudeMetadata: claudeMetadata,
-            codexThreads: dataSources.codexThreads,
+            codexThreads: codexThreads,
             now: now
+        )
+    }
+
+    private nonisolated static func batchedCodexThreadState(
+        in sessions: [Session],
+        codexThreads: any CodexThreadStateProviding
+    ) -> FrozenCodexThreadState {
+        let threadIDs = codexThreadIDs(in: sessions)
+        guard !threadIDs.isEmpty else {
+            return FrozenCodexThreadState(index: CodexThreadStateIndex())
+        }
+        return FrozenCodexThreadState(index: codexThreads.stateIndex(matching: threadIDs))
+    }
+
+    private nonisolated static func codexThreadIDs(in sessions: [Session]) -> Set<String> {
+        Set(
+            sessions
+                .filter { $0.isCodex || $0.isCodexDesktopHost }
+                .map(\.sessionId)
         )
     }
 
@@ -427,11 +479,7 @@ extension SessionManager {
         in sessions: [Session],
         codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup()
     ) -> Set<String> {
-        let threadIDs = Set(
-            sessions
-                .filter { $0.isCodex || $0.isCodexDesktopHost }
-                .map(\.sessionId)
-        )
+        let threadIDs = codexThreadIDs(in: sessions)
         return codexThreads.subagentThreadIDs(matching: threadIDs) ?? []
     }
 
@@ -448,11 +496,7 @@ extension SessionManager {
         in sessions: [Session],
         codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup()
     ) -> Set<String> {
-        let threadIDs = Set(
-            sessions
-                .filter { $0.isCodex || $0.isCodexDesktopHost }
-                .map(\.sessionId)
-        )
+        let threadIDs = codexThreadIDs(in: sessions)
         return codexThreads.execHelperThreadIDs(matching: threadIDs) ?? []
     }
 
@@ -682,9 +726,10 @@ extension SessionManager {
             projectNames.merge(claudeMetadata.projectNamesBySessionID) { current, _ in current }
         }
 
-        let codexThreadIDs = Set(sessions.filter(\.isCodexDesktopHost).map(\.sessionId))
+        let codexDesktopThreadIDs = Set(sessions.filter(\.isCodexDesktopHost).map(\.sessionId))
+        let codexThreadIDs = Self.codexThreadIDs(in: sessions)
         if let codexProjectNames = codexThreads.projectNames(matching: codexThreadIDs) {
-            projectNames.merge(codexProjectNames) { current, _ in current }
+            projectNames.merge(codexProjectNames.filter { codexDesktopThreadIDs.contains($0.key) }) { current, _ in current }
         }
 
         return projectNames

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -57,7 +57,11 @@ struct FrozenCodexThreadState: CodexThreadStateProviding {
     }
 
     func archivedThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
-        index.map { $0.archivedThreadIDs.intersection(threadIDs) } ?? []
+        guard let index else { return [] }
+        guard index.unknownThreadIDs.isDisjoint(with: threadIDs) else {
+            return nil
+        }
+        return index.archivedThreadIDs.intersection(threadIDs)
     }
 
     func subagentThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {

--- a/menubar/CctopMenubarTests/CodexThreadArchiveLookupTests.swift
+++ b/menubar/CctopMenubarTests/CodexThreadArchiveLookupTests.swift
@@ -270,6 +270,35 @@ final class CodexThreadArchiveLookupTests: XCTestCase {
         XCTAssertNil(lookup.archivedThreadIDs(matching: ["target-thread"]))
     }
 
+    func testCodexThreadLookupKeepsEarlierAnswersWhenLaterCandidateIsUnreadable() throws {
+        let root = NSTemporaryDirectory() + "cctop-codex-lookup-unreadable-fallback-\(UUID().uuidString)"
+        let preferredDB = (root as NSString).appendingPathComponent("runtime/state_5.sqlite")
+        let fallbackDB = (root as NSString).appendingPathComponent("root/state_5.sqlite")
+        try FileManager.default.createDirectory(
+            atPath: (fallbackDB as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        try writeCodexStateDatabase(path: preferredDB, archivedThreads: ["desktop-thread"])
+        try executeSQLite(
+            """
+            UPDATE threads
+            SET git_origin_url = 'git@github.com:st0012/cctop.git'
+            WHERE id = 'desktop-thread';
+            """,
+            path: preferredDB
+        )
+        try Data("this is not a sqlite database".utf8).write(to: URL(fileURLWithPath: fallbackDB))
+
+        let lookup = CodexThreadArchiveLookup(stateDatabasePaths: { [preferredDB, fallbackDB] })
+        let index = try XCTUnwrap(lookup.stateIndex(matching: ["desktop-thread", "cli-thread"]))
+
+        XCTAssertEqual(index.existingThreadIDs, ["desktop-thread"])
+        XCTAssertEqual(index.archivedThreadIDs, ["desktop-thread"])
+        XCTAssertEqual(index.projectNamesByThreadID["desktop-thread"], "cctop")
+    }
+
     func testCodexThreadLookupReusesResolvedDatabaseCandidatesAcrossMetadataLookups() {
         let missing = NSTemporaryDirectory() + "cctop-codex-missing-db-\(UUID().uuidString)/state_5.sqlite"
         var resolveCount = 0

--- a/menubar/CctopMenubarTests/CodexThreadArchiveLookupTests.swift
+++ b/menubar/CctopMenubarTests/CodexThreadArchiveLookupTests.swift
@@ -300,6 +300,8 @@ final class CodexThreadArchiveLookupTests: XCTestCase {
         XCTAssertEqual(index.unknownThreadIDs, ["cli-thread"])
         XCTAssertEqual(lookup.existingThreadIDs(matching: ["desktop-thread"]), ["desktop-thread"])
         XCTAssertNil(lookup.existingThreadIDs(matching: ["cli-thread"]))
+        XCTAssertEqual(lookup.archivedThreadIDs(matching: ["desktop-thread"]), ["desktop-thread"])
+        XCTAssertNil(lookup.archivedThreadIDs(matching: ["cli-thread"]))
     }
 
     func testCodexThreadLookupReusesResolvedDatabaseCandidatesAcrossMetadataLookups() {

--- a/menubar/CctopMenubarTests/CodexThreadArchiveLookupTests.swift
+++ b/menubar/CctopMenubarTests/CodexThreadArchiveLookupTests.swift
@@ -297,6 +297,9 @@ final class CodexThreadArchiveLookupTests: XCTestCase {
         XCTAssertEqual(index.existingThreadIDs, ["desktop-thread"])
         XCTAssertEqual(index.archivedThreadIDs, ["desktop-thread"])
         XCTAssertEqual(index.projectNamesByThreadID["desktop-thread"], "cctop")
+        XCTAssertEqual(index.unknownThreadIDs, ["cli-thread"])
+        XCTAssertEqual(lookup.existingThreadIDs(matching: ["desktop-thread"]), ["desktop-thread"])
+        XCTAssertNil(lookup.existingThreadIDs(matching: ["cli-thread"]))
     }
 
     func testCodexThreadLookupReusesResolvedDatabaseCandidatesAcrossMetadataLookups() {

--- a/menubar/CctopMenubarTests/SessionLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/SessionLifecycleTests.swift
@@ -104,6 +104,77 @@ final class SessionLifecycleTests: XCTestCase {
         XCTAssertEqual(requestedBundleIDSets, [[HostAppBundleID.codexDesktop, HostAppBundleID.claudeDesktop]])
     }
 
+    func testBuildCandidatesWarmsCodexThreadLookupWithAllCodexSessionIDs() {
+        var desktop = codexDesktopSession(sessionId: "codex-desktop", projectPath: "/tmp/desktop")
+        desktop.pid = nil
+        var cli = codexTerminalSession(sessionId: "codex-cli", projectPath: "/tmp/cli")
+        cli.pid = nil
+        let codexThreads = RecordingCodexThreadState(
+            projectNamesByThreadID: [
+                "codex-desktop": "desktop-project",
+                "codex-cli": "cli-project"
+            ]
+        )
+
+        let candidates = SessionManager.buildCandidates(
+            [
+                (URL(fileURLWithPath: "/tmp/codex-desktop.json"), desktop),
+                (URL(fileURLWithPath: "/tmp/codex-cli.json"), cli)
+            ],
+            now: Self.lifeNow,
+            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true },
+            claudeMetadata: nil,
+            codexThreads: codexThreads,
+            processAlive: { _ in false }
+        )
+        let namesByID = Dictionary(uniqueKeysWithValues: candidates.map { ($0.session.sessionId, $0.session.desktopProjectName) })
+
+        XCTAssertEqual(codexThreads.projectNameRequests, [["codex-cli", "codex-desktop"]])
+        XCTAssertEqual(namesByID["codex-desktop"]!, "desktop-project")
+        XCTAssertNil(namesByID["codex-cli"]!)
+    }
+
+    @MainActor
+    func testSessionManagerBatchesCodexThreadLookupDuringRefresh() throws {
+        let root = NSTemporaryDirectory() + "cctop-batched-codex-thread-state-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let desktopID = "codex-desktop"
+        var desktop = codexDesktopSession(sessionId: desktopID, projectPath: "/tmp/desktop")
+        desktop.pid = nil
+        try desktop.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("codex-\(desktopID).json"))
+
+        let cliID = "codex-cli"
+        var cli = codexTerminalSession(sessionId: cliID, projectPath: "/tmp/cli")
+        cli.pid = nil
+        try cli.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("codex-\(cliID).json"))
+
+        let codexThreads = RecordingCodexThreadState(
+            projectNamesByThreadID: [
+                desktopID: "desktop-project",
+                cliID: "cli-project"
+            ]
+        )
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
+        sources.codexThreads = codexThreads
+        sources.desktopAppConnection = DesktopAppConnectionLookup { _ in false }
+        sources.processAlive = { _ in false }
+
+        _ = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        XCTAssertEqual(codexThreads.stateIndexRequests, [[desktopID, cliID]])
+        XCTAssertEqual(codexThreads.projectNameRequests, [])
+    }
+
     @MainActor
     func testSessionManagerClearsDisconnectedAtWhenDesktopHostAppIsRunning() throws {
         let root = NSTemporaryDirectory() + "cctop-desktop-reconnected-\(UUID().uuidString)"
@@ -1014,5 +1085,44 @@ final class SessionLifecycleTests: XCTestCase {
         var working = session
         working.status = .working
         XCTAssertEqual(SessionManager.adjustIdleTimeout(working, now: pastTimeout).status, .working)
+    }
+}
+
+private final class RecordingCodexThreadState: CodexThreadStateProviding {
+    private let projectNamesByThreadID: [String: String]
+    private(set) var stateIndexRequests: [Set<String>] = []
+    private(set) var projectNameRequests: [Set<String>] = []
+
+    init(projectNamesByThreadID: [String: String]) {
+        self.projectNamesByThreadID = projectNamesByThreadID
+    }
+
+    func stateIndex(matching threadIDs: Set<String>) -> CodexThreadStateIndex? {
+        stateIndexRequests.append(threadIDs)
+        var index = CodexThreadStateIndex()
+        index.existingThreadIDs = threadIDs
+        index.projectNamesByThreadID = projectNamesByThreadID.filter { threadIDs.contains($0.key) }
+        return index
+    }
+
+    func existingThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        threadIDs
+    }
+
+    func archivedThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        []
+    }
+
+    func subagentThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        []
+    }
+
+    func execHelperThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        []
+    }
+
+    func projectNames(matching threadIDs: Set<String>) -> [String: String]? {
+        projectNameRequests.append(threadIDs)
+        return projectNamesByThreadID.filter { threadIDs.contains($0.key) }
     }
 }

--- a/menubar/CctopMenubarTests/SessionTestSupport.swift
+++ b/menubar/CctopMenubarTests/SessionTestSupport.swift
@@ -235,6 +235,16 @@ struct StubCodexThreadState: CodexThreadStateProviding {
     var execHelpers: Set<String>? = []
     var projectNamesByThreadID: [String: String]? = [:]
 
+    func stateIndex(matching threadIDs: Set<String>) -> CodexThreadStateIndex? {
+        var index = CodexThreadStateIndex()
+        index.existingThreadIDs = (existing ?? threadIDs).intersection(threadIDs)
+        index.archivedThreadIDs = (archived ?? []).intersection(threadIDs)
+        index.subagentThreadIDs = (subagents ?? []).intersection(threadIDs)
+        index.execHelperThreadIDs = (execHelpers ?? []).intersection(threadIDs)
+        index.projectNamesByThreadID = (projectNamesByThreadID ?? [:]).filter { threadIDs.contains($0.key) }
+        return index
+    }
+
     func existingThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
         existing.map { $0.intersection(threadIDs) }
     }


### PR DESCRIPTION
## Problem

After the notification-envelope cleanup shipped, the running app could beachball while refreshing sessions. Sampling the frozen app did not implicate notification display, notification delegate work, or envelope sanitization. The hot path was `SessionManager.loadSessions()` repeatedly asking the live Codex SQLite state reader for separate pieces of metadata during the same main-thread refresh.

That meant one visible refresh could reopen or revalidate Codex thread state for project names, archive state, missing-thread checks, subagent classification, and exec-helper classification. On a busy Codex state database, that repeated synchronous work was enough to make the menubar app feel stuck.

## Solution

- Add a batched Codex thread-state index path so the live SQLite reader can load all metadata needed for a set of thread IDs in one pass.
- Freeze that batched Codex state for the duration of a `SessionManager` refresh and reuse it for project names, archive classification, missing-thread checks, subagent filtering, and exec-helper filtering.
- Keep the desktop GC safety path separate: deletion checks still revalidate under the per-session lock instead of relying on the display refresh snapshot.
- Extend tests to cover the batched refresh path and keep the existing per-field uncertainty semantics for in-memory Codex state stubs.
