### PR TITLE
Keep Active session order stable within status groups

### DIFF
--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -760,9 +760,7 @@ extension AppDelegate {
                 Self.urlLogger.notice("Ignored malformed cctop focus command")
                 return
             }
-            let visibleSessions = Session.sorted(
-                SessionDisplayPolicy.activeSessions(from: sessionManager.sessions)
-            )
+            let visibleSessions = SessionDisplayPolicy.activeSessions(from: sessionManager.sessions)
             guard let session = SessionIdentityPolicy.session(
                 matchingDisplayID: displayID,
                 in: visibleSessions

--- a/menubar/CctopMenubar/Models/SessionDisplayPolicy.swift
+++ b/menubar/CctopMenubar/Models/SessionDisplayPolicy.swift
@@ -24,6 +24,37 @@ enum SessionDisplayPolicy {
         }
     }
 
+    /// Returns the full session array with surviving Active sessions in their published order,
+    /// newcomers appended, and the non-Active remainder untouched. The initial/newcomer order
+    /// matches the legacy status-and-recency presentation order, with stable identity as a tie-breaker.
+    static func reconcilingActiveOrder(
+        in sessions: [Session],
+        preserving previousSessions: [Session],
+        now: Date = Date()
+    ) -> [Session] {
+        let active = activeSessions(from: sessions, now: now)
+        let activeByKey = Dictionary(
+            active.map { (SessionIdentityPolicy.stableKey(for: $0), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let activeKeys = Set(activeByKey.keys)
+        let retainedKeys = activeSessions(from: previousSessions, now: now)
+            .map { SessionIdentityPolicy.stableKey(for: $0) }
+            .filter(activeKeys.contains)
+        let retainedKeySet = Set(retainedKeys)
+        let newcomerKeys = activeKeys
+            .subtracting(retainedKeySet)
+            .sorted { lhsKey, rhsKey in
+                guard let lhs = activeByKey[lhsKey], let rhs = activeByKey[rhsKey] else {
+                    return lhsKey < rhsKey
+                }
+                return initialActiveOrder(lhs, precedes: rhs)
+            }
+        let orderedActive = (retainedKeys + newcomerKeys).compactMap { activeByKey[$0] }
+        let nonActive = sessions.filter { !activeKeys.contains(SessionIdentityPolicy.stableKey(for: $0)) }
+        return orderedActive + nonActive
+    }
+
     static func signature(for sessions: [Session], now: Date = Date()) -> Signature {
         Signature(
             activeIDs: activeSessions(from: sessions, now: now).map(\.id),
@@ -34,5 +65,15 @@ enum SessionDisplayPolicy {
     private static func isStaleActiveIdle(_ session: Session, now: Date) -> Bool {
         guard session.lifecycle == .active, session.status == .idle else { return false }
         return now.timeIntervalSince(session.lastActivity) > staleIdleInterval
+    }
+
+    private static func initialActiveOrder(_ lhs: Session, precedes rhs: Session) -> Bool {
+        if lhs.status.sortOrder != rhs.status.sortOrder {
+            return lhs.status.sortOrder < rhs.status.sortOrder
+        }
+        if lhs.lastActivity != rhs.lastActivity {
+            return lhs.lastActivity > rhs.lastActivity
+        }
+        return SessionIdentityPolicy.stableKey(for: lhs) < SessionIdentityPolicy.stableKey(for: rhs)
     }
 }

--- a/menubar/CctopMenubar/Models/SessionDisplayPolicy.swift
+++ b/menubar/CctopMenubar/Models/SessionDisplayPolicy.swift
@@ -24,9 +24,9 @@ enum SessionDisplayPolicy {
         }
     }
 
-    /// Returns the full session array with surviving Active sessions in their published order,
-    /// newcomers appended, and the non-Active remainder untouched. The initial/newcomer order
-    /// matches the legacy status-and-recency presentation order, with stable identity as a tie-breaker.
+    /// Keeps Active status groups in priority order while preserving the relative order of peers
+    /// that remain in a group. Sessions entering a group append after its surviving members, and
+    /// the full-array return value leaves the current non-Active remainder unchanged.
     static func reconcilingActiveOrder(
         in sessions: [Session],
         preserving previousSessions: [Session],
@@ -38,19 +38,23 @@ enum SessionDisplayPolicy {
             uniquingKeysWith: { first, _ in first }
         )
         let activeKeys = Set(activeByKey.keys)
-        let retainedKeys = activeSessions(from: previousSessions, now: now)
-            .map { SessionIdentityPolicy.stableKey(for: $0) }
-            .filter(activeKeys.contains)
-        let retainedKeySet = Set(retainedKeys)
-        let newcomerKeys = activeKeys
-            .subtracting(retainedKeySet)
-            .sorted { lhsKey, rhsKey in
-                guard let lhs = activeByKey[lhsKey], let rhs = activeByKey[rhsKey] else {
-                    return lhsKey < rhsKey
-                }
-                return initialActiveOrder(lhs, precedes: rhs)
-            }
-        let orderedActive = (retainedKeys + newcomerKeys).compactMap { activeByKey[$0] }
+        var groups = Array(repeating: [Session](), count: SessionStatus.idle.sortOrder + 1)
+        var placedKeys: Set<String> = []
+
+        for previous in activeSessions(from: previousSessions, now: now) {
+            let key = SessionIdentityPolicy.stableKey(for: previous)
+            guard let current = activeByKey[key], current.status.sortOrder == previous.status.sortOrder else { continue }
+            groups[current.status.sortOrder].append(current)
+            placedKeys.insert(key)
+        }
+
+        for current in active {
+            let key = SessionIdentityPolicy.stableKey(for: current)
+            guard placedKeys.insert(key).inserted else { continue }
+            groups[current.status.sortOrder].append(current)
+        }
+
+        let orderedActive = groups.flatMap { $0 }
         let nonActive = sessions.filter { !activeKeys.contains(SessionIdentityPolicy.stableKey(for: $0)) }
         return orderedActive + nonActive
     }
@@ -67,13 +71,4 @@ enum SessionDisplayPolicy {
         return now.timeIntervalSince(session.lastActivity) > staleIdleInterval
     }
 
-    private static func initialActiveOrder(_ lhs: Session, precedes rhs: Session) -> Bool {
-        if lhs.status.sortOrder != rhs.status.sortOrder {
-            return lhs.status.sortOrder < rhs.status.sortOrder
-        }
-        if lhs.lastActivity != rhs.lastActivity {
-            return lhs.lastActivity > rhs.lastActivity
-        }
-        return SessionIdentityPolicy.stableKey(for: lhs) < SessionIdentityPolicy.stableKey(for: rhs)
-    }
 }

--- a/menubar/CctopMenubar/Services/DisplayStateWriter.swift
+++ b/menubar/CctopMenubar/Services/DisplayStateWriter.swift
@@ -98,7 +98,7 @@ final class DisplayStateWriter {
         appIdentity: DisplayState.ProcessIdentity?,
         now: Date
     ) -> DisplayState {
-        let ordered = Session.sorted(SessionDisplayPolicy.activeSessions(from: sessions, now: now))
+        let ordered = SessionDisplayPolicy.activeSessions(from: sessions, now: now)
         return DisplayState(
             version: schemaVersion,
             generatedAt: timestampFormatter.string(from: now),

--- a/menubar/CctopMenubar/Services/NavigateController.swift
+++ b/menubar/CctopMenubar/Services/NavigateController.swift
@@ -6,13 +6,13 @@ class NavigateController: ObservableObject {
     let didActivateSubject = PassthroughSubject<Void, Never>()
     let didConfirmSubject = PassthroughSubject<Void, Never>()
     let navActionSubject = PassthroughSubject<PanelNavAction, Never>()
-    /// Sorted session snapshot captured when navigate activates.
+    /// Canonically ordered session snapshot captured when navigate activates.
     /// Prevents reordering while badges are visible.
     private(set) var frozenSessions: [Session] = []
     private var timeoutWork: DispatchWorkItem?
 
     func activate(sessions: [Session]) {
-        frozenSessions = Session.sorted(sessions)
+        frozenSessions = sessions
         isActive = true
         didActivateSubject.send()
     }

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -94,9 +94,8 @@ class SessionManager: ObservableObject {
         // Publish active + dormant; finished are hidden (swept below / by GC).
         let winners = SessionIdentityPolicy.dedupedCandidatesByStableKey(displayCandidates)
         let now = dataSources.now()
-        let newSessions = winners
-            .filter { $0.session.lifecycle != .finished }
-            .map { adjustDisplayStatus($0.session) }
+        let loadedSessions = winners.filter { $0.session.lifecycle != .finished }.map { adjustDisplayStatus($0.session) }
+        let newSessions = SessionDisplayPolicy.reconcilingActiveOrder(in: loadedSessions, preserving: oldSessions, now: now)
         let displaySignature = SessionDisplayPolicy.signature(for: newSessions, now: now)
         syncTransitionNotifications(for: newSessions, oldSessions: oldSessions)
         // Only publish when data actually changed, or when the presentation bucket changed

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -356,7 +356,7 @@ extension PopupView {
         if isNavigateActive, let frozen = navigate?.frozenSessions, !frozen.isEmpty {
             return frozen
         }
-        return Session.sorted(SessionDisplayPolicy.activeSessions(from: sessions))
+        return SessionDisplayPolicy.activeSessions(from: sessions)
     }
     private var sortedIdleSessions: [Session] {
         Session.sorted(SessionDisplayPolicy.idleSessions(from: sessions))

--- a/menubar/CctopMenubarTests/DisplayStateWriterTests.swift
+++ b/menubar/CctopMenubarTests/DisplayStateWriterTests.swift
@@ -12,7 +12,7 @@ final class DisplayStateWriterTests: XCTestCase {
         workingNew.lastActivity = now.addingTimeInterval(-10)
         var idle = Session.mock(id: "d", project: "delta", status: .idle)
         idle.lastActivity = now.addingTimeInterval(-60)
-        let sessions = [workingOld, idle, permission, workingNew]
+        let sessions = [permission, workingOld, workingNew, idle]
 
         let snapshot = DisplayStateWriter.snapshot(
             sessions: sessions,
@@ -24,7 +24,7 @@ final class DisplayStateWriterTests: XCTestCase {
 
         let expected = SessionDisplayPolicy.activeSessions(from: sessions, now: now)
         XCTAssertEqual(snapshot.sessions.map(\.id), expected.map(\.id))
-        XCTAssertEqual(snapshot.sessions.map(\.id), ["b", "d", "a", "c"])
+        XCTAssertEqual(snapshot.sessions.map(\.id), ["a", "b", "c", "d"])
     }
 
     func testSnapshotExcludesSessionsTheAppDoesNotDisplay() {

--- a/menubar/CctopMenubarTests/DisplayStateWriterTests.swift
+++ b/menubar/CctopMenubarTests/DisplayStateWriterTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import CctopMenubar
 
 final class DisplayStateWriterTests: XCTestCase {
-    func testSnapshotOrderMatchesPanelAndNavigateOrder() {
+    func testSnapshotPreservesCanonicalPanelAndNavigateOrder() {
         let now = Date()
         var permission = Session.mock(id: "a", project: "alpha", status: .waitingPermission)
         permission.lastActivity = now.addingTimeInterval(-30)
@@ -12,7 +12,7 @@ final class DisplayStateWriterTests: XCTestCase {
         workingNew.lastActivity = now.addingTimeInterval(-10)
         var idle = Session.mock(id: "d", project: "delta", status: .idle)
         idle.lastActivity = now.addingTimeInterval(-60)
-        let sessions = [idle, workingOld, workingNew, permission]
+        let sessions = [workingOld, idle, permission, workingNew]
 
         let snapshot = DisplayStateWriter.snapshot(
             sessions: sessions,
@@ -22,9 +22,9 @@ final class DisplayStateWriterTests: XCTestCase {
             now: now
         )
 
-        let expected = Session.sorted(SessionDisplayPolicy.activeSessions(from: sessions, now: now))
+        let expected = SessionDisplayPolicy.activeSessions(from: sessions, now: now)
         XCTAssertEqual(snapshot.sessions.map(\.id), expected.map(\.id))
-        XCTAssertEqual(snapshot.sessions.map(\.id), ["a", "c", "b", "d"])
+        XCTAssertEqual(snapshot.sessions.map(\.id), ["b", "d", "a", "c"])
     }
 
     func testSnapshotExcludesSessionsTheAppDoesNotDisplay() {

--- a/menubar/CctopMenubarTests/NavigateControllerTests.swift
+++ b/menubar/CctopMenubarTests/NavigateControllerTests.swift
@@ -38,14 +38,17 @@ final class NavigateControllerTests: XCTestCase {
     }
 
     func testActivatePreservesCanonicalSessionOrder() {
-        var idle = Session.mock(id: "1", project: "alpha", status: .idle)
-        idle.lastActivity = Date().addingTimeInterval(-60)
-        let working = Session.mock(id: "2", project: "beta", status: .working)
+        let now = Date()
+        let waiting = Session.mock(id: "1", project: "alpha", status: .waitingInput)
+        var workingOld = Session.mock(id: "2", project: "beta", status: .working)
+        workingOld.lastActivity = now.addingTimeInterval(-600)
+        var workingNew = Session.mock(id: "3", project: "gamma", status: .working)
+        workingNew.lastActivity = now
+        let idle = Session.mock(id: "4", project: "delta", status: .idle)
 
-        sut.activate(sessions: [idle, working])
+        sut.activate(sessions: [waiting, workingOld, workingNew, idle])
 
-        XCTAssertEqual(sut.frozenSessions[0].projectName, "alpha")
-        XCTAssertEqual(sut.frozenSessions[1].projectName, "beta")
+        XCTAssertEqual(sut.frozenSessions.map(\.projectName), ["alpha", "beta", "gamma", "delta"])
     }
 
     func testActivateWithEmptySessions() {
@@ -198,17 +201,6 @@ final class NavigateControllerTests: XCTestCase {
     }
 
     // MARK: - Canonical order in frozen sessions
-
-    func testFrozenSessionsPreserveOrderAcrossStatuses() {
-        var idle = Session.mock(id: "1", status: .idle)
-        idle.lastActivity = Date().addingTimeInterval(-60)
-        let attention = Session.mock(id: "2", status: .waitingPermission)
-        let working = Session.mock(id: "3", status: .working)
-
-        sut.activate(sessions: [idle, attention, working])
-
-        XCTAssertEqual(sut.frozenSessions.map(\.status), [.idle, .waitingPermission, .working])
-    }
 
     func testFrozenSessionsPreserveOrderAcrossActivityTimes() {
         var older = Session.mock(id: "1", project: "older", status: .working)

--- a/menubar/CctopMenubarTests/NavigateControllerTests.swift
+++ b/menubar/CctopMenubarTests/NavigateControllerTests.swift
@@ -37,16 +37,15 @@ final class NavigateControllerTests: XCTestCase {
         XCTAssertEqual(sut.frozenSessions.count, 2)
     }
 
-    func testActivateSortsSessions() {
+    func testActivatePreservesCanonicalSessionOrder() {
         var idle = Session.mock(id: "1", project: "alpha", status: .idle)
         idle.lastActivity = Date().addingTimeInterval(-60)
         let working = Session.mock(id: "2", project: "beta", status: .working)
 
         sut.activate(sessions: [idle, working])
 
-        // Working sessions sort before idle
-        XCTAssertEqual(sut.frozenSessions[0].projectName, "beta")
-        XCTAssertEqual(sut.frozenSessions[1].projectName, "alpha")
+        XCTAssertEqual(sut.frozenSessions[0].projectName, "alpha")
+        XCTAssertEqual(sut.frozenSessions[1].projectName, "beta")
     }
 
     func testActivateWithEmptySessions() {
@@ -198,9 +197,9 @@ final class NavigateControllerTests: XCTestCase {
         }
     }
 
-    // MARK: - Sort order in frozen sessions
+    // MARK: - Canonical order in frozen sessions
 
-    func testFrozenSessionsSortAttentionBeforeWorking() {
+    func testFrozenSessionsPreserveOrderAcrossStatuses() {
         var idle = Session.mock(id: "1", status: .idle)
         idle.lastActivity = Date().addingTimeInterval(-60)
         let attention = Session.mock(id: "2", status: .waitingPermission)
@@ -208,12 +207,10 @@ final class NavigateControllerTests: XCTestCase {
 
         sut.activate(sessions: [idle, attention, working])
 
-        XCTAssertEqual(sut.frozenSessions[0].status, .waitingPermission)
-        XCTAssertEqual(sut.frozenSessions[1].status, .working)
-        XCTAssertEqual(sut.frozenSessions[2].status, .idle)
+        XCTAssertEqual(sut.frozenSessions.map(\.status), [.idle, .waitingPermission, .working])
     }
 
-    func testFrozenSessionsSortByRecencyWithinSameStatus() {
+    func testFrozenSessionsPreserveOrderAcrossActivityTimes() {
         var older = Session.mock(id: "1", project: "older", status: .working)
         older.lastActivity = Date().addingTimeInterval(-120)
         var newer = Session.mock(id: "2", project: "newer", status: .working)
@@ -221,7 +218,7 @@ final class NavigateControllerTests: XCTestCase {
 
         sut.activate(sessions: [older, newer])
 
-        XCTAssertEqual(sut.frozenSessions[0].projectName, "newer")
-        XCTAssertEqual(sut.frozenSessions[1].projectName, "older")
+        XCTAssertEqual(sut.frozenSessions[0].projectName, "older")
+        XCTAssertEqual(sut.frozenSessions[1].projectName, "newer")
     }
 }

--- a/menubar/CctopMenubarTests/SessionDisplayPolicyTests.swift
+++ b/menubar/CctopMenubarTests/SessionDisplayPolicyTests.swift
@@ -40,6 +40,120 @@ final class SessionDisplayPolicyTests: XCTestCase {
         )
     }
 
+    func testReconciledActiveOrderPreservesExistingPositionsAcrossPayloadUpdates() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        var alpha = Session.mock(id: "alpha", status: .working, lastTool: "Read", lastToolDetail: "old")
+        alpha.lastActivity = now.addingTimeInterval(-300)
+        var beta = Session.mock(id: "beta", status: .waitingInput, notificationMessage: "old")
+        beta.lastActivity = now.addingTimeInterval(-200)
+        let previous = [beta, alpha]
+
+        alpha.status = .waitingPermission
+        alpha.lastActivity = now
+        alpha.notificationMessage = "Approve command"
+        beta.status = .working
+        beta.lastActivity = now.addingTimeInterval(-1)
+        beta.lastTool = "Bash"
+        beta.lastToolDetail = "make test"
+
+        let result = SessionDisplayPolicy.reconcilingActiveOrder(
+            in: [alpha, beta],
+            preserving: previous,
+            now: now
+        )
+
+        XCTAssertEqual(result.map(\.id), ["beta", "alpha"])
+        XCTAssertEqual(result.map(\.status), [.working, .waitingPermission])
+        XCTAssertEqual(result.first?.lastToolDetail, "make test")
+        XCTAssertEqual(result.last?.notificationMessage, "Approve command")
+    }
+
+    func testReconciledActiveOrderAppendsNewcomersInDeterministicLegacyOrder() {
+        let now = Date(timeIntervalSince1970: 20_000)
+        var survivor = Session.mock(id: "survivor", status: .idle)
+        survivor.lastActivity = now.addingTimeInterval(-60)
+        var permission = Session.mock(id: "permission", status: .waitingPermission)
+        permission.lastActivity = now.addingTimeInterval(-30)
+        var tieB = Session.mock(id: "b", status: .working)
+        tieB.lastActivity = now
+        var tieA = Session.mock(id: "a", status: .working)
+        tieA.lastActivity = now
+
+        let result = SessionDisplayPolicy.reconcilingActiveOrder(
+            in: [tieB, survivor, tieA, permission],
+            preserving: [survivor],
+            now: now
+        )
+
+        XCTAssertEqual(result.map(\.id), ["survivor", "permission", "a", "b"])
+    }
+
+    func testReconciledActiveOrderCompactsSurvivorsAndKeepsNonActiveRemainderOrder() {
+        let now = Date(timeIntervalSince1970: 30_000)
+        let alpha = Session.mock(id: "alpha", status: .working)
+        var beta = Session.mock(id: "beta", status: .idle)
+        let charlie = Session.mock(id: "charlie", status: .working)
+        var dormant = Session.mock(id: "dormant", status: .idle)
+        beta.lifecycle = .dormant
+        dormant.lifecycle = .dormant
+
+        let result = SessionDisplayPolicy.reconcilingActiveOrder(
+            in: [beta, dormant, alpha],
+            preserving: [alpha, beta, charlie],
+            now: now
+        )
+
+        XCTAssertEqual(result.map(\.id), ["alpha", "beta", "dormant"])
+        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: result, now: now).map(\.id), ["alpha"])
+        XCTAssertEqual(SessionDisplayPolicy.idleSessions(from: result, now: now).map(\.id), ["beta", "dormant"])
+    }
+
+    func testReconciledActiveOrderTreatsStaleIdleReentryAsNewcomer() {
+        let now = Date(timeIntervalSince1970: 40_000)
+        let survivor = Session.mock(id: "survivor", status: .working)
+        var returning = Session.mock(id: "returning", status: .idle)
+        returning.lastActivity = now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 1)
+        let previous = [returning, survivor]
+
+        returning.status = .working
+        returning.lastActivity = now
+        let result = SessionDisplayPolicy.reconcilingActiveOrder(
+            in: [returning, survivor],
+            preserving: previous,
+            now: now
+        )
+
+        XCTAssertEqual(result.map(\.id), ["survivor", "returning"])
+    }
+
+    func testReconciledActiveOrderUsesStableConversationIdentityAcrossDesktopPIDChange() {
+        let now = Date(timeIntervalSince1970: 50_000)
+        let terminal = TerminalInfo(program: "Claude", bundleId: HostAppBundleID.claudeDesktop)
+        var desktop = Session.mock(
+            id: "conversation",
+            status: .working,
+            pid: 100,
+            terminal: terminal,
+            source: Session.ccSource
+        )
+        let other = Session.mock(id: "other", status: .working, source: Session.codexSource)
+        let previous = [desktop, other]
+
+        desktop.pid = 200
+        desktop.lastActivity = now
+        let result = SessionDisplayPolicy.reconcilingActiveOrder(
+            in: [other, desktop],
+            preserving: previous,
+            now: now
+        )
+
+        XCTAssertEqual(result.map(\.id), ["200", "other"])
+        XCTAssertEqual(
+            SessionIdentityPolicy.stableKey(for: previous[0]),
+            SessionIdentityPolicy.stableKey(for: result[0])
+        )
+    }
+
     private func activeIdle(id: String, lastActivity: Date) -> Session {
         var session = Session.mock(id: id, status: .idle)
         session.lifecycle = .active

--- a/menubar/CctopMenubarTests/SessionDisplayPolicyTests.swift
+++ b/menubar/CctopMenubarTests/SessionDisplayPolicyTests.swift
@@ -40,76 +40,155 @@ final class SessionDisplayPolicyTests: XCTestCase {
         )
     }
 
-    func testReconciledActiveOrderPreservesExistingPositionsAcrossPayloadUpdates() {
+    func testReconciledActiveOrderKeepsWaitingPeerOrderAcrossSameGroupUpdates() {
         let now = Date(timeIntervalSince1970: 10_000)
-        var alpha = Session.mock(id: "alpha", status: .working, lastTool: "Read", lastToolDetail: "old")
-        alpha.lastActivity = now.addingTimeInterval(-300)
-        var beta = Session.mock(id: "beta", status: .waitingInput, notificationMessage: "old")
-        beta.lastActivity = now.addingTimeInterval(-200)
-        let previous = [beta, alpha]
+        var first = Session.mock(id: "first", status: .waitingInput, notificationMessage: "old")
+        first.lastActivity = now.addingTimeInterval(-300)
+        var second = Session.mock(id: "second", status: .needsAttention, notificationMessage: "old")
+        second.lastActivity = now.addingTimeInterval(-200)
+        let previous = [first, second]
 
-        alpha.status = .waitingPermission
-        alpha.lastActivity = now
-        alpha.notificationMessage = "Approve command"
-        beta.status = .working
-        beta.lastActivity = now.addingTimeInterval(-1)
-        beta.lastTool = "Bash"
-        beta.lastToolDetail = "make test"
+        first.status = .needsAttention
+        first.lastActivity = now
+        first.notificationMessage = "Review failure"
+        second.status = .waitingInput
+        second.lastActivity = now.addingTimeInterval(-600)
+        second.notificationMessage = "Continue?"
 
         let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [alpha, beta],
+            in: [second, first],
             preserving: previous,
             now: now
         )
 
-        XCTAssertEqual(result.map(\.id), ["beta", "alpha"])
-        XCTAssertEqual(result.map(\.status), [.working, .waitingPermission])
-        XCTAssertEqual(result.first?.lastToolDetail, "make test")
-        XCTAssertEqual(result.last?.notificationMessage, "Approve command")
+        XCTAssertEqual(result.map(\.id), ["first", "second"])
+        XCTAssertEqual(result.map(\.status), [.needsAttention, .waitingInput])
+        XCTAssertEqual(result.map(\.notificationMessage), ["Review failure", "Continue?"])
     }
 
-    func testReconciledActiveOrderAppendsNewcomersInDeterministicLegacyOrder() {
+    func testReconciledActiveOrderKeepsWorkingAndActiveIdlePeerOrderAcrossActivityChanges() {
         let now = Date(timeIntervalSince1970: 20_000)
-        var survivor = Session.mock(id: "survivor", status: .idle)
-        survivor.lastActivity = now.addingTimeInterval(-60)
-        var permission = Session.mock(id: "permission", status: .waitingPermission)
-        permission.lastActivity = now.addingTimeInterval(-30)
-        var tieB = Session.mock(id: "b", status: .working)
-        tieB.lastActivity = now
-        var tieA = Session.mock(id: "a", status: .working)
-        tieA.lastActivity = now
+        var workA = Session.mock(id: "work-a", status: .working)
+        var workB = Session.mock(id: "work-b", status: .working)
+        var idleA = Session.mock(id: "idle-a", status: .idle)
+        var idleB = Session.mock(id: "idle-b", status: .idle)
+        let previous = [workA, workB, idleA, idleB]
+
+        workA.lastActivity = now
+        workB.lastActivity = now.addingTimeInterval(-600)
+        idleA.lastActivity = now.addingTimeInterval(-60)
+        idleB.lastActivity = now.addingTimeInterval(-1_200)
 
         let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [tieB, survivor, tieA, permission],
-            preserving: [survivor],
+            in: [idleB, workB, idleA, workA],
+            preserving: previous,
             now: now
         )
 
-        XCTAssertEqual(result.map(\.id), ["survivor", "permission", "a", "b"])
+        XCTAssertEqual(result.map(\.id), ["work-a", "work-b", "idle-a", "idle-b"])
+    }
+
+    func testReconciledActiveOrderMovesWorkingSessionToWaitingGroupTail() {
+        let now = Date(timeIntervalSince1970: 30_000)
+        let waitA = Session.mock(id: "wait-a", status: .waitingInput)
+        let waitB = Session.mock(id: "wait-b", status: .needsAttention)
+        var working = Session.mock(id: "working", status: .working)
+        let previous = [waitA, waitB, working]
+
+        working.status = .waitingInput
+
+        let result = SessionDisplayPolicy.reconcilingActiveOrder(
+            in: [working, waitB, waitA],
+            preserving: previous,
+            now: now
+        )
+
+        XCTAssertEqual(result.map(\.id), ["wait-a", "wait-b", "working"])
+    }
+
+    func testReconciledActiveOrderMovesWaitingSessionToWorkingGroupTail() {
+        let now = Date(timeIntervalSince1970: 40_000)
+        var waiting = Session.mock(id: "waiting", status: .waitingInput)
+        let workA = Session.mock(id: "work-a", status: .working)
+        let workB = Session.mock(id: "work-b", status: .working)
+        let previous = [waiting, workA, workB]
+
+        waiting.status = .working
+        let result = SessionDisplayPolicy.reconcilingActiveOrder(
+            in: [waiting, workB, workA],
+            preserving: previous,
+            now: now
+        )
+
+        XCTAssertEqual(result.map(\.id), ["work-a", "work-b", "waiting"])
+    }
+
+    func testReconciledActiveOrderAppendsNewcomersWithinEachPriorityGroup() {
+        let now = Date(timeIntervalSince1970: 50_000)
+        let permission = Session.mock(id: "permission", status: .waitingPermission)
+        let waiting = Session.mock(id: "waiting", status: .waitingInput)
+        let working = Session.mock(id: "working", status: .working)
+        let compacting = Session.mock(id: "compacting", status: .compacting)
+        let idle = Session.mock(id: "idle", status: .idle)
+        let newPermission = Session.mock(id: "new-permission", status: .waitingPermission)
+        let newWaiting = Session.mock(id: "new-waiting", status: .waitingInput)
+        let newWorking = Session.mock(id: "new-working", status: .working)
+        let newCompacting = Session.mock(id: "new-compacting", status: .compacting)
+        let newIdle = Session.mock(id: "new-idle", status: .idle)
+
+        let result = SessionDisplayPolicy.reconcilingActiveOrder(
+            in: [newIdle, newCompacting, newWorking, newWaiting, newPermission, idle, compacting, working, waiting, permission],
+            preserving: [permission, waiting, working, compacting, idle],
+            now: now
+        )
+
+        XCTAssertEqual(
+            result.map(\.id),
+            [
+                "permission", "new-permission", "waiting", "new-waiting", "working", "new-working",
+                "compacting", "new-compacting", "idle", "new-idle",
+            ]
+        )
     }
 
     func testReconciledActiveOrderCompactsSurvivorsAndKeepsNonActiveRemainderOrder() {
-        let now = Date(timeIntervalSince1970: 30_000)
-        let alpha = Session.mock(id: "alpha", status: .working)
-        var beta = Session.mock(id: "beta", status: .idle)
-        let charlie = Session.mock(id: "charlie", status: .working)
+        let now = Date(timeIntervalSince1970: 60_000)
+        let waitA = Session.mock(id: "wait-a", status: .waitingInput)
+        let waitB = Session.mock(id: "wait-b", status: .waitingInput)
+        let workA = Session.mock(id: "work-a", status: .working)
+        let workB = Session.mock(id: "work-b", status: .working)
         var dormant = Session.mock(id: "dormant", status: .idle)
-        beta.lifecycle = .dormant
         dormant.lifecycle = .dormant
 
         let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [beta, dormant, alpha],
-            preserving: [alpha, beta, charlie],
+            in: [workB, dormant, waitB],
+            preserving: [waitA, waitB, workA, workB],
             now: now
         )
 
-        XCTAssertEqual(result.map(\.id), ["alpha", "beta", "dormant"])
-        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: result, now: now).map(\.id), ["alpha"])
-        XCTAssertEqual(SessionDisplayPolicy.idleSessions(from: result, now: now).map(\.id), ["beta", "dormant"])
+        XCTAssertEqual(result.map(\.id), ["wait-b", "work-b", "dormant"])
+        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: result, now: now).map(\.id), ["wait-b", "work-b"])
+        XCTAssertEqual(SessionDisplayPolicy.idleSessions(from: result, now: now).map(\.id), ["dormant"])
     }
 
-    func testReconciledActiveOrderTreatsStaleIdleReentryAsNewcomer() {
-        let now = Date(timeIntervalSince1970: 40_000)
+    func testReconciledActiveOrderUsesDeterministicCurrentInputOnInitialLoad() {
+        let now = Date(timeIntervalSince1970: 70_000)
+        let workA = Session.mock(id: "a-work", status: .working)
+        let waiting = Session.mock(id: "b-wait", status: .waitingInput)
+        let workB = Session.mock(id: "c-work", status: .working)
+        let idle = Session.mock(id: "d-idle", status: .idle)
+
+        let result = SessionDisplayPolicy.reconcilingActiveOrder(
+            in: [workA, waiting, workB, idle],
+            preserving: [],
+            now: now
+        )
+
+        XCTAssertEqual(result.map(\.id), ["b-wait", "a-work", "c-work", "d-idle"])
+    }
+
+    func testReconciledActiveOrderTreatsStaleIdleReentryAsGroupEntrant() {
+        let now = Date(timeIntervalSince1970: 80_000)
         let survivor = Session.mock(id: "survivor", status: .working)
         var returning = Session.mock(id: "returning", status: .idle)
         returning.lastActivity = now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 1)
@@ -127,7 +206,7 @@ final class SessionDisplayPolicyTests: XCTestCase {
     }
 
     func testReconciledActiveOrderUsesStableConversationIdentityAcrossDesktopPIDChange() {
-        let now = Date(timeIntervalSince1970: 50_000)
+        let now = Date(timeIntervalSince1970: 90_000)
         let terminal = TerminalInfo(program: "Claude", bundleId: HostAppBundleID.claudeDesktop)
         var desktop = Session.mock(
             id: "conversation",

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -820,6 +820,70 @@ final class SessionManagerVisibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testSessionManagerPublishesOneStableActiveOrderThroughRealisticFileUpdates() throws {
+        let root = NSTemporaryDirectory() + "cctop-stable-active-order-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        let now = Date(timeIntervalSince1970: 1_900_000_000)
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let alphaPath = (sessionsDir as NSString).appendingPathComponent("101.json")
+        let betaPath = (sessionsDir as NSString).appendingPathComponent("202.json")
+        let gammaPath = (sessionsDir as NSString).appendingPathComponent("303.json")
+        var alpha = Session.mock(id: "alpha", status: .working, pid: 101, source: Session.opencodeSource)
+        alpha.lastActivity = now.addingTimeInterval(-60)
+        var beta = Session.mock(id: "beta", status: .waitingPermission, pid: 202, source: Session.opencodeSource)
+        beta.lastActivity = now.addingTimeInterval(-120)
+        try alpha.writeToFile(path: alphaPath)
+        try beta.writeToFile(path: betaPath)
+
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            processAlive: { _ in true },
+            now: { now }
+        )
+        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["202", "101"])
+
+        alpha.status = .waitingPermission
+        alpha.lastActivity = now
+        alpha.notificationMessage = "Approve command"
+        beta.status = .idle
+        beta.lastActivity = now.addingTimeInterval(-300)
+        beta.lastTool = "Bash"
+        beta.lastToolDetail = "make test"
+        var gamma = Session.mock(id: "gamma", status: .waitingInput, pid: 303, source: Session.opencodeSource)
+        gamma.lastActivity = now.addingTimeInterval(-1)
+        try alpha.writeToFile(path: alphaPath)
+        try beta.writeToFile(path: betaPath)
+        try gamma.writeToFile(path: gammaPath)
+        manager.loadSessions()
+
+        let activeAfterUpdates = SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now)
+        XCTAssertEqual(activeAfterUpdates.map(\.id), ["202", "101", "303"])
+        let snapshot = DisplayStateWriter.snapshot(
+            sessions: manager.sessions,
+            theme: .claude,
+            appRunning: true,
+            appIdentity: DisplayState.ProcessIdentity(pid: 999, startTime: 1_234),
+            now: now
+        )
+        XCTAssertEqual(snapshot.sessions.map(\.id), activeAfterUpdates.map(\.id))
+
+        alpha.hidden = true
+        try alpha.writeToFile(path: alphaPath)
+        manager.loadSessions()
+        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["202", "303"])
+
+        beta.endedAt = now
+        try beta.writeToFile(path: betaPath)
+        manager.loadSessions()
+        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["303"])
+    }
+
+    @MainActor
     func testSessionManagerKeepsUserVisibleCodexExecThreads() throws {
         let root = NSTemporaryDirectory() + "cctop-codex-user-exec-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -820,7 +820,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
     }
 
     @MainActor
-    func testSessionManagerPublishesOneStableActiveOrderThroughRealisticFileUpdates() throws {
+    func testSessionManagerPublishesOneGroupedActiveOrderThroughRealisticFileUpdates() throws {
         let root = NSTemporaryDirectory() + "cctop-stable-active-order-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")
         let historyDir = (root as NSString).appendingPathComponent("history")
@@ -832,10 +832,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let alphaPath = (sessionsDir as NSString).appendingPathComponent("101.json")
         let betaPath = (sessionsDir as NSString).appendingPathComponent("202.json")
         let gammaPath = (sessionsDir as NSString).appendingPathComponent("303.json")
+        let deltaPath = (sessionsDir as NSString).appendingPathComponent("404.json")
         var alpha = Session.mock(id: "alpha", status: .working, pid: 101, source: Session.opencodeSource)
         alpha.lastActivity = now.addingTimeInterval(-60)
-        var beta = Session.mock(id: "beta", status: .waitingPermission, pid: 202, source: Session.opencodeSource)
-        beta.lastActivity = now.addingTimeInterval(-120)
+        var beta = Session.mock(id: "beta", status: .working, pid: 202, source: Session.opencodeSource)
+        beta.lastActivity = now.addingTimeInterval(-10)
         try alpha.writeToFile(path: alphaPath)
         try beta.writeToFile(path: betaPath)
 
@@ -845,24 +846,30 @@ final class SessionManagerVisibilityTests: XCTestCase {
             processAlive: { _ in true },
             now: { now }
         )
-        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["202", "101"])
+        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["101", "202"])
 
-        alpha.status = .waitingPermission
+        var gamma = Session.mock(id: "gamma", status: .waitingInput, pid: 303, source: Session.opencodeSource)
+        gamma.lastActivity = now.addingTimeInterval(-30)
+        var delta = Session.mock(id: "delta", status: .waitingInput, pid: 404, source: Session.opencodeSource)
+        delta.lastActivity = now.addingTimeInterval(-20)
+        try gamma.writeToFile(path: gammaPath)
+        try delta.writeToFile(path: deltaPath)
+        manager.loadSessions()
+        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["303", "404", "101", "202"])
+
+        alpha.status = .waitingInput
         alpha.lastActivity = now
-        alpha.notificationMessage = "Approve command"
+        alpha.notificationMessage = "Continue?"
         beta.status = .idle
         beta.lastActivity = now.addingTimeInterval(-300)
         beta.lastTool = "Bash"
         beta.lastToolDetail = "make test"
-        var gamma = Session.mock(id: "gamma", status: .waitingInput, pid: 303, source: Session.opencodeSource)
-        gamma.lastActivity = now.addingTimeInterval(-1)
         try alpha.writeToFile(path: alphaPath)
         try beta.writeToFile(path: betaPath)
-        try gamma.writeToFile(path: gammaPath)
         manager.loadSessions()
 
         let activeAfterUpdates = SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now)
-        XCTAssertEqual(activeAfterUpdates.map(\.id), ["202", "101", "303"])
+        XCTAssertEqual(activeAfterUpdates.map(\.id), ["303", "404", "101", "202"])
         let snapshot = DisplayStateWriter.snapshot(
             sessions: manager.sessions,
             theme: .claude,
@@ -875,12 +882,12 @@ final class SessionManagerVisibilityTests: XCTestCase {
         alpha.hidden = true
         try alpha.writeToFile(path: alphaPath)
         manager.loadSessions()
-        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["202", "303"])
+        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["303", "404", "202"])
 
         beta.endedAt = now
         try beta.writeToFile(path: betaPath)
         manager.loadSessions()
-        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["303"])
+        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["303", "404"])
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Stabilizes Active session order within each status group while preserving the existing status priority, without introducing persistent ordering state.

- preserves the relative order of surviving sessions while they remain in the same status group
- moves sessions with changed status into the correct priority group, after that group's surviving sessions; new sessions append the same way
- removes ended or hidden sessions while compacting remaining peers
- keeps the panel, navigation, URL focus path, display-state publisher, and Stream Deck on one authoritative Active order
- leaves Idle, Recent, and Cleanup ordering unchanged

Focused policy and file-backed reload coverage exercises stable peer order, group transitions, desktop conversation identity, lifecycle compaction, and the shared panel/Stream Deck projection.