### PR TITLE
Use supported Homebrew macOS dependency syntax

### DIFF
--- a/packaging/homebrew-cask.rb
+++ b/packaging/homebrew-cask.rb
@@ -28,7 +28,7 @@ cask "cctop" do
   end
 
   auto_updates true
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "cctop.app"
   binary "#{appdir}/cctop.app/Contents/MacOS/cctop-hook"


### PR DESCRIPTION
## Problem

Homebrew 6 deprecates comparator strings in `depends_on macos:`. The canonical cctop cask template still uses `">= :ventura"`, so Homebrew emits a deprecation warning and the release workflow would continue copying deprecated syntax into the tap.

## Solution

- Express the existing Ventura-or-newer requirement as `depends_on macos: :ventura`, preserving the minimum macOS target with supported syntax.