### PR TITLE
Allow force removal of detached cleanup worktrees

### DIFF
--- a/menubar/CctopMenubar/Models/WorktreeCleanupCandidate.swift
+++ b/menubar/CctopMenubar/Models/WorktreeCleanupCandidate.swift
@@ -8,7 +8,8 @@ struct WorktreeCleanupCandidate: Identifiable, Equatable {
     static let initializedSubmodulesReason = "Worktree contains initialized submodules"
     static let indexHiddenTrackedFilesReason = "Worktree has tracked files hidden by Git index flags"
     static let statusUnreadableReason = "Git status could not be read"
-    static let branchUnknownReason = "Branch is unknown or detached"
+    static let branchUnknownReason = "Branch safety cannot be verified because the branch is unknown or detached"
+    static let unknownBranchDisplayName = "unknown / detached"
     static let mainWorktreePathUnverifiedReason = "Main checkout path could not be verified"
     static let commitSafetyUnknownReason = "Branch upstream or commit safety could not be verified"
     static let protectedFolderAccessReason = "File access is needed to inspect this protected worktree"
@@ -91,7 +92,11 @@ struct WorktreeCleanupCandidate: Identifiable, Equatable {
         Self.formatStorage(bytes: storageBytes)
     }
 
-    var requiresForceWorktreeRemoval: Bool {
+    var requiresForceRemovalReview: Bool {
+        requiresGitForceRemoval || state.reasons.contains(Self.branchUnknownReason)
+    }
+
+    var requiresGitForceRemoval: Bool {
         state.reasons.contains(Self.untrackedFilesReason)
             || state.reasons.contains(Self.trackedChangesReason)
     }
@@ -138,15 +143,18 @@ struct WorktreeCleanupReviewEvidence: Equatable {
     let untrackedPreview: WorktreeCleanupUntrackedPreview?
     let ignoredPreview: WorktreeCleanupUntrackedPreview?
     let trackedPathSignature: [String]
+    let headRevision: String?
 
     init(
         untrackedPreview: WorktreeCleanupUntrackedPreview? = nil,
         ignoredPreview: WorktreeCleanupUntrackedPreview? = nil,
-        trackedPathSignature: [String] = []
+        trackedPathSignature: [String] = [],
+        headRevision: String? = nil
     ) {
         self.untrackedPreview = untrackedPreview
         self.ignoredPreview = ignoredPreview
         self.trackedPathSignature = trackedPathSignature
+        self.headRevision = headRevision
     }
 
     var hasLocalFilePreview: Bool {
@@ -259,9 +267,23 @@ enum WorktreeRemovalConfirmation: Identifiable, Equatable {
             return "Runs git worktree remove for \(candidate.worktreeName). "
                 + "\(Self.reviewEvidenceCopy(for: candidate)) \(Self.branchRetentionCopy)"
         case .review(.forceRemove(let candidate)):
-            return "Runs git worktree remove --force for \(candidate.worktreeName). "
-                + "\(Self.reviewEvidenceCopy(for: candidate)) "
-                + "This removes local file changes and files in that worktree. \(Self.branchRetentionCopy)"
+            let command = candidate.requiresGitForceRemoval ? "git worktree remove --force" : "git worktree remove"
+            let fileRiskCopy = candidate.requiresGitForceRemoval
+                ? "This removes local file changes and files in that worktree."
+                : ""
+            let lateChangeGuard = candidate.requiresGitForceRemoval
+                ? ""
+                : "Git will refuse removal if tracked changes or non-ignored untracked files appeared after this review."
+            let branchRetention = candidate.state.reasons.contains(WorktreeCleanupCandidate.branchUnknownReason)
+                ? ""
+                : Self.branchRetentionCopy
+            return [
+                "Runs \(command) for \(candidate.worktreeName).",
+                Self.reviewEvidenceCopy(for: candidate),
+                fileRiskCopy,
+                lateChangeGuard,
+                branchRetention,
+            ].filter { !$0.isEmpty }.joined(separator: " ")
         case .review(.blocked(_, let reason)):
             return reason
         }
@@ -302,9 +324,7 @@ enum WorktreeRemovalConfirmation: Identifiable, Equatable {
         }
         if let preview = candidate.reviewEvidence.ignoredPreview {
             parts.append("Ignored files: \(preview.decisionEvidenceText).")
-            if !candidate.requiresForceWorktreeRemoval {
-                parts.append("Ignored files will be removed with this worktree.")
-            }
+            parts.append("Ignored files will be removed with this worktree.")
         }
 
         return parts.joined(separator: " ")

--- a/menubar/CctopMenubar/Services/GitWorktreeInspector.swift
+++ b/menubar/CctopMenubar/Services/GitWorktreeInspector.swift
@@ -86,6 +86,7 @@ struct GitWorktreeInspector {
             isLocked: entries[matchIndex].isLocked,
             mainWorktreePath: mainWorktreePath,
             branchName: branch,
+            headRevision: entries[matchIndex].headRevision,
             statusEntries: statusEntries,
             uniqueCommitCount: uniqueCommitCount,
             failureReasons: failures
@@ -206,6 +207,7 @@ struct GitWorktreeInspector {
         var entries: [GitWorktreeListEntry] = []
         var path: String?
         var branch: String?
+        var headRevision: String?
         var isPrunable = false
         var isLocked = false
 
@@ -215,12 +217,14 @@ struct GitWorktreeInspector {
                 GitWorktreeListEntry(
                     path: currentPath,
                     branchName: branch,
+                    headRevision: headRevision,
                     isPrunable: isPrunable,
                     isLocked: isLocked
                 )
             )
             path = nil
             branch = nil
+            headRevision = nil
             isPrunable = false
             isLocked = false
         }
@@ -234,6 +238,8 @@ struct GitWorktreeInspector {
                 path = String(line.dropFirst("worktree ".count))
             } else if line.hasPrefix("branch refs/heads/") {
                 branch = String(line.dropFirst("branch refs/heads/".count))
+            } else if line.hasPrefix("HEAD ") {
+                headRevision = String(line.dropFirst("HEAD ".count))
             } else if line.hasPrefix("prunable") {
                 isPrunable = true
             } else if line.hasPrefix("locked") {
@@ -317,8 +323,23 @@ struct GitWorktreeInspector {
 struct GitWorktreeListEntry: Equatable {
     let path: String
     let branchName: String?
+    let headRevision: String?
     let isPrunable: Bool
     let isLocked: Bool
+
+    init(
+        path: String,
+        branchName: String?,
+        headRevision: String? = nil,
+        isPrunable: Bool,
+        isLocked: Bool
+    ) {
+        self.path = path
+        self.branchName = branchName
+        self.headRevision = headRevision
+        self.isPrunable = isPrunable
+        self.isLocked = isLocked
+    }
 }
 
 private struct IndexHiddenTrackedEntry {

--- a/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
@@ -30,9 +30,32 @@ struct GitWorktreeInspection: Equatable {
     let isLocked: Bool
     let mainWorktreePath: String?
     let branchName: String?
+    let headRevision: String?
     let statusEntries: [String]?
     let uniqueCommitCount: Int?
     let failureReasons: [String]
+
+    init(
+        isRegisteredWorktree: Bool,
+        isLinkedWorktree: Bool,
+        isLocked: Bool,
+        mainWorktreePath: String?,
+        branchName: String?,
+        headRevision: String? = nil,
+        statusEntries: [String]?,
+        uniqueCommitCount: Int?,
+        failureReasons: [String]
+    ) {
+        self.isRegisteredWorktree = isRegisteredWorktree
+        self.isLinkedWorktree = isLinkedWorktree
+        self.isLocked = isLocked
+        self.mainWorktreePath = mainWorktreePath
+        self.branchName = branchName
+        self.headRevision = headRevision
+        self.statusEntries = statusEntries
+        self.uniqueCommitCount = uniqueCommitCount
+        self.failureReasons = failureReasons
+    }
 }
 
 struct WorktreeCleanupScanner {
@@ -144,7 +167,8 @@ struct WorktreeCleanupScanner {
         }
 
         let inspection = inspectGit(context.path)
-        let branchName = inspection.branchName ?? context.fallbackBranch
+        let branchName = inspection.branchName
+            ?? (inspection.isRegisteredWorktree ? WorktreeCleanupCandidate.unknownBranchDisplayName : context.fallbackBranch)
         guard inspection.isRegisteredWorktree else {
             return ignoredCandidate(
                 context: context,
@@ -262,7 +286,7 @@ struct WorktreeCleanupScanner {
     private static func isCommitSafetyReason(_ reason: String) -> Bool {
         reason.localizedCaseInsensitiveContains("upstream")
             || reason.localizedCaseInsensitiveContains("commit")
-            || reason.localizedCaseInsensitiveContains("Branch is unknown")
+            || reason == WorktreeCleanupCandidate.branchUnknownReason
     }
 
     static func untrackedPaths(fromStatusEntries entries: [String]) -> [String] {
@@ -309,18 +333,16 @@ struct WorktreeCleanupScanner {
 
     static func reviewEvidence(for inspection: GitWorktreeInspection) -> WorktreeCleanupReviewEvidence {
         guard let statusEntries = inspection.statusEntries else {
-            return .empty
+            return WorktreeCleanupReviewEvidence(headRevision: inspection.headRevision)
         }
         let untrackedPreview = WorktreeCleanupUntrackedPreview(paths: untrackedPaths(fromStatusEntries: statusEntries))
         let ignoredPreview = WorktreeCleanupUntrackedPreview(paths: ignoredPaths(fromStatusEntries: statusEntries))
         let trackedPathSignature = trackedPaths(fromStatusEntries: statusEntries)
-        guard untrackedPreview != nil || ignoredPreview != nil || !trackedPathSignature.isEmpty else {
-            return .empty
-        }
         return WorktreeCleanupReviewEvidence(
             untrackedPreview: untrackedPreview,
             ignoredPreview: ignoredPreview,
-            trackedPathSignature: trackedPathSignature
+            trackedPathSignature: trackedPathSignature,
+            headRevision: inspection.headRevision
         )
     }
 

--- a/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
+++ b/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
@@ -38,7 +38,7 @@ struct WorktreeRemovalService {
             if readiness.candidate.state.reasons.contains(WorktreeCleanupCandidate.lockedReason) {
                 return .blocked(readiness.candidate, readiness.candidate.blockedRemovalReason)
             }
-            if readiness.candidate.requiresForceWorktreeRemoval {
+            if readiness.candidate.requiresForceRemovalReview {
                 return .forceRemove(readiness.candidate)
             }
             return .normalRemove(readiness.candidate)
@@ -59,7 +59,7 @@ struct WorktreeRemovalService {
             guard let readiness = removalReadiness(from: candidate) else {
                 return .refused(candidate)
             }
-            let result = runGit(removeArguments(for: readiness, force: true))
+            let result = runGit(removeArguments(for: readiness, force: candidate.requiresGitForceRemoval))
             return result.exitCode == 0 ? .removed(result) : .failed(result)
         case .blocked(let candidate, _):
             return .refused(candidate)
@@ -153,9 +153,7 @@ struct WorktreeRemovalService {
               inspection.isLinkedWorktree else {
             return .refused(preflightCandidate)
         }
-        guard let branchName = inspection.branchName else {
-            return .refused(preflightCandidate)
-        }
+        let branchName = inspection.branchName ?? WorktreeCleanupCandidate.unknownBranchDisplayName
         let finalCandidate = preflightCandidate.refreshed(with: inspection, branchName: branchName)
         if let refusal = finalCandidate.refusalCandidate(
             comparedTo: preflightCandidate,
@@ -201,7 +199,7 @@ private extension WorktreeCleanupCandidate {
         if candidate.state.reasons.contains(WorktreeCleanupCandidate.protectedFolderAccessReason) {
             // Passive protected-folder rows intentionally skip identity and file-evidence probes.
             guard worktreePath == candidate.worktreePath else { return self }
-        } else if changesWorktreeIdentity(comparedTo: candidate) || changesLocalFileReviewEvidence(comparedTo: candidate) {
+        } else if changesWorktreeIdentity(comparedTo: candidate) || changesRemovalEvidence(comparedTo: candidate) {
             return self
         }
         if state.reasons.contains(WorktreeCleanupCandidate.initializedSubmodulesReason)
@@ -234,7 +232,7 @@ private extension WorktreeCleanupCandidate {
             || branchName != candidate.branchName
     }
 
-    func changesLocalFileReviewEvidence(comparedTo candidate: WorktreeCleanupCandidate) -> Bool {
+    func changesRemovalEvidence(comparedTo candidate: WorktreeCleanupCandidate) -> Bool {
         let confirmedReasons = Set(candidate.state.reasons)
         let localFileEvidencePairs = [
             (
@@ -252,12 +250,14 @@ private extension WorktreeCleanupCandidate {
             let addedReason = state.reasons.contains(pair.reason) && !confirmedReasons.contains(pair.reason)
             return pair.preflightPreview != pair.confirmedPreview || addedReason
         }
-        return changedPreview || reviewEvidence.trackedPathSignature != candidate.reviewEvidence.trackedPathSignature
+        return changedPreview
+            || reviewEvidence.trackedPathSignature != candidate.reviewEvidence.trackedPathSignature
+            || reviewEvidence.headRevision != candidate.reviewEvidence.headRevision
     }
 
     func matchesConfirmedRemovalEvidence(comparedTo candidate: WorktreeCleanupCandidate) -> Bool {
         !changesWorktreeIdentity(comparedTo: candidate)
-            && !changesLocalFileReviewEvidence(comparedTo: candidate)
+            && !changesRemovalEvidence(comparedTo: candidate)
             && Set(state.reasons) == Set(candidate.state.reasons)
     }
 
@@ -276,9 +276,6 @@ private extension WorktreeCleanupCandidate {
         }
         if state.reasons.contains(Self.lockedReason) {
             return "This worktree is locked. Unlock it before removing."
-        }
-        if state.reasons.contains(Self.branchUnknownReason) {
-            return "The branch is unknown or detached, so cctop cannot verify branch safety."
         }
         if state.reasons.contains(Self.mainWorktreePathUnverifiedReason) {
             return "The main checkout path could not be verified, so cctop cannot run worktree removal safely."

--- a/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
@@ -12,10 +12,12 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
         let untrackedOnly: WorktreeCleanupCandidate
         let secondaryReview: WorktreeCleanupCandidate
         let longStress: WorktreeCleanupCandidate
-        let unknownSafety: WorktreeCleanupCandidate
+        let unknownBranch: WorktreeCleanupCandidate
+        let detachedHead: WorktreeCleanupCandidate
+        let hardBlocked: WorktreeCleanupCandidate
 
         var allCandidates: [WorktreeCleanupCandidate] {
-            [clean, review, untrackedOnly, secondaryReview, longStress, unknownSafety]
+            [clean, review, untrackedOnly, secondaryReview, longStress, unknownBranch, detachedHead, hardBlocked]
         }
 
         var productInputCandidates: [WorktreeCleanupCandidate] {
@@ -113,16 +115,21 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
             filename: "worktree-cleanup-detail-untracked-only.png"
         )
         let unknownSize = try renderScreenshot(
-            view: cleanupPopup(candidates: scenario.productInputCandidates, selectedCandidate: scenario.unknownSafety),
+            view: cleanupPopup(candidates: scenario.productInputCandidates, selectedCandidate: scenario.unknownBranch),
             colorScheme: .dark,
-            filename: "worktree-cleanup-detail-unknown-safety.png"
+            filename: "worktree-cleanup-detail-unknown-branch.png"
+        )
+        let detachedSize = try renderScreenshot(
+            view: cleanupPopup(candidates: scenario.productInputCandidates, selectedCandidate: scenario.detachedHead),
+            colorScheme: .dark,
+            filename: "worktree-cleanup-detail-detached-head.png"
         )
         let blockedSize = try renderScreenshot(
             view: cleanupDetail(
-                candidate: scenario.untrackedOnly,
+                candidate: scenario.hardBlocked,
                 notice: WorktreeRemovalNotice(
                     title: "Removal Blocked",
-                    message: "Cleanup evidence changed. Review the updated worktree before removing.",
+                    message: "This worktree is locked. Unlock it before removing.",
                     blocksRemoval: true
                 )
             ),
@@ -146,6 +153,7 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
         XCTAssertLessThanOrEqual(longSize.width, 320)
         XCTAssertLessThanOrEqual(untrackedOnlySize.width, 320)
         XCTAssertLessThanOrEqual(unknownSize.width, 320)
+        XCTAssertLessThanOrEqual(detachedSize.width, 320)
         XCTAssertLessThanOrEqual(blockedSize.width, 320)
         XCTAssertLessThanOrEqual(forceFailureSize.width, 320)
         XCTAssertLessThanOrEqual(cleanSize.height, 430)
@@ -153,19 +161,24 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
         XCTAssertLessThanOrEqual(longSize.height, 430)
         XCTAssertLessThanOrEqual(untrackedOnlySize.height, 430)
         XCTAssertLessThanOrEqual(unknownSize.height, 430)
+        XCTAssertLessThanOrEqual(detachedSize.height, 430)
         XCTAssertLessThanOrEqual(blockedSize.height, 430)
         XCTAssertLessThanOrEqual(forceFailureSize.height, 430)
-        XCTAssertEqual(scenario.unknownSafety.formattedStorage, "Unknown")
+        XCTAssertEqual(scenario.unknownBranch.formattedStorage, "Unknown")
     }
 
     private func renderConfirmationScreenshots(for scenario: Scenario) throws {
         XCTAssertFalse(
-            scenario.secondaryReview.requiresForceWorktreeRemoval,
+            scenario.secondaryReview.requiresForceRemovalReview,
             "Normal-review confirmation proof must use a review candidate that does not require --force."
         )
         XCTAssertTrue(
-            scenario.untrackedOnly.requiresForceWorktreeRemoval,
+            scenario.untrackedOnly.requiresForceRemovalReview,
             "Force confirmation proof must use a review candidate with local file loss evidence."
+        )
+        XCTAssertTrue(
+            scenario.unknownBranch.requiresForceRemovalReview,
+            "Unknown branch confirmation proof must use the force-removal path."
         )
 
         let reviewSize = try renderScreenshot(
@@ -178,11 +191,18 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
             colorScheme: .dark,
             filename: "worktree-cleanup-confirmation-force.png"
         )
+        let unknownForceSize = try renderScreenshot(
+            view: CleanupConfirmationProofView(confirmation: .review(.forceRemove(scenario.unknownBranch))),
+            colorScheme: .dark,
+            filename: "worktree-cleanup-confirmation-unknown-force.png"
+        )
 
         XCTAssertLessThanOrEqual(reviewSize.width, 320)
         XCTAssertLessThanOrEqual(forceSize.width, 320)
+        XCTAssertLessThanOrEqual(unknownForceSize.width, 320)
         XCTAssertLessThanOrEqual(reviewSize.height, 430)
         XCTAssertLessThanOrEqual(forceSize.height, 430)
+        XCTAssertLessThanOrEqual(unknownForceSize.height, 430)
     }
 
     private func renderSpecialStateScreenshots(for scenario: Scenario) throws {
@@ -262,6 +282,18 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
             view: scanningPreviousCandidates,
             colorScheme: .dark,
             filename: "worktree-cleanup-scanning-with-candidates.png"
+        )
+
+        let afterSuccessfulRemoval = WorktreeCleanupTabView(
+            candidates: [scenario.clean, scenario.secondaryReview],
+            selectedIndex: nil,
+            selectedCandidate: Binding<WorktreeCleanupCandidate?>.constant(nil),
+            onRemove: { _ in }
+        )
+        try renderScreenshot(
+            view: afterSuccessfulRemoval,
+            colorScheme: .dark,
+            filename: "worktree-cleanup-after-successful-removal.png"
         )
     }
 
@@ -367,14 +399,18 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
                 ])
             )
         )
-        let unknownSafety = unknownSafetyCandidate(now: now)
+        let unknownBranch = unknownBranchCandidate(now: now)
+        let detachedHead = detachedHeadCandidate(now: now)
+        let hardBlocked = hardBlockedCandidate(now: now)
         return Scenario(
             clean: clean,
             review: review,
             untrackedOnly: untrackedOnly,
             secondaryReview: secondaryReview,
             longStress: worstCaseReviewCleanupCandidate(now: now),
-            unknownSafety: unknownSafety
+            unknownBranch: unknownBranch,
+            detachedHead: detachedHead,
+            hardBlocked: hardBlocked
         )
     }
 
@@ -393,34 +429,77 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
         )
     }
 
-    private func unknownSafetyCandidate(now: Date) -> WorktreeCleanupCandidate {
+    private func unknownBranchCandidate(now: Date) -> WorktreeCleanupCandidate {
         cleanupScenarioCandidate(
             CandidateSeed(
-                path: "/Users/st0012/projects/codex/.codex/worktrees/detached-unknown-safety",
-                sessionName: "Inspect detached worktree with unknown cleanup safety",
-                branch: "detached@unknown",
+                path: "/Users/st0012/projects/codex/.codex/worktrees/unknown-branch-with-an-intentionally-long-worktree-name",
+                sessionName: "Inspect an unknown cleanup branch with a deliberately long session title",
+                branch: WorktreeCleanupCandidate.unknownBranchDisplayName,
                 lastActiveAt: now.addingTimeInterval(-86_400 * 31),
                 storageBytes: nil,
-                state: .review([
-                    "Branch is unknown or detached",
-                    "Git status could not be read",
-                    "Main checkout path could not be verified",
-                    "Branch upstream or commit safety could not be verified",
-                    "Worktree is locked",
-                ]),
-                checks: [
-                    WorktreeCleanupCheck(label: "No active cctop sessions here", status: .ok),
-                    WorktreeCleanupCheck(label: "Path is a registered linked worktree", status: .ok),
-                    WorktreeCleanupCheck(label: "No uncommitted tracked changes", status: .review),
-                    WorktreeCleanupCheck(label: "No untracked files", status: .review),
-                    WorktreeCleanupCheck(label: "No ignored files", status: .review),
-                    WorktreeCleanupCheck(label: "Branch has no unique local commits", status: .review),
-                    WorktreeCleanupCheck(label: "Main checkout path is known", status: .review),
-                    WorktreeCleanupCheck(label: "Worktree is not locked", status: .review),
-                    WorktreeCleanupCheck(label: "Storage size scan completed", status: .ignored),
-                ]
+                state: .review([WorktreeCleanupCandidate.branchUnknownReason]),
+                checks: branchUncertaintyChecks(storageBytes: nil)
             )
         )
+    }
+
+    private func detachedHeadCandidate(now: Date) -> WorktreeCleanupCandidate {
+        cleanupScenarioCandidate(
+            CandidateSeed(
+                path: "/Users/st0012/projects/cctop/.codex/worktrees/detached-head-3cc8390",
+                sessionName: "Remove an ended session left on a detached HEAD",
+                branch: WorktreeCleanupCandidate.unknownBranchDisplayName,
+                lastActiveAt: now.addingTimeInterval(-86_400 * 28),
+                storageBytes: 18 * 1_024 * 1_024,
+                state: .review([WorktreeCleanupCandidate.branchUnknownReason]),
+                checks: branchUncertaintyChecks(storageBytes: 18 * 1_024 * 1_024)
+            )
+        )
+    }
+
+    private func hardBlockedCandidate(now: Date) -> WorktreeCleanupCandidate {
+        cleanupScenarioCandidate(
+            CandidateSeed(
+                path: "/Users/st0012/projects/cctop/.codex/worktrees/locked-cleanup",
+                sessionName: "Locked worktree remains protected",
+                branch: "feature/locked-cleanup",
+                lastActiveAt: now.addingTimeInterval(-86_400 * 35),
+                storageBytes: 6 * 1_024 * 1_024,
+                state: .review([WorktreeCleanupCandidate.lockedReason]),
+                checks: lockedWorktreeChecks()
+            )
+        )
+    }
+
+    private func branchUncertaintyChecks(storageBytes: Int64?) -> [WorktreeCleanupCheck] {
+        cleanupSafetyChecks(
+            branchStatus: .review,
+            lockStatus: .ok,
+            storageStatus: storageBytes == nil ? .ignored : .ok
+        )
+    }
+
+    private func lockedWorktreeChecks() -> [WorktreeCleanupCheck] {
+        cleanupSafetyChecks(branchStatus: .ok, lockStatus: .review, storageStatus: .ok)
+    }
+
+    private func cleanupSafetyChecks(
+        branchStatus: WorktreeCleanupCheck.Status,
+        lockStatus: WorktreeCleanupCheck.Status,
+        storageStatus: WorktreeCleanupCheck.Status
+    ) -> [WorktreeCleanupCheck] {
+        [
+            WorktreeCleanupCheck(label: "No active cctop sessions here", status: .ok),
+            WorktreeCleanupCheck(label: "Path is a registered linked worktree", status: .ok),
+            WorktreeCleanupCheck(label: "No uncommitted tracked changes", status: .ok),
+            WorktreeCleanupCheck(label: "No index-hidden tracked files", status: .ok),
+            WorktreeCleanupCheck(label: "No untracked files", status: .ok),
+            WorktreeCleanupCheck(label: "No ignored files", status: .ok),
+            WorktreeCleanupCheck(label: "Branch has no unique local commits", status: branchStatus),
+            WorktreeCleanupCheck(label: "Main checkout path is known", status: .ok),
+            WorktreeCleanupCheck(label: "Worktree is not locked", status: lockStatus),
+            WorktreeCleanupCheck(label: "Storage size scan completed", status: storageStatus),
+        ]
     }
 
     private func overflowCandidates(now: Date = Date()) -> [WorktreeCleanupCandidate] {
@@ -533,7 +612,7 @@ private struct CleanupConfirmationProofView: View {
             .padding(16)
             Spacer(minLength: 18)
         }
-        .frame(maxWidth: .infinity, minHeight: 220)
+        .frame(maxWidth: .infinity, minHeight: 300)
     }
 }
 // swiftlint:enable type_body_length

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1026,15 +1026,26 @@ final class WorktreeCleanupTests: XCTestCase {
     func testInspectorReadsZPorcelainWorktreeListLockedMetadata() {
         let entries = GitWorktreeInspector.parseWorktreeList(
             "worktree /Users/dev/projects/billing-api\0"
+                + "HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\0"
                 + "branch refs/heads/main\0\0"
                 + "worktree /Users/dev/.codex/worktrees/billing-api\0"
+                + "HEAD bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\0"
                 + "branch refs/heads/feature/invoices\0"
                 + "locked maintenance reason\0\0"
         )
 
         XCTAssertEqual(entries, [
-            worktreeEntry("/Users/dev/projects/billing-api", branch: "main"),
-            worktreeEntry("/Users/dev/.codex/worktrees/billing-api", branch: "feature/invoices", isLocked: true),
+            worktreeEntry(
+                "/Users/dev/projects/billing-api",
+                branch: "main",
+                headRevision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            worktreeEntry(
+                "/Users/dev/.codex/worktrees/billing-api",
+                branch: "feature/invoices",
+                headRevision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                isLocked: true
+            ),
         ])
     }
 
@@ -2913,6 +2924,52 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(inspectedPaths, [worktreePath, worktreePath])
     }
 
+    func testRemovalServiceNormalizesProtectedDetachedBranchBeforeForceReview() {
+        let worktreePath = "/Users/dev/Documents/app/.claude/worktrees/detached"
+        let session = historySession(path: worktreePath, branch: "stale/historical-branch")
+        let inspection = GitWorktreeInspection(
+            isRegisteredWorktree: true,
+            isLinkedWorktree: true,
+            isLocked: false,
+            mainWorktreePath: "/Users/dev/projects/app",
+            branchName: nil,
+            statusEntries: [],
+            uniqueCommitCount: nil,
+            failureReasons: [WorktreeCleanupCandidate.branchUnknownReason]
+        )
+        let scanner = WorktreeCleanupScanner(
+            fileExists: { _ in
+                XCTFail("Protected cleanup selection should not probe file existence")
+                return false
+            },
+            resolveWorktreeRoot: { _ in
+                XCTFail("Protected cleanup selection should not resolve roots before explicit inspection")
+                return nil
+            },
+            inspectGit: { _ in inspection },
+            measureSize: { _ in nil }
+        )
+        let candidate = scanner.candidates(from: [session], activeProjectPaths: [])[0]
+        let service = WorktreeRemovalService(
+            scanner: scanner,
+            runGit: { _ in
+                XCTFail("Selecting a removal action should not run Git removal")
+                return GitCommandResult(exitCode: 1, stdout: "", stderr: "")
+            }
+        )
+
+        let action = service.selectedAction(for: candidate, cleanupSources: [session], activeProjectPaths: [])
+
+        guard case .forceRemove(let selectedCandidate) = action else {
+            return XCTFail("Expected detached protected worktree to enter force review, got \(action)")
+        }
+        XCTAssertEqual(selectedCandidate.branchName, WorktreeCleanupCandidate.unknownBranchDisplayName)
+        XCTAssertEqual(selectedCandidate.state, .review([WorktreeCleanupCandidate.branchUnknownReason]))
+        guard case .review(.forceRemove)? = WorktreeRemovalConfirmation.review(for: action) else {
+            return XCTFail("Expected the force-removal confirmation")
+        }
+    }
+
     func testRemovalServiceSelectsNormalActionForUniqueLocalCommitsOnly() {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
         let session = historySession(path: worktreePath)
@@ -4380,21 +4437,10 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(preflightCandidate.state, .ignored(["Active cctop session is using this path"]))
     }
 
-    func testRemovalServiceRefusesDetachedBranchReviewCandidateWithoutInvokingGit() {
+    func testRemovalServiceSelectsForceActionForUnknownBranchWithoutInvokingGit() {
         let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
         let session = historySession(path: worktreePath)
-        let candidate = WorktreeCleanupCandidate(
-            id: worktreePath,
-            sessionName: "Detached cleanup",
-            worktreePath: worktreePath,
-            worktreeName: "billing-api",
-            branchName: "unknown",
-            lastActiveAt: now,
-            storageBytes: 1_024,
-            state: .review(["Branch is unknown or detached"]),
-            checks: []
-        )
-        let detachedInspection = GitWorktreeInspection(
+        let unknownBranchInspection = GitWorktreeInspection(
             isRegisteredWorktree: true,
             isLinkedWorktree: true,
             isLocked: false,
@@ -4402,24 +4448,234 @@ final class WorktreeCleanupTests: XCTestCase {
             branchName: nil,
             statusEntries: [],
             uniqueCommitCount: nil,
-            failureReasons: ["Branch is unknown or detached"]
+            failureReasons: [WorktreeCleanupCandidate.branchUnknownReason]
         )
         var didRunGit = false
+        let scanner = scanner(existingPaths: [worktreePath], inspections: [worktreePath: unknownBranchInspection])
+        guard let candidate = scanner.candidates(from: [session], activeProjectPaths: []).first else {
+            return XCTFail("Expected an ended-session cleanup candidate")
+        }
         let service = WorktreeRemovalService(
-            scanner: scanner(existingPaths: [worktreePath], inspections: [worktreePath: detachedInspection]),
+            scanner: scanner,
             runGit: { _ in
                 didRunGit = true
                 return GitCommandResult(exitCode: 0, stdout: "", stderr: "")
             }
         )
 
-        let result = service.remove(candidate, cleanupSources: [session], activeProjectPaths: [])
+        let action = service.selectedAction(for: candidate, cleanupSources: [session], activeProjectPaths: [])
 
         XCTAssertFalse(didRunGit)
-        guard case .refused(let preflightCandidate) = result else {
-            return XCTFail("Expected detached branch review candidate to be refused, got \(result)")
+        guard case .forceRemove(let preflightCandidate) = action else {
+            return XCTFail("Expected unknown branch review candidate to require force removal, got \(action)")
         }
-        XCTAssertEqual(preflightCandidate.state, .review(["Branch is unknown or detached"]))
+        XCTAssertEqual(preflightCandidate.branchName, WorktreeCleanupCandidate.unknownBranchDisplayName)
+        XCTAssertEqual(preflightCandidate.state, .review([WorktreeCleanupCandidate.branchUnknownReason]))
+    }
+
+    func testUnknownBranchForceReviewReturnsPlainGitRemovalFailureWithoutForceRetry() throws {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let mainPath = "/Users/dev/projects/billing-api"
+        let session = historySession(path: worktreePath)
+        let inspection = GitWorktreeInspection(
+            isRegisteredWorktree: true,
+            isLinkedWorktree: true,
+            isLocked: false,
+            mainWorktreePath: mainPath,
+            branchName: nil,
+            headRevision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            statusEntries: [],
+            uniqueCommitCount: nil,
+            failureReasons: [WorktreeCleanupCandidate.branchUnknownReason]
+        )
+        let scanner = scanner(existingPaths: [worktreePath], inspections: [worktreePath: inspection])
+        let candidate = try XCTUnwrap(scanner.candidates(from: [session], activeProjectPaths: []).first)
+        var gitArguments: [[String]] = []
+        let failure = GitCommandResult(exitCode: 128, stdout: "", stderr: "worktree contains modified or untracked files")
+        let service = WorktreeRemovalService(
+            scanner: scanner,
+            runGit: { arguments in
+                gitArguments.append(arguments)
+                return failure
+            }
+        )
+
+        let action = service.selectedAction(for: candidate, cleanupSources: [session], activeProjectPaths: [])
+        guard case .forceRemove = action else {
+            return XCTFail("Expected branch uncertainty to keep the Force Remove review")
+        }
+
+        let result = service.executeConfirmed(action, cleanupSources: [session], activeProjectPaths: [])
+
+        XCTAssertEqual(result, .failed(failure))
+        XCTAssertEqual(gitArguments, [["-C", mainPath, "worktree", "remove", worktreePath]])
+    }
+
+    func testUnknownBranchWithLockedWorktreeStaysBlockedBeforeConfirmation() throws {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath, branch: "unknown")
+        let inspection = GitWorktreeInspection(
+            isRegisteredWorktree: true,
+            isLinkedWorktree: true,
+            isLocked: true,
+            mainWorktreePath: "/Users/dev/projects/billing-api",
+            branchName: nil,
+            statusEntries: [],
+            uniqueCommitCount: nil,
+            failureReasons: [WorktreeCleanupCandidate.branchUnknownReason]
+        )
+        let scanner = scanner(existingPaths: [worktreePath], inspections: [worktreePath: inspection])
+        let candidate = try XCTUnwrap(scanner.candidates(from: [session], activeProjectPaths: []).first)
+        var didRunGit = false
+        let service = WorktreeRemovalService(
+            scanner: scanner,
+            runGit: { _ in
+                didRunGit = true
+                return GitCommandResult(exitCode: 0, stdout: "", stderr: "")
+            }
+        )
+
+        let action = service.selectedAction(for: candidate, cleanupSources: [session], activeProjectPaths: [])
+
+        XCTAssertFalse(didRunGit)
+        guard case .blocked(let blockedCandidate, let reason) = action else {
+            return XCTFail("Expected locked unknown-branch worktree to stay blocked, got \(action)")
+        }
+        XCTAssertTrue(blockedCandidate.state.reasons.contains(WorktreeCleanupCandidate.branchUnknownReason))
+        XCTAssertTrue(blockedCandidate.state.reasons.contains(WorktreeCleanupCandidate.lockedReason))
+        XCTAssertEqual(reason, "This worktree is locked. Unlock it before removing.")
+        XCTAssertNil(WorktreeRemovalConfirmation.review(for: action))
+    }
+
+    func testUnknownBranchWithoutMainCheckoutStaysBlockedBeforeConfirmation() throws {
+        let worktreePath = "/Users/dev/.codex/worktrees/billing-api"
+        let session = historySession(path: worktreePath, branch: "unknown")
+        let inspection = GitWorktreeInspection(
+            isRegisteredWorktree: true,
+            isLinkedWorktree: true,
+            isLocked: false,
+            mainWorktreePath: nil,
+            branchName: nil,
+            statusEntries: [],
+            uniqueCommitCount: nil,
+            failureReasons: [WorktreeCleanupCandidate.branchUnknownReason]
+        )
+        let scanner = scanner(existingPaths: [worktreePath], inspections: [worktreePath: inspection])
+        let candidate = try XCTUnwrap(scanner.candidates(from: [session], activeProjectPaths: []).first)
+        let service = WorktreeRemovalService(
+            scanner: scanner,
+            runGit: { _ in
+                XCTFail("A missing main checkout must block before Git removal")
+                return GitCommandResult(exitCode: 1, stdout: "", stderr: "")
+            }
+        )
+
+        let action = service.selectedAction(for: candidate, cleanupSources: [session], activeProjectPaths: [])
+
+        guard case .blocked(_, let reason) = action else {
+            return XCTFail("Expected unknown branch without a main checkout to stay blocked, got \(action)")
+        }
+        XCTAssertEqual(reason, "The main checkout path could not be verified, so cctop cannot run worktree removal safely.")
+        XCTAssertNil(WorktreeRemovalConfirmation.review(for: action))
+    }
+
+    func testDetachedWorktreeRequiresForceConfirmationBeforeRealRemoval() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-detached-removal-\(UUID().uuidString)")
+        let repo = root.appendingPathComponent("repo")
+        let worktree = root.appendingPathComponent("detached-worktree-with-a-long-name")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer {
+            _ = GitCommand.run(cwd: repo.path, arguments: ["worktree", "remove", "--force", worktree.path])
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let initResult = GitCommand.run(cwd: repo.path, arguments: ["init", "-q"])
+        try XCTSkipUnless(initResult.exitCode == 0, "git init failed: \(initResult.stderr)")
+        try Data("seed\n".utf8).write(to: repo.appendingPathComponent("README.md"))
+        try Data(".ignored-local\n".utf8).write(to: repo.appendingPathComponent(".gitignore"))
+        XCTAssertEqual(GitCommand.run(cwd: repo.path, arguments: ["add", "README.md", ".gitignore"]).exitCode, 0)
+        let commitResult = GitCommand.run(
+            cwd: repo.path,
+            arguments: [
+                "-c", "user.name=cctop tests",
+                "-c", "user.email=cctop-tests@example.invalid",
+                "commit", "-q", "-m", "seed",
+            ]
+        )
+        XCTAssertEqual(commitResult.exitCode, 0, commitResult.stderr)
+        let addResult = GitCommand.run(cwd: repo.path, arguments: ["worktree", "add", "--detach", worktree.path, "HEAD"])
+        XCTAssertEqual(addResult.exitCode, 0, addResult.stderr)
+        let ignoredFile = worktree.appendingPathComponent(".ignored-local")
+        try Data("ignored proof\n".utf8).write(to: ignoredFile)
+
+        let session = historySession(path: worktree.path, name: "Detached cleanup", branch: "unknown")
+        let scanner = WorktreeCleanupScanner.live()
+        let candidate = try XCTUnwrap(scanner.candidates(from: [session], activeProjectPaths: []).first)
+        XCTAssertEqual(
+            Set(candidate.state.reasons),
+            Set([WorktreeCleanupCandidate.branchUnknownReason, WorktreeCleanupCandidate.ignoredFilesReason])
+        )
+        let service = WorktreeRemovalService.live()
+
+        let action = service.selectedAction(for: candidate, cleanupSources: [session], activeProjectPaths: [])
+        guard case .forceRemove = action else {
+            return XCTFail("Expected detached HEAD to enter force-removal review, got \(action)")
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: worktree.path), "Selecting Remove must not remove the worktree")
+
+        let confirmation = try XCTUnwrap(WorktreeRemovalConfirmation.review(for: action))
+        guard case .review(.forceRemove) = confirmation else {
+            return XCTFail("Expected the force-removal confirmation, got \(confirmation)")
+        }
+        XCTAssertTrue(confirmation.message.contains("Ignored files will be removed with this worktree."))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: worktree.path), "Cancelling Force Remove must keep the worktree")
+        let worktreeListBeforeConfirmation = GitCommand.run(cwd: repo.path, arguments: ["worktree", "list", "--porcelain"])
+        XCTAssertEqual(worktreeListBeforeConfirmation.exitCode, 0, worktreeListBeforeConfirmation.stderr)
+        XCTAssertTrue(worktreeListBeforeConfirmation.stdout.contains(worktree.path))
+
+        try Data("changed after review\n".utf8).write(to: worktree.appendingPathComponent("after-review.txt"))
+        XCTAssertEqual(GitCommand.run(cwd: worktree.path, arguments: ["add", "after-review.txt"]).exitCode, 0)
+        let changedCommit = GitCommand.run(
+            cwd: worktree.path,
+            arguments: [
+                "-c", "user.name=cctop tests",
+                "-c", "user.email=cctop-tests@example.invalid",
+                "commit", "-q", "-m", "change detached HEAD after review",
+            ]
+        )
+        XCTAssertEqual(changedCommit.exitCode, 0, changedCommit.stderr)
+
+        let staleResult = service.executeConfirmed(action, cleanupSources: [session], activeProjectPaths: [])
+
+        guard case .refused = staleResult else {
+            return XCTFail("Expected a changed detached HEAD to require a fresh confirmation, got \(staleResult)")
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: worktree.path))
+        let worktreeListAfterRefusal = GitCommand.run(cwd: repo.path, arguments: ["worktree", "list", "--porcelain"])
+        XCTAssertEqual(worktreeListAfterRefusal.exitCode, 0, worktreeListAfterRefusal.stderr)
+        XCTAssertTrue(worktreeListAfterRefusal.stdout.contains(worktree.path))
+
+        let refreshedCandidate = try XCTUnwrap(scanner.candidates(from: [session], activeProjectPaths: []).first)
+        let refreshedAction = service.selectedAction(
+            for: refreshedCandidate,
+            cleanupSources: [session],
+            activeProjectPaths: []
+        )
+        guard case .forceRemove = refreshedAction else {
+            return XCTFail("Expected the refreshed detached worktree to remain in Force Remove review")
+        }
+
+        let result = service.executeConfirmed(refreshedAction, cleanupSources: [session], activeProjectPaths: [])
+
+        guard case .removed = result else {
+            return XCTFail("Expected confirmed force removal to succeed, got \(result)")
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: worktree.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: ignoredFile.path))
+        let worktreeList = GitCommand.run(cwd: repo.path, arguments: ["worktree", "list", "--porcelain"])
+        XCTAssertEqual(worktreeList.exitCode, 0, worktreeList.stderr)
+        XCTAssertFalse(worktreeList.stdout.contains(worktree.path))
     }
 
     func testRemovalServiceRefusesIgnoredCandidateWithoutInvokingGit() {
@@ -4558,8 +4814,116 @@ final class WorktreeCleanupTests: XCTestCase {
 
         XCTAssertEqual(confirmation.primaryButtonTitle, "Force Remove")
         XCTAssertTrue(confirmation.message.contains("git worktree remove --force"))
-        XCTAssertTrue(confirmation.message.contains("local file changes and files"))
+        XCTAssertTrue(confirmation.message.contains("This removes local file changes and files"))
         XCTAssertTrue(confirmation.message.contains("does not delete the branch"))
+    }
+
+    func testUnknownBranchConfirmationCombinesBranchSafetyAndForceWarning() throws {
+        let review = WorktreeCleanupCandidate(
+            id: "/Users/dev/.codex/worktrees/detached",
+            sessionName: "Detached cleanup",
+            worktreePath: "/Users/dev/.codex/worktrees/detached",
+            worktreeName: "detached",
+            mainWorktreePath: "/Users/dev/projects/app",
+            branchName: "unknown",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([WorktreeCleanupCandidate.branchUnknownReason]),
+            checks: []
+        )
+        let action = WorktreeRemovalService.RemovalAction.forceRemove(review)
+
+        let confirmation = try XCTUnwrap(WorktreeRemovalConfirmation.review(for: action))
+
+        guard case .review(.forceRemove) = confirmation else {
+            return XCTFail("Expected the force-removal confirmation, got \(confirmation)")
+        }
+        XCTAssertEqual(confirmation.title, "Force Remove Worktree?")
+        XCTAssertEqual(confirmation.primaryButtonTitle, "Force Remove")
+        XCTAssertTrue(confirmation.message.contains(WorktreeCleanupCandidate.branchUnknownReason))
+        XCTAssertTrue(confirmation.message.contains("Runs git worktree remove for detached"))
+        XCTAssertFalse(confirmation.message.contains("git worktree remove --force"))
+        XCTAssertTrue(
+            confirmation.message.contains(
+                "Git will refuse removal if tracked changes or non-ignored untracked files appeared after this review"
+            )
+        )
+        XCTAssertFalse(confirmation.message.contains("does not delete the branch"))
+    }
+
+    func testUnknownBranchWithKnownLocalChangesUsesDefinitiveFileRemovalWarning() {
+        let review = WorktreeCleanupCandidate(
+            id: "/Users/dev/.codex/worktrees/detached-dirty",
+            sessionName: "Detached dirty cleanup",
+            worktreePath: "/Users/dev/.codex/worktrees/detached-dirty",
+            worktreeName: "detached-dirty",
+            mainWorktreePath: "/Users/dev/projects/app",
+            branchName: WorktreeCleanupCandidate.unknownBranchDisplayName,
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([
+                WorktreeCleanupCandidate.branchUnknownReason,
+                WorktreeCleanupCandidate.untrackedFilesReason,
+            ]),
+            checks: []
+        )
+
+        let confirmation = WorktreeRemovalConfirmation.review(.forceRemove(review))
+
+        XCTAssertTrue(confirmation.message.contains("This removes local file changes and files"))
+        XCTAssertFalse(confirmation.message.contains("--force can remove local changes and files"))
+        XCTAssertFalse(confirmation.message.contains("does not delete the branch"))
+    }
+
+    func testUnknownBranchWithIgnoredFilesKeepsDefinitiveDeletionWarning() {
+        let review = WorktreeCleanupCandidate(
+            id: "/Users/dev/.codex/worktrees/detached-ignored",
+            sessionName: "Detached ignored cleanup",
+            worktreePath: "/Users/dev/.codex/worktrees/detached-ignored",
+            worktreeName: "detached-ignored",
+            mainWorktreePath: "/Users/dev/projects/app",
+            branchName: WorktreeCleanupCandidate.unknownBranchDisplayName,
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review([
+                WorktreeCleanupCandidate.branchUnknownReason,
+                WorktreeCleanupCandidate.ignoredFilesReason,
+            ]),
+            checks: [],
+            reviewEvidence: WorktreeCleanupReviewEvidence(
+                ignoredPreview: WorktreeCleanupUntrackedPreview(paths: [".env.local"])
+            )
+        )
+
+        let confirmation = WorktreeRemovalConfirmation.review(.forceRemove(review))
+
+        XCTAssertTrue(confirmation.message.contains("Ignored files: .env.local."))
+        XCTAssertTrue(confirmation.message.contains("Ignored files will be removed with this worktree."))
+        XCTAssertFalse(confirmation.message.contains("git worktree remove --force"))
+    }
+
+    func testOrdinaryReviewConfirmationStillHasOneDestructiveGate() throws {
+        let review = WorktreeCleanupCandidate(
+            id: "/Users/dev/.codex/worktrees/review",
+            sessionName: "Needs review",
+            worktreePath: "/Users/dev/.codex/worktrees/review",
+            worktreeName: "review",
+            mainWorktreePath: "/Users/dev/projects/app",
+            branchName: "feature/review",
+            lastActiveAt: now,
+            storageBytes: 1_024,
+            state: .review(["Branch has 1 unique local commit"]),
+            checks: []
+        )
+
+        let confirmation = try XCTUnwrap(
+            WorktreeRemovalConfirmation.review(for: .normalRemove(review))
+        )
+
+        guard case .review(.normalRemove) = confirmation else {
+            return XCTFail("Expected the existing ordinary review confirmation, got \(confirmation)")
+        }
+        XCTAssertEqual(confirmation.primaryButtonTitle, "Remove")
     }
 
     func testReviewRemovalConfirmationIncludesReasonsAndEvidence() {
@@ -4698,6 +5062,7 @@ final class WorktreeCleanupTests: XCTestCase {
 
     private func cleanInspection(
         branch: String = "feature/invoices",
+        headRevision: String? = nil,
         statusEntries: [String] = [],
         uniqueCommitCount: Int? = 0,
         isLocked: Bool = false,
@@ -4709,6 +5074,7 @@ final class WorktreeCleanupTests: XCTestCase {
             isLocked: isLocked,
             mainWorktreePath: "/Users/dev/projects/billing-api",
             branchName: branch,
+            headRevision: headRevision,
             statusEntries: statusEntries,
             uniqueCommitCount: uniqueCommitCount,
             failureReasons: failureReasons
@@ -4718,10 +5084,17 @@ final class WorktreeCleanupTests: XCTestCase {
     private func worktreeEntry(
         _ path: String,
         branch: String,
+        headRevision: String? = nil,
         isPrunable: Bool = false,
         isLocked: Bool = false
     ) -> GitWorktreeListEntry {
-        GitWorktreeListEntry(path: path, branchName: branch, isPrunable: isPrunable, isLocked: isLocked)
+        GitWorktreeListEntry(
+            path: path,
+            branchName: branch,
+            headRevision: headRevision,
+            isPrunable: isPrunable,
+            isLocked: isLocked
+        )
     }
 
     private func hiddenTrackedEditInspection(


### PR DESCRIPTION
Allows ended-session cleanup worktrees with unknown or detached branch identity to enter the existing Force Remove review flow instead of being blocked solely by branch uncertainty.

- Keeps “Branch safety cannot be verified” visible in the cleanup detail and final confirmation.
- Uses the existing row Remove → Force Remove interaction; cancelling leaves the worktree untouched.
- Revalidates a detached HEAD while confirmation is open and preserves Git’s dirty-worktree refusal for branch-only uncertainty; known tracked or untracked changes still use `--force`.
- Preserves existing hard blockers and ordinary review behavior.