### PR TITLE
Add manual session hiding

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -318,6 +318,7 @@ when you glance at it from peripheral vision.
 | **Row 3 — waiting**       | 10.5 px `textSecondary` note: `notificationMessage ?? contextLine ?? "Waiting for input"`. Permission notes are 10.5 px italic `statusAttention`. |
 | Selected / hover          | `cardSelectionStyle` uses a theme-ink 7–7.5% fill, radius 10, and an 8 px horizontal inset. It has no stroke, divider, or left accent bar. |
 | Source badge visibility   | Shown only when `Set(sessions.map(\.agentBadge)).count > 1` (keyed on `agentBadge`, not `sourceLabel`, so CC + Claude Desktop counts as multiple sources) |
+| Hide interaction          | A native context-menu item and named accessibility action open the same destructive confirmation. Left-click remains jump-to-session. |
 
 #### Source badge (`SourceBadgeView.swift`) — six variants
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -70,6 +70,16 @@ It does not prove that a path is still safe to act on. Cleanup, navigation, and
 lifecycle features should use session data as the starting point, then verify
 current local state before making safety claims.
 
+### Manual visibility is not lifecycle
+
+Users may hide a session they no longer want to monitor, but cctop must explain
+that this only removes the session from user-facing surfaces: it does not stop
+the underlying session or delete its data. Because there is no in-app restore,
+the action requires confirmation and must say that the session cannot be shown
+again while its local record exists. Persist the preference by stable identity,
+while continuing lifecycle classification and Cleanup protection from the full
+local session inventory.
+
 ### Show decision evidence inline
 
 When cctop asks users to decide, the evidence needed for that decision should be

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -76,7 +76,7 @@ Users may hide a session they no longer want to monitor, but cctop must explain
 that this only removes the session from user-facing surfaces: it does not stop
 the underlying session or delete its data. Because there is no in-app restore,
 the action requires confirmation and must say that the session cannot be shown
-again while its local record exists. Persist the preference by stable identity,
+again while its local record exists. Persist the preference by cctop's permanent session identity,
 while continuing lifecycle classification and Cleanup protection from the full
 local session inventory.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ project with a keystroke.
 ## Why cctop
 
 - See at a glance which coding sessions are working, idle, or waiting on you.
+- Right-click to hide a session from cctop without stopping it or deleting its data.
+  cctop asks first because you cannot show it again while its local session record exists.
 - Jump directly to the right editor window, terminal pane, desktop thread, or project.
 - Keep recent projects close without leaving a menubar app open all day.
 - Find leftover ended-session worktrees, check Git safety, and remove the ones

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -155,6 +155,19 @@ Use `hidden` for real session records that should remain on disk for liveness, d
 
 Do not use file deletion as the hiding signal. Delete a session file only when the session is genuinely obsolete and no longer useful as state.
 
+### Manual hiding
+
+The app's user-triggered **Hide Session** action is separate from the session
+file's `hidden` field. After confirmation, cctop stores only the session's opaque
+`SessionIdentityPolicy` stable key in local preferences; it does not rewrite the
+hook-owned JSON or persist the session title, project path, prompts, or tool data.
+
+Manual hiding removes the session from the panel, navigation, notifications, and
+Stream Deck output while the full record remains available for lifecycle and
+Cleanup tracking. There is no in-app restore. cctop prunes the preference only
+after a complete local inventory proves the session record is gone; partial or
+unreadable inventories retain it to avoid unexpectedly revealing the session.
+
 ### `is_subagent`
 
 Type: `boolean`

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -81,8 +81,9 @@ This version does not reconcile multiple clients or multiple simultaneous focus
 targets. If the same conversation is open in more than one place, observations
 may remain separate or several rows may share one ID and resolve to the first
 current canonical target. Cross-client equivalence and cross-machine identity
-are out of scope. Panel identity, notifications, hiding, cleanup, history, and
-other persisted preferences continue to use their existing contracts.
+are out of scope. Manual hiding uses `cctop_session_id` as its preference key;
+notification grouping, cleanup, history, and other persisted preferences keep
+their separate contracts.
 
 ## Terminal Focus Metadata
 
@@ -159,8 +160,8 @@ Do not use file deletion as the hiding signal. Delete a session file only when t
 
 The app's user-triggered **Hide Session** action is separate from the session
 file's `hidden` field. After confirmation, cctop stores only the session's opaque
-`SessionIdentityPolicy` stable key in local preferences; it does not rewrite the
-hook-owned JSON or persist the session title, project path, prompts, or tool data.
+`cctop_session_id` in local preferences; it does not rewrite the hook-owned JSON
+or persist the session title, project path, prompts, or tool data.
 
 Manual hiding removes the session from the panel, navigation, notifications, and
 Stream Deck output while the full record remains available for lifecycle and

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -630,8 +630,8 @@ extension AppDelegate {
     }
 
     @MainActor private func jumpToSession(index: Int) {
-        guard index < navigateController.frozenSessions.count else { return }
-        focusTerminal(session: navigateController.frozenSessions[index])
+        guard let sessions = navigateController.activeSessionSnapshot, sessions.indices.contains(index) else { return }
+        focusTerminal(session: sessions[index])
         handleEvent(.navigateConfirmed)
     }
 

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -732,7 +732,15 @@ private func loadOrCreateSession(
                 incomingSessionId: fresh.sessionId
             )
         }
-        return (fresh, true)
+        var replacement = fresh
+        if CctopSessionIdentityStore.durableEvidence(
+            source: fresh.source,
+            harnessSessionId: fresh.harnessSessionId,
+            legacySessionId: fresh.sessionId
+        ) == nil {
+            replacement.cctopSessionId = Session.makeCctopSessionId()
+        }
+        return (replacement, true)
     }
     // Same PID, different session — a PID-keyed source reused the process for a new
     // conversation. Raw references are compared when the record has one, so two

--- a/menubar/CctopMenubar/Models/RecentResumeTarget.swift
+++ b/menubar/CctopMenubar/Models/RecentResumeTarget.swift
@@ -3,11 +3,30 @@ import Foundation
 enum RecentResumeTarget: Identifiable, Equatable {
     struct DesktopThread: Equatable {
         let sessionId: String
+        let cctopSessionId: String?
         let title: String
         let projectPath: String
         let projectName: String
         let sourceApp: HostApp
         let lastActiveAt: Date
+
+        init(
+            sessionId: String,
+            cctopSessionId: String? = nil,
+            title: String,
+            projectPath: String,
+            projectName: String,
+            sourceApp: HostApp,
+            lastActiveAt: Date
+        ) {
+            self.sessionId = sessionId
+            self.cctopSessionId = cctopSessionId
+            self.title = title
+            self.projectPath = projectPath
+            self.projectName = projectName
+            self.sourceApp = sourceApp
+            self.lastActiveAt = lastActiveAt
+        }
     }
 
     case project(RecentProject)
@@ -38,6 +57,11 @@ enum RecentResumeTarget: Identifiable, Equatable {
         case .desktopThread(let thread):
             return thread.projectPath
         }
+    }
+
+    var cctopSessionId: String? {
+        guard case .desktopThread(let thread) = self else { return nil }
+        return thread.cctopSessionId
     }
 
     var lastSessionAt: Date {
@@ -128,13 +152,13 @@ enum RecentResumeTarget: Identifiable, Equatable {
     static func build(
         projects: [RecentProject],
         classification: SessionClassificationSnapshot,
-        excludingDesktopSessionKeys: Set<String> = [],
+        excludingDesktopSessionIDs: Set<String> = [],
         limit: Int = 10
     ) -> [RecentResumeTarget] {
         let projectTargets = projects.map(RecentResumeTarget.project)
         let desktopTargets = desktopThreadTargets(
             from: classification,
-            excludingSessionKeys: excludingDesktopSessionKeys
+            excludingSessionIDs: excludingDesktopSessionIDs
         )
         return Array((projectTargets + desktopTargets)
             .sorted { $0.lastSessionAt > $1.lastSessionAt }
@@ -143,13 +167,14 @@ enum RecentResumeTarget: Identifiable, Equatable {
 
     private static func desktopThreadTargets(
         from classification: SessionClassificationSnapshot,
-        excludingSessionKeys: Set<String>
+        excludingSessionIDs: Set<String>
     ) -> [RecentResumeTarget] {
         var targetsByID: [String: RecentResumeTarget] = [:]
         for record in classification.records {
-            guard !excludingSessionKeys.contains(
-                SessionIdentityPolicy.stableKey(for: record.candidate.session)
-            ) else { continue }
+            if let cctopSessionID = record.candidate.session.cctopSessionId,
+               excludingSessionIDs.contains(cctopSessionID) {
+                continue
+            }
             guard let sourceApp = desktopThreadSourceApp(for: record.disposition),
                   let thread = DesktopThread(session: record.candidate.session, sourceApp: sourceApp) else {
                 continue
@@ -213,6 +238,7 @@ extension RecentResumeTarget.DesktopThread {
         guard !title.isEmpty else { return nil }
         self.init(
             sessionId: session.sessionId,
+            cctopSessionId: session.cctopSessionId,
             title: title,
             projectPath: session.projectPath,
             projectName: session.desktopProjectName ?? session.projectName,

--- a/menubar/CctopMenubar/Models/RecentResumeTarget.swift
+++ b/menubar/CctopMenubar/Models/RecentResumeTarget.swift
@@ -128,18 +128,28 @@ enum RecentResumeTarget: Identifiable, Equatable {
     static func build(
         projects: [RecentProject],
         classification: SessionClassificationSnapshot,
+        excludingDesktopSessionKeys: Set<String> = [],
         limit: Int = 10
     ) -> [RecentResumeTarget] {
         let projectTargets = projects.map(RecentResumeTarget.project)
-        let desktopTargets = desktopThreadTargets(from: classification)
+        let desktopTargets = desktopThreadTargets(
+            from: classification,
+            excludingSessionKeys: excludingDesktopSessionKeys
+        )
         return Array((projectTargets + desktopTargets)
             .sorted { $0.lastSessionAt > $1.lastSessionAt }
             .prefix(limit))
     }
 
-    private static func desktopThreadTargets(from classification: SessionClassificationSnapshot) -> [RecentResumeTarget] {
+    private static func desktopThreadTargets(
+        from classification: SessionClassificationSnapshot,
+        excludingSessionKeys: Set<String>
+    ) -> [RecentResumeTarget] {
         var targetsByID: [String: RecentResumeTarget] = [:]
         for record in classification.records {
+            guard !excludingSessionKeys.contains(
+                SessionIdentityPolicy.stableKey(for: record.candidate.session)
+            ) else { continue }
             guard let sourceApp = desktopThreadSourceApp(for: record.disposition),
                   let thread = DesktopThread(session: record.candidate.session, sourceApp: sourceApp) else {
                 continue

--- a/menubar/CctopMenubar/Services/NavigateController.swift
+++ b/menubar/CctopMenubar/Services/NavigateController.swift
@@ -17,6 +17,13 @@ class NavigateController: ObservableObject {
         didActivateSubject.send()
     }
 
+    /// Remove a hidden session without disturbing the frozen order of the remaining rows.
+    func removeSession(withStableKey stableKey: String) {
+        frozenSessions.removeAll {
+            SessionIdentityPolicy.stableKey(for: $0) == stableKey
+        }
+    }
+
     /// Resets all navigate state.
     func deactivate() {
         isActive = false

--- a/menubar/CctopMenubar/Services/NavigateController.swift
+++ b/menubar/CctopMenubar/Services/NavigateController.swift
@@ -9,6 +9,9 @@ class NavigateController: ObservableObject {
     /// Canonically ordered session snapshot captured when navigate activates.
     /// Prevents reordering while badges are visible.
     private(set) var frozenSessions: [Session] = []
+    var activeSessionSnapshot: [Session]? {
+        isActive ? frozenSessions : nil
+    }
     private var timeoutWork: DispatchWorkItem?
 
     func activate(sessions: [Session]) {

--- a/menubar/CctopMenubar/Services/NavigateController.swift
+++ b/menubar/CctopMenubar/Services/NavigateController.swift
@@ -18,10 +18,8 @@ class NavigateController: ObservableObject {
     }
 
     /// Remove a hidden session without disturbing the frozen order of the remaining rows.
-    func removeSession(withStableKey stableKey: String) {
-        frozenSessions.removeAll {
-            SessionIdentityPolicy.stableKey(for: $0) == stableKey
-        }
+    func removeSession(withCctopSessionID cctopSessionID: String) {
+        frozenSessions.removeAll { $0.cctopSessionId == cctopSessionID }
     }
 
     /// Resets all navigate state.

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -3,6 +3,7 @@ import Foundation
 enum SessionIdentityPolicy {
     static let notificationSessionIDKey = "sessionID"
     static let notificationSessionPIDKey = "sessionPID"
+    static let notificationCctopSessionIDKey = "cctopSessionID"
 
     /// Stable grouping key shared by dedup and notification transition guards.
     static func stableKey(for session: Session) -> String {
@@ -20,10 +21,21 @@ enum SessionIdentityPolicy {
     }
 
     static func notificationUserInfo(for session: Session) -> [AnyHashable: Any] {
-        [
+        var userInfo: [AnyHashable: Any] = [
             notificationSessionIDKey: notificationSessionID(for: session),
             notificationSessionPIDKey: session.pid.map(String.init) ?? "",
         ]
+        if let cctopSessionID = session.cctopSessionId,
+           Session.isValidCctopSessionId(cctopSessionID) {
+            userInfo[notificationCctopSessionIDKey] = cctopSessionID
+        }
+        return userInfo
+    }
+
+    static func cctopSessionID(matchingNotificationUserInfo userInfo: [AnyHashable: Any]) -> String? {
+        guard let cctopSessionID = nonEmptyString(userInfo[notificationCctopSessionIDKey]),
+              Session.isValidCctopSessionId(cctopSessionID) else { return nil }
+        return cctopSessionID
     }
 
     static func session(

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -88,9 +88,9 @@ enum SessionIdentityPolicy {
 }
 
 /// Persists manual visibility preferences independently from hook-owned session files.
-/// The stored payload is intentionally limited to opaque stable identity keys.
+/// The stored payload is intentionally limited to opaque cctop-owned session IDs.
 struct ManualSessionVisibilityStore {
-    static let defaultsKey = "manuallyHiddenSessionStableKeys"
+    static let defaultsKey = "manuallyHiddenCctopSessionIDs"
     static let live = ManualSessionVisibilityStore(defaults: .standard)
 
     private let defaults: UserDefaults
@@ -99,33 +99,37 @@ struct ManualSessionVisibilityStore {
         self.defaults = defaults
     }
 
-    var hiddenKeys: Set<String> {
-        Set(defaults.stringArray(forKey: Self.defaultsKey) ?? [])
+    var hiddenSessionIDs: Set<String> {
+        Set((defaults.stringArray(forKey: Self.defaultsKey) ?? []).filter(Session.isValidCctopSessionId))
     }
 
     func isHidden(_ session: Session) -> Bool {
-        hiddenKeys.contains(SessionIdentityPolicy.stableKey(for: session))
+        guard let cctopSessionID = session.cctopSessionId,
+              Session.isValidCctopSessionId(cctopSessionID) else { return false }
+        return hiddenSessionIDs.contains(cctopSessionID)
     }
 
     func hide(_ session: Session) {
-        var keys = hiddenKeys
-        keys.insert(SessionIdentityPolicy.stableKey(for: session))
-        save(keys)
+        guard let cctopSessionID = session.cctopSessionId,
+              Session.isValidCctopSessionId(cctopSessionID) else { return }
+        var sessionIDs = hiddenSessionIDs
+        sessionIDs.insert(cctopSessionID)
+        save(sessionIDs)
     }
 
-    /// Remove keys only after the caller has completed an authoritative local inventory.
-    func prune(retaining validKeys: Set<String>) {
-        let current = hiddenKeys
-        let retained = current.intersection(validKeys)
+    /// Remove IDs only after the caller has completed an authoritative local inventory.
+    func prune(retaining validSessionIDs: Set<String>) {
+        let current = hiddenSessionIDs
+        let retained = current.intersection(validSessionIDs)
         guard retained != current else { return }
         save(retained)
     }
 
-    private func save(_ keys: Set<String>) {
-        if keys.isEmpty {
+    private func save(_ sessionIDs: Set<String>) {
+        if sessionIDs.isEmpty {
             defaults.removeObject(forKey: Self.defaultsKey)
         } else {
-            defaults.set(keys.sorted(), forKey: Self.defaultsKey)
+            defaults.set(sessionIDs.sorted(), forKey: Self.defaultsKey)
         }
     }
 }

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -86,3 +86,46 @@ enum SessionIdentityPolicy {
         return byKey.values.sorted { stableKey(for: $0.session) < stableKey(for: $1.session) }
     }
 }
+
+/// Persists manual visibility preferences independently from hook-owned session files.
+/// The stored payload is intentionally limited to opaque stable identity keys.
+struct ManualSessionVisibilityStore {
+    static let defaultsKey = "manuallyHiddenSessionStableKeys"
+    static let live = ManualSessionVisibilityStore(defaults: .standard)
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    var hiddenKeys: Set<String> {
+        Set(defaults.stringArray(forKey: Self.defaultsKey) ?? [])
+    }
+
+    func isHidden(_ session: Session) -> Bool {
+        hiddenKeys.contains(SessionIdentityPolicy.stableKey(for: session))
+    }
+
+    func hide(_ session: Session) {
+        var keys = hiddenKeys
+        keys.insert(SessionIdentityPolicy.stableKey(for: session))
+        save(keys)
+    }
+
+    /// Remove keys only after the caller has completed an authoritative local inventory.
+    func prune(retaining validKeys: Set<String>) {
+        let current = hiddenKeys
+        let retained = current.intersection(validKeys)
+        guard retained != current else { return }
+        save(retained)
+    }
+
+    private func save(_ keys: Set<String>) {
+        if keys.isEmpty {
+            defaults.removeObject(forKey: Self.defaultsKey)
+        } else {
+            defaults.set(keys.sorted(), forKey: Self.defaultsKey)
+        }
+    }
+}

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// The external inputs SessionManager consults while deriving session state: the sessions
 /// directory, the Codex/Claude Desktop archive stores, desktop-app liveness, process liveness,
-/// the notification preference, and the clock. Production uses `.live()`; tests override
+/// notification and manual-visibility preferences, and the clock. Production uses `.live()`; tests override
 /// individual fields to run the full pipeline against temp directories, stub lookups, and a
 /// deterministic clock. One state-deriving input remains outside this seam:
 /// `adjustPermissionStatus` probes the live process tree (`proc_listchildpids`) directly.
@@ -15,6 +15,7 @@ struct SessionDataSources {
     var processAlive: (Session) -> Bool
     var notificationsEnabled: () -> Bool
     var notificationClient: SessionNotificationClient = .live
+    var manualSessionVisibility: ManualSessionVisibilityStore = .live
     var now: () -> Date
 
     /// A function rather than a stored constant so `Config.sessionsDir()` is resolved

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -163,6 +163,14 @@ struct SessionClassificationSnapshot {
         }
     }
 
+    func manualHiddenFinishedProjectPaths(_ hiddenSessionIDs: Set<String>) -> Set<String> {
+        Set(finishedNonDesktopCandidates.compactMap { candidate in
+            guard let cctopSessionID = candidate.session.cctopSessionId,
+                  hiddenSessionIDs.contains(cctopSessionID) else { return nil }
+            return candidate.session.projectPath
+        })
+    }
+
     /// Archived desktop conversations stay hidden and resumable in Recent, but a known
     /// project path can still seed worktree cleanup while preserving the session file.
     /// Non-desktop cleanup rows come from history.

--- a/menubar/CctopMenubar/Services/SessionManager+Loading.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Loading.swift
@@ -145,6 +145,50 @@ extension SessionManager {
         return assigningCctopSessionIdentities(to: publishableWinners, knownRecords: knownRecords)
     }
 
+    func identifyingRecentDesktopRecords(
+        in classification: SessionClassificationSnapshot,
+        knownRecords: [(url: URL, session: Session)]
+    ) -> SessionClassificationSnapshot {
+        let indices = classification.records.indices.filter { index in
+            let record = classification.records[index]
+            guard !Session.isValidCctopSessionId(record.candidate.session.cctopSessionId),
+                  case .hidden(let reason) = record.disposition else { return false }
+            switch reason {
+            case .archivedCodexDesktop, .archivedClaudeDesktop:
+                return CctopSessionIdentityStore.durableEvidence(
+                    source: record.candidate.session.source,
+                    harnessSessionId: record.candidate.session.harnessSessionId,
+                    legacySessionId: record.candidate.session.sessionId
+                ) != nil
+            case .persistedHidden, .autoHidden, .missingCodexDesktopThread, .codexInternalHelper, .codexExecHelper,
+                 .orphanedEndedClaudeDesktop, .claudeDesktopStartupPlaceholder:
+                return false
+            }
+        }
+        guard !indices.isEmpty else { return classification }
+
+        let identified = assigningCctopSessionIdentities(
+            to: indices.map { classification.records[$0].candidate },
+            knownRecords: knownRecords
+        )
+        var records = classification.records
+        for (index, session) in zip(indices, identified) {
+            let record = records[index]
+            let candidate = record.candidate
+            records[index] = ClassifiedSessionRecord(
+                url: record.url,
+                candidate: DedupCandidate(
+                    session: session,
+                    lifecycleRank: candidate.lifecycleRank,
+                    mtime: candidate.mtime,
+                    path: candidate.path
+                ),
+                disposition: record.disposition
+            )
+        }
+        return SessionClassificationSnapshot(records: records, evidence: classification.evidence)
+    }
+
     private func scheduleRecordLocalCctopSessionIdentityStamp(url: URL, snapshot: Session) {
         guard pendingIdentityMigrationPaths.insert(url.path).inserted else { return }
         cctopIdentityMigrationQueue.async { [weak self] in

--- a/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
@@ -26,6 +26,23 @@ enum SessionNotificationAction: Equatable {
 
 @MainActor
 extension SessionManager {
+    func hideSession(_ session: Session) {
+        let stableKey = SessionIdentityPolicy.stableKey(for: session)
+        guard sessions.contains(where: { SessionIdentityPolicy.stableKey(for: $0) == stableKey }) else { return }
+
+        dataSources.manualSessionVisibility.hide(session)
+        let visibleSessions = sessions.filter {
+            SessionIdentityPolicy.stableKey(for: $0) != stableKey
+        }
+
+        syncTransitionNotifications(for: visibleSessions, oldSessions: sessions)
+        sessions = visibleSessions
+    }
+
+    func isManuallyHidden(_ session: Session) -> Bool {
+        dataSources.manualSessionVisibility.isHidden(session)
+    }
+
     func syncTransitionNotifications(for newSessions: [Session], oldSessions: [Session]) {
         for action in Self.notificationActions(
             newSessions: newSessions,
@@ -91,6 +108,11 @@ extension SessionManager {
     }
 
     func postNotification(for session: Session) {
+        let stableKey = SessionIdentityPolicy.stableKey(for: session)
+        guard !isManuallyHidden(session),
+              sessions.contains(where: { SessionIdentityPolicy.stableKey(for: $0) == stableKey }) else {
+            return
+        }
         let client = dataSources.notificationClient
         let request = Self.notificationRequest(for: session)
         client.removePending([request.identifier])

--- a/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
@@ -27,14 +27,13 @@ enum SessionNotificationAction: Equatable {
 @MainActor
 extension SessionManager {
     func hideSession(_ session: Session) {
-        let stableKey = SessionIdentityPolicy.stableKey(for: session)
-        guard sessions.contains(where: { SessionIdentityPolicy.stableKey(for: $0) == stableKey }) else { return }
+        guard let cctopSessionID = session.cctopSessionId,
+              Session.isValidCctopSessionId(cctopSessionID),
+              sessions.contains(where: { $0.cctopSessionId == cctopSessionID }) else { return }
 
         dataSources.manualSessionVisibility.hide(session)
-        let visibleSessions = sessions.filter {
-            SessionIdentityPolicy.stableKey(for: $0) != stableKey
-        }
-
+        let visibleSessions = sessions.filter { $0.cctopSessionId != cctopSessionID }
+        recentResumeTargets.removeAll { $0.cctopSessionId == cctopSessionID }
         syncTransitionNotifications(for: visibleSessions, oldSessions: sessions)
         sessions = visibleSessions
     }

--- a/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
@@ -107,9 +107,10 @@ extension SessionManager {
     }
 
     func postNotification(for session: Session) {
-        let stableKey = SessionIdentityPolicy.stableKey(for: session)
-        guard !isManuallyHidden(session),
-              sessions.contains(where: { SessionIdentityPolicy.stableKey(for: $0) == stableKey }) else {
+        guard let cctopSessionID = session.cctopSessionId,
+              Session.isValidCctopSessionId(cctopSessionID),
+              !isManuallyHidden(session),
+              SessionIdentityPolicy.session(matchingCctopSessionID: cctopSessionID, in: sessions) != nil else {
             return
         }
         let client = dataSources.notificationClient

--- a/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
@@ -5,6 +5,30 @@ struct SessionNotificationClient {
     var add: (UNNotificationRequest, @escaping (Error?) -> Void) -> Void
     var removePending: ([String]) -> Void
     var removeDelivered: ([String]) -> Void
+    var removeByCctopSessionID: (String) -> Void
+
+    init(
+        add: @escaping (UNNotificationRequest, @escaping (Error?) -> Void) -> Void,
+        removePending: @escaping ([String]) -> Void,
+        removeDelivered: @escaping ([String]) -> Void,
+        removeByCctopSessionID: @escaping (String) -> Void = { _ in }
+    ) {
+        self.add = add
+        self.removePending = removePending
+        self.removeDelivered = removeDelivered
+        self.removeByCctopSessionID = removeByCctopSessionID
+    }
+
+    static func identifiers(
+        belongingTo cctopSessionID: String,
+        in requests: [UNNotificationRequest]
+    ) -> [String] {
+        requests.compactMap { request in
+            SessionIdentityPolicy.cctopSessionID(matchingNotificationUserInfo: request.content.userInfo) == cctopSessionID
+                ? request.identifier
+                : nil
+        }
+    }
 
     static let live = SessionNotificationClient(
         add: { request, completion in
@@ -15,6 +39,22 @@ struct SessionNotificationClient {
         },
         removeDelivered: { identifiers in
             UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: identifiers)
+        },
+        removeByCctopSessionID: { cctopSessionID in
+            let center = UNUserNotificationCenter.current()
+            center.getPendingNotificationRequests { requests in
+                center.removePendingNotificationRequests(
+                    withIdentifiers: SessionNotificationClient.identifiers(belongingTo: cctopSessionID, in: requests)
+                )
+            }
+            center.getDeliveredNotifications { notifications in
+                center.removeDeliveredNotifications(
+                    withIdentifiers: SessionNotificationClient.identifiers(
+                        belongingTo: cctopSessionID,
+                        in: notifications.map(\.request)
+                    )
+                )
+            }
         }
     )
 }
@@ -32,14 +72,20 @@ extension SessionManager {
               sessions.contains(where: { $0.cctopSessionId == cctopSessionID }) else { return }
 
         let hiddenSessions = sessions.filter { $0.cctopSessionId == cctopSessionID }
+        let hiddenProjectPaths = Set(hiddenSessions.map { HistoryManager.canonicalRecentProjectPath($0.projectPath) })
         let notificationIdentifiers = Set(
             hiddenSessions.map(SessionIdentityPolicy.notificationRequestIdentifier)
         ).sorted()
         dataSources.manualSessionVisibility.hide(session)
         let visibleSessions = sessions.filter { $0.cctopSessionId != cctopSessionID }
-        recentResumeTargets.removeAll { $0.cctopSessionId == cctopSessionID }
+        recentResumeTargets.removeAll { target in
+            if target.cctopSessionId == cctopSessionID { return true }
+            guard case .project = target else { return false }
+            return hiddenProjectPaths.contains(HistoryManager.canonicalRecentProjectPath(target.projectPath))
+        }
         dataSources.notificationClient.removePending(notificationIdentifiers)
         dataSources.notificationClient.removeDelivered(notificationIdentifiers)
+        dataSources.notificationClient.removeByCctopSessionID(cctopSessionID)
         sessions = visibleSessions
     }
 

--- a/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
@@ -31,10 +31,15 @@ extension SessionManager {
               Session.isValidCctopSessionId(cctopSessionID),
               sessions.contains(where: { $0.cctopSessionId == cctopSessionID }) else { return }
 
+        let hiddenSessions = sessions.filter { $0.cctopSessionId == cctopSessionID }
+        let notificationIdentifiers = Set(
+            hiddenSessions.map(SessionIdentityPolicy.notificationRequestIdentifier)
+        ).sorted()
         dataSources.manualSessionVisibility.hide(session)
         let visibleSessions = sessions.filter { $0.cctopSessionId != cctopSessionID }
         recentResumeTargets.removeAll { $0.cctopSessionId == cctopSessionID }
-        syncTransitionNotifications(for: visibleSessions, oldSessions: sessions)
+        dataSources.notificationClient.removePending(notificationIdentifiers)
+        dataSources.notificationClient.removeDelivered(notificationIdentifiers)
         sessions = visibleSessions
     }
 
@@ -107,12 +112,43 @@ extension SessionManager {
     }
 
     func postNotification(for session: Session) {
-        guard let cctopSessionID = session.cctopSessionId,
-              Session.isValidCctopSessionId(cctopSessionID),
-              !isManuallyHidden(session),
-              SessionIdentityPolicy.session(matchingCctopSessionID: cctopSessionID, in: sessions) != nil else {
-            return
+        let currentSession: Session?
+        if let cctopSessionID = session.cctopSessionId,
+           Session.isValidCctopSessionId(cctopSessionID) {
+            let requestIdentifier = SessionIdentityPolicy.notificationRequestIdentifier(for: session)
+            let matches = sessions.filter {
+                $0.cctopSessionId == cctopSessionID
+                    && SessionIdentityPolicy.notificationRequestIdentifier(for: $0) == requestIdentifier
+            }
+            currentSession = matches.count == 1 ? matches[0] : nil
+        } else if session.cctopSessionId == nil {
+            let matches = sessions.filter { current in
+                guard let pendingPID = session.pid,
+                      current.pid == pendingPID,
+                      let pendingStart = session.pidStartTime,
+                      let currentStart = current.pidStartTime,
+                      abs(pendingStart - currentStart) <= 1.0,
+                      (session.source ?? Session.ccSource) == (current.source ?? Session.ccSource) else {
+                    return false
+                }
+                switch (session.harnessSessionId, current.harnessSessionId) {
+                case let (pendingHarnessID?, currentHarnessID?):
+                    return pendingHarnessID == currentHarnessID
+                case (nil, nil):
+                    return session.sessionId == current.sessionId
+                default:
+                    return false
+                }
+            }
+            currentSession = matches.count == 1 ? matches[0] : nil
+        } else {
+            currentSession = nil
         }
+        guard let currentSession,
+              currentSession.lifecycle == .active,
+              currentSession.shouldPostAttentionNotification,
+              !isManuallyHidden(currentSession) else { return }
+
         let client = dataSources.notificationClient
         let request = Self.notificationRequest(for: session)
         client.removePending([request.identifier])

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -82,7 +82,7 @@ class SessionManager: ObservableObject {
         let jsonFiles = sessionJSONFiles(in: files)
         let allDecoded = decodedSessions(from: jsonFiles)
         let inventoryComplete = allDecoded.count == jsonFiles.count
-        let classification = deriveSessionClassification(from: allDecoded)
+        let classification = identifyingRecentDesktopRecords(in: deriveSessionClassification(from: allDecoded), knownRecords: allDecoded)
         let hidden = classification.records.filter { $0.disposition == .hidden(.persistedHidden) }
         let autoHidden = classification.autoHiddenSessions
         let displayCandidates = classification.displayCandidates
@@ -141,7 +141,7 @@ class SessionManager: ObservableObject {
 
         // Prune permanent IDs only after a complete inventory; partial reads retain them to avoid revealing sessions.
         if inventoryComplete {
-            let identifiedInventory = allDecoded.map(\.session) + identifiedSessions
+            let identifiedInventory = allDecoded.map(\.session) + classification.records.map(\.candidate.session) + identifiedSessions
             let validSessionIDs = Set(identifiedInventory.compactMap(\.cctopSessionId).filter(Session.isValidCctopSessionId))
             dataSources.manualSessionVisibility.prune(retaining: validSessionIDs)
         }

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -61,7 +61,9 @@ class SessionManager: ObservableObject {
         }
     }
 
+    // swiftlint:disable:next function_body_length
     func loadSessions() {
+        let hiddenKeys = dataSources.manualSessionVisibility.hiddenKeys
         guard let files = try? FileManager.default.contentsOfDirectory(
             at: sessionsDir,
             includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey]
@@ -71,7 +73,7 @@ class SessionManager: ObservableObject {
             lastLoadLogSignature = nil
             sessionFileCache.removeAll()
             sessions = []
-            publishRecentResumeTargets(historyManager.recentProjects.map(RecentResumeTarget.project))
+            if hiddenKeys.isEmpty { publishRecentResumeTargets(historyManager.recentProjects.map(RecentResumeTarget.project)) }
             return
         }
 
@@ -79,6 +81,7 @@ class SessionManager: ObservableObject {
 
         let jsonFiles = sessionJSONFiles(in: files)
         let allDecoded = decodedSessions(from: jsonFiles)
+        let inventoryComplete = allDecoded.count == jsonFiles.count
         let classification = deriveSessionClassification(from: allDecoded)
         let hidden = classification.records.filter { $0.disposition == .hidden(.persistedHidden) }
         let autoHidden = classification.autoHiddenSessions
@@ -97,7 +100,15 @@ class SessionManager: ObservableObject {
         let now = dataSources.now()
         let identifiedSessions = identifiedPublishableSessions(winners: winners, knownRecords: allDecoded)
         let loadedSessions = identifiedSessions.map { adjustDisplayStatus($0) }
-        let newSessions = SessionDisplayPolicy.reconcilingActiveOrder(in: loadedSessions, preserving: oldSessions, now: now)
+        let orderedSessions = SessionDisplayPolicy.reconcilingActiveOrder(
+            in: loadedSessions,
+            preserving: oldSessions,
+            now: now
+        )
+        let newSessions = orderedSessions.filter {
+            guard let cctopSessionID = $0.cctopSessionId else { return true }
+            return !hiddenKeys.contains(cctopSessionID)
+        }
         let displaySignature = SessionDisplayPolicy.signature(for: newSessions, now: now)
         syncTransitionNotifications(for: newSessions, oldSessions: oldSessions)
         // Only publish when data actually changed, or when the presentation bucket changed
@@ -120,9 +131,23 @@ class SessionManager: ObservableObject {
         // only by the slow, lock-held GC. No dormant file is ever deleted on this fast path.
         archiveAndRemoveFinishedNonDesktop(classification.finishedNonDesktopCandidates, winners: winners)
         let activeProjectPaths = classification.protectedProjectPathsForCleanup
-        _ = historyManager.rebuildRecentProjects(excludingActive: activeProjectPaths)
-        publishRecentResumeTargets(RecentResumeTarget.build(projects: historyManager.recentProjects, classification: classification))
-        refreshCleanupSources(from: classification.cleanupSources, activeProjectPaths: activeProjectPaths)
+        if inventoryComplete || hiddenKeys.isEmpty {
+            _ = historyManager.rebuildRecentProjects(excludingActive: activeProjectPaths)
+            publishRecentResumeTargets(RecentResumeTarget.build(
+                projects: historyManager.recentProjects,
+                classification: classification,
+                excludingDesktopSessionKeys: hiddenKeys
+            ))
+            refreshCleanupSources(from: classification.cleanupSources, activeProjectPaths: activeProjectPaths)
+        }
+
+        // Stable keys are safe to prune only when every local session file decoded. Preserve
+        // preferences on partial reads so transient filesystem failures cannot reveal a session.
+        if inventoryComplete {
+            dataSources.manualSessionVisibility.prune(retaining: Set(allDecoded.map {
+                SessionIdentityPolicy.stableKey(for: $0.session)
+            }))
+        }
     }
 
     private func publishRecentResumeTargets(_ targets: [RecentResumeTarget]) {

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -63,7 +63,7 @@ class SessionManager: ObservableObject {
 
     // swiftlint:disable:next function_body_length
     func loadSessions() {
-        let hiddenKeys = dataSources.manualSessionVisibility.hiddenKeys
+        let hiddenSessionIDs = dataSources.manualSessionVisibility.hiddenSessionIDs
         guard let files = try? FileManager.default.contentsOfDirectory(
             at: sessionsDir,
             includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey]
@@ -73,7 +73,7 @@ class SessionManager: ObservableObject {
             lastLoadLogSignature = nil
             sessionFileCache.removeAll()
             sessions = []
-            if hiddenKeys.isEmpty { publishRecentResumeTargets(historyManager.recentProjects.map(RecentResumeTarget.project)) }
+            if hiddenSessionIDs.isEmpty { publishRecentResumeTargets(historyManager.recentProjects.map(RecentResumeTarget.project)) }
             return
         }
 
@@ -105,10 +105,7 @@ class SessionManager: ObservableObject {
             preserving: oldSessions,
             now: now
         )
-        let newSessions = orderedSessions.filter {
-            guard let cctopSessionID = $0.cctopSessionId else { return true }
-            return !hiddenKeys.contains(cctopSessionID)
-        }
+        let newSessions = orderedSessions.filter { !($0.cctopSessionId.map(hiddenSessionIDs.contains) ?? false) }
         let displaySignature = SessionDisplayPolicy.signature(for: newSessions, now: now)
         syncTransitionNotifications(for: newSessions, oldSessions: oldSessions)
         // Only publish when data actually changed, or when the presentation bucket changed
@@ -131,22 +128,22 @@ class SessionManager: ObservableObject {
         // only by the slow, lock-held GC. No dormant file is ever deleted on this fast path.
         archiveAndRemoveFinishedNonDesktop(classification.finishedNonDesktopCandidates, winners: winners)
         let activeProjectPaths = classification.protectedProjectPathsForCleanup
-        if inventoryComplete || hiddenKeys.isEmpty {
+        if inventoryComplete || hiddenSessionIDs.isEmpty {
             _ = historyManager.rebuildRecentProjects(excludingActive: activeProjectPaths)
             publishRecentResumeTargets(RecentResumeTarget.build(
                 projects: historyManager.recentProjects,
                 classification: classification,
-                excludingDesktopSessionKeys: hiddenKeys
+                excludingDesktopSessionIDs: hiddenSessionIDs
             ))
             refreshCleanupSources(from: classification.cleanupSources, activeProjectPaths: activeProjectPaths)
         }
 
-        // Stable keys are safe to prune only when every local session file decoded. Preserve
+        // Permanent IDs are safe to prune only when every local session file decoded. Preserve
         // preferences on partial reads so transient filesystem failures cannot reveal a session.
         if inventoryComplete {
-            dataSources.manualSessionVisibility.prune(retaining: Set(allDecoded.map {
-                SessionIdentityPolicy.stableKey(for: $0.session)
-            }))
+            let identifiedInventory = allDecoded.map(\.session) + identifiedSessions
+            let validSessionIDs = Set(identifiedInventory.compactMap(\.cctopSessionId).filter(Session.isValidCctopSessionId))
+            dataSources.manualSessionVisibility.prune(retaining: validSessionIDs)
         }
     }
 

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -118,14 +118,14 @@ class SessionManager: ObservableObject {
         hideCodexInternalHelperSessions(classification.codexInternalHelperCandidates)
         clearReconnectedDesktopSessions(displayCandidates, now: now)
         stampDisconnectedDesktopSessions(displayCandidates, now: now)
-
         // Non-desktop finished sessions keep today's behavior: archive to Recent Projects and
         // remove now (no Recent-Projects lag). Desktop files are retained while dormant and reaped
         // only by the slow, lock-held GC. No dormant file is ever deleted on this fast path.
         archiveAndRemoveFinishedNonDesktop(classification.finishedNonDesktopCandidates, winners: winners)
         let activeProjectPaths = classification.protectedProjectPathsForCleanup
+        let recentExcludedPaths = activeProjectPaths.union(classification.manualHiddenFinishedProjectPaths(hiddenSessionIDs))
         if inventoryComplete || hiddenSessionIDs.isEmpty {
-            _ = historyManager.rebuildRecentProjects(excludingActive: activeProjectPaths)
+            _ = historyManager.rebuildRecentProjects(excludingActive: recentExcludedPaths)
             publishRecentResumeTargets(RecentResumeTarget.build(
                 projects: historyManager.recentProjects,
                 classification: classification,

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -100,11 +100,7 @@ class SessionManager: ObservableObject {
         let now = dataSources.now()
         let identifiedSessions = identifiedPublishableSessions(winners: winners, knownRecords: allDecoded)
         let loadedSessions = identifiedSessions.map { adjustDisplayStatus($0) }
-        let orderedSessions = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: loadedSessions,
-            preserving: oldSessions,
-            now: now
-        )
+        let orderedSessions = SessionDisplayPolicy.reconcilingActiveOrder(in: loadedSessions, preserving: oldSessions, now: now)
         let newSessions = orderedSessions.filter { !($0.cctopSessionId.map(hiddenSessionIDs.contains) ?? false) }
         let displaySignature = SessionDisplayPolicy.signature(for: newSessions, now: now)
         syncTransitionNotifications(for: newSessions, oldSessions: oldSessions)
@@ -136,10 +132,14 @@ class SessionManager: ObservableObject {
                 excludingDesktopSessionIDs: hiddenSessionIDs
             ))
             refreshCleanupSources(from: classification.cleanupSources, activeProjectPaths: activeProjectPaths)
+        } else if !activeProjectPaths.isSubset(of: cleanupActiveProjectPaths) { // Freeze items; only grow path protection.
+            refreshCleanupSources(
+                from: currentClassificationCleanupSources,
+                activeProjectPaths: cleanupActiveProjectPaths.union(activeProjectPaths)
+            )
         }
 
-        // Permanent IDs are safe to prune only when every local session file decoded. Preserve
-        // preferences on partial reads so transient filesystem failures cannot reveal a session.
+        // Prune permanent IDs only after a complete inventory; partial reads retain them to avoid revealing sessions.
         if inventoryComplete {
             let identifiedInventory = allDecoded.map(\.session) + identifiedSessions
             let validSessionIDs = Set(identifiedInventory.compactMap(\.cctopSessionId).filter(Session.isValidCctopSessionId))

--- a/menubar/CctopMenubar/Views/PopupView+Cleanup.swift
+++ b/menubar/CctopMenubar/Views/PopupView+Cleanup.swift
@@ -1,6 +1,13 @@
 import SwiftUI
 
 extension PopupView {
+    static func confirmationAfterCleanupReview(
+        _ confirmation: WorktreeRemovalConfirmation,
+        preserving current: PopupConfirmation?
+    ) -> PopupConfirmation {
+        current ?? .cleanup(confirmation)
+    }
+
     static func noticeAfterCleanupCandidatesChanged(_ notice: WorktreeRemovalNotice?) -> WorktreeRemovalNotice? {
         notice?.blocksRemoval == true ? notice : nil
     }
@@ -51,8 +58,14 @@ extension PopupView {
                     )
                 default:
                     if let confirmation = WorktreeRemovalConfirmation.review(for: action) {
-                        cleanupRemovalSelectsCandidateOnResult = selectsCandidateOnResult
-                        pendingConfirmation = .cleanup(confirmation)
+                        let nextConfirmation = Self.confirmationAfterCleanupReview(
+                            confirmation,
+                            preserving: pendingConfirmation
+                        )
+                        if nextConfirmation != pendingConfirmation {
+                            cleanupRemovalSelectsCandidateOnResult = selectsCandidateOnResult
+                            pendingConfirmation = nextConfirmation
+                        }
                     } else {
                         performCleanupRemovalAction(action, selectsCandidateOnResult: selectsCandidateOnResult)
                     }

--- a/menubar/CctopMenubar/Views/PopupView+Cleanup.swift
+++ b/menubar/CctopMenubar/Views/PopupView+Cleanup.swift
@@ -52,7 +52,7 @@ extension PopupView {
                 default:
                     if let confirmation = WorktreeRemovalConfirmation.review(for: action) {
                         cleanupRemovalSelectsCandidateOnResult = selectsCandidateOnResult
-                        pendingRemovalConfirmation = confirmation
+                        pendingConfirmation = .cleanup(confirmation)
                     } else {
                         performCleanupRemovalAction(action, selectsCandidateOnResult: selectsCandidateOnResult)
                     }

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -19,6 +19,7 @@ struct PopupView: View {
     var initialTab: PopupTab = .active
     var initialCleanupCandidate: WorktreeCleanupCandidate?
     var onOpenUpdater: (() -> Void)?
+    var onHideSession: (Session) -> Void = { _ in }
     var onSelectCleanupRemovalAction: ((WorktreeCleanupCandidate) async -> WorktreeRemovalService.RemovalAction)?
     var onExecuteCleanupRemovalAction: ((WorktreeRemovalService.RemovalAction) async -> WorktreeRemovalService.RemovalResult)?
     var onCleanupTabVisible: () -> Void = {}
@@ -33,7 +34,7 @@ struct PopupView: View {
     @State var selectedCleanupCandidate: WorktreeCleanupCandidate?
     @State var cleanupRemovalNotice: WorktreeRemovalNotice?
     @State var removingCleanupCandidateID: String?
-    @State var pendingRemovalConfirmation: WorktreeRemovalConfirmation?
+    @State var pendingConfirmation: PopupConfirmation?
     @State var cleanupRemovalSelectsCandidateOnResult = true
     @State private var ocBannerInstalled = false
     @State private var lastFocusTime: Date = .distantPast
@@ -107,7 +108,7 @@ struct PopupView: View {
         .onChange(of: actionableCleanupCandidates) { _ in handleCleanupCandidatesChanged() }
         .onChange(of: cleanupIsScanning) { _ in handleCleanupScanningChanged() }
         .onChange(of: selectedCleanupCandidate?.id) { _ in notifyLayoutChanged() }
-        .alert(item: $pendingRemovalConfirmation) { removalAlert(for: $0) }
+        .alert(item: $pendingConfirmation) { confirmationAlert(for: $0) }
         .onAppear {
             selectedTab = availableTabs.contains(initialTab) ? initialTab : .active
             if selectedTab == .cleanup,
@@ -228,8 +229,11 @@ struct PopupView: View {
                 Button { copyPath(session.projectPath) } label: {
                     Label("Copy Project Path", systemImage: "doc.on.doc")
                 }
+                Divider()
+                Button { requestHideSession(session) } label: { Label("Hide Session", systemImage: "eye.slash") }
             }
             .help("Click to jump to session")
+            .accessibilityAction(named: Text("Hide Session")) { requestHideSession(session) }
         }
     }
 

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -231,12 +231,14 @@ struct PopupView: View {
                 }
                 Divider()
                 Button { requestHideSession(session) } label: { Label("Hide Session", systemImage: "eye.slash") }
+                    .disabled(!Session.isValidCctopSessionId(session.cctopSessionId))
             }
             .help("Click to jump to session")
-            .accessibilityAction(named: Text("Hide Session")) { requestHideSession(session) }
+            .accessibilityActions {
+                Button("Hide Session") { requestHideSession(session) }.disabled(!Session.isValidCctopSessionId(session.cctopSessionId))
+            }
         }
     }
-
     func panelList<Item: Identifiable, Row: View>(
         _ list: [Item],
         tab: PopupTab,

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -369,10 +369,8 @@ extension PopupView {
     private var isNavigateActive: Bool { navigate?.isActive ?? false }
     private var hasMultipleSources: Bool { Set(sessions.map(\.agentBadge)).count > 1 }
     private var sortedActiveSessions: [Session] {
-        if isNavigateActive, let frozen = navigate?.frozenSessions, !frozen.isEmpty {
-            return frozen
-        }
-        return SessionDisplayPolicy.activeSessions(from: sessions)
+        let current = SessionDisplayPolicy.activeSessions(from: sessions)
+        return navigate?.activeSessionSnapshot ?? current
     }
     private var sortedIdleSessions: [Session] {
         Session.sorted(SessionDisplayPolicy.idleSessions(from: sessions))

--- a/menubar/CctopMenubar/Views/PopupViewHelpers.swift
+++ b/menubar/CctopMenubar/Views/PopupViewHelpers.swift
@@ -3,9 +3,17 @@ import SwiftUI
 
 struct ManualSessionHideConfirmation: Identifiable, Equatable {
     let session: Session
+    let cctopSessionID: String
+
+    init?(session: Session) {
+        guard let cctopSessionID = session.cctopSessionId,
+              Session.isValidCctopSessionId(cctopSessionID) else { return nil }
+        self.session = session
+        self.cctopSessionID = cctopSessionID
+    }
 
     var id: String {
-        "hide:\(SessionIdentityPolicy.stableKey(for: session))"
+        "hide:\(cctopSessionID)"
     }
 
     var title: String {
@@ -264,7 +272,8 @@ struct FooterUpdateStatusView: View {
 
 extension PopupView {
     func requestHideSession(_ session: Session) {
-        pendingConfirmation = .sessionHide(ManualSessionHideConfirmation(session: session))
+        guard let confirmation = ManualSessionHideConfirmation(session: session) else { return }
+        pendingConfirmation = .sessionHide(confirmation)
     }
 
     func confirmationAlert(for confirmation: PopupConfirmation) -> Alert {
@@ -288,10 +297,11 @@ extension PopupView {
     }
 
     func hideSession(_ session: Session) {
-        let stableKey = SessionIdentityPolicy.stableKey(for: session)
-        guard sessions.contains(where: { SessionIdentityPolicy.stableKey(for: $0) == stableKey }) else { return }
+        guard let cctopSessionID = session.cctopSessionId,
+              Session.isValidCctopSessionId(cctopSessionID),
+              sessions.contains(where: { $0.cctopSessionId == cctopSessionID }) else { return }
         onHideSession(session)
-        navigate?.removeSession(withStableKey: stableKey)
+        navigate?.removeSession(withCctopSessionID: cctopSessionID)
         selectedIndex = nil
     }
 }

--- a/menubar/CctopMenubar/Views/PopupViewHelpers.swift
+++ b/menubar/CctopMenubar/Views/PopupViewHelpers.swift
@@ -1,6 +1,38 @@
 import AppKit
 import SwiftUI
 
+struct ManualSessionHideConfirmation: Identifiable, Equatable {
+    let session: Session
+
+    var id: String {
+        "hide:\(SessionIdentityPolicy.stableKey(for: session))"
+    }
+
+    var title: String {
+        "Hide “\(session.displayName)” from cctop?"
+    }
+
+    let message = "It will disappear from the panel, notifications, Navigate mode, and Stream Deck. "
+        + "This does not stop or delete the underlying session; cctop will keep it available for lifecycle and Cleanup. "
+        + "You cannot show it again while its local session record exists."
+
+    let primaryButtonTitle = "Hide Session"
+}
+
+enum PopupConfirmation: Identifiable, Equatable {
+    case cleanup(WorktreeRemovalConfirmation)
+    case sessionHide(ManualSessionHideConfirmation)
+
+    var id: String {
+        switch self {
+        case .cleanup(let confirmation):
+            return "cleanup:\(confirmation.id)"
+        case .sessionHide(let confirmation):
+            return "session-hide:\(confirmation.id)"
+        }
+    }
+}
+
 enum PopupOverlay: Equatable {
     case settings, about
 }
@@ -230,6 +262,40 @@ struct FooterUpdateStatusView: View {
     }
 }
 
+extension PopupView {
+    func requestHideSession(_ session: Session) {
+        pendingConfirmation = .sessionHide(ManualSessionHideConfirmation(session: session))
+    }
+
+    func confirmationAlert(for confirmation: PopupConfirmation) -> Alert {
+        switch confirmation {
+        case .cleanup(let cleanupConfirmation):
+            return removalAlert(for: cleanupConfirmation)
+        case .sessionHide(let sessionConfirmation):
+            return sessionHideAlert(for: sessionConfirmation)
+        }
+    }
+
+    func sessionHideAlert(for confirmation: ManualSessionHideConfirmation) -> Alert {
+        Alert(
+            title: Text(confirmation.title),
+            message: Text(confirmation.message),
+            primaryButton: .destructive(Text(confirmation.primaryButtonTitle)) {
+                hideSession(confirmation.session)
+            },
+            secondaryButton: .cancel()
+        )
+    }
+
+    func hideSession(_ session: Session) {
+        let stableKey = SessionIdentityPolicy.stableKey(for: session)
+        guard sessions.contains(where: { SessionIdentityPolicy.stableKey(for: $0) == stableKey }) else { return }
+        onHideSession(session)
+        navigate?.removeSession(withStableKey: stableKey)
+        selectedIndex = nil
+    }
+}
+
 // MARK: - Panel content wrapper (used by AppDelegate)
 
 struct PanelContentView: View {
@@ -263,6 +329,7 @@ struct PanelContentView: View {
             navigate: navigate,
             overlayController: overlayController,
             onOpenUpdater: onOpenUpdater,
+            onHideSession: { sessionManager.hideSession($0) },
             onSelectCleanupRemovalAction: onSelectCleanupRemovalAction,
             onExecuteCleanupRemovalAction: onExecuteCleanupRemovalAction,
             onCleanupTabVisible: onCleanupTabVisible,

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -1093,14 +1093,31 @@ final class HookHandlerTests: XCTestCase {
     /// process's conversation state.
     func testSessionStart_samePIDDifferentStartTime_dropsPreviousSessionState() throws {
         try handleFixture("SessionStart-opencode", deps: makeDeps(startTime: 1000))
+        let originalCctopSessionID = try XCTUnwrap(loadSession().cctopSessionId)
         try handleFixture("UserPromptSubmit-opencode", deps: makeDeps(startTime: 1000))
         XCTAssertEqual(try loadSession().lastPrompt, "Help me debug this")
 
         try handleFixture("SessionStart-opencode", deps: makeDeps(startTime: 2000))
 
         let session = try loadSession()
+        XCTAssertNotEqual(session.cctopSessionId, originalCctopSessionID)
         XCTAssertNil(session.lastPrompt, "conversation state must not leak across PID reuse")
         XCTAssertEqual(session.pidStartTime, 2000)
+    }
+
+    func testSessionStart_samePIDDifferentStartTime_preservesDurableClaudeIdentity() throws {
+        let reference = "11111111-2222-4333-8444-555555555555"
+        let input = """
+        {"session_id": "\(reference)", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart", "harness_name": "cc"}
+        """
+        try handleHook(input, hookName: "SessionStart", deps: makeDeps(startTime: 1_000))
+        let originalCctopSessionID = try XCTUnwrap(loadSession().cctopSessionId)
+
+        try handleHook(input, hookName: "SessionStart", deps: makeDeps(startTime: 2_000))
+
+        let resumed = try loadSession()
+        XCTAssertEqual(resumed.cctopSessionId, originalCctopSessionID)
+        XCTAssertEqual(resumed.pidStartTime, 2_000)
     }
 
     // MARK: - Git branch capture

--- a/menubar/CctopMenubarTests/NavigateControllerTests.swift
+++ b/menubar/CctopMenubarTests/NavigateControllerTests.swift
@@ -101,6 +101,17 @@ final class NavigateControllerTests: XCTestCase {
         XCTAssertEqual(sut.frozenSessions.count, 1)
     }
 
+    func testRemovingHiddenSessionPreservesFrozenSurvivorOrder() {
+        let first = Session.mock(id: "first", status: .waitingInput, source: Session.codexSource)
+        let hidden = Session.mock(id: "hidden", status: .working, source: Session.codexSource)
+        let last = Session.mock(id: "last", status: .idle, source: Session.codexSource)
+        sut.activate(sessions: [first, hidden, last])
+
+        sut.removeSession(withStableKey: SessionIdentityPolicy.stableKey(for: hidden))
+
+        XCTAssertEqual(sut.frozenSessions.map(\.sessionId), ["first", "last"])
+    }
+
     // MARK: - Timeout
 
     func testTimeoutFiresWhenActive() {

--- a/menubar/CctopMenubarTests/NavigateControllerTests.swift
+++ b/menubar/CctopMenubarTests/NavigateControllerTests.swift
@@ -102,12 +102,26 @@ final class NavigateControllerTests: XCTestCase {
     }
 
     func testRemovingHiddenSessionPreservesFrozenSurvivorOrder() {
-        let first = Session.mock(id: "first", status: .waitingInput, source: Session.codexSource)
-        let hidden = Session.mock(id: "hidden", status: .working, source: Session.codexSource)
-        let last = Session.mock(id: "last", status: .idle, source: Session.codexSource)
-        sut.activate(sessions: [first, hidden, last])
+        let hiddenSessionID = "22222222-2222-4222-8222-222222222222"
+        let first = Session.mock(
+            id: "first", cctopSessionId: "11111111-1111-4111-8111-111111111111",
+            status: .waitingInput, source: Session.codexSource
+        )
+        let hidden = Session.mock(
+            id: "hidden", cctopSessionId: hiddenSessionID,
+            status: .working, source: Session.codexSource
+        )
+        let secondHiddenObservation = Session.mock(
+            id: "hidden-again", cctopSessionId: hiddenSessionID,
+            status: .idle, source: Session.codexSource
+        )
+        let last = Session.mock(
+            id: "last", cctopSessionId: "33333333-3333-4333-8333-333333333333",
+            status: .idle, source: Session.codexSource
+        )
+        sut.activate(sessions: [first, hidden, secondHiddenObservation, last])
 
-        sut.removeSession(withStableKey: SessionIdentityPolicy.stableKey(for: hidden))
+        sut.removeSession(withCctopSessionID: hiddenSessionID)
 
         XCTAssertEqual(sut.frozenSessions.map(\.sessionId), ["first", "last"])
     }

--- a/menubar/CctopMenubarTests/NavigateControllerTests.swift
+++ b/menubar/CctopMenubarTests/NavigateControllerTests.swift
@@ -126,6 +126,24 @@ final class NavigateControllerTests: XCTestCase {
         XCTAssertEqual(sut.frozenSessions.map(\.sessionId), ["first", "last"])
     }
 
+    func testRemovingLastHiddenSessionPreservesActiveEmptySnapshot() {
+        let hiddenSessionID = "22222222-2222-4222-8222-222222222222"
+        let hidden = Session.mock(
+            id: "hidden", cctopSessionId: hiddenSessionID,
+            status: .working, source: Session.codexSource
+        )
+        sut.activate(sessions: [hidden])
+
+        sut.removeSession(withCctopSessionID: hiddenSessionID)
+
+        XCTAssertEqual(sut.activeSessionSnapshot, [])
+        XCTAssertTrue(sut.isActive)
+    }
+
+    func testInactiveControllerHasNoActiveSnapshot() {
+        XCTAssertNil(sut.activeSessionSnapshot)
+    }
+
     // MARK: - Timeout
 
     func testTimeoutFiresWhenActive() {

--- a/menubar/CctopMenubarTests/SessionLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/SessionLifecycleTests.swift
@@ -736,7 +736,7 @@ final class SessionLifecycleTests: XCTestCase {
         let visibleAfterHidingCodex = RecentResumeTarget.build(
             projects: [],
             classification: classification,
-            excludingDesktopSessionKeys: [SessionIdentityPolicy.stableKey(for: codex.session)]
+            excludingDesktopSessionIDs: Set([codex.session.cctopSessionId].compactMap { $0 })
         )
         XCTAssertEqual(visibleAfterHidingCodex.map(\.title), ["Run plugin node:test suites in CI"])
     }

--- a/menubar/CctopMenubarTests/SessionLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/SessionLifecycleTests.swift
@@ -732,6 +732,13 @@ final class SessionLifecycleTests: XCTestCase {
         XCTAssertFalse(targets.contains { $0.openActionLabel.contains("Thread") || ($0.inlineActionLabel?.contains("Thread") ?? false) })
         XCTAssertFalse(targets.contains { $0.showsFinderAction })
         XCTAssertFalse(targets.contains { $0.showsCopyPathAction })
+
+        let visibleAfterHidingCodex = RecentResumeTarget.build(
+            projects: [],
+            classification: classification,
+            excludingDesktopSessionKeys: [SessionIdentityPolicy.stableKey(for: codex.session)]
+        )
+        XCTAssertEqual(visibleAfterHidingCodex.map(\.title), ["Run plugin node:test suites in CI"])
     }
 
     func testRecentResumeTargetsExcludeNonArchivedDesktopHiddenReasons() {

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -187,7 +187,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
     }
 
     @MainActor
-    func testManualHidePreservesRecentAndCleanupWhenSessionDecodeBecomesIncomplete() throws {
+    func testManualHidePreservesRecentAndMergesCleanupProtectionWhenInventoryBecomesIncomplete() throws {
         let root = NSTemporaryDirectory() + "cctop-manual-hide-recent-partial-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")
         let historyDir = (root as NSString).appendingPathComponent("history")
@@ -232,13 +232,37 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertTrue(manager.cleanupActiveProjectPaths.contains(projectPath))
+        let cleanupSourceIDs = manager.cleanupSources.map(\.sessionId)
+        var refreshedActivePaths: Set<String>?
+        manager.cleanupRefreshHandler = { _, activePaths in
+            refreshedActivePaths = activePaths
+        }
 
         try Data("not valid session json".utf8).write(to: hiddenURL)
+        let newActivePath = (root as NSString).appendingPathComponent("worktrees/new-active")
+        var newActive = Session(
+            sessionId: "new-active-during-partial-read",
+            projectPath: newActivePath,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        newActive.pid = 4_206
+        newActive.status = .working
+        try newActive.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("4206.json"))
         manager.loadSessions()
 
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
-        XCTAssertTrue(manager.cleanupActiveProjectPaths.contains(projectPath))
+        XCTAssertEqual(manager.cleanupActiveProjectPaths, [projectPath, newActivePath])
+        XCTAssertEqual(manager.cleanupSources.map(\.sessionId), cleanupSourceIDs)
+        XCTAssertEqual(refreshedActivePaths, [projectPath, newActivePath])
         XCTAssertTrue(visibility.isHidden(hidden))
+
+        let snapshot = manager.cleanupSnapshotForRemoval()
+        XCTAssertEqual(snapshot.activeProjectPaths, [projectPath, newActivePath])
+
+        try FileManager.default.removeItem(at: hiddenURL)
+        manager.loadSessions()
+        XCTAssertEqual(manager.cleanupActiveProjectPaths, [newActivePath])
     }
 
     @MainActor

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -194,8 +194,13 @@ final class SessionManagerVisibilityTests: XCTestCase {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .path
-        var hidden = Session.mock(id: "hidden-directory-session", source: Session.codexSource)
-        hidden.projectPath = projectPath
+        var hidden = Session(
+            sessionId: "hidden-directory-session",
+            projectPath: projectPath,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        hidden.source = Session.codexSource
 
         var history = hidden
         history.sessionId = "ended-hidden-directory-project"

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -51,13 +51,14 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         let originalOrder = manager.sessions.map { SessionIdentityPolicy.stableKey(for: $0) }
         let hidden = try XCTUnwrap(manager.sessions.dropFirst().first)
-        let hiddenKey = SessionIdentityPolicy.stableKey(for: hidden)
+        let hiddenStableKey = SessionIdentityPolicy.stableKey(for: hidden)
+        let hiddenSessionID = try XCTUnwrap(hidden.cctopSessionId)
 
         manager.hideSession(hidden)
 
         XCTAssertEqual(
             manager.sessions.map { SessionIdentityPolicy.stableKey(for: $0) },
-            originalOrder.filter { $0 != hiddenKey }
+            originalOrder.filter { $0 != hiddenStableKey }
         )
         XCTAssertEqual(StatusCounts(sessions: manager.sessions).total, 2)
         XCTAssertEqual(
@@ -77,7 +78,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
         XCTAssertEqual(
             manager.sessions.map { SessionIdentityPolicy.stableKey(for: $0) },
-            originalOrder.filter { $0 != hiddenKey }
+            originalOrder.filter { $0 != hiddenStableKey }
         )
         XCTAssertTrue(manager.cleanupActiveProjectPaths.contains(hidden.projectPath))
 
@@ -87,11 +88,71 @@ final class SessionManagerVisibilityTests: XCTestCase {
             processAlive: { _ in true },
             manualSessionVisibility: visibility
         )
-        XCTAssertFalse(reloaded.sessions.contains { SessionIdentityPolicy.stableKey(for: $0) == hiddenKey })
+        XCTAssertFalse(reloaded.sessions.contains { $0.cctopSessionId == hiddenSessionID })
 
         try FileManager.default.removeItem(atPath: hiddenPath)
         reloaded.loadSessions()
-        XCTAssertFalse(visibility.hiddenKeys.contains(hiddenKey))
+        XCTAssertFalse(visibility.hiddenSessionIDs.contains(hiddenSessionID))
+    }
+
+    @MainActor
+    func testManualHideImmediatelyRemovesEveryProjectionSharingPermanentIdentity() throws {
+        let root = NSTemporaryDirectory() + "cctop-manual-hide-shared-id-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let suiteName = "cctop-manual-hide-shared-id-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+        let sharedID = "22222222-2222-4222-8222-222222222222"
+        var live = Session(
+            sessionId: "live-terminal",
+            projectPath: "/tmp/live-terminal",
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        live.cctopSessionId = sharedID
+        live.pid = 4_204
+        live.status = .working
+        try live.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("live-terminal.json"))
+
+        let archivedID = "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
+        var archived = codexDesktopSession(
+            sessionId: archivedID,
+            projectPath: "/tmp/archived-desktop"
+        )
+        archived.cctopSessionId = sharedID
+        archived.sessionName = "Archived desktop observation"
+        archived.lastActivity = Date(timeIntervalSince1970: 2_000)
+        try archived.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("codex-\(archivedID).json"))
+        try Data("not valid session json".utf8).write(
+            to: URL(fileURLWithPath: (sessionsDir as NSString).appendingPathComponent("unrelated-broken.json"))
+        )
+
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
+        sources.codexThreads = StubCodexThreadState(archived: [archivedID])
+        sources.desktopAppConnection = DesktopAppConnectionLookup { _ in false }
+        sources.processAlive = { _ in true }
+        sources.manualSessionVisibility = visibility
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            dataSources: sources,
+            startMonitoring: false
+        )
+        let hidden = try XCTUnwrap(manager.sessions.first { $0.sessionId == live.sessionId })
+        XCTAssertEqual(manager.recentResumeTargets.map(\.title), ["Archived desktop observation"])
+        XCTAssertEqual(manager.recentResumeTargets.compactMap(\.cctopSessionId), [sharedID])
+
+        manager.hideSession(hidden)
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(visibility.hiddenSessionIDs, [sharedID])
     }
 
     @MainActor

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -15,6 +15,237 @@ final class SessionManagerVisibilityTests: XCTestCase {
         """
     }
 
+    // MARK: - Manual session visibility
+
+    @MainActor
+    func testManualHideIsImmediatePersistentAndLeavesTrackingIntact() throws {
+        let root = NSTemporaryDirectory() + "cctop-manual-hide-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let suiteName = "cctop-manual-hide-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+
+        for pid in 4_201...4_203 {
+            var session = Session(
+                sessionId: "session-\(pid)",
+                projectPath: (root as NSString).appendingPathComponent("worktrees/\(pid)"),
+                branch: "main",
+                terminal: TerminalInfo(program: "zsh")
+            )
+            session.pid = UInt32(pid)
+            session.status = .working
+            try session.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("\(pid).json"))
+        }
+
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            processAlive: { _ in true },
+            manualSessionVisibility: visibility
+        )
+        let originalOrder = manager.sessions.map { SessionIdentityPolicy.stableKey(for: $0) }
+        let hidden = try XCTUnwrap(manager.sessions.dropFirst().first)
+        let hiddenKey = SessionIdentityPolicy.stableKey(for: hidden)
+
+        manager.hideSession(hidden)
+
+        XCTAssertEqual(
+            manager.sessions.map { SessionIdentityPolicy.stableKey(for: $0) },
+            originalOrder.filter { $0 != hiddenKey }
+        )
+        XCTAssertEqual(StatusCounts(sessions: manager.sessions).total, 2)
+        XCTAssertEqual(
+            DisplayStateWriter.snapshot(
+                sessions: manager.sessions,
+                theme: .claude,
+                appRunning: true,
+                appIdentity: nil,
+                now: Date()
+            ).sessions.count,
+            2
+        )
+        XCTAssertTrue(manager.cleanupActiveProjectPaths.contains(hidden.projectPath))
+        let hiddenPath = (sessionsDir as NSString).appendingPathComponent("\(hidden.pid!).json")
+        XCTAssertFalse(try Session.fromFile(path: hiddenPath).hidden)
+
+        manager.loadSessions()
+        XCTAssertEqual(
+            manager.sessions.map { SessionIdentityPolicy.stableKey(for: $0) },
+            originalOrder.filter { $0 != hiddenKey }
+        )
+        XCTAssertTrue(manager.cleanupActiveProjectPaths.contains(hidden.projectPath))
+
+        let reloaded = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            processAlive: { _ in true },
+            manualSessionVisibility: visibility
+        )
+        XCTAssertFalse(reloaded.sessions.contains { SessionIdentityPolicy.stableKey(for: $0) == hiddenKey })
+
+        try FileManager.default.removeItem(atPath: hiddenPath)
+        reloaded.loadSessions()
+        XCTAssertFalse(visibility.hiddenKeys.contains(hiddenKey))
+    }
+
+    @MainActor
+    func testManualHideKeySurvivesIncompleteSessionInventory() throws {
+        let root = NSTemporaryDirectory() + "cctop-manual-hide-partial-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let suiteName = "cctop-manual-hide-partial-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+        let hidden = Session.mock(id: "hidden-thread", source: Session.codexSource)
+        visibility.hide(hidden)
+        try Data("not valid session json".utf8).write(
+            to: URL(fileURLWithPath: (sessionsDir as NSString).appendingPathComponent("broken.json"))
+        )
+
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            manualSessionVisibility: visibility
+        )
+
+        XCTAssertTrue(visibility.isHidden(hidden))
+        try FileManager.default.removeItem(atPath: (sessionsDir as NSString).appendingPathComponent("broken.json"))
+        manager.loadSessions()
+        XCTAssertFalse(visibility.isHidden(hidden))
+    }
+
+    @MainActor
+    func testManualHidePreservesRecentAndCleanupWhenSessionDecodeBecomesIncomplete() throws {
+        let root = NSTemporaryDirectory() + "cctop-manual-hide-recent-partial-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let projectPath = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .path
+        var hidden = Session(
+            sessionId: "hidden-live-project",
+            projectPath: projectPath,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        hidden.source = Session.codexSource
+        hidden.pid = 4_204
+        hidden.status = .working
+        let hiddenURL = URL(fileURLWithPath: sessionsDir).appendingPathComponent("codex-hidden-live-project.json")
+        try hidden.writeToFile(path: hiddenURL.path)
+
+        var history = hidden
+        history.sessionId = "ended-hidden-project"
+        history.pid = 4_205
+        history.endedAt = Date(timeIntervalSince1970: 2_000)
+        try history.writeToFile(path: (historyDir as NSString).appendingPathComponent("history.json"))
+
+        let suiteName = "cctop-manual-hide-recent-partial-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+        visibility.hide(hidden)
+
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            processAlive: { _ in true },
+            manualSessionVisibility: visibility
+        )
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertTrue(manager.cleanupActiveProjectPaths.contains(projectPath))
+
+        try Data("not valid session json".utf8).write(to: hiddenURL)
+        manager.loadSessions()
+
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertTrue(manager.cleanupActiveProjectPaths.contains(projectPath))
+        XCTAssertTrue(visibility.isHidden(hidden))
+    }
+
+    @MainActor
+    func testManualHideKeepsRecentEmptyWhenSessionDirectoryReadFails() throws {
+        let root = NSTemporaryDirectory() + "cctop-manual-hide-recent-directory-\(UUID().uuidString)"
+        let sessionsPath = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let projectPath = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .path
+        var hidden = Session.mock(id: "hidden-directory-session", source: Session.codexSource)
+        hidden.projectPath = projectPath
+
+        var history = hidden
+        history.sessionId = "ended-hidden-directory-project"
+        history.endedAt = Date(timeIntervalSince1970: 2_000)
+        try history.writeToFile(path: (historyDir as NSString).appendingPathComponent("history.json"))
+        try Data("not a directory".utf8).write(to: URL(fileURLWithPath: sessionsPath))
+
+        let suiteName = "cctop-manual-hide-recent-directory-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+        visibility.hide(hidden)
+
+        let manager = makeManager(
+            sessionsDir: sessionsPath,
+            historyDir: historyDir,
+            manualSessionVisibility: visibility
+        )
+
+        XCTAssertEqual(manager.historyManager.recentProjects.map(\.projectPath), [projectPath])
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertTrue(visibility.isHidden(hidden))
+    }
+
+    @MainActor
+    func testManualHideIgnoresSessionThatIsNoLongerVisible() throws {
+        let root = NSTemporaryDirectory() + "cctop-manual-hide-vanished-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let suiteName = "cctop-manual-hide-vanished-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+        let vanished = Session.mock(id: "vanished", source: Session.codexSource)
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            manualSessionVisibility: visibility
+        )
+
+        manager.hideSession(vanished)
+
+        XCTAssertFalse(visibility.isHidden(vanished))
+        XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.defaultsKey))
+    }
+
     // MARK: - Codex memory maintenance sessions
 
     func testCodexMemoryMaintenanceSessionUsesConfiguredDirectory() {

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -397,6 +397,84 @@ final class SessionManagerVisibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testManualHideRemovesFrozenRecentProjectDuringIncompleteInventory() throws {
+        let root = NSTemporaryDirectory() + "cctop-manual-hide-frozen-recent-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        let hiddenProjectPath = (root as NSString).appendingPathComponent("worktrees/hidden")
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .path
+        let targetProjectPath = (repositoryRoot as NSString).appendingPathComponent("menubar")
+        let targetProjectAlias = (repositoryRoot as NSString).appendingPathComponent("menubar/../menubar")
+        let unrelatedProjectPath = (repositoryRoot as NSString).appendingPathComponent("plugins")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        var hidden = Session(
+            sessionId: "already-hidden",
+            projectPath: hiddenProjectPath,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        hidden.cctopSessionId = "11111111-1111-4111-8111-111111111111"
+        hidden.pid = 4_201
+        hidden.status = .working
+        let hiddenURL = URL(fileURLWithPath: sessionsDir).appendingPathComponent("4201.json")
+        try hidden.writeToFile(path: hiddenURL.path)
+
+        for (sessionID, projectPath) in [
+            ("target-history", targetProjectPath),
+            ("unrelated-history", unrelatedProjectPath),
+        ] {
+            var history = Session(
+                sessionId: sessionID,
+                projectPath: projectPath,
+                branch: "main",
+                terminal: TerminalInfo(program: "zsh")
+            )
+            history.endedAt = Date().addingTimeInterval(sessionID == "target-history" ? -3_600 : -7_200)
+            try history.writeToFile(path: (historyDir as NSString).appendingPathComponent("\(sessionID).json"))
+        }
+
+        let suiteName = "cctop-manual-hide-frozen-recent-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+        visibility.hide(hidden)
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            processAlive: { _ in true },
+            manualSessionVisibility: visibility
+        )
+        XCTAssertEqual(Set(manager.recentResumeTargets.map(\.projectPath)), [targetProjectPath, unrelatedProjectPath])
+
+        try Data("not valid session json".utf8).write(to: hiddenURL)
+        var live = Session(
+            sessionId: "live-target",
+            projectPath: targetProjectAlias,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        live.cctopSessionId = "22222222-2222-4222-8222-222222222222"
+        live.pid = 4_202
+        live.status = .working
+        try live.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("4202.json"))
+        manager.loadSessions()
+
+        let visible = try XCTUnwrap(manager.sessions.first { $0.cctopSessionId == live.cctopSessionId })
+        XCTAssertEqual(Set(manager.recentResumeTargets.map(\.projectPath)), [targetProjectPath, unrelatedProjectPath])
+
+        manager.hideSession(visible)
+
+        XCTAssertEqual(manager.recentResumeTargets.map(\.projectPath), [unrelatedProjectPath])
+    }
+
+    @MainActor
     func testManualHideKeepsRecentEmptyWhenSessionDirectoryReadFails() throws {
         let root = NSTemporaryDirectory() + "cctop-manual-hide-recent-directory-\(UUID().uuidString)"
         let sessionsPath = (root as NSString).appendingPathComponent("sessions")

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -228,6 +228,65 @@ final class SessionManagerVisibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testManualHideKeepsFinishedProjectOutOfRecentWhenArchiveFails() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-manual-hide-archive-failure-\(UUID().uuidString)", isDirectory: true)
+        let sessionsURL = root.appendingPathComponent("sessions", isDirectory: true)
+        let historyURL = root.appendingPathComponent("history", isDirectory: true)
+        let projectPath = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
+        try FileManager.default.createDirectory(at: sessionsURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: historyURL, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: historyURL.path)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let suiteName = "cctop-manual-hide-archive-failure-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+        let hiddenID = "44444444-4444-4444-8444-444444444444"
+
+        var previous = Session(
+            sessionId: "previous",
+            projectPath: projectPath,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        previous.endedAt = Date().addingTimeInterval(-3_600)
+        try previous.writeToFile(path: historyURL.appendingPathComponent("previous.json").path)
+        let historyManager = HistoryManager(historyDir: historyURL)
+        XCTAssertEqual(historyManager.recentProjects.map(\.projectPath), [projectPath])
+
+        var finished = Session(
+            sessionId: "hidden-finished",
+            projectPath: projectPath,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        finished.cctopSessionId = hiddenID
+        finished.pid = 44_444
+        finished.status = .working
+        let finishedURL = sessionsURL.appendingPathComponent("hidden-finished.json")
+        try finished.writeToFile(path: finishedURL.path)
+        visibility.hide(finished)
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: historyURL.path)
+
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = sessionsURL
+        sources.processAlive = { _ in false }
+        sources.manualSessionVisibility = visibility
+        let manager = SessionManager(historyManager: historyManager, dataSources: sources, startMonitoring: false)
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: finishedURL.path))
+        XCTAssertEqual(visibility.hiddenSessionIDs, [hiddenID])
+        XCTAssertFalse(manager.cleanupActiveProjectPaths.contains(projectPath))
+        XCTAssertTrue(manager.cleanupSources.contains { $0.projectPath == projectPath })
+    }
+
+    @MainActor
     func testManualHideKeySurvivesIncompleteSessionInventory() throws {
         let root = NSTemporaryDirectory() + "cctop-manual-hide-partial-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -109,6 +109,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
         let sharedID = "22222222-2222-4222-8222-222222222222"
+        let durableConversationID = "39253133-4a65-48fb-af2b-844463d3b5bb"
         var live = Session(
             sessionId: "live-terminal",
             projectPath: "/tmp/live-terminal",
@@ -116,26 +117,32 @@ final class SessionManagerVisibilityTests: XCTestCase {
             terminal: TerminalInfo(program: "zsh")
         )
         live.cctopSessionId = sharedID
+        live.harnessSessionId = durableConversationID
+        live.source = Session.ccSource
         live.pid = 4_204
         live.status = .working
         try live.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("live-terminal.json"))
 
-        let archivedID = "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
-        var archived = codexDesktopSession(
-            sessionId: archivedID,
+        var archived = claudeDesktopSession(
+            sessionId: durableConversationID,
             projectPath: "/tmp/archived-desktop"
         )
-        archived.cctopSessionId = sharedID
+        archived.cctopSessionId = nil
+        archived.harnessSessionId = durableConversationID
         archived.sessionName = "Archived desktop observation"
         archived.lastActivity = Date(timeIntervalSince1970: 2_000)
-        try archived.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("codex-\(archivedID).json"))
+        try archived.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("archived-desktop.json"))
         try Data("not valid session json".utf8).write(
             to: URL(fileURLWithPath: (sessionsDir as NSString).appendingPathComponent("unrelated-broken.json"))
         )
 
         var sources = SessionDataSources.live()
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
-        sources.codexThreads = StubCodexThreadState(archived: [archivedID])
+        sources.claudeDesktopSessions = StubClaudeDesktopState(snapshot: ClaudeDesktopSessionMetadataSnapshot(
+            matchedSessionIDs: [durableConversationID],
+            archivedSessionIDs: [durableConversationID],
+            isAuthoritative: true
+        ))
         sources.desktopAppConnection = DesktopAppConnectionLookup { _ in false }
         sources.processAlive = { _ in true }
         sources.manualSessionVisibility = visibility
@@ -151,6 +158,71 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.hideSession(hidden)
 
         XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(visibility.hiddenSessionIDs, [sharedID])
+
+        try FileManager.default.removeItem(
+            atPath: (sessionsDir as NSString).appendingPathComponent("unrelated-broken.json")
+        )
+        manager.loadSessions()
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(visibility.hiddenSessionIDs, [sharedID])
+    }
+
+    @MainActor
+    func testManualHideKeySurvivesArchivedOnlyIdentityResolution() throws {
+        let root = NSTemporaryDirectory() + "cctop-manual-hide-archived-only-\(UUID().uuidString)"
+        let sessionsURL = URL(fileURLWithPath: root).appendingPathComponent("sessions", isDirectory: true)
+        let historyURL = URL(fileURLWithPath: root).appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: historyURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let suiteName = "cctop-manual-hide-archived-only-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+        let sharedID = "33333333-3333-4333-8333-333333333333"
+        let durableConversationID = "49253133-4a65-48fb-af2b-844463d3b5bb"
+        _ = try CctopSessionIdentityStore(sessionsDir: sessionsURL).resolve(
+            source: Session.ccSource,
+            harnessSessionId: durableConversationID,
+            legacySessionId: durableConversationID,
+            knownExistingIDs: [sharedID]
+        )
+
+        var hidden = claudeDesktopSession(sessionId: durableConversationID, projectPath: "/tmp/archived-only")
+        hidden.cctopSessionId = sharedID
+        visibility.hide(hidden)
+        hidden.cctopSessionId = nil
+        hidden.harnessSessionId = durableConversationID
+        hidden.sessionName = "Archived-only observation"
+        try hidden.writeToFile(path: sessionsURL.appendingPathComponent("archived-only.json").path)
+
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = sessionsURL
+        sources.claudeDesktopSessions = StubClaudeDesktopState(snapshot: ClaudeDesktopSessionMetadataSnapshot(
+            matchedSessionIDs: [durableConversationID],
+            archivedSessionIDs: [durableConversationID],
+            isAuthoritative: true
+        ))
+        sources.desktopAppConnection = DesktopAppConnectionLookup { _ in false }
+        sources.manualSessionVisibility = visibility
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: historyURL),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(visibility.hiddenSessionIDs, [sharedID])
+
+        manager.sessionFileCache.removeAll()
+        manager.loadSessions()
+
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [sharedID])
     }

--- a/menubar/CctopMenubarTests/SessionTestSupport.swift
+++ b/menubar/CctopMenubarTests/SessionTestSupport.swift
@@ -2,6 +2,26 @@ import XCTest
 @testable import CctopMenubar
 
 extension XCTestCase {
+    func isolatedSessionDataSources(
+        prefix: String
+    ) throws -> (sources: SessionDataSources, visibility: ManualSessionVisibilityStore) {
+        let sessionsDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        let suiteName = "\(prefix)-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: sessionsDir)
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = sessionsDir
+        sources.manualSessionVisibility = visibility
+        return (sources, visibility)
+    }
+
     func executeSQLite(_ sql: String, path: String) throws {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")

--- a/menubar/CctopMenubarTests/SessionTestSupport.swift
+++ b/menubar/CctopMenubarTests/SessionTestSupport.swift
@@ -211,6 +211,7 @@ extension XCTestCase {
         historyDir: String,
         desktopAppConnection: DesktopAppConnectionLookup? = nil,
         processAlive: ((Session) -> Bool)? = nil,
+        manualSessionVisibility: ManualSessionVisibilityStore? = nil,
         now: (() -> Date)? = nil
     ) -> SessionManager {
         var sources = SessionDataSources.live()
@@ -220,6 +221,9 @@ extension XCTestCase {
         }
         if let processAlive {
             sources.processAlive = processAlive
+        }
+        if let manualSessionVisibility {
+            sources.manualSessionVisibility = manualSessionVisibility
         }
         if let now {
             sources.now = now

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -736,6 +736,7 @@ final class SessionTests: XCTestCase {
         )
         let session = Session.mock(
             id: "claude-desktop-thread-1",
+            status: .waitingPermission,
             pid: 12345,
             terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop),
             source: "cc"
@@ -777,7 +778,10 @@ final class SessionTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = ManualSessionVisibilityStore(defaults: defaults)
-        let session = Session.mock(id: "hidden-attention", source: Session.codexSource)
+        let session = Session.mock(
+            id: "hidden-attention", status: .waitingPermission,
+            source: Session.codexSource
+        )
 
         let recorder = Recorder()
         var sources = SessionDataSources.live()
@@ -796,6 +800,11 @@ final class SessionTests: XCTestCase {
             dataSources: sources,
             startMonitoring: false
         )
+        var noLongerNeedsAttention = session
+        noLongerNeedsAttention.status = .working
+        manager.sessions = [noLongerNeedsAttention]
+        manager.postNotification(for: session)
+
         manager.sessions = [session]
         store.hide(session)
 
@@ -846,6 +855,239 @@ final class SessionTests: XCTestCase {
         manager.postNotification(for: original)
 
         XCTAssertTrue(recorder.events.isEmpty)
+    }
+
+    @MainActor
+    func testPostNotificationAllowsUnstampedLegacySessionForSameProcessGeneration() throws {
+        final class Recorder {
+            var events: [String] = []
+        }
+
+        let recorder = Recorder()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-legacy-notification").sources
+        sources.notificationClient = SessionNotificationClient(
+            add: { _, completion in
+                recorder.events.append("add")
+                completion(nil)
+            },
+            removePending: { _ in recorder.events.append("removePending") },
+            removeDelivered: { _ in recorder.events.append("removeDelivered") }
+        )
+        var legacy = Session.mock(
+            id: "legacy-session", harnessSessionId: "legacy-session",
+            status: .waitingInput, pid: 42_042, pidStartTime: 1_000,
+            source: Session.opencodeSource
+        )
+        legacy.cctopSessionId = nil
+        legacy.lifecycle = .active
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: FileManager.default.temporaryDirectory),
+            dataSources: sources,
+            startMonitoring: false
+        )
+        manager.sessions = [legacy]
+
+        manager.postNotification(for: legacy)
+
+        XCTAssertNil(legacy.cctopSessionId)
+        XCTAssertEqual(recorder.events, ["removePending", "removeDelivered", "add"])
+    }
+
+    @MainActor
+    func testPostNotificationRejectsUnstampedLegacySessionWithoutSameGenerationAndConversation() throws {
+        final class Recorder {
+            var events: [String] = []
+        }
+
+        let recorder = Recorder()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-legacy-notification-rejection").sources
+        sources.notificationClient = SessionNotificationClient(
+            add: { _, completion in
+                recorder.events.append("add")
+                completion(nil)
+            },
+            removePending: { _ in recorder.events.append("removePending") },
+            removeDelivered: { _ in recorder.events.append("removeDelivered") }
+        )
+        var pending = Session.mock(
+            id: "legacy-session", harnessSessionId: "legacy-session",
+            status: .waitingInput, pid: 42_042, pidStartTime: 1_000,
+            source: Session.opencodeSource
+        )
+        pending.cctopSessionId = nil
+        pending.lifecycle = .active
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: FileManager.default.temporaryDirectory),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        var replacement = pending
+        replacement.pidStartTime = 2_000
+        manager.sessions = [replacement]
+        manager.postNotification(for: pending)
+        XCTAssertTrue(recorder.events.isEmpty)
+
+        var otherConversation = pending.withSessionId("other-session")
+        otherConversation.harnessSessionId = "other-session"
+        manager.sessions = [otherConversation]
+        manager.postNotification(for: pending)
+        XCTAssertTrue(recorder.events.isEmpty)
+
+        var otherSource = pending
+        otherSource.source = Session.ccSource
+        manager.sessions = [otherSource]
+        manager.postNotification(for: pending)
+        XCTAssertTrue(recorder.events.isEmpty)
+
+        var missingGeneration = pending
+        missingGeneration.pidStartTime = nil
+        manager.sessions = [missingGeneration]
+        manager.postNotification(for: pending)
+        XCTAssertTrue(recorder.events.isEmpty)
+
+        var noLongerNeedsAttention = pending
+        noLongerNeedsAttention.status = .working
+        manager.sessions = [noLongerNeedsAttention]
+        manager.postNotification(for: pending)
+        XCTAssertTrue(recorder.events.isEmpty)
+        recorder.events.removeAll()
+
+        var oneSidedHarnessEvidence = pending
+        oneSidedHarnessEvidence.harnessSessionId = nil
+        manager.sessions = [oneSidedHarnessEvidence]
+        manager.postNotification(for: pending)
+        XCTAssertTrue(recorder.events.isEmpty)
+        recorder.events.removeAll()
+
+        manager.sessions = [pending, pending]
+        manager.postNotification(for: pending)
+        XCTAssertTrue(recorder.events.isEmpty)
+    }
+
+    @MainActor
+    func testPostNotificationRejectsUnstampedLegacySessionWhenCurrentObservationIsHidden() throws {
+        final class Recorder {
+            var events: [String] = []
+        }
+
+        let isolated = try isolatedSessionDataSources(prefix: "cctop-legacy-hidden-notification")
+        let visibility = isolated.visibility
+        let recorder = Recorder()
+        var sources = isolated.sources
+        sources.notificationClient = SessionNotificationClient(
+            add: { _, completion in
+                recorder.events.append("add")
+                completion(nil)
+            },
+            removePending: { _ in recorder.events.append("removePending") },
+            removeDelivered: { _ in recorder.events.append("removeDelivered") }
+        )
+        var pending = Session.mock(
+            id: "legacy-session", harnessSessionId: "legacy-session",
+            status: .waitingInput, pid: 42_042, pidStartTime: 1_000,
+            source: Session.opencodeSource
+        )
+        pending.cctopSessionId = nil
+        pending.lifecycle = .active
+        var current = pending
+        current.cctopSessionId = "11111111-1111-4111-8111-111111111111"
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: FileManager.default.temporaryDirectory),
+            dataSources: sources,
+            startMonitoring: false
+        )
+        manager.sessions = [current]
+        visibility.hide(current)
+
+        manager.postNotification(for: pending)
+
+        XCTAssertTrue(recorder.events.isEmpty)
+    }
+
+    @MainActor
+    func testPostNotificationMatchesCurrentCanonicalObservationForPendingRequest() throws {
+        final class Recorder {
+            var events: [String] = []
+        }
+
+        let recorder = Recorder()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-canonical-notification").sources
+        sources.notificationClient = SessionNotificationClient(
+            add: { _, completion in
+                recorder.events.append("add")
+                completion(nil)
+            },
+            removePending: { _ in recorder.events.append("removePending") },
+            removeDelivered: { _ in recorder.events.append("removeDelivered") }
+        )
+        let sharedID = "11111111-1111-4111-8111-111111111111"
+        var working = Session.mock(
+            id: "first", cctopSessionId: sharedID,
+            status: .working, pid: 11_111, source: Session.opencodeSource
+        )
+        working.lifecycle = .active
+        var waiting = Session.mock(
+            id: "second", cctopSessionId: sharedID,
+            status: .waitingPermission, pid: 22_222, source: Session.opencodeSource
+        )
+        waiting.lifecycle = .active
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: FileManager.default.temporaryDirectory),
+            dataSources: sources,
+            startMonitoring: false
+        )
+        manager.sessions = [working, waiting]
+
+        manager.postNotification(for: waiting)
+
+        XCTAssertEqual(recorder.events, ["removePending", "removeDelivered", "add"])
+        recorder.events.removeAll()
+        var staleWaitingSnapshot = working
+        staleWaitingSnapshot.status = .waitingPermission
+        manager.postNotification(for: staleWaitingSnapshot)
+        XCTAssertTrue(recorder.events.isEmpty)
+    }
+
+    @MainActor
+    func testHideSessionRemovesNotificationsForEveryDiscardedObservation() throws {
+        final class Recorder {
+            var pending: [[String]] = []
+            var delivered: [[String]] = []
+        }
+
+        let recorder = Recorder()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-hide-all-notifications").sources
+        sources.notificationsEnabled = { false }
+        sources.notificationClient = SessionNotificationClient(
+            add: { _, completion in completion(nil) },
+            removePending: { recorder.pending.append($0) },
+            removeDelivered: { recorder.delivered.append($0) }
+        )
+        let sharedID = "11111111-1111-4111-8111-111111111111"
+        let first = Session.mock(
+            id: "first", cctopSessionId: sharedID,
+            status: .working, pid: 11_111, source: Session.opencodeSource
+        )
+        let second = Session.mock(
+            id: "second", cctopSessionId: sharedID,
+            status: .working, pid: 22_222, source: Session.opencodeSource
+        )
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: FileManager.default.temporaryDirectory),
+            dataSources: sources,
+            startMonitoring: false
+        )
+        manager.sessions = [first, second]
+
+        manager.hideSession(first)
+
+        let expectedIdentifiers = Set([first, second].map(SessionIdentityPolicy.notificationRequestIdentifier))
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertEqual(Set(recorder.pending.flatMap { $0 }), expectedIdentifiers)
+        XCTAssertEqual(recorder.pending.flatMap { $0 }.count, expectedIdentifiers.count)
+        XCTAssertEqual(Set(recorder.delivered.flatMap { $0 }), expectedIdentifiers)
+        XCTAssertEqual(recorder.delivered.flatMap { $0 }.count, expectedIdentifiers.count)
     }
 
     @MainActor

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -808,6 +808,47 @@ final class SessionTests: XCTestCase {
     }
 
     @MainActor
+    func testPostNotificationDoesNotReuseLegacyPIDIdentityDuringPermissionDelay() throws {
+        final class Recorder {
+            var events: [String] = []
+        }
+
+        let recorder = Recorder()
+        var sources = SessionDataSources.live()
+        let sessionsDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sessionsDir) }
+        sources.sessionsDir = sessionsDir
+        sources.notificationClient = SessionNotificationClient(
+            add: { _, completion in
+                recorder.events.append("add")
+                completion(nil)
+            },
+            removePending: { _ in recorder.events.append("removePending") },
+            removeDelivered: { _ in recorder.events.append("removeDelivered") }
+        )
+        let original = Session.mock(
+            id: "reused-pid", cctopSessionId: "11111111-1111-4111-8111-111111111111",
+            pid: 42_042, source: Session.ccSource
+        )
+        let replacement = Session.mock(
+            id: "reused-pid", cctopSessionId: "22222222-2222-4222-8222-222222222222",
+            pid: 42_042, source: Session.ccSource
+        )
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: FileManager.default.temporaryDirectory),
+            dataSources: sources,
+            startMonitoring: false
+        )
+        manager.sessions = [replacement]
+
+        manager.postNotification(for: original)
+
+        XCTAssertTrue(recorder.events.isEmpty)
+    }
+
+    @MainActor
     func testHideSessionRemovesOutstandingAttentionNotification() throws {
         final class Recorder {
             var events: [String] = []

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -583,6 +583,87 @@ final class SessionTests: XCTestCase {
         )
     }
 
+    func testManualSessionVisibilityPersistsOnlySortedStableKeys() throws {
+        let suiteName = "cctop-manual-visibility-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = ManualSessionVisibilityStore(defaults: defaults)
+
+        var terminal = Session(
+            sessionId: "private-terminal-conversation",
+            projectPath: "/private/project/path",
+            branch: "secret-branch",
+            terminal: TerminalInfo()
+        )
+        terminal.pid = 42
+        terminal.sessionName = "Private session title"
+        let codex = Session.mock(id: "codex-thread", source: Session.codexSource)
+
+        store.hide(terminal)
+        store.hide(codex)
+
+        let stored = try XCTUnwrap(defaults.stringArray(forKey: ManualSessionVisibilityStore.defaultsKey))
+        XCTAssertEqual(stored, ["active:42", "codex:codex-thread"])
+        let payload = stored.joined(separator: "\n")
+        XCTAssertFalse(payload.contains(terminal.sessionName!))
+        XCTAssertFalse(payload.contains(terminal.projectPath))
+        XCTAssertFalse(payload.contains(terminal.branch))
+    }
+
+    func testManualSessionVisibilityPrunesOnlyMissingStableKeys() {
+        let suiteName = "cctop-manual-visibility-prune-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = ManualSessionVisibilityStore(defaults: defaults)
+        let first = Session.mock(id: "first", source: Session.codexSource)
+        let second = Session.mock(id: "second", source: Session.codexSource)
+
+        store.hide(first)
+        store.hide(second)
+        store.prune(retaining: [SessionIdentityPolicy.stableKey(for: second)])
+
+        XCTAssertEqual(store.hiddenKeys, [SessionIdentityPolicy.stableKey(for: second)])
+    }
+
+    func testManualSessionHideConfirmationDescribesIrreversibleVisibleEffect() {
+        let session = Session.mock(
+            id: "private-session",
+            project: "cctop",
+            sessionName: "Investigate lifecycle",
+            source: Session.codexSource
+        )
+
+        let confirmation = ManualSessionHideConfirmation(session: session)
+
+        XCTAssertEqual(confirmation.id, "hide:codex:private-session")
+        XCTAssertEqual(confirmation.title, "Hide “Investigate lifecycle” from cctop?")
+        XCTAssertEqual(confirmation.primaryButtonTitle, "Hide Session")
+        XCTAssertEqual(
+            confirmation.message,
+            "It will disappear from the panel, notifications, Navigate mode, and Stream Deck. "
+                + "This does not stop or delete the underlying session; cctop will keep it available for lifecycle and Cleanup. "
+                + "You cannot show it again while its local session record exists."
+        )
+        XCTAssertEqual(confirmation.session, session)
+    }
+
+    func testPopupConfirmationRoutesCleanupAndSessionHideWithDistinctIdentity() {
+        let cleanupConfirmation = WorktreeRemovalConfirmation.review(
+            .normalRemove(.mock(state: .review(["Worktree has untracked files"])))
+        )
+        let sessionConfirmation = ManualSessionHideConfirmation(
+            session: .mock(id: "private-session", source: Session.codexSource)
+        )
+        let cleanupRoute = PopupConfirmation.cleanup(cleanupConfirmation)
+        let sessionRoute = PopupConfirmation.sessionHide(sessionConfirmation)
+
+        XCTAssertEqual(cleanupRoute.id, "cleanup:\(cleanupConfirmation.id)")
+        XCTAssertEqual(sessionRoute.id, "session-hide:\(sessionConfirmation.id)")
+        XCTAssertNotEqual(cleanupRoute.id, sessionRoute.id)
+        XCTAssertEqual(cleanupRoute, .cleanup(cleanupConfirmation))
+        XCTAssertEqual(sessionRoute, .sessionHide(sessionConfirmation))
+    }
+
     func testNotificationRequestDoesNotUseVisibleThreadGrouping() {
         let session = Session.mock(
             id: "claude-desktop-thread-1",
@@ -632,6 +713,7 @@ final class SessionTests: XCTestCase {
             dataSources: sources,
             startMonitoring: false
         )
+        manager.sessions = [session]
 
         manager.postNotification(for: session)
 
@@ -643,6 +725,103 @@ final class SessionTests: XCTestCase {
                 "add:session-desktop:claude-desktop-thread-1",
             ]
         )
+    }
+
+    @MainActor
+    func testPostNotificationSkipsHiddenOrVanishedSessionDuringPermissionDelay() throws {
+        final class Recorder {
+            var events: [String] = []
+        }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-hidden-notification-\(UUID().uuidString)", isDirectory: true)
+        let sessionsDir = root.appendingPathComponent("sessions", isDirectory: true)
+        let historyDir = root.appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let suiteName = "cctop-hidden-notification-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = ManualSessionVisibilityStore(defaults: defaults)
+        let session = Session.mock(id: "hidden-attention", source: Session.codexSource)
+
+        let recorder = Recorder()
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = sessionsDir
+        sources.manualSessionVisibility = store
+        sources.notificationClient = SessionNotificationClient(
+            add: { request, completion in
+                recorder.events.append("add:\(request.identifier)")
+                completion(nil)
+            },
+            removePending: { _ in recorder.events.append("removePending") },
+            removeDelivered: { _ in recorder.events.append("removeDelivered") }
+        )
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: historyDir),
+            dataSources: sources,
+            startMonitoring: false
+        )
+        manager.sessions = [session]
+        store.hide(session)
+
+        manager.postNotification(for: session)
+        store.prune(retaining: [])
+        manager.sessions = []
+        manager.postNotification(for: session)
+
+        XCTAssertEqual(recorder.events, [])
+    }
+
+    @MainActor
+    func testHideSessionRemovesOutstandingAttentionNotification() throws {
+        final class Recorder {
+            var events: [String] = []
+        }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-hide-notification-\(UUID().uuidString)", isDirectory: true)
+        let sessionsDir = root.appendingPathComponent("sessions", isDirectory: true)
+        let historyDir = root.appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let suiteName = "cctop-hide-notification-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let recorder = Recorder()
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = sessionsDir
+        sources.manualSessionVisibility = ManualSessionVisibilityStore(defaults: defaults)
+        sources.notificationsEnabled = { false }
+        sources.notificationClient = SessionNotificationClient(
+            add: { _, completion in completion(nil) },
+            removePending: { identifiers in
+                recorder.events.append("pending:\(identifiers.joined(separator: ","))")
+            },
+            removeDelivered: { identifiers in
+                recorder.events.append("delivered:\(identifiers.joined(separator: ","))")
+            }
+        )
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: historyDir),
+            dataSources: sources,
+            startMonitoring: false
+        )
+        var attention = Session.mock(id: "attention", status: .waitingInput, source: Session.codexSource)
+        attention.lifecycle = .active
+        manager.sessions = [attention]
+
+        manager.hideSession(attention)
+
+        XCTAssertEqual(manager.sessions, [])
+        XCTAssertEqual(recorder.events, [
+            "pending:session-codex:attention",
+            "delivered:session-codex:attention",
+        ])
     }
 
     func testNotificationLookupPrefersDesktopSessionIDOverPID() {

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -583,7 +583,7 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testManualSessionVisibilityPersistsOnlySortedStableKeys() throws {
+    func testManualSessionVisibilityPersistsOnlySortedCctopSessionIDs() throws {
         let suiteName = "cctop-manual-visibility-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -595,47 +595,75 @@ final class SessionTests: XCTestCase {
             branch: "secret-branch",
             terminal: TerminalInfo()
         )
+        terminal.cctopSessionId = "11111111-1111-4111-8111-111111111111"
         terminal.pid = 42
         terminal.sessionName = "Private session title"
-        let codex = Session.mock(id: "codex-thread", source: Session.codexSource)
+        let codex = Session.mock(
+            id: "codex-thread",
+            cctopSessionId: "22222222-2222-4222-8222-222222222222",
+            source: Session.codexSource
+        )
 
         store.hide(terminal)
         store.hide(codex)
 
         let stored = try XCTUnwrap(defaults.stringArray(forKey: ManualSessionVisibilityStore.defaultsKey))
-        XCTAssertEqual(stored, ["active:42", "codex:codex-thread"])
+        XCTAssertEqual(stored, [
+            "11111111-1111-4111-8111-111111111111",
+            "22222222-2222-4222-8222-222222222222",
+        ])
         let payload = stored.joined(separator: "\n")
+        XCTAssertFalse(payload.contains("active:42"))
         XCTAssertFalse(payload.contains(terminal.sessionName!))
         XCTAssertFalse(payload.contains(terminal.projectPath))
         XCTAssertFalse(payload.contains(terminal.branch))
     }
 
-    func testManualSessionVisibilityPrunesOnlyMissingStableKeys() {
+    func testManualSessionVisibilityPrunesOnlyMissingCctopSessionIDs() {
         let suiteName = "cctop-manual-visibility-prune-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = ManualSessionVisibilityStore(defaults: defaults)
-        let first = Session.mock(id: "first", source: Session.codexSource)
-        let second = Session.mock(id: "second", source: Session.codexSource)
+        let first = Session.mock(
+            id: "first", cctopSessionId: "11111111-1111-4111-8111-111111111111"
+        )
+        let secondID = "22222222-2222-4222-8222-222222222222"
+        let second = Session.mock(id: "second", cctopSessionId: secondID)
 
         store.hide(first)
         store.hide(second)
-        store.prune(retaining: [SessionIdentityPolicy.stableKey(for: second)])
+        store.prune(retaining: [secondID])
 
-        XCTAssertEqual(store.hiddenKeys, [SessionIdentityPolicy.stableKey(for: second)])
+        XCTAssertEqual(store.hiddenSessionIDs, [secondID])
     }
 
-    func testManualSessionHideConfirmationDescribesIrreversibleVisibleEffect() {
+    func testManualSessionVisibilityIgnoresRowsWithoutPermanentIdentity() {
+        let suiteName = "cctop-manual-visibility-legacy-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = ManualSessionVisibilityStore(defaults: defaults)
+        var legacy = Session.mock(id: "legacy")
+        legacy.cctopSessionId = nil
+
+        store.hide(legacy)
+
+        XCTAssertFalse(store.isHidden(legacy))
+        XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.defaultsKey))
+        XCTAssertNil(ManualSessionHideConfirmation(session: legacy))
+    }
+
+    func testManualSessionHideConfirmationDescribesIrreversibleVisibleEffect() throws {
         let session = Session.mock(
             id: "private-session",
+            cctopSessionId: "11111111-1111-4111-8111-111111111111",
             project: "cctop",
             sessionName: "Investigate lifecycle",
             source: Session.codexSource
         )
 
-        let confirmation = ManualSessionHideConfirmation(session: session)
+        let confirmation = try XCTUnwrap(ManualSessionHideConfirmation(session: session))
 
-        XCTAssertEqual(confirmation.id, "hide:codex:private-session")
+        XCTAssertEqual(confirmation.id, "hide:11111111-1111-4111-8111-111111111111")
         XCTAssertEqual(confirmation.title, "Hide “Investigate lifecycle” from cctop?")
         XCTAssertEqual(confirmation.primaryButtonTitle, "Hide Session")
         XCTAssertEqual(
@@ -647,13 +675,17 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(confirmation.session, session)
     }
 
-    func testPopupConfirmationRoutesCleanupAndSessionHideWithDistinctIdentity() {
+    func testPopupConfirmationRoutesCleanupAndSessionHideWithDistinctIdentity() throws {
         let cleanupConfirmation = WorktreeRemovalConfirmation.review(
             .normalRemove(.mock(state: .review(["Worktree has untracked files"])))
         )
-        let sessionConfirmation = ManualSessionHideConfirmation(
-            session: .mock(id: "private-session", source: Session.codexSource)
-        )
+        let sessionConfirmation = try XCTUnwrap(ManualSessionHideConfirmation(
+            session: .mock(
+                id: "private-session",
+                cctopSessionId: "11111111-1111-4111-8111-111111111111",
+                source: Session.codexSource
+            )
+        ))
         let cleanupRoute = PopupConfirmation.cleanup(cleanupConfirmation)
         let sessionRoute = PopupConfirmation.sessionHide(sessionConfirmation)
 

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -504,6 +504,44 @@ final class SessionTests: XCTestCase {
             userInfo[SessionIdentityPolicy.notificationSessionPIDKey] as? String,
             "12345"
         )
+        XCTAssertEqual(
+            userInfo["cctopSessionID"] as? String,
+            session.cctopSessionId
+        )
+    }
+
+    func testNotificationMetadataFindsPriorProcessObservationByPermanentIdentity() {
+        let sharedID = "11111111-1111-4111-8111-111111111111"
+        let oldObservation = Session.mock(
+            id: "old-process", cctopSessionId: sharedID,
+            status: .waitingPermission, pid: 11_111, source: Session.opencodeSource
+        )
+        let currentObservation = Session.mock(
+            id: "new-process", cctopSessionId: sharedID,
+            status: .waitingPermission, pid: 22_222, source: Session.opencodeSource
+        )
+        let unrelated = Session.mock(
+            id: "unrelated", cctopSessionId: "22222222-2222-4222-8222-222222222222",
+            status: .waitingPermission, pid: 33_333, source: Session.opencodeSource
+        )
+        let oldRequest = SessionManager.notificationRequest(for: oldObservation)
+        let currentRequest = SessionManager.notificationRequest(for: currentObservation)
+        let unrelatedRequest = SessionManager.notificationRequest(for: unrelated)
+        let malformedContent = UNMutableNotificationContent()
+        malformedContent.userInfo = [SessionIdentityPolicy.notificationCctopSessionIDKey: "not-a-uuid"]
+        let malformedRequest = UNNotificationRequest(identifier: "malformed", content: malformedContent, trigger: nil)
+        let missingRequest = UNNotificationRequest(
+            identifier: "missing", content: UNMutableNotificationContent(), trigger: nil
+        )
+
+        XCTAssertNotEqual(oldRequest.identifier, currentRequest.identifier)
+        XCTAssertEqual(
+            SessionNotificationClient.identifiers(
+                belongingTo: sharedID,
+                in: [oldRequest, unrelatedRequest, malformedRequest, missingRequest]
+            ),
+            [oldRequest.identifier]
+        )
     }
 
     func testNotificationLookupPrefersStableSessionIDOverSharedCodexPID() {
@@ -694,6 +732,14 @@ final class SessionTests: XCTestCase {
         XCTAssertNotEqual(cleanupRoute.id, sessionRoute.id)
         XCTAssertEqual(cleanupRoute, .cleanup(cleanupConfirmation))
         XCTAssertEqual(sessionRoute, .sessionHide(sessionConfirmation))
+        XCTAssertEqual(
+            PopupView.confirmationAfterCleanupReview(cleanupConfirmation, preserving: sessionRoute),
+            sessionRoute
+        )
+        XCTAssertEqual(
+            PopupView.confirmationAfterCleanupReview(cleanupConfirmation, preserving: nil),
+            cleanupRoute
+        )
     }
 
     func testNotificationRequestDoesNotUseVisibleThreadGrouping() {
@@ -1054,6 +1100,7 @@ final class SessionTests: XCTestCase {
         final class Recorder {
             var pending: [[String]] = []
             var delivered: [[String]] = []
+            var cctopSessionIDs: [String] = []
         }
 
         let recorder = Recorder()
@@ -1062,7 +1109,8 @@ final class SessionTests: XCTestCase {
         sources.notificationClient = SessionNotificationClient(
             add: { _, completion in completion(nil) },
             removePending: { recorder.pending.append($0) },
-            removeDelivered: { recorder.delivered.append($0) }
+            removeDelivered: { recorder.delivered.append($0) },
+            removeByCctopSessionID: { recorder.cctopSessionIDs.append($0) }
         )
         let sharedID = "11111111-1111-4111-8111-111111111111"
         let first = Session.mock(
@@ -1088,6 +1136,7 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(recorder.pending.flatMap { $0 }.count, expectedIdentifiers.count)
         XCTAssertEqual(Set(recorder.delivered.flatMap { $0 }), expectedIdentifiers)
         XCTAssertEqual(recorder.delivered.flatMap { $0 }.count, expectedIdentifiers.count)
+        XCTAssertEqual(recorder.cctopSessionIDs, [sharedID])
     }
 
     @MainActor


### PR DESCRIPTION
Adds a confirmed right-click action to hide a session from cctop for as long as its local record exists, without stopping or deleting the underlying session.

- Persists only the permanent `cctop_session_id` and prunes stale preferences only after a complete local inventory.
- Removes hidden sessions immediately from panel navigation, visible counts, notifications, Recent desktop targets, and Stream Deck output without changing survivor order.
- Keeps full session records available for lifecycle and Cleanup, including privacy-safe behavior when session files are temporarily unreadable.
- Uses the panel root confirmation flow for both mouse and accessibility actions, and documents the hide-only behavior.