### PR TITLE
Add permanent local session identities for Stream Deck

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -406,10 +406,13 @@ profiles unchanged.
 ## Jump-to-Session Behavior
 
 - **Stream Deck**: Session keys ask macOS Launch Services to deliver an encoded
-  `cctop://focus?sid=...` command. cctop exact-matches the published `Session.id`
-  against its current visible sessions and calls the same `focusTerminal(session:)`
-  path as its UI. Never fall back from a missing display id to a conversation id
-  or another slot. Toggle Panel uses `cctop://toggle`.
+  `cctop://focus?sid=...` command. cctop exact-matches the published action id
+  (`SessionIdentityPolicy.actionID`, an opaque derived token — see
+  [`docs/session-files.md`](docs/session-files.md)) against its current visible
+  sessions and calls the same `focusTerminal(session:)` path as its UI. Never
+  fall back from a missing display id to a conversation id, a raw PID, or
+  another slot — a stale command finds nothing rather than a wrong target.
+  Toggle Panel uses `cctop://toggle`.
 
 - **VS Code / Cursor**: Uses `NSWorkspace.open` with the editor's bundle ID to focus the project window. Does not shell out to `code`/`cursor` CLI (avoids PATH issues after Sparkle updates). If a `.code-workspace` file is detected in the project directory, it's passed instead of the folder path.
 - **Workspace limitation**: cctop detects workspace files by scanning the project directory at session start. If the project folder contains a `.code-workspace` file but you opened the folder directly (not via the workspace file), cctop may incorrectly open the workspace instead of focusing the folder window. VS Code does not expose which mode was used via environment variables or APIs.
@@ -480,7 +483,7 @@ The pi extension (`cctop.ts`) translates pi events to cctop-hook calls. Non-inte
 
 ### Session File Format
 
-Non-Codex session files are keyed by PID (`{pid}.json`). Codex files are keyed by session ID (`codex-<session_id>.json`) because multiple conversations can share one host PID. Each file stores `pid_start_time` (from `sysctl`) to detect PID reuse where PID identity applies. Desktop-hosted sessions use desktop lifecycle rules, app liveness/recency, and archive visibility checks. Each session includes `"source": "<harness>"` (`"cc"`, `"opencode"`, `"pi"`, `"codex"`). Legacy sessions without the field are treated as Claude Code.
+Non-Codex session files are keyed by PID (`{pid}.json`). Codex files are keyed by session ID (`codex-<session_id>.json`) because multiple conversations can share one host PID. Each file stores `pid_start_time` (from `sysctl`) to detect PID reuse where PID identity applies. Hooks also stamp `harness_session_id`, the exact unsanitized reference supplied to the hook. External surfaces identify each live focus target by an opaque action id derived from that reference plus process generation (see [`docs/session-files.md`](docs/session-files.md)); action ids are runtime routing values, never durable preference keys. Desktop-hosted sessions use desktop lifecycle rules, app liveness/recency, and archive visibility checks. Each session includes `"source": "<harness>"` (`"cc"`, `"opencode"`, `"pi"`, `"codex"`). Legacy sessions without the field are treated as Claude Code.
 
 The `active_subagents` field tracks currently running subagents (Agent tool). It's `nil` for sessions that haven't reported subagent events (old plugin), `[]` when no subagents are active, or an array of `{agent_id, agent_type, started_at}` objects. The menubar app shows an agent-count label (e.g. "2 agents") when the count is > 0.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -406,12 +406,12 @@ profiles unchanged.
 ## Jump-to-Session Behavior
 
 - **Stream Deck**: Session keys ask macOS Launch Services to deliver an encoded
-  `cctop://focus?sid=...` command. cctop exact-matches the published action id
-  (`SessionIdentityPolicy.actionID`, an opaque derived token — see
-  [`docs/session-files.md`](docs/session-files.md)) against its current visible
-  sessions and calls the same `focusTerminal(session:)` path as its UI. Never
-  fall back from a missing display id to a conversation id, a raw PID, or
-  another slot — a stale command finds nothing rather than a wrong target.
+  `cctop://focus?sid=...` command. cctop exact-matches the published permanent
+  `cctop_session_id` against its current visible sessions in canonical
+  `SessionManager.sessions` order, then calls the same `focusTerminal(session:)`
+  path as its UI. Stream Deck caches the ID the key rendered, so row reordering
+  cannot retarget a press to an unrelated session. Never fall back from a missing
+  cctop session ID to a conversation reference, raw PID, or slot.
   Toggle Panel uses `cctop://toggle`.
 
 - **VS Code / Cursor**: Uses `NSWorkspace.open` with the editor's bundle ID to focus the project window. Does not shell out to `code`/`cursor` CLI (avoids PATH issues after Sparkle updates). If a `.code-workspace` file is detected in the project directory, it's passed instead of the folder path.
@@ -483,7 +483,7 @@ The pi extension (`cctop.ts`) translates pi events to cctop-hook calls. Non-inte
 
 ### Session File Format
 
-Non-Codex session files are keyed by PID (`{pid}.json`). Codex files are keyed by session ID (`codex-<session_id>.json`) because multiple conversations can share one host PID. Each file stores `pid_start_time` (from `sysctl`) to detect PID reuse where PID identity applies. Hooks also stamp `harness_session_id`, the exact unsanitized reference supplied to the hook. External surfaces identify each live focus target by an opaque action id derived from that reference plus process generation (see [`docs/session-files.md`](docs/session-files.md)); action ids are runtime routing values, never durable preference keys. Desktop-hosted sessions use desktop lifecycle rules, app liveness/recency, and archive visibility checks. Each session includes `"source": "<harness>"` (`"cc"`, `"opencode"`, `"pi"`, `"codex"`). Legacy sessions without the field are treated as Claude Code.
+Non-Codex session files are keyed by PID (`{pid}.json`). Codex files are keyed by session ID (`codex-<session_id>.json`) because multiple conversations can share one host PID. Each file stores `pid_start_time` (from `sysctl`) to detect PID reuse where PID identity applies. Hooks also stamp `harness_session_id`, the exact unsanitized reference supplied to the hook, as lookup evidence. Each observed record receives a cctop-owned permanent `cctop_session_id`; external surfaces use that ID and cctop separately resolves it to the current live focus target. Same-machine resume continuity is guaranteed only for the client contracts listed in [`docs/session-files.md`](docs/session-files.md). Desktop-hosted sessions use desktop lifecycle rules, app liveness/recency, and archive visibility checks. Each session includes `"source": "<harness>"` (`"cc"`, `"opencode"`, `"pi"`, `"codex"`). Legacy sessions without the field are treated as Claude Code.
 
 The `active_subagents` field tracks currently running subagents (Agent tool). It's `nil` for sessions that haven't reported subagent events (old plugin), `[]` when no subagents are active, or an array of `{agent_id, agent_type, started_at}` objects. The menubar app shows an agent-count label (e.g. "2 agents") when the count is > 0.
 

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -6,6 +6,33 @@ Session files are intentionally local and inspectable. Missing optional fields m
 
 ## Identity
 
+### `cctop_session_id`
+
+Type: `string` (lowercase UUID)
+
+Default: absent only on legacy records awaiting migration.
+
+`cctop_session_id` is an opaque identifier generated and owned by cctop for a
+logical session. It is random: it is never derived from the client, title,
+project path, prompt or transcript content, PID, process generation, terminal,
+window, or focus target. When a client supplies a supported durable resume
+reference, the value remains stable across cctop and client restarts on the
+same machine while cctop's local identity data remains. Otherwise it is
+permanent only for that observed record.
+
+For supported resume contracts, cctop keeps a private UUID-only mapping under
+`~/.cctop/session-identities/`. Mapping filenames hash the source-scoped client
+reference; the raw reference is not copied into this directory. Existing
+publishable session JSON files without the field are assigned an ID once and
+stamped with the same per-file locking and atomic-write rules as hook updates.
+Hidden, finished, cleanup, and history records keep their existing identity
+contracts until a current hook or later visible observation needs this field.
+Identity mappings intentionally outlive session and history cleanup and are not
+automatically pruned in this version.
+
+Deleting cctop's local session and identity data resets this continuity.
+Cross-machine sync is not supported.
+
 ### `harness_session_id`
 
 Type: `string`
@@ -18,41 +45,44 @@ OpenCode intentionally continues to supply its process-scoped synthetic referenc
 until all of its per-session event payloads can be routed consistently. `session_id` is
 sanitized to a restricted character set and truncated to 64 characters so it can
 safely appear in file names and logs, which makes it a lossy projection of the
-hook reference; `harness_session_id` preserves the original value for
-identity derivation. The hook stamps it after a matching event loads the record,
+hook reference; `harness_session_id` preserves the original value for resume
+lookup. It is evidence, not cctop identity. The hook stamps it after a matching event loads the record,
 so records created by pre-field hooks gain it in place. A different conversation
 may replace a PID-keyed record only through `SessionStart`-driven rotation.
 
-### Action identity
+### Resume support
 
-External control surfaces (Stream Deck entries in `display-state.json`,
-`cctop://focus?sid=...`) identify each currently visible focus target with an
-opaque derived token:
-`s-` followed by 32 hex characters (a 128-bit truncated SHA-256 over a
-runtime routing tuple, computed by `SessionIdentityPolicy.actionID`).
+| Client | Same cctop ID after reopen/resume | Evidence |
+|---|---|---|
+| Codex CLI/Desktop | Yes | The client supplies the same UUID conversation reference across process generations. |
+| Claude Code/Desktop | Yes when a UUID session reference is available | Claude session/transcript state preserves that UUID across resume. |
+| pi | Yes only when `getSessionId()` supplies a real UUID | Synthetic `pi-<pid>` fallback observations remain record-local. |
+| OpenCode | Not yet | The plugin intentionally uses a process-scoped synthetic reference until per-event session routing is reliable. |
 
-The tuple includes:
+Every newly observed record still receives a `cctop_session_id`; “not yet” means
+cctop cannot promise that a later reopened observation will recover the same
+one. References are always source-scoped. cctop never infers that conversations
+from different clients contain the same content.
 
-- the session source;
-- `harness_session_id`, or the legacy sanitized `session_id` when absent; and
-- process-generation identity (`pid` plus `pid_start_time`) when available, or
-  the existing row identity for records without process metadata.
+### Stream Deck routing
 
-Including process generation keeps two visible processes that host the same
-conversation one-to-one with their panel rows and Stream Deck slots. A resumed
-conversation can therefore receive a different action id in a different process.
+Display-state schema v2 publishes `cctop_session_id` for every session row.
+Stream Deck caches the ID that a key rendered, so a press cannot accidentally
+target an unrelated session that moved into the same slot. cctop then resolves
+that permanent session ID against the current canonical `SessionManager.sessions`
+order and focuses the first currently available target for that session.
 
-Consumers must treat the token as opaque. It deliberately reveals nothing about
-how the client keys its sessions (PID-shared or not), and nothing recovers a
-PID or session id from it. Do not reproduce the derivation outside cctop; read
-the published values. Action identity is intentionally separate from cctop's
-internal dedup/grouping keys, which may evolve independently.
+Panel, URL focus, DisplayStateWriter, and Stream Deck all consume that canonical
+order. The projection never independently sorts, deduplicates, or removes rows,
+so slots stay aligned with the panel even when two observations share one
+`cctop_session_id`.
 
-Action ids are live runtime routing identifiers, not durable session identity.
-Their derivation may evolve, so never persist one as a preference key. Consume
-the current published value, as the Stream Deck plugin does. Durable per-session
-preferences require a separate canonical identity design and are outside this
-contract.
+This version does not reconcile multiple clients or multiple simultaneous focus
+targets. If the same conversation is open in more than one place, observations
+may remain separate or several rows may share one ID and resolve to the first
+current canonical target. Cross-client equivalence and cross-machine identity
+are out of scope. Panel identity, notifications, hiding, cleanup, history, and
+other persisted preferences continue to use their existing contracts.
 
 ## Terminal Focus Metadata
 

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -4,6 +4,56 @@ cctop stores live session state as JSON files in `~/.cctop/sessions/`. The menub
 
 Session files are intentionally local and inspectable. Missing optional fields must be treated as their default values so older files continue to load.
 
+## Identity
+
+### `harness_session_id`
+
+Type: `string`
+
+Default: `null` when omitted.
+
+The exact unsanitized session reference supplied to `cctop-hook`, byte-for-byte.
+For integrations that expose a real conversation reference, this preserves it;
+OpenCode intentionally continues to supply its process-scoped synthetic reference
+until all of its per-session event payloads can be routed consistently. `session_id` is
+sanitized to a restricted character set and truncated to 64 characters so it can
+safely appear in file names and logs, which makes it a lossy projection of the
+hook reference; `harness_session_id` preserves the original value for
+identity derivation. The hook stamps it after a matching event loads the record,
+so records created by pre-field hooks gain it in place. A different conversation
+may replace a PID-keyed record only through `SessionStart`-driven rotation.
+
+### Action identity
+
+External control surfaces (Stream Deck entries in `display-state.json`,
+`cctop://focus?sid=...`) identify each currently visible focus target with an
+opaque derived token:
+`s-` followed by 32 hex characters (a 128-bit truncated SHA-256 over a
+runtime routing tuple, computed by `SessionIdentityPolicy.actionID`).
+
+The tuple includes:
+
+- the session source;
+- `harness_session_id`, or the legacy sanitized `session_id` when absent; and
+- process-generation identity (`pid` plus `pid_start_time`) when available, or
+  the existing row identity for records without process metadata.
+
+Including process generation keeps two visible processes that host the same
+conversation one-to-one with their panel rows and Stream Deck slots. A resumed
+conversation can therefore receive a different action id in a different process.
+
+Consumers must treat the token as opaque. It deliberately reveals nothing about
+how the client keys its sessions (PID-shared or not), and nothing recovers a
+PID or session id from it. Do not reproduce the derivation outside cctop; read
+the published values. Action identity is intentionally separate from cctop's
+internal dedup/grouping keys, which may evolve independently.
+
+Action ids are live runtime routing identifiers, not durable session identity.
+Their derivation may evolve, so never persist one as a preference key. Consume
+the current published value, as the Stream Deck plugin does. Durable per-session
+preferences require a separate canonical identity design and are outside this
+contract.
+
 ## Terminal Focus Metadata
 
 ### `terminal.multiplexer`

--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -148,6 +148,8 @@
 		WCT000010000000000000001 /* WorktreeCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = WCT000020000000000000001 /* WorktreeCleanupTests.swift */; };
 		SLP000010000000000000001 /* SessionLifecyclePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = SLP000020000000000000001 /* SessionLifecyclePolicy.swift */; };
 		SIP000010000000000000001 /* SessionIdentityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = SIP000020000000000000001 /* SessionIdentityPolicy.swift */; };
+		CSI000010000000000000001 /* CctopSessionIdentityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CSI000030000000000000001 /* CctopSessionIdentityStore.swift */; };
+		CSI000020000000000000001 /* CctopSessionIdentityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CSI000030000000000000001 /* CctopSessionIdentityStore.swift */; };
 		DCL000010000000000000001 /* DesktopAppConnectionLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCL000020000000000000001 /* DesktopAppConnectionLookup.swift */; };
 		CTA000010000000000000001 /* CodexThreadArchiveLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTA000020000000000000001 /* CodexThreadArchiveLookup.swift */; };
 		CTQ000010000000000000001 /* CodexThreadArchiveLookup+Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTQ000020000000000000001 /* CodexThreadArchiveLookup+Query.swift */; };
@@ -190,6 +192,7 @@
 		C10000020000000000000001 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		SLP000020000000000000001 /* SessionLifecyclePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLifecyclePolicy.swift; sourceTree = "<group>"; };
 		SIP000020000000000000001 /* SessionIdentityPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIdentityPolicy.swift; sourceTree = "<group>"; };
+		CSI000030000000000000001 /* CctopSessionIdentityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CctopSessionIdentityStore.swift; sourceTree = "<group>"; };
 		DCL000020000000000000001 /* DesktopAppConnectionLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopAppConnectionLookup.swift; sourceTree = "<group>"; };
 		CTA000020000000000000001 /* CodexThreadArchiveLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexThreadArchiveLookup.swift; sourceTree = "<group>"; };
 		CTQ000020000000000000001 /* CodexThreadArchiveLookup+Query.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CodexThreadArchiveLookup+Query.swift"; sourceTree = "<group>"; };
@@ -369,6 +372,7 @@
 				C10000020000000000000001 /* SessionManager.swift */,
 				SLP000020000000000000001 /* SessionLifecyclePolicy.swift */,
 				SIP000020000000000000001 /* SessionIdentityPolicy.swift */,
+				CSI000030000000000000001 /* CctopSessionIdentityStore.swift */,
 				DCL000020000000000000001 /* DesktopAppConnectionLookup.swift */,
 				CTA000020000000000000001 /* CodexThreadArchiveLookup.swift */,
 				CTQ000020000000000000001 /* CodexThreadArchiveLookup+Query.swift */,
@@ -698,6 +702,7 @@
 				C10000010000000000000001 /* SessionManager.swift in Sources */,
 				SLP000010000000000000001 /* SessionLifecyclePolicy.swift in Sources */,
 				SIP000010000000000000001 /* SessionIdentityPolicy.swift in Sources */,
+				CSI000010000000000000001 /* CctopSessionIdentityStore.swift in Sources */,
 				DCL000010000000000000001 /* DesktopAppConnectionLookup.swift in Sources */,
 				CTA000010000000000000001 /* CodexThreadArchiveLookup.swift in Sources */,
 				CTQ000010000000000000001 /* CodexThreadArchiveLookup+Query.swift in Sources */,
@@ -795,6 +800,7 @@
 				P10000010000000000000001 /* HookMain.swift in Sources */,
 				P10000030000000000000001 /* HookInput.swift in Sources */,
 				P10000050000000000000001 /* HookHandler.swift in Sources */,
+				CSI000020000000000000001 /* CctopSessionIdentityStore.swift in Sources */,
 				HD0000020000000000000001 /* HookDependencies.swift in Sources */,
 				P10000070000000000000001 /* HookLogger.swift in Sources */,
 				SN0000010000000000000001 /* SessionNameLookup.swift in Sources */,

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -754,13 +754,13 @@ extension AppDelegate {
         case "toggle":
             togglePanel()
         case "focus":
-            guard let displayID = Self.focusTargetID(from: url) else {
+            guard let cctopSessionID = Self.focusSessionID(from: url) else {
                 Self.urlLogger.notice("Ignored malformed cctop focus command")
                 return
             }
             let visibleSessions = SessionDisplayPolicy.activeSessions(from: sessionManager.sessions)
             guard let session = SessionIdentityPolicy.session(
-                matchingDisplayID: displayID,
+                matchingCctopSessionID: cctopSessionID,
                 in: visibleSessions
             ) else {
                 Self.urlLogger.notice("Ignored cctop focus command for unavailable session")
@@ -779,7 +779,7 @@ extension AppDelegate {
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
     }
 
-    nonisolated static func focusTargetID(from url: URL) -> String? {
+    nonisolated static func focusSessionID(from url: URL) -> String? {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let value = components.queryItems?.first(where: { $0.name == "sid" })?.value,
               !value.isEmpty else { return nil }

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -35,6 +35,7 @@ enum HookHandler {
         try withSessionLock(sessionPath: sessionPath, onError: deps.logger.logError) {
             var freshSession = Session(sessionId: safeId, projectPath: input.cwd, branch: branch, terminal: terminal)
             freshSession.source = input.resolvedHarnessName
+            freshSession.harnessSessionId = input.sessionId
             let loaded: (session: Session, isNewSessionFile: Bool)
             do {
                 loaded = try loadOrCreateSession(
@@ -49,6 +50,9 @@ enum HookHandler {
 
             session.pid = pid
             session.pidStartTime = startTime
+            // Stamped after a matching event loads the record so pre-field files gain the
+            // exact reference mid-life; only SessionStart may rotate conversations.
+            session.harnessSessionId = input.sessionId
 
             let (oldStatus, newStatus) = applyTransition(&session, event: event, input: input, branch: branch, terminal: terminal)
             applySessionName(&session, event: event, input: input, names: deps.names)
@@ -383,11 +387,15 @@ extension HookHandler {
         let sessionsDir = deps.sessionsDir()
         let primaryPath = (sessionsDir as NSString).appendingPathComponent(sessionFileName(input: input, pid: pid, safeSessionId: safeId))
         let label = HookLogger.sessionLabel(cwd: input.cwd, sessionId: safeId)
+        let source = input.resolvedHarnessName ?? Session.ccSource
 
         // The end-time parent walk can resolve a different PID than at start (ancestors
         // exit during teardown), so the PID-derived path may miss the session's file or
         // hold a different conversation. Key the stamp to session_id (issue #155 P3).
-        guard let path = sessionEndTargetPath(primaryPath: primaryPath, sessionsDir: sessionsDir, safeId: safeId) else {
+        guard let target = sessionEndTarget(
+            primaryPath: primaryPath, sessionsDir: sessionsDir, safeId: safeId,
+            rawId: input.sessionId, source: source
+        ) else {
             // No file holds this session. Keep the legacy corrupt-file cleanup on the
             // primary path, but never touch another conversation's healthy file.
             try? withSessionLock(sessionPath: primaryPath, onError: deps.logger.logError) {
@@ -399,9 +407,21 @@ extension HookHandler {
         }
 
         // Stamp endedAt instead of deleting — the menubar app archives to history on next poll.
-        try? withSessionLock(sessionPath: path, onError: deps.logger.logError) {
+        try? withSessionLock(sessionPath: target.path, onError: deps.logger.logError) {
             // Re-validate under the lock: the file can change between the scan and the stamp.
-            guard var session = try? Session.fromFile(path: path), session.sessionId == safeId else { return }
+            guard var session = try? Session.fromFile(path: target.path),
+                  sessionEndIdentityMatch(
+                    session, safeId: safeId, rawId: input.sessionId, source: source
+                  ) == target.match else { return }
+            // A legacy match is allowed only while it remains the sole fallback. If an
+            // exact record appeared or another legacy candidate became visible after the
+            // first scan, fail closed instead of ending an arbitrary record.
+            if target.match == .legacy {
+                guard sessionEndTarget(
+                    primaryPath: primaryPath, sessionsDir: sessionsDir, safeId: safeId,
+                    rawId: input.sessionId, source: source
+                ) == target else { return }
+            }
             let endedAt = Date()
             session.endedAt = endedAt
             if hasTrustedDesktopBundle(session, sourceOverride: input.resolvedHarnessName) {
@@ -409,7 +429,7 @@ extension HookHandler {
             }
             session.markWrittenByHook(version: Config.hookVersion, isNewSessionFile: false)
             do {
-                try session.writeToFile(path: path)
+                try session.writeToFile(path: target.path)
             } catch {
                 deps.logger.logError("\(hookName): \(error)")
                 return
@@ -418,26 +438,63 @@ extension HookHandler {
         }
     }
 
-    /// Path of the session file owning `safeId`: the PID-derived path when it matches;
-    /// otherwise the best directory match by session_id — preferring a file not yet
-    /// ended (the live conversation), then the most recently active one.
-    private static func sessionEndTargetPath(primaryPath: String, sessionsDir: String, safeId: String) -> String? {
-        if let session = try? Session.fromFile(path: primaryPath), session.sessionId == safeId {
-            return primaryPath
-        }
-        var best: (path: String, session: Session)?
+    private enum SessionEndIdentityMatch: Equatable {
+        case exact
+        case legacy
+    }
+
+    private struct SessionEndTarget: Equatable {
+        let path: String
+        let match: SessionEndIdentityMatch
+    }
+
+    private static func sessionEndIdentityMatch(
+        _ session: Session, safeId: String, rawId: String, source: String
+    ) -> SessionEndIdentityMatch? {
+        guard session.sessionId == safeId,
+              (session.source ?? Session.ccSource) == source else { return nil }
+        guard let harnessSessionId = session.harnessSessionId else { return .legacy }
+        return harnessSessionId == rawId ? .exact : nil
+    }
+
+    /// Find the record owning an ending conversation. Exact raw/source matches win
+    /// globally; only when none exist may one unambiguous legacy record fall back to the
+    /// lossy sanitized id. The primary PID path breaks ties only between exact matches.
+    private static func sessionEndTarget(
+        primaryPath: String, sessionsDir: String, safeId: String, rawId: String, source: String
+    ) -> SessionEndTarget? {
+        var exact: [(path: String, session: Session)] = []
+        var legacyPaths: [String] = []
         forEachSession(in: sessionsDir) { path, session in
-            guard session.sessionId == safeId else { return }
-            guard let current = best else { best = (path, session); return }
-            let candidateUnended = session.endedAt == nil
-            let currentUnended = current.session.endedAt == nil
-            if candidateUnended != currentUnended {
-                if candidateUnended { best = (path, session) }
-            } else if session.lastActivity > current.session.lastActivity {
-                best = (path, session)
+            switch sessionEndIdentityMatch(session, safeId: safeId, rawId: rawId, source: source) {
+            case .exact:
+                exact.append((path, session))
+            case .legacy:
+                legacyPaths.append(path)
+            case nil:
+                break
             }
         }
-        return best?.path
+
+        if !exact.isEmpty {
+            if exact.contains(where: { $0.path == primaryPath }) {
+                return SessionEndTarget(path: primaryPath, match: .exact)
+            }
+            var best = exact[0]
+            for candidate in exact.dropFirst() {
+                let candidateUnended = candidate.session.endedAt == nil
+                let currentUnended = best.session.endedAt == nil
+                if candidateUnended != currentUnended {
+                    if candidateUnended { best = candidate }
+                } else if candidate.session.lastActivity > best.session.lastActivity {
+                    best = candidate
+                }
+            }
+            return SessionEndTarget(path: best.path, match: .exact)
+        }
+
+        guard legacyPaths.count == 1, let path = legacyPaths.first else { return nil }
+        return SessionEndTarget(path: path, match: .legacy)
     }
 
     static func cleanupSessionsForProject(
@@ -576,10 +633,14 @@ private func loadOrCreateSession(
         }
         return (fresh, true)
     }
-    // Same PID, different session_id — a PID-keyed source (opencode/pi) reused the
-    // process for a new conversation. Drop conversation-specific state (project, name,
-    // prompt, tools, etc.) and carry over only PID liveness metadata.
-    guard existing.sessionId == fresh.sessionId else {
+    // Same PID, different session — a PID-keyed source reused the process for a new
+    // conversation. Raw references are compared when the record has one, so two
+    // conversations whose sanitized ids collide don't silently share a record; legacy
+    // records without the field can only compare sanitized ids. Drop conversation-specific
+    // state (project, name, prompt, tools, etc.) and carry over only PID liveness metadata.
+    let sameConversation = existing.sessionId == fresh.sessionId
+        && (existing.harnessSessionId == nil || existing.harnessSessionId == fresh.harnessSessionId)
+    guard sameConversation else {
         guard canReplaceDecodedSessionFile(existing: existing, fresh: fresh, event: event) else {
             throw SessionLoadError.decodedReplacementRefused(
                 existingSessionId: existing.sessionId,

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -7,6 +7,9 @@ enum HookHandler {
     // MIGRATION(v0.6.0): Remove after all users have migrated to PID-keyed sessions.
     private static let noPIDMaxAge: TimeInterval = 300
 
+    // Identity resolution and the lock-held transition stay together so callers cannot
+    // accidentally reorder the mapping and session-file locks.
+    // swiftlint:disable:next function_body_length
     static func handleHook(hookName: String, input: HookInput, deps: HookDependencies = .live) throws {
         let event = HookEvent.parse(hookName: hookName, notificationType: input.notificationType)
 
@@ -18,12 +21,17 @@ enum HookHandler {
         let sessionsDir = deps.sessionsDir()
         let safeId = Session.sanitizeSessionId(raw: input.sessionId)
         let pid = deps.process.parentPID()
+        let source = input.resolvedHarnessName ?? Session.ccSource
         let label = HookLogger.sessionLabel(cwd: input.cwd, sessionId: safeId)
         let sessionPath = (sessionsDir as NSString).appendingPathComponent(sessionFileName(input: input, pid: pid, safeSessionId: safeId))
 
         let branch = deps.currentBranch(input.cwd)
         let terminal = captureTerminalInfo(env: deps.environment(), process: deps.process)
         let startTime = deps.process.startTime(pid: pid)
+        let cctopSessionId = try resolvedCctopSessionID(
+            input: input, sessionPath: sessionPath,
+            sessionsDir: sessionsDir, source: source, safeId: safeId
+        )
 
         logForeignHarnessWarning(pid: pid, input: input, hookName: hookName, label: label, deps: deps)
 
@@ -34,7 +42,8 @@ enum HookHandler {
         var didApplyHook = false
         try withSessionLock(sessionPath: sessionPath, onError: deps.logger.logError) {
             var freshSession = Session(sessionId: safeId, projectPath: input.cwd, branch: branch, terminal: terminal)
-            freshSession.source = input.resolvedHarnessName
+            freshSession.source = source
+            freshSession.cctopSessionId = cctopSessionId
             freshSession.harnessSessionId = input.sessionId
             let loaded: (session: Session, isNewSessionFile: Bool)
             do {
@@ -48,11 +57,11 @@ enum HookHandler {
             var session = loaded.session
             let isNewSessionFile = loaded.isNewSessionFile
 
-            session.pid = pid
-            session.pidStartTime = startTime
-            // Stamped after a matching event loads the record so pre-field files gain the
-            // exact reference mid-life; only SessionStart may rotate conversations.
-            session.harnessSessionId = input.sessionId
+            stampFocusTarget(&session, pid: pid, startTime: startTime)
+            stampSessionIdentity(
+                &session, cctopSessionId: cctopSessionId,
+                input: input, source: source, safeId: safeId
+            )
 
             let (oldStatus, newStatus) = applyTransition(&session, event: event, input: input, branch: branch, terminal: terminal)
             applySessionName(&session, event: event, input: input, names: deps.names)
@@ -381,6 +390,8 @@ enum HookHandler {
 extension HookHandler {
     // MARK: - Cleanup
 
+    // Target selection, identity resolution, and lock-held revalidation form one fail-closed cycle.
+    // swiftlint:disable:next function_body_length
     private static func handleSessionEnd(hookName: String, input: HookInput, deps: HookDependencies) {
         let pid = deps.process.parentPID()
         let safeId = Session.sanitizeSessionId(raw: input.sessionId)
@@ -406,6 +417,18 @@ extension HookHandler {
             return
         }
 
+        let existingTarget = try? Session.fromFile(path: target.path)
+        let existingCctopSessionId = existingTarget.flatMap { session -> String? in
+            guard sessionEndIdentityMatch(
+                session, safeId: safeId, rawId: input.sessionId, source: source
+            ) == target.match, Session.isValidCctopSessionId(session.cctopSessionId) else { return nil }
+            return session.cctopSessionId
+        }
+        guard let cctopSessionId = existingCctopSessionId ?? resolvedCctopSessionIDForEnd(
+            input: input, sessionsDir: sessionsDir, source: source,
+            safeId: safeId, logger: deps.logger
+        ) else { return }
+
         // Stamp endedAt instead of deleting — the menubar app archives to history on next poll.
         try? withSessionLock(sessionPath: target.path, onError: deps.logger.logError) {
             // Re-validate under the lock: the file can change between the scan and the stamp.
@@ -423,6 +446,9 @@ extension HookHandler {
                 ) == target else { return }
             }
             let endedAt = Date()
+            if shouldAdoptResolvedCctopSessionID(session, input: input, source: source, safeId: safeId) {
+                session.cctopSessionId = cctopSessionId
+            }
             session.endedAt = endedAt
             if hasTrustedDesktopBundle(session, sourceOverride: input.resolvedHarnessName) {
                 session.disconnectedAt = session.disconnectedAt ?? endedAt
@@ -441,6 +467,76 @@ extension HookHandler {
     private enum SessionEndIdentityMatch: Equatable {
         case exact
         case legacy
+    }
+
+    private static func resolveCctopSessionID(
+        input: HookInput, sessionsDir: String, source: String, safeId: String
+    ) throws -> String {
+        try CctopSessionIdentityStore(sessionsDir: URL(fileURLWithPath: sessionsDir)).resolve(
+            source: source,
+            harnessSessionId: input.sessionId,
+            legacySessionId: safeId
+        )
+    }
+
+    private static func resolvedCctopSessionID(
+        input: HookInput, sessionPath: String, sessionsDir: String,
+        source: String, safeId: String
+    ) throws -> String {
+        if let session = try? Session.fromFile(path: sessionPath),
+           (session.source ?? Session.ccSource) == source,
+           session.harnessSessionId == input.sessionId,
+           Session.isValidCctopSessionId(session.cctopSessionId),
+           let cctopSessionId = session.cctopSessionId {
+            return cctopSessionId
+        }
+        return try resolveCctopSessionID(
+            input: input, sessionsDir: sessionsDir, source: source, safeId: safeId
+        )
+    }
+
+    private static func resolvedCctopSessionIDForEnd(
+        input: HookInput, sessionsDir: String,
+        source: String, safeId: String, logger: HookLogger
+    ) -> String? {
+        do {
+            return try resolveCctopSessionID(
+                input: input, sessionsDir: sessionsDir, source: source, safeId: safeId
+            )
+        } catch {
+            logger.logError("SessionEnd: could not resolve cctop session identity: \(error)")
+            return nil
+        }
+    }
+
+    private static func stampFocusTarget(
+        _ session: inout Session, pid: UInt32, startTime: TimeInterval?
+    ) {
+        session.pid = pid
+        session.pidStartTime = startTime
+    }
+
+    private static func stampSessionIdentity(
+        _ session: inout Session, cctopSessionId: String,
+        input: HookInput, source: String, safeId: String
+    ) {
+        if shouldAdoptResolvedCctopSessionID(session, input: input, source: source, safeId: safeId) {
+            session.cctopSessionId = cctopSessionId
+        }
+        // Stamped after a matching event loads the record so pre-field files gain the
+        // exact reference mid-life; only SessionStart may rotate conversations.
+        session.harnessSessionId = input.sessionId
+    }
+
+    private static func shouldAdoptResolvedCctopSessionID(
+        _ session: Session, input: HookInput, source: String, safeId: String
+    ) -> Bool {
+        !Session.isValidCctopSessionId(session.cctopSessionId)
+            || CctopSessionIdentityStore.durableEvidence(
+                source: source,
+                harnessSessionId: input.sessionId,
+                legacySessionId: safeId
+            ) != nil
     }
 
     private struct SessionEndTarget: Equatable {
@@ -620,11 +716,16 @@ private func loadOrCreateSession(
     } catch SessionLoadError.undecodableExistingFile(_) where event == .sessionStart {
         return (fresh, true)
     }
+    let sameConversation = existing.sessionId == fresh.sessionId
+        && (existing.harnessSessionId == nil || existing.harnessSessionId == fresh.harnessSessionId)
     // PID reuse: different process start time means a new process reused this PID.
     if event == .sessionStart,
        let storedStart = existing.pidStartTime,
        let currentStart = startTime,
        abs(storedStart - currentStart) > 1.0 {
+        if existing.isCodex, fresh.isCodex, sameConversation {
+            return (existing, false)
+        }
         guard canReplaceDecodedSessionFile(existing: existing, fresh: fresh, event: event) else {
             throw SessionLoadError.decodedReplacementRefused(
                 existingSessionId: existing.sessionId,
@@ -638,8 +739,6 @@ private func loadOrCreateSession(
     // conversations whose sanitized ids collide don't silently share a record; legacy
     // records without the field can only compare sanitized ids. Drop conversation-specific
     // state (project, name, prompt, tools, etc.) and carry over only PID liveness metadata.
-    let sameConversation = existing.sessionId == fresh.sessionId
-        && (existing.harnessSessionId == nil || existing.harnessSessionId == fresh.harnessSessionId)
     guard sameConversation else {
         guard canReplaceDecodedSessionFile(existing: existing, fresh: fresh, event: event) else {
             throw SessionLoadError.decodedReplacementRefused(

--- a/menubar/CctopMenubar/Models/Session+Mock.swift
+++ b/menubar/CctopMenubar/Models/Session+Mock.swift
@@ -3,6 +3,7 @@ import Foundation
 extension Session {
     static func mock(
         id: String = "test-123",
+        cctopSessionId: String? = nil,
         harnessSessionId: String? = nil,
         project: String = "cctop",
         branch: String = "main",
@@ -21,6 +22,7 @@ extension Session {
     ) -> Session {
         var session = Session(
             sessionId: id,
+            cctopSessionId: cctopSessionId ?? "00000000-0000-4000-8000-000000000001",
             harnessSessionId: harnessSessionId,
             projectPath: "/Users/test/projects/\(project)",
             projectName: project,

--- a/menubar/CctopMenubar/Models/Session+Mock.swift
+++ b/menubar/CctopMenubar/Models/Session+Mock.swift
@@ -3,6 +3,7 @@ import Foundation
 extension Session {
     static func mock(
         id: String = "test-123",
+        harnessSessionId: String? = nil,
         project: String = "cctop",
         branch: String = "main",
         sessionName: String? = nil,
@@ -20,6 +21,7 @@ extension Session {
     ) -> Session {
         var session = Session(
             sessionId: id,
+            harnessSessionId: harnessSessionId,
             projectPath: "/Users/test/projects/\(project)",
             projectName: project,
             branch: branch,

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -212,6 +212,11 @@ enum SessionLifecycle: Int, Equatable {
 
 struct Session: Codable, Identifiable, Equatable {
     var sessionId: String
+    /// The exact unsanitized session reference supplied to the hook, byte-for-byte. `sessionId` is
+    /// sanitized and truncated for file-name safety, which makes it lossy; identity
+    /// derivation (`SessionIdentityPolicy.actionID`) needs the unmodified reference.
+    /// Nil on records written by hooks that predate the field.
+    var harnessSessionId: String?
     let projectPath: String
     let projectName: String
     var branch: String
@@ -288,6 +293,7 @@ struct Session: Codable, Identifiable, Equatable {
 
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"
+        case harnessSessionId = "harness_session_id"
         case projectPath = "project_path"
         case projectName = "project_name"
         case branch, status
@@ -317,6 +323,7 @@ struct Session: Codable, Identifiable, Equatable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         sessionId = try container.decode(String.self, forKey: .sessionId)
+        harnessSessionId = try container.decodeIfPresent(String.self, forKey: .harnessSessionId)
         projectPath = try container.decode(String.self, forKey: .projectPath)
         projectName = try container.decode(String.self, forKey: .projectName)
         branch = try container.decode(String.self, forKey: .branch)
@@ -346,6 +353,7 @@ struct Session: Codable, Identifiable, Equatable {
     /// Full memberwise init (used by mocks and tests).
     init(
         sessionId: String,
+        harnessSessionId: String? = nil,
         projectPath: String,
         projectName: String,
         branch: String,
@@ -372,6 +380,7 @@ struct Session: Codable, Identifiable, Equatable {
         lastWrittenByHookVersion: String? = nil
     ) {
         self.sessionId = sessionId
+        self.harnessSessionId = harnessSessionId
         self.projectPath = projectPath
         self.projectName = projectName
         self.branch = branch

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -212,9 +212,12 @@ enum SessionLifecycle: Int, Equatable {
 
 struct Session: Codable, Identifiable, Equatable {
     var sessionId: String
-    /// The exact unsanitized session reference supplied to the hook, byte-for-byte. `sessionId` is
-    /// sanitized and truncated for file-name safety, which makes it lossy; identity
-    /// derivation (`SessionIdentityPolicy.actionID`) needs the unmodified reference.
+    /// Cctop-owned identity for this logical session. It is deliberately independent of
+    /// harness references and live focus-target metadata. Nil only on legacy records that
+    /// have not yet been migrated by the app or touched by a current hook.
+    var cctopSessionId: String?
+    /// The exact unsanitized session reference supplied to the hook, byte-for-byte.
+    /// This is lookup evidence for supported resume mappings, never cctop identity.
     /// Nil on records written by hooks that predate the field.
     var harnessSessionId: String?
     let projectPath: String
@@ -293,6 +296,7 @@ struct Session: Codable, Identifiable, Equatable {
 
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"
+        case cctopSessionId = "cctop_session_id"
         case harnessSessionId = "harness_session_id"
         case projectPath = "project_path"
         case projectName = "project_name"
@@ -323,6 +327,7 @@ struct Session: Codable, Identifiable, Equatable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         sessionId = try container.decode(String.self, forKey: .sessionId)
+        cctopSessionId = try container.decodeIfPresent(String.self, forKey: .cctopSessionId)
         harnessSessionId = try container.decodeIfPresent(String.self, forKey: .harnessSessionId)
         projectPath = try container.decode(String.self, forKey: .projectPath)
         projectName = try container.decode(String.self, forKey: .projectName)
@@ -353,6 +358,7 @@ struct Session: Codable, Identifiable, Equatable {
     /// Full memberwise init (used by mocks and tests).
     init(
         sessionId: String,
+        cctopSessionId: String? = nil,
         harnessSessionId: String? = nil,
         projectPath: String,
         projectName: String,
@@ -380,6 +386,7 @@ struct Session: Codable, Identifiable, Equatable {
         lastWrittenByHookVersion: String? = nil
     ) {
         self.sessionId = sessionId
+        self.cctopSessionId = cctopSessionId
         self.harnessSessionId = harnessSessionId
         self.projectPath = projectPath
         self.projectName = projectName
@@ -413,6 +420,7 @@ struct Session: Codable, Identifiable, Equatable {
     init(sessionId: String, projectPath: String, branch: String, terminal: TerminalInfo) {
         self.init(
             sessionId: sessionId,
+            cctopSessionId: Self.makeCctopSessionId(),
             projectPath: projectPath,
             projectName: Self.extractProjectName(projectPath),
             branch: branch,
@@ -426,6 +434,15 @@ struct Session: Codable, Identifiable, Equatable {
             lastToolDetail: nil,
             notificationMessage: nil
         )
+    }
+
+    static func makeCctopSessionId() -> String {
+        UUID().uuidString.lowercased()
+    }
+
+    static func isValidCctopSessionId(_ value: String?) -> Bool {
+        guard let value, let uuid = UUID(uuidString: value) else { return false }
+        return uuid.uuidString.lowercased() == value
     }
 
     mutating func markWrittenByHook(version: String, isNewSessionFile: Bool) {

--- a/menubar/CctopMenubar/Services/CctopSessionIdentityStore.swift
+++ b/menubar/CctopMenubar/Services/CctopSessionIdentityStore.swift
@@ -1,0 +1,148 @@
+import CryptoKit
+import Foundation
+
+/// Persists cctop-owned session identities separately from live session records.
+/// Client references are used only as lookup evidence for clients whose local
+/// resume contracts expose a stable UUID.
+struct CctopSessionIdentityStore {
+    enum StoreError: Error {
+        case corruptMapping(String)
+        case conflictingExistingIdentities(String)
+    }
+
+    private struct Mapping: Codable {
+        let cctopSessionId: String
+    }
+
+    private let sessionsDir: URL
+
+    init(sessionsDir: URL) {
+        self.sessionsDir = sessionsDir
+    }
+
+    // Resolution intentionally keeps mapping validation and creation under one flock.
+    // swiftlint:disable:next function_body_length
+    func resolve(
+        source: String?,
+        harnessSessionId: String?,
+        legacySessionId: String,
+        knownExistingIDs: Set<String>? = nil
+    ) throws -> String {
+        guard let evidence = Self.durableEvidence(
+            source: source,
+            harnessSessionId: harnessSessionId,
+            legacySessionId: legacySessionId
+        ) else {
+            return Session.makeCctopSessionId()
+        }
+
+        let directory = identityDirectory
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+        let mappingURL = directory.appendingPathComponent(Self.mappingFileName(for: evidence))
+        var resolved: String?
+        try withSessionLock(sessionPath: mappingURL.path) {
+            if FileManager.default.fileExists(atPath: mappingURL.path) {
+                let decoder = JSONDecoder()
+                decoder.keyDecodingStrategy = .convertFromSnakeCase
+                let mapping = try decoder.decode(Mapping.self, from: Data(contentsOf: mappingURL))
+                guard Session.isValidCctopSessionId(mapping.cctopSessionId) else {
+                    throw StoreError.corruptMapping(mappingURL.lastPathComponent)
+                }
+                resolved = mapping.cctopSessionId
+                return
+            }
+
+            var existing = knownExistingIDs ?? []
+            if knownExistingIDs == nil {
+                for url in sessionFiles() {
+                    guard let session = try? Session.fromFile(path: url.path),
+                          Self.durableEvidence(
+                            source: session.source,
+                            harnessSessionId: session.harnessSessionId,
+                            legacySessionId: session.sessionId
+                          ) == evidence,
+                          Session.isValidCctopSessionId(session.cctopSessionId),
+                          let cctopSessionId = session.cctopSessionId else { continue }
+                    existing.insert(cctopSessionId)
+                }
+            }
+            guard existing.count <= 1 else {
+                throw StoreError.conflictingExistingIdentities(mappingURL.lastPathComponent)
+            }
+
+            let cctopSessionId = existing.first ?? Session.makeCctopSessionId()
+            try writeMapping(Mapping(cctopSessionId: cctopSessionId), to: mappingURL)
+            resolved = cctopSessionId
+        }
+        guard let resolved else {
+            throw StoreError.corruptMapping(mappingURL.lastPathComponent)
+        }
+        return resolved
+    }
+
+    /// Current reliable same-machine resume evidence. OpenCode deliberately remains
+    /// record-local, and pi only participates when it supplies a real UUID rather than
+    /// the synthetic process fallback.
+    static func durableEvidence(
+        source: String?,
+        harnessSessionId: String?,
+        legacySessionId: String
+    ) -> String? {
+        // The established session-file migration contract treats a missing source as
+        // Claude Code; retain that narrow legacy rule without inferring across clients.
+        let normalizedSource = source ?? Session.ccSource
+        guard [Session.codexSource, Session.ccSource, Session.piSource].contains(normalizedSource) else {
+            return nil
+        }
+        let reference = harnessSessionId.flatMap { $0.isEmpty ? nil : $0 } ?? legacySessionId
+        guard let uuid = UUID(uuidString: reference), uuid.uuidString.lowercased() == reference.lowercased() else {
+            return nil
+        }
+        return "\(normalizedSource):\(uuid.uuidString.lowercased())"
+    }
+
+    private var identityDirectory: URL {
+        if sessionsDir.lastPathComponent == "sessions" {
+            return sessionsDir.deletingLastPathComponent()
+                .appendingPathComponent("session-identities", isDirectory: true)
+        }
+        // CCTOP_SESSIONS_DIR may point directly at an isolated test or diagnostic
+        // directory. Keep its identities inside that boundary instead of sharing the
+        // override's parent with unrelated runs.
+        return sessionsDir.appendingPathComponent(".session-identities", isDirectory: true)
+    }
+
+    private func sessionFiles() -> [URL] {
+        (try? FileManager.default.contentsOfDirectory(at: sessionsDir, includingPropertiesForKeys: nil))?
+            .filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasSuffix(".tmp") } ?? []
+    }
+
+    private static func mappingFileName(for evidence: String) -> String {
+        let canonical = "v1:\(evidence.utf8.count):\(evidence)"
+        let digest = SHA256.hash(data: Data(canonical.utf8))
+        return "v1-\(digest.map { String(format: "%02x", $0) }.joined()).json"
+    }
+
+    private func writeMapping(_ mapping: Mapping, to url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(mapping)
+        let tempURL = url.appendingPathExtension("\(ProcessInfo.processInfo.processIdentifier).\(UUID().uuidString).tmp")
+        do {
+            try data.write(to: tempURL)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tempURL.path)
+            guard rename(tempURL.path, url.path) == 0 else {
+                throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: tempURL)
+            throw error
+        }
+    }
+}

--- a/menubar/CctopMenubar/Services/DisplayStateWriter.swift
+++ b/menubar/CctopMenubar/Services/DisplayStateWriter.swift
@@ -17,7 +17,7 @@ struct DisplayState: Encodable {
     }
 
     struct Entry: Encodable, Equatable {
-        let id: String
+        let cctopSessionId: String
         let name: String
         let status: String
         let color: String
@@ -52,7 +52,7 @@ struct DisplayState: Encodable {
 /// Publishes cctop's resolved display model to ~/.cctop/display-state.json.
 /// This file is the Stream Deck API boundary, not an intermediate session source.
 final class DisplayStateWriter {
-    static let schemaVersion = 1
+    static let schemaVersion = 2
 
     private var lastSnapshot: Data?
 
@@ -106,8 +106,13 @@ final class DisplayStateWriter {
             appPID: appRunning ? appIdentity?.pid : nil,
             appStartTime: appRunning ? appIdentity?.startTime : nil,
             sessions: ordered.map { session in
-                DisplayState.Entry(
-                    id: SessionIdentityPolicy.actionID(for: session),
+                // SessionManager assigns every publishable legacy record an id before
+                // reaching this boundary. Keep an invalid record in its original slot if
+                // that invariant is ever broken; the consumer renders an empty key rather
+                // than shifting later targets forward.
+                let cctopSessionId = session.cctopSessionId ?? ""
+                return DisplayState.Entry(
+                    cctopSessionId: cctopSessionId,
                     name: session.displayName,
                     status: session.status.rawValue,
                     color: hexColor(for: session.status, theme: theme)

--- a/menubar/CctopMenubar/Services/DisplayStateWriter.swift
+++ b/menubar/CctopMenubar/Services/DisplayStateWriter.swift
@@ -107,7 +107,7 @@ final class DisplayStateWriter {
             appStartTime: appRunning ? appIdentity?.startTime : nil,
             sessions: ordered.map { session in
                 DisplayState.Entry(
-                    id: session.id,
+                    id: SessionIdentityPolicy.actionID(for: session),
                     name: session.displayName,
                     status: session.status.rawValue,
                     color: hexColor(for: session.status, theme: theme)

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 
 enum SessionIdentityPolicy {
@@ -44,47 +43,11 @@ enum SessionIdentityPolicy {
         }
     }
 
-    /// Opaque, deterministic identity for acting on one live focus target from an
-    /// external control surface (Stream Deck keys, `cctop://focus`). It combines the
-    /// integration's exact session reference with process-generation identity, so two
-    /// visible processes hosting the same conversation still receive different ids.
-    /// Deliberately separate from `stableKey`: this is a short-lived routing token, not
-    /// canonical session identity or a persistence key.
-    static func actionID(for session: Session) -> String {
-        hashedActionID(components: actionIdentityComponents(for: session))
-    }
-
-    private static func actionIdentityComponents(for session: Session) -> [String] {
-        let source = session.source ?? Session.ccSource
-        let sessionReference = session.harnessSessionId.flatMap { $0.isEmpty ? nil : $0 } ?? session.sessionId
-        var components = ["action", source, sessionReference]
-        if let pid = session.pid {
-            let start = session.pidStartTime.map { String(format: "%.6f", $0) } ?? ""
-            components.append(contentsOf: ["process", String(pid), start])
-        } else {
-            // Records without process metadata are uncommon and cannot name a separate
-            // process generation; retain their existing row identity as the fallback.
-            components.append(contentsOf: ["record", session.id])
-        }
-        return components
-    }
-
-    /// Netstring-style length prefixes make the encoding injective: no combination of
-    /// component values can collide with a different component split. 128-bit truncation
-    /// keeps the token short while staying far beyond collision range for local sessions.
-    private static func hashedActionID(components: [String]) -> String {
-        let canonical = components.map { "\($0.utf8.count):\($0)" }.joined()
-        let digest = SHA256.hash(data: Data(canonical.utf8))
-        let hex = digest.prefix(16).map { String(format: "%02x", $0) }.joined()
-        return "s-\(hex)"
-    }
-
-    /// Match a session by the opaque action id published to external control surfaces.
-    /// Exact match only — pre-action-id published values (raw pid strings) are deliberately
-    /// not aliased, because a recycled PID could focus an unrelated session; a stale
-    /// pre-upgrade command simply finds nothing.
-    static func session(matchingDisplayID displayID: String, in sessions: [Session]) -> Session? {
-        sessions.first { actionID(for: $0) == displayID }
+    /// Match a session by the permanent cctop-owned id published to external control
+    /// surfaces. Exact match only. When several live observations share one logical id,
+    /// canonical SessionManager order selects the currently associated focus target.
+    static func session(matchingCctopSessionID cctopSessionID: String, in sessions: [Session]) -> Session? {
+        sessions.first { $0.cctopSessionId == cctopSessionID }
     }
 
     private static func notificationSessionID(for session: Session) -> String {

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 enum SessionIdentityPolicy {
@@ -43,9 +44,47 @@ enum SessionIdentityPolicy {
         }
     }
 
-    /// Match a session by the stable display id published to external control surfaces.
+    /// Opaque, deterministic identity for acting on one live focus target from an
+    /// external control surface (Stream Deck keys, `cctop://focus`). It combines the
+    /// integration's exact session reference with process-generation identity, so two
+    /// visible processes hosting the same conversation still receive different ids.
+    /// Deliberately separate from `stableKey`: this is a short-lived routing token, not
+    /// canonical session identity or a persistence key.
+    static func actionID(for session: Session) -> String {
+        hashedActionID(components: actionIdentityComponents(for: session))
+    }
+
+    private static func actionIdentityComponents(for session: Session) -> [String] {
+        let source = session.source ?? Session.ccSource
+        let sessionReference = session.harnessSessionId.flatMap { $0.isEmpty ? nil : $0 } ?? session.sessionId
+        var components = ["action", source, sessionReference]
+        if let pid = session.pid {
+            let start = session.pidStartTime.map { String(format: "%.6f", $0) } ?? ""
+            components.append(contentsOf: ["process", String(pid), start])
+        } else {
+            // Records without process metadata are uncommon and cannot name a separate
+            // process generation; retain their existing row identity as the fallback.
+            components.append(contentsOf: ["record", session.id])
+        }
+        return components
+    }
+
+    /// Netstring-style length prefixes make the encoding injective: no combination of
+    /// component values can collide with a different component split. 128-bit truncation
+    /// keeps the token short while staying far beyond collision range for local sessions.
+    private static func hashedActionID(components: [String]) -> String {
+        let canonical = components.map { "\($0.utf8.count):\($0)" }.joined()
+        let digest = SHA256.hash(data: Data(canonical.utf8))
+        let hex = digest.prefix(16).map { String(format: "%02x", $0) }.joined()
+        return "s-\(hex)"
+    }
+
+    /// Match a session by the opaque action id published to external control surfaces.
+    /// Exact match only — pre-action-id published values (raw pid strings) are deliberately
+    /// not aliased, because a recycled PID could focus an unrelated session; a stale
+    /// pre-upgrade command simply finds nothing.
     static func session(matchingDisplayID displayID: String, in sessions: [Session]) -> Session? {
-        sessions.first { $0.id == displayID }
+        sessions.first { actionID(for: $0) == displayID }
     }
 
     private static func notificationSessionID(for session: Session) -> String {

--- a/menubar/CctopMenubar/Services/SessionManager+Loading.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Loading.swift
@@ -1,6 +1,11 @@
 import Darwin
 import Foundation
 
+private let cctopIdentityMigrationQueue = DispatchQueue(
+    label: "com.st0012.CctopMenubar.SessionIdentityMigration",
+    qos: .utility
+)
+
 struct SessionLoadSummary: Equatable {
     let files: Int
     let decoded: Int
@@ -36,7 +41,7 @@ extension SessionManager {
         let currentPaths = Set(jsonFiles.map(\.path))
         sessionFileCache = sessionFileCache.filter { currentPaths.contains($0.key) }
 
-        return jsonFiles.compactMap { url in
+        let decoded = jsonFiles.compactMap { url -> (url: URL, session: Session)? in
             guard let fingerprint = sessionFileFingerprint(for: url) else {
                 sessionFileCache.removeValue(forKey: url.path)
                 sessionManagerLogger.warning("loadSessions: could not stat \(url.lastPathComponent, privacy: .public)")
@@ -61,6 +66,140 @@ extension SessionManager {
                 sessionFileCache.removeValue(forKey: url.path)
                 sessionManagerLogger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public): \(error, privacy: .public)")
                 return nil
+            }
+        }
+        return decoded
+    }
+
+    // Build one evidence index and resolve the bounded publishable set in a single pass.
+    func assigningCctopSessionIdentities(
+        to candidates: [DedupCandidate],
+        knownRecords: [(url: URL, session: Session)]
+    ) -> [Session] {
+        var records = candidates.map { (url: URL(fileURLWithPath: $0.path), session: $0.session) }
+        var idsByEvidence: [String: Set<String>] = [:]
+        for record in knownRecords where Session.isValidCctopSessionId(record.session.cctopSessionId) {
+            guard let evidence = CctopSessionIdentityStore.durableEvidence(
+                source: record.session.source,
+                harnessSessionId: record.session.harnessSessionId,
+                legacySessionId: record.session.sessionId
+            ), let cctopSessionId = record.session.cctopSessionId else { continue }
+            idsByEvidence[evidence, default: []].insert(cctopSessionId)
+        }
+
+        let identityStore = CctopSessionIdentityStore(sessionsDir: dataSources.sessionsDir)
+        for index in records.indices where !Session.isValidCctopSessionId(records[index].session.cctopSessionId) {
+            var session = records[index].session
+            let evidence = CctopSessionIdentityStore.durableEvidence(
+                source: session.source,
+                harnessSessionId: session.harnessSessionId,
+                legacySessionId: session.sessionId
+            )
+            guard let evidence else {
+                scheduleRecordLocalCctopSessionIdentityStamp(
+                    url: records[index].url,
+                    snapshot: session
+                )
+                continue
+            }
+            let knownIDs = idsByEvidence[evidence] ?? []
+            do {
+                let cctopSessionId = try identityStore.resolve(
+                    source: session.source,
+                    harnessSessionId: session.harnessSessionId,
+                    legacySessionId: session.sessionId,
+                    knownExistingIDs: knownIDs
+                )
+                session.cctopSessionId = cctopSessionId
+                records[index].session = session
+                idsByEvidence[evidence, default: []].insert(cctopSessionId)
+                cacheMigratedSession(session, at: records[index].url.path)
+                scheduleCctopSessionIdentityStamp(
+                    url: records[index].url,
+                    snapshot: records[index].session
+                )
+            } catch {
+                let fileName = records[index].url.lastPathComponent
+                let reason = error.localizedDescription
+                sessionManagerLogger.error(
+                    "loadSessions: identity migration failed for \(fileName, privacy: .public): \(reason, privacy: .public)"
+                )
+            }
+        }
+        return records.map(\.session)
+    }
+
+    private func cacheMigratedSession(_ session: Session, at path: String) {
+        guard let cached = sessionFileCache[path] else { return }
+        sessionFileCache[path] = SessionFileCacheEntry(
+            fingerprint: cached.fingerprint,
+            session: session
+        )
+    }
+
+    func identifiedPublishableSessions(
+        winners: [DedupCandidate],
+        knownRecords: [(url: URL, session: Session)]
+    ) -> [Session] {
+        let publishableWinners = winners.filter { $0.session.lifecycle != .finished }
+        return assigningCctopSessionIdentities(to: publishableWinners, knownRecords: knownRecords)
+    }
+
+    private func scheduleRecordLocalCctopSessionIdentityStamp(url: URL, snapshot: Session) {
+        guard pendingIdentityMigrationPaths.insert(url.path).inserted else { return }
+        cctopIdentityMigrationQueue.async { [weak self] in
+            do {
+                _ = try withSessionLockIfAvailable(sessionPath: url.path) {
+                    guard var current = try? Session.fromFile(path: url.path),
+                          !Session.isValidCctopSessionId(current.cctopSessionId),
+                          current.sessionId == snapshot.sessionId,
+                          current.source == snapshot.source,
+                          current.harnessSessionId == snapshot.harnessSessionId else { return }
+                    current.cctopSessionId = Session.makeCctopSessionId()
+                    try current.writeToFile(path: url.path)
+                }
+            } catch {
+                let fileName = url.lastPathComponent
+                let reason = error.localizedDescription
+                sessionManagerLogger.warning(
+                    "record-local identity stamp failed for \(fileName, privacy: .public): \(reason, privacy: .public)"
+                )
+            }
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.pendingIdentityMigrationPaths.remove(url.path)
+                self.sessionFileCache.removeValue(forKey: url.path)
+            }
+        }
+    }
+
+    private func scheduleCctopSessionIdentityStamp(url: URL, snapshot: Session) {
+        guard let cctopSessionId = snapshot.cctopSessionId,
+              pendingIdentityMigrationPaths.insert(url.path).inserted else { return }
+        cctopIdentityMigrationQueue.async { [weak self] in
+            do {
+                _ = try withSessionLockIfAvailable(sessionPath: url.path) {
+                    guard var current = try? Session.fromFile(path: url.path) else { return }
+                    if Session.isValidCctopSessionId(current.cctopSessionId) {
+                        return
+                    }
+                    guard current.sessionId == snapshot.sessionId,
+                          current.source == snapshot.source,
+                          current.harnessSessionId == snapshot.harnessSessionId else { return }
+                    current.cctopSessionId = cctopSessionId
+                    try current.writeToFile(path: url.path)
+                }
+            } catch {
+                let fileName = url.lastPathComponent
+                let reason = error.localizedDescription
+                sessionManagerLogger.warning(
+                    "identity stamp failed for \(fileName, privacy: .public): \(reason, privacy: .public)"
+                )
+            }
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.pendingIdentityMigrationPaths.remove(url.path)
+                self.sessionFileCache.removeValue(forKey: url.path)
             }
         }
     }

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -32,6 +32,7 @@ class SessionManager: ObservableObject {
     private var lastDisplaySignature = SessionDisplayPolicy.Signature.empty
     var lastLoadLogSignature: SessionLoadLogSignature?
     var sessionFileCache: [String: SessionFileCacheEntry] = [:]
+    var pendingIdentityMigrationPaths: Set<String> = []
     /// Lifecycle windows: desktop app liveness decides connection when available; `active` is the
     /// fallback recency threshold and `retention` controls dormant desktop cleanup.
     nonisolated static let lifecycleWindows = LifecycleWindows(active: 600, retention: 1_209_600)
@@ -94,7 +95,8 @@ class SessionManager: ObservableObject {
         // Publish active + dormant; finished are hidden (swept below / by GC).
         let winners = SessionIdentityPolicy.dedupedCandidatesByStableKey(displayCandidates)
         let now = dataSources.now()
-        let loadedSessions = winners.filter { $0.session.lifecycle != .finished }.map { adjustDisplayStatus($0.session) }
+        let identifiedSessions = identifiedPublishableSessions(winners: winners, knownRecords: allDecoded)
+        let loadedSessions = identifiedSessions.map { adjustDisplayStatus($0) }
         let newSessions = SessionDisplayPolicy.reconcilingActiveOrder(in: loadedSessions, preserving: oldSessions, now: now)
         let displaySignature = SessionDisplayPolicy.signature(for: newSessions, now: now)
         syncTransitionNotifications(for: newSessions, oldSessions: oldSessions)

--- a/menubar/CctopMenubarTests/DisplayStateWriterTests.swift
+++ b/menubar/CctopMenubarTests/DisplayStateWriterTests.swift
@@ -23,9 +23,10 @@ final class DisplayStateWriterTests: XCTestCase {
         )
 
         let expected = SessionDisplayPolicy.activeSessions(from: sessions, now: now)
+        XCTAssertEqual(snapshot.sessions.count, expected.count)
         XCTAssertEqual(
-            snapshot.sessions.map(\.id),
-            expected.map { SessionIdentityPolicy.actionID(for: $0) }
+            snapshot.sessions.map(\.cctopSessionId),
+            expected.map { $0.cctopSessionId ?? "" }
         )
         XCTAssertEqual(snapshot.sessions.map(\.name), ["alpha", "bravo", "charlie", "delta"])
     }
@@ -46,7 +47,7 @@ final class DisplayStateWriterTests: XCTestCase {
             now: now
         )
 
-        XCTAssertEqual(snapshot.sessions.map(\.id), [SessionIdentityPolicy.actionID(for: active)])
+        XCTAssertEqual(snapshot.sessions.map(\.cctopSessionId), [active.cctopSessionId ?? ""])
     }
 
     func testProjectionContainsOnlyAppOwnedDisplayFields() throws {
@@ -78,12 +79,9 @@ final class DisplayStateWriterTests: XCTestCase {
         XCTAssertEqual(object["app_pid"] as? Int, 456)
         XCTAssertEqual(object["app_start_time"] as? Double, 1_234.5)
         let entry = try XCTUnwrap((object["sessions"] as? [[String: Any]])?.first)
-        XCTAssertEqual(Set(entry.keys), ["id", "name", "status", "color"])
-        XCTAssertEqual(entry["id"] as? String, SessionIdentityPolicy.actionID(for: session))
-        // Published ids are opaque tokens: no pid, session id, or source shape leaks through.
-        XCTAssertNotNil(
-            (entry["id"] as? String)?.range(of: "^s-[0-9a-f]{32}$", options: .regularExpression)
-        )
+        XCTAssertEqual(Set(entry.keys), ["cctop_session_id", "name", "status", "color"])
+        XCTAssertEqual(entry["cctop_session_id"] as? String, session.cctopSessionId)
+        XCTAssertTrue(Session.isValidCctopSessionId(entry["cctop_session_id"] as? String))
         XCTAssertEqual(entry["name"] as? String, "fix panel drift")
         XCTAssertEqual(entry["status"] as? String, "working")
         XCTAssertEqual(entry["color"] as? String, "#7EAA6E")
@@ -102,18 +100,19 @@ final class DisplayStateWriterTests: XCTestCase {
         XCTAssertFalse(snapshot.appRunning)
         XCTAssertNil(snapshot.appPID)
         XCTAssertNil(snapshot.appStartTime)
-        XCTAssertEqual(snapshot.sessions.map(\.id), [SessionIdentityPolicy.actionID(for: session)])
+        XCTAssertEqual(snapshot.sessions.map(\.cctopSessionId), [session.cctopSessionId ?? ""])
     }
 
     func testSnapshotKeepsOneOrderedEntryPerVisibleFocusTarget() {
         let now = Date()
+        let cctopSessionID = "11111111-2222-4333-8444-555555555555"
         var original = Session.mock(
-            id: "conv-1", harnessSessionId: "conv-1", project: "first",
+            id: "conv-1", cctopSessionId: cctopSessionID, harnessSessionId: "conv-1", project: "first",
             status: .working, pid: 111, pidStartTime: 1_000
         )
         original.lastActivity = now.addingTimeInterval(-10)
         var resumedElsewhere = Session.mock(
-            id: "conv-1", harnessSessionId: "conv-1", project: "second",
+            id: "conv-1", cctopSessionId: cctopSessionID, harnessSessionId: "conv-1", project: "second",
             status: .working, pid: 999, pidStartTime: 2_000
         )
         resumedElsewhere.lastActivity = now.addingTimeInterval(-20)
@@ -127,8 +126,25 @@ final class DisplayStateWriterTests: XCTestCase {
             now: now
         )
 
-        XCTAssertEqual(snapshot.sessions.map(\.id), canonical.map { SessionIdentityPolicy.actionID(for: $0) })
-        XCTAssertEqual(Set(snapshot.sessions.map(\.id)).count, 2)
+        XCTAssertEqual(snapshot.sessions.map(\.cctopSessionId), [cctopSessionID, cctopSessionID])
+        XCTAssertEqual(snapshot.sessions.map(\.name), ["first", "second"])
+    }
+
+    func testMissingLegacyIdentityLeavesAnEmptySlotWithoutShiftingLaterRows() {
+        var legacy = Session.mock(id: "legacy", project: "first", status: .working)
+        legacy.cctopSessionId = nil
+        let current = Session.mock(id: "current", project: "second", status: .working)
+
+        let snapshot = DisplayStateWriter.snapshot(
+            sessions: [legacy, current],
+            theme: .claude,
+            appRunning: true,
+            appIdentity: nil,
+            now: Date()
+        )
+
+        XCTAssertEqual(snapshot.sessions.count, 2)
+        XCTAssertEqual(snapshot.sessions.map(\.cctopSessionId), ["", current.cctopSessionId ?? ""])
         XCTAssertEqual(snapshot.sessions.map(\.name), ["first", "second"])
     }
 

--- a/menubar/CctopMenubarTests/DisplayStateWriterTests.swift
+++ b/menubar/CctopMenubarTests/DisplayStateWriterTests.swift
@@ -23,8 +23,11 @@ final class DisplayStateWriterTests: XCTestCase {
         )
 
         let expected = SessionDisplayPolicy.activeSessions(from: sessions, now: now)
-        XCTAssertEqual(snapshot.sessions.map(\.id), expected.map(\.id))
-        XCTAssertEqual(snapshot.sessions.map(\.id), ["a", "b", "c", "d"])
+        XCTAssertEqual(
+            snapshot.sessions.map(\.id),
+            expected.map { SessionIdentityPolicy.actionID(for: $0) }
+        )
+        XCTAssertEqual(snapshot.sessions.map(\.name), ["alpha", "bravo", "charlie", "delta"])
     }
 
     func testSnapshotExcludesSessionsTheAppDoesNotDisplay() {
@@ -43,7 +46,7 @@ final class DisplayStateWriterTests: XCTestCase {
             now: now
         )
 
-        XCTAssertEqual(snapshot.sessions.map(\.id), ["active"])
+        XCTAssertEqual(snapshot.sessions.map(\.id), [SessionIdentityPolicy.actionID(for: active)])
     }
 
     func testProjectionContainsOnlyAppOwnedDisplayFields() throws {
@@ -76,15 +79,20 @@ final class DisplayStateWriterTests: XCTestCase {
         XCTAssertEqual(object["app_start_time"] as? Double, 1_234.5)
         let entry = try XCTUnwrap((object["sessions"] as? [[String: Any]])?.first)
         XCTAssertEqual(Set(entry.keys), ["id", "name", "status", "color"])
-        XCTAssertEqual(entry["id"] as? String, "stable-display-id")
+        XCTAssertEqual(entry["id"] as? String, SessionIdentityPolicy.actionID(for: session))
+        // Published ids are opaque tokens: no pid, session id, or source shape leaks through.
+        XCTAssertNotNil(
+            (entry["id"] as? String)?.range(of: "^s-[0-9a-f]{32}$", options: .regularExpression)
+        )
         XCTAssertEqual(entry["name"] as? String, "fix panel drift")
         XCTAssertEqual(entry["status"] as? String, "working")
         XCTAssertEqual(entry["color"] as? String, "#7EAA6E")
     }
 
     func testStoppedSnapshotPreservesRecentTargetsButDropsProcessIdentity() {
+        let session = Session.mock(id: "stable-display-id", status: .working)
         let snapshot = DisplayStateWriter.snapshot(
-            sessions: [Session.mock(id: "stable-display-id", status: .working)],
+            sessions: [session],
             theme: .claude,
             appRunning: false,
             appIdentity: DisplayState.ProcessIdentity(pid: 456, startTime: 1_234.5),
@@ -94,7 +102,34 @@ final class DisplayStateWriterTests: XCTestCase {
         XCTAssertFalse(snapshot.appRunning)
         XCTAssertNil(snapshot.appPID)
         XCTAssertNil(snapshot.appStartTime)
-        XCTAssertEqual(snapshot.sessions.map(\.id), ["stable-display-id"])
+        XCTAssertEqual(snapshot.sessions.map(\.id), [SessionIdentityPolicy.actionID(for: session)])
+    }
+
+    func testSnapshotKeepsOneOrderedEntryPerVisibleFocusTarget() {
+        let now = Date()
+        var original = Session.mock(
+            id: "conv-1", harnessSessionId: "conv-1", project: "first",
+            status: .working, pid: 111, pidStartTime: 1_000
+        )
+        original.lastActivity = now.addingTimeInterval(-10)
+        var resumedElsewhere = Session.mock(
+            id: "conv-1", harnessSessionId: "conv-1", project: "second",
+            status: .working, pid: 999, pidStartTime: 2_000
+        )
+        resumedElsewhere.lastActivity = now.addingTimeInterval(-20)
+        let canonical = [original, resumedElsewhere]
+
+        let snapshot = DisplayStateWriter.snapshot(
+            sessions: canonical,
+            theme: .claude,
+            appRunning: true,
+            appIdentity: DisplayState.ProcessIdentity(pid: 123, startTime: 1_000),
+            now: now
+        )
+
+        XCTAssertEqual(snapshot.sessions.map(\.id), canonical.map { SessionIdentityPolicy.actionID(for: $0) })
+        XCTAssertEqual(Set(snapshot.sessions.map(\.id)).count, 2)
+        XCTAssertEqual(snapshot.sessions.map(\.name), ["first", "second"])
     }
 
     func testHexColorsUseCctopThemeVariants() {

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -150,6 +150,115 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertEqual(session.lastWrittenByHookVersion, Config.hookVersion)
     }
 
+    // The persisted session_id is sanitized for file-name safety (lossy); the raw
+    // harness reference must survive byte-for-byte for identity derivation.
+    func testHookStampsExactHarnessSessionReference() throws {
+        try handleHook("""
+        {"session_id": "raw|session:ref", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart"}
+        """, hookName: "SessionStart")
+        let session = try loadSession()
+
+        XCTAssertEqual(session.sessionId, "rawsessionref")
+        XCTAssertEqual(session.harnessSessionId, "raw|session:ref")
+    }
+
+    // Two conversations whose raw references sanitize to the same session_id must not
+    // share a record: the second SessionStart replaces the file as a new conversation.
+    func testHookRotatesRecordWhenRawReferencesCollideAfterSanitization() throws {
+        try handleHook("""
+        {"session_id": "conv|A", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart"}
+        """, hookName: "SessionStart")
+        try handleHook("""
+        {"session_id": "conv|A", "cwd": "/tmp/test-project", "hook_event_name": "UserPromptSubmit", "prompt": "hi"}
+        """, hookName: "UserPromptSubmit")
+        XCTAssertEqual(try loadSession().lastPrompt, "hi")
+
+        try handleHook("""
+        {"session_id": "convA", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart"}
+        """, hookName: "SessionStart")
+
+        let rotated = try loadSession()
+        XCTAssertEqual(rotated.sessionId, "convA")
+        XCTAssertEqual(rotated.harnessSessionId, "convA")
+        XCTAssertNil(rotated.lastPrompt)
+    }
+
+    // SessionEnd must stamp the record owning the exact raw reference, not another
+    // conversation whose raw reference sanitizes to the same session_id.
+    func testSessionEndMatchesTargetByRawReference() throws {
+        try handleHook("""
+        {"session_id": "end|A", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart"}
+        """, hookName: "SessionStart", deps: makeDeps(pid: 5001))
+        try handleHook("""
+        {"session_id": "endA", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart"}
+        """, hookName: "SessionStart", deps: makeDeps(pid: 5002))
+
+        // The end-time parent walk resolves an unrelated PID, forcing the directory scan.
+        try handleHook("""
+        {"session_id": "endA", "cwd": "/tmp/test-project", "hook_event_name": "SessionEnd"}
+        """, hookName: "SessionEnd", deps: makeDeps(pid: 5999))
+
+        XCTAssertNil(try loadSession("5001.json").endedAt)
+        XCTAssertNotNil(try loadSession("5002.json").endedAt)
+    }
+
+    func testSessionEndExactMatchWinsOverLegacyPrimaryPath() throws {
+        var legacy = Session.mock(id: "endA", pid: 4242, source: "cc")
+        legacy.harnessSessionId = nil
+        try legacy.writeToFile(path: sessionFilePath())
+
+        let exact = Session.mock(id: "endA", harnessSessionId: "endA", pid: 5002, source: "cc")
+        try exact.writeToFile(path: sessionFilePath("5002.json"))
+
+        try handleHook("""
+        {"session_id": "endA", "cwd": "/tmp/test-project", "hook_event_name": "SessionEnd", "harness_name": "cc"}
+        """, hookName: "SessionEnd")
+
+        XCTAssertNil(try loadSession().endedAt)
+        XCTAssertNotNil(try loadSession("5002.json").endedAt)
+    }
+
+    func testSessionEndDoesNotUseAmbiguousLegacyFallback() throws {
+        let first = Session.mock(id: "legacy-end", pid: 4242, source: "cc")
+        let second = Session.mock(id: "legacy-end", pid: 5002, source: "cc")
+        try first.writeToFile(path: sessionFilePath())
+        try second.writeToFile(path: sessionFilePath("5002.json"))
+
+        try handleHook("""
+        {"session_id": "legacy-end", "cwd": "/tmp/test-project", "hook_event_name": "SessionEnd", "harness_name": "cc"}
+        """, hookName: "SessionEnd")
+
+        XCTAssertNil(try loadSession().endedAt)
+        XCTAssertNil(try loadSession("5002.json").endedAt)
+    }
+
+    func testSessionEndDoesNotMatchExactReferenceFromAnotherSource() throws {
+        let opencode = Session.mock(
+            id: "shared-end", harnessSessionId: "shared-end", pid: 5002, source: "opencode"
+        )
+        try opencode.writeToFile(path: sessionFilePath("5002.json"))
+
+        try handleHook("""
+        {"session_id": "shared-end", "cwd": "/tmp/test-project", "hook_event_name": "SessionEnd", "harness_name": "cc"}
+        """, hookName: "SessionEnd")
+
+        XCTAssertNil(try loadSession("5002.json").endedAt)
+    }
+
+    // Records created by pre-field hooks gain the exact reference on their next event.
+    func testHookStampsHarnessSessionReferenceOnExistingLegacyRecord() throws {
+        try handleFixture("SessionStart")
+        var legacy = try loadSession()
+        legacy.harnessSessionId = nil
+        try legacy.writeToFile(path: sessionFilePath())
+
+        try handleHook("""
+        {"session_id": "test-session-001", "cwd": "/tmp/test-project", "hook_event_name": "PreToolUse", "tool_name": "Bash"}
+        """, hookName: "PreToolUse")
+
+        XCTAssertEqual(try loadSession().harnessSessionId, "test-session-001")
+    }
+
     func testSessionStartCapturesCmuxMultiplexerContext() throws {
         let cmuxPath = try makeExecutable(named: "cmux")
         let env = [
@@ -741,8 +850,8 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertFalse(sessionFileExists())
     }
 
-    // When two files share a session_id, the PID-derived path is authoritative.
-    func testSessionEndPrefersPidPathWhenTwoFilesShareSessionId() throws {
+    // An exact raw match at the PID-derived path wins over a legacy sanitized-id match.
+    func testSessionEndPrefersExactPrimaryOverLegacyTwin() throws {
         try handleFixture("SessionStart")
         let primary = sessionFilePath()
         let twinPath = (sessionsDir as NSString).appendingPathComponent("7777.json")
@@ -754,17 +863,21 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertNil(try Session.fromFile(path: twinPath).endedAt)
     }
 
-    // When the PID-derived path misses, the by-session_id scan must pick the live
-    // (un-ended) duplicate, not a stale already-ended one.
+    // When the PID-derived path misses, multiple exact raw/source matches prefer the
+    // live (un-ended) process generation over a stale already-ended one.
     func testSessionEndStampsUnendedDuplicateWhenPrimaryMisses() throws {
         var stale = Session.mock(id: "dup-sid", pid: 1111)
+        stale.harnessSessionId = "dup-sid"
+        stale.source = "cc"
         let staleEnd = Date(timeIntervalSince1970: 1_000)
         stale.endedAt = staleEnd
         let stalePath = (sessionsDir as NSString).appendingPathComponent("1111.json")
         try stale.writeToFile(path: stalePath)
 
         let livePath = (sessionsDir as NSString).appendingPathComponent("2222.json")
-        try Session.mock(id: "dup-sid", pid: 2222).writeToFile(path: livePath)
+        try Session.mock(
+            id: "dup-sid", harnessSessionId: "dup-sid", pid: 2222, source: "cc"
+        ).writeToFile(path: livePath)
 
         try handleHook("""
         {"session_id":"dup-sid","cwd":"/tmp/test-project","hook_event_name":"SessionEnd","harness_name":"cc"}

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -140,6 +140,7 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertEqual(session.projectName, "test-project")
         XCTAssertEqual(session.pid, 4242)
         XCTAssertEqual(session.activeSubagents?.count, 0)
+        XCTAssertTrue(Session.isValidCctopSessionId(session.cctopSessionId))
     }
 
     func testNewHookSessionFileRecordsWriterMetadata() throws {
@@ -162,16 +163,75 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertEqual(session.harnessSessionId, "raw|session:ref")
     }
 
+    func testClaudeUUIDResumeAcrossProcessesReusesCctopSessionID() throws {
+        let reference = "11111111-2222-4333-8444-555555555555"
+        let input = """
+        {"session_id": "\(reference)", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart", "harness_name": "cc"}
+        """
+        try handleHook(input, hookName: "SessionStart", deps: makeDeps(pid: 4242, startTime: 1_000))
+        let firstCctopSessionID = try loadSession("4242.json").cctopSessionId
+        try handleHook(input, hookName: "SessionStart", deps: makeDeps(pid: 5002, startTime: 2_000))
+
+        XCTAssertEqual(
+            firstCctopSessionID,
+            try loadSession("5002.json").cctopSessionId
+        )
+    }
+
+    func testCodexResumeUpdatesFocusTargetAndPreservesCctopSessionID() throws {
+        let reference = "11111111-2222-4333-8444-555555555555"
+        let input = """
+        {"session_id": "\(reference)", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart", "harness_name": "codex"}
+        """
+        let fileName = "codex-\(reference).json"
+        try handleHook(input, hookName: "SessionStart", deps: makeDeps(pid: 4242, startTime: 1_000))
+        let first = try loadSession(fileName)
+        try handleHook(input, hookName: "SessionStart", deps: makeDeps(pid: 5002, startTime: 2_000))
+        let resumed = try loadSession(fileName)
+
+        XCTAssertEqual(resumed.cctopSessionId, first.cctopSessionId)
+        XCTAssertEqual(resumed.startedAt, first.startedAt)
+        XCTAssertEqual(resumed.pid, 5002)
+        XCTAssertEqual(resumed.pidStartTime, 2_000)
+    }
+
+    func testOpenCodeProcessObservationsRemainSeparateCctopSessions() throws {
+        let input = """
+        {"session_id": "ses_same", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart", "harness_name": "opencode"}
+        """
+        try handleHook(input, hookName: "SessionStart", deps: makeDeps(pid: 4242, startTime: 1_000))
+        let firstCctopSessionID = try loadSession("4242.json").cctopSessionId
+        try handleHook(input, hookName: "SessionStart", deps: makeDeps(pid: 5002, startTime: 2_000))
+
+        XCTAssertNotEqual(
+            firstCctopSessionID,
+            try loadSession("5002.json").cctopSessionId
+        )
+    }
+
+    func testCodexSanitizedCollisionStillFailsClosed() throws {
+        try handleHook("""
+        {"session_id": "conv|A", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart", "harness_name": "codex"}
+        """, hookName: "SessionStart")
+
+        try handleHook("""
+        {"session_id": "convA", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart", "harness_name": "codex"}
+        """, hookName: "SessionStart")
+        XCTAssertEqual(try loadSession("codex-convA.json").harnessSessionId, "conv|A")
+    }
+
     // Two conversations whose raw references sanitize to the same session_id must not
     // share a record: the second SessionStart replaces the file as a new conversation.
     func testHookRotatesRecordWhenRawReferencesCollideAfterSanitization() throws {
         try handleHook("""
         {"session_id": "conv|A", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart"}
         """, hookName: "SessionStart")
+        let originalCctopSessionID = try loadSession().cctopSessionId
         try handleHook("""
         {"session_id": "conv|A", "cwd": "/tmp/test-project", "hook_event_name": "UserPromptSubmit", "prompt": "hi"}
         """, hookName: "UserPromptSubmit")
         XCTAssertEqual(try loadSession().lastPrompt, "hi")
+        XCTAssertEqual(try loadSession().cctopSessionId, originalCctopSessionID)
 
         try handleHook("""
         {"session_id": "convA", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart"}
@@ -180,6 +240,7 @@ final class HookHandlerTests: XCTestCase {
         let rotated = try loadSession()
         XCTAssertEqual(rotated.sessionId, "convA")
         XCTAssertEqual(rotated.harnessSessionId, "convA")
+        XCTAssertNotEqual(rotated.cctopSessionId, originalCctopSessionID)
         XCTAssertNil(rotated.lastPrompt)
     }
 

--- a/menubar/CctopMenubarTests/PanelToggleTests.swift
+++ b/menubar/CctopMenubarTests/PanelToggleTests.swift
@@ -33,11 +33,11 @@ final class PanelToggleTests: XCTestCase {
         )
     }
 
-    func testFocusTargetDecodesStableDisplayIdentity() throws {
+    func testFocusTargetDecodesCctopSessionIdentity() throws {
         let url = try XCTUnwrap(URL(string: "cctop://focus?sid=codex%3Aabc%2Fdef%3Fghi"))
         XCTAssertEqual(AppDelegate.urlCommand(from: url), "focus")
-        XCTAssertEqual(AppDelegate.focusTargetID(from: url), "codex:abc/def?ghi")
-        XCTAssertNil(AppDelegate.focusTargetID(from: try XCTUnwrap(URL(string: "cctop://focus"))))
-        XCTAssertNil(AppDelegate.focusTargetID(from: try XCTUnwrap(URL(string: "cctop://focus?sid="))))
+        XCTAssertEqual(AppDelegate.focusSessionID(from: url), "codex:abc/def?ghi")
+        XCTAssertNil(AppDelegate.focusSessionID(from: try XCTUnwrap(URL(string: "cctop://focus"))))
+        XCTAssertNil(AppDelegate.focusSessionID(from: try XCTUnwrap(URL(string: "cctop://focus?sid="))))
     }
 }

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -877,7 +877,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
             appIdentity: DisplayState.ProcessIdentity(pid: 999, startTime: 1_234),
             now: now
         )
-        XCTAssertEqual(snapshot.sessions.map(\.id), activeAfterUpdates.map(\.id))
+        XCTAssertEqual(
+            snapshot.sessions.map(\.id),
+            activeAfterUpdates.map { SessionIdentityPolicy.actionID(for: $0) }
+        )
 
         alpha.hidden = true
         try alpha.writeToFile(path: alphaPath)

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -878,9 +878,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
             now: now
         )
         XCTAssertEqual(
-            snapshot.sessions.map(\.id),
-            activeAfterUpdates.map { SessionIdentityPolicy.actionID(for: $0) }
+            snapshot.sessions.map(\.cctopSessionId),
+            activeAfterUpdates.map { $0.cctopSessionId ?? "" }
         )
+        XCTAssertEqual(snapshot.sessions.count, activeAfterUpdates.count)
+        XCTAssertTrue(activeAfterUpdates.allSatisfy { Session.isValidCctopSessionId($0.cctopSessionId) })
 
         alpha.hidden = true
         try alpha.writeToFile(path: alphaPath)
@@ -891,6 +893,125 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try beta.writeToFile(path: betaPath)
         manager.loadSessions()
         XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["303", "404"])
+    }
+
+    @MainActor
+    func testLegacyIdentityMigrationRetriesAfterBusySessionLock() throws {
+        let root = NSTemporaryDirectory() + "cctop-identity-retry-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("4242.json")
+        var legacy = Session.mock(id: "legacy", pid: 4242, source: Session.opencodeSource)
+        legacy.cctopSessionId = nil
+        try legacy.writeToFile(path: sessionPath)
+
+        let readyPath = (root as NSString).appendingPathComponent("identity-lock-ready")
+        let lockHolder = try startSessionLockHolder(
+            lockPath: sessionPath + ".lock",
+            readyPath: readyPath,
+            holdSeconds: 10
+        )
+        defer { terminateProcess(lockHolder) }
+
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            processAlive: { _ in true }
+        )
+        XCTAssertNil(manager.sessions.first?.cctopSessionId)
+        waitForIdentityMigrationQueue(manager)
+        XCTAssertNil(try Session.fromFile(path: sessionPath).cctopSessionId)
+
+        terminateProcess(lockHolder)
+        let hookInput = try JSONDecoder().decode(HookInput.self, from: Data("""
+        {"session_id":"legacy","cwd":"/tmp/project","hook_event_name":"PreToolUse","harness_name":"opencode"}
+        """.utf8))
+        let hookDeps = HookDependencies(
+            sessionsDir: { sessionsDir },
+            environment: { [:] },
+            currentBranch: { _ in "main" },
+            process: VisibilityHookProcessProber(),
+            names: VisibilityHookNameResolver(),
+            logger: HookLogger(logsDir: (root as NSString).appendingPathComponent("logs"))
+        )
+        try HookHandler.handleHook(hookName: "PreToolUse", input: hookInput, deps: hookDeps)
+        let hookAssignedID = try XCTUnwrap(Session.fromFile(path: sessionPath).cctopSessionId)
+        manager.loadSessions()
+        waitForIdentityMigrationQueue(manager)
+
+        XCTAssertEqual(try Session.fromFile(path: sessionPath).cctopSessionId, hookAssignedID)
+        XCTAssertEqual(manager.sessions.first?.cctopSessionId, hookAssignedID)
+    }
+
+    @MainActor
+    func testLegacyDurableDuplicatesMigrateToOneCctopSessionID() throws {
+        let root = NSTemporaryDirectory() + "cctop-identity-duplicates-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let reference = "11111111-2222-4333-8444-555555555555"
+        for pid: UInt32 in [4242, 5002] {
+            var session = Session.mock(id: reference, pid: pid, source: Session.ccSource)
+            session.cctopSessionId = nil
+            session.harnessSessionId = reference
+            try session.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("\(pid).json"))
+        }
+
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            processAlive: { _ in true }
+        )
+        let publishedIDs = Set(manager.sessions.compactMap(\.cctopSessionId))
+        XCTAssertEqual(manager.sessions.count, 2)
+        XCTAssertEqual(publishedIDs.count, 1)
+        XCTAssertTrue(publishedIDs.allSatisfy(Session.isValidCctopSessionId))
+
+        waitForIdentityMigrationQueue(manager)
+        let persistedIDs = try Set([4242, 5002].map { pid in
+            try XCTUnwrap(Session.fromFile(path: (sessionsDir as NSString).appendingPathComponent("\(pid).json")).cctopSessionId)
+        })
+        XCTAssertEqual(persistedIDs, publishedIDs)
+    }
+
+    @MainActor
+    func testConflictingDurableLegacyIdentitiesFailClosed() throws {
+        let root = NSTemporaryDirectory() + "cctop-identity-conflict-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let reference = "11111111-2222-4333-8444-555555555555"
+        let existingIDs = [
+            "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        ]
+        for (index, pid) in [4242, 5002, 6003].enumerated() {
+            var session = Session.mock(id: reference, pid: UInt32(pid), source: Session.ccSource)
+            session.cctopSessionId = index < existingIDs.count ? existingIDs[index] : nil
+            session.harnessSessionId = reference
+            try session.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("\(pid).json"))
+        }
+
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            processAlive: { _ in true }
+        )
+
+        XCTAssertNil(manager.sessions.first(where: { $0.pid == 6003 })?.cctopSessionId)
+        XCTAssertNil(try Session.fromFile(
+            path: (sessionsDir as NSString).appendingPathComponent("6003.json")
+        ).cctopSessionId)
     }
 
     @MainActor
@@ -1607,6 +1728,29 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.garbageCollectFinished()
         XCTAssertFalse(FileManager.default.fileExists(atPath: sessionPath))
     }
+}
+
+@MainActor
+private func waitForIdentityMigrationQueue(_ manager: SessionManager, timeout: TimeInterval = 3) {
+    let deadline = Date().addingTimeInterval(timeout)
+    while !manager.pendingIdentityMigrationPaths.isEmpty, Date() < deadline {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+    }
+    XCTAssertTrue(manager.pendingIdentityMigrationPaths.isEmpty)
+}
+
+private struct VisibilityHookProcessProber: ProcessProbing {
+    func parentPID() -> UInt32 { 4242 }
+    func startTime(pid: UInt32) -> TimeInterval? { 1_000 }
+    func isAlive(pid: UInt32) -> Bool { true }
+    func commandName(pid: UInt32) -> String? { nil }
+    func controllingTTY() -> String? { nil }
+}
+
+private struct VisibilityHookNameResolver: SessionNameResolving {
+    func codexThreadName(sessionId: String) -> String? { nil }
+    func claudeDesktopTitle(cliSessionId: String) -> String? { nil }
+    func transcriptSessionName(transcriptPath: String?, sessionId: String) -> String? { nil }
 }
 
 private func startSessionLockHolder(lockPath: String, readyPath: String, holdSeconds: TimeInterval) throws -> Process {

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -29,6 +29,7 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.lastTool, "Bash")
         XCTAssertEqual(session.pid, 12345)
         XCTAssertFalse(session.hidden)
+        XCTAssertNil(session.cctopSessionId)
     }
 
     func testDecodesHiddenSessionJSON() throws {
@@ -1101,6 +1102,7 @@ final class SessionTests: XCTestCase {
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
         XCTAssertEqual(object["created_by_hook_version"] as? String, "0.16.0")
         XCTAssertEqual(object["last_written_by_hook_version"] as? String, "0.16.1")
+        XCTAssertEqual(object["cctop_session_id"] as? String, session.cctopSessionId)
     }
 
     func testMarkWrittenByHookDoesNotBackfillLegacyCreator() {
@@ -1635,11 +1637,11 @@ final class SessionTests: XCTestCase {
         return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 
-    // 26 persisted fields + the transient `lifecycle`. If this fails, a stored property was
+    // 27 persisted fields + the transient `lifecycle`. If this fails, a stored property was
     // added or removed: wire it through CodingKeys, init(from:), the memberwise init, and
     // makeFullyPopulatedSession() above, then update this count.
     func testStoredPropertyCountTripwire() {
-        XCTAssertEqual(Mirror(reflecting: makeFullyPopulatedSession()).children.count, 27)
+        XCTAssertEqual(Mirror(reflecting: makeFullyPopulatedSession()).children.count, 28)
     }
 
     // Catches asymmetry between CodingKeys, init(from:), and the synthesized encode: a field
@@ -1678,32 +1680,32 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(rotated.terminal, newTerminal)
     }
 
-    func testExternalDisplayIdentityMatchesOnlyPublishedActionID() {
-        let target = Session.mock(id: "abc", harnessSessionId: "abc", pid: 111)
+    func testExternalDisplayIdentityMatchesOnlyPublishedCctopSessionID() {
+        let targetID = "11111111-2222-4333-8444-555555555555"
+        let target = Session.mock(id: "abc", cctopSessionId: targetID, harnessSessionId: "abc", pid: 111)
         let other = Session.mock(id: "def", harnessSessionId: "def", pid: 222)
 
         XCTAssertEqual(
             SessionIdentityPolicy.session(
-                matchingDisplayID: SessionIdentityPolicy.actionID(for: target),
+                matchingCctopSessionID: targetID,
                 in: [other, target]
             )?.sessionId,
             "abc"
         )
-        // Pre-action-id published values (pid strings, session ids) must not match:
-        // a recycled PID could focus an unrelated session.
-        XCTAssertNil(SessionIdentityPolicy.session(matchingDisplayID: "111", in: [other, target]))
-        XCTAssertNil(SessionIdentityPolicy.session(matchingDisplayID: "abc", in: [other, target]))
+        XCTAssertNil(SessionIdentityPolicy.session(matchingCctopSessionID: "111", in: [other, target]))
+        XCTAssertNil(SessionIdentityPolicy.session(matchingCctopSessionID: "abc", in: [other, target]))
     }
 
-    func testEachVisibleProcessGenerationResolvesByItsPublishedActionID() throws {
+    func testRepeatedCctopSessionIDKeepsRowsAndResolvesFirstCanonicalTarget() throws {
         let now = Date()
+        let cctopSessionID = "11111111-2222-4333-8444-555555555555"
         var working = Session.mock(
-            id: "conv-1", harnessSessionId: "conv-1", status: .working,
+            id: "conv-1", cctopSessionId: cctopSessionID, harnessSessionId: "conv-1", status: .working,
             pid: 111, pidStartTime: 1_000
         )
         working.lastActivity = now.addingTimeInterval(-10)
         var idle = Session.mock(
-            id: "conv-1", harnessSessionId: "conv-1", status: .idle,
+            id: "conv-1", cctopSessionId: cctopSessionID, harnessSessionId: "conv-1", status: .idle,
             pid: 999, pidStartTime: 2_000
         )
         idle.lastActivity = now.addingTimeInterval(-5)
@@ -1718,92 +1720,185 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(snapshot.sessions.count, 2)
 
         let ordered = SessionDisplayPolicy.activeSessions(from: [idle, working], now: now)
-        XCTAssertEqual(snapshot.sessions.map(\.id), ordered.map { SessionIdentityPolicy.actionID(for: $0) })
-        for (published, expected) in zip(snapshot.sessions, ordered) {
-            let resolved = try XCTUnwrap(
-                SessionIdentityPolicy.session(matchingDisplayID: published.id, in: ordered)
-            )
-            XCTAssertEqual(resolved.pid, expected.pid)
+        XCTAssertEqual(snapshot.sessions.map(\.cctopSessionId), [cctopSessionID, cctopSessionID])
+        let resolved = try XCTUnwrap(
+            SessionIdentityPolicy.session(matchingCctopSessionID: cctopSessionID, in: ordered)
+        )
+        XCTAssertEqual(resolved.pid, ordered.first?.pid)
+    }
+
+    // MARK: - Cctop session identity
+
+    func testNewSessionsReceiveIndependentLowercaseUUIDs() throws {
+        let terminal = TerminalInfo(program: "Terminal")
+        let first = Session(sessionId: "same", projectPath: "/tmp/project", branch: "main", terminal: terminal)
+        let second = Session(sessionId: "same", projectPath: "/tmp/project", branch: "main", terminal: terminal)
+        let firstID = try XCTUnwrap(first.cctopSessionId)
+        let secondID = try XCTUnwrap(second.cctopSessionId)
+
+        XCTAssertTrue(Session.isValidCctopSessionId(firstID))
+        XCTAssertTrue(Session.isValidCctopSessionId(secondID))
+        XCTAssertNotEqual(firstID, secondID)
+        XCTAssertEqual(firstID, firstID.lowercased())
+        XCTAssertEqual(secondID, secondID.lowercased())
+    }
+
+    func testCctopSessionIDDoesNotChangeWithFocusTargetMetadata() {
+        let cctopSessionID = "11111111-2222-4333-8444-555555555555"
+        let original = Session.mock(cctopSessionId: cctopSessionID, pid: 111, pidStartTime: 1_000)
+        let resumed = Session.mock(cctopSessionId: cctopSessionID, pid: 999, pidStartTime: 2_000)
+
+        XCTAssertEqual(original.cctopSessionId, resumed.cctopSessionId)
+    }
+}
+
+final class CctopSessionIdentityStoreTests: XCTestCase {
+    private var rootURL: URL!
+    private var sessionsURL: URL!
+
+    override func setUpWithError() throws {
+        rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-identity-store-\(UUID().uuidString)", isDirectory: true)
+        sessionsURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsURL, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: rootURL)
+    }
+
+    func testDurableSourcesReuseOpaqueIdentityWithoutCrossSourceInference() throws {
+        let reference = "11111111-2222-4333-8444-555555555555"
+        let store = CctopSessionIdentityStore(sessionsDir: sessionsURL)
+
+        let codexFirst = try store.resolve(
+            source: Session.codexSource, harnessSessionId: reference, legacySessionId: reference
+        )
+        let codexAgain = try store.resolve(
+            source: Session.codexSource, harnessSessionId: reference, legacySessionId: reference
+        )
+        let claude = try store.resolve(
+            source: Session.ccSource, harnessSessionId: reference, legacySessionId: reference
+        )
+
+        XCTAssertEqual(codexFirst, codexAgain)
+        XCTAssertNotEqual(codexFirst, claude)
+        XCTAssertNotEqual(codexFirst, reference)
+        XCTAssertTrue(Session.isValidCctopSessionId(codexFirst))
+        XCTAssertTrue(Session.isValidCctopSessionId(claude))
+    }
+
+    func testUnsupportedAndSyntheticReferencesRemainRecordLocal() throws {
+        let store = CctopSessionIdentityStore(sessionsDir: sessionsURL)
+        let opencodeFirst = try store.resolve(
+            source: Session.opencodeSource, harnessSessionId: "ses_abc", legacySessionId: "ses_abc"
+        )
+        let opencodeSecond = try store.resolve(
+            source: Session.opencodeSource, harnessSessionId: "ses_abc", legacySessionId: "ses_abc"
+        )
+        let piFirst = try store.resolve(
+            source: Session.piSource, harnessSessionId: "pi-123", legacySessionId: "pi-123"
+        )
+        let piSecond = try store.resolve(
+            source: Session.piSource, harnessSessionId: "pi-123", legacySessionId: "pi-123"
+        )
+
+        XCTAssertNotEqual(opencodeFirst, opencodeSecond)
+        XCTAssertNotEqual(piFirst, piSecond)
+    }
+
+    func testPiRealUUIDReusesCctopSessionID() throws {
+        let reference = "11111111-2222-4333-8444-555555555555"
+        let store = CctopSessionIdentityStore(sessionsDir: sessionsURL)
+
+        let first = try store.resolve(
+            source: Session.piSource, harnessSessionId: reference, legacySessionId: reference
+        )
+        let resumed = try store.resolve(
+            source: Session.piSource, harnessSessionId: reference, legacySessionId: reference
+        )
+
+        XCTAssertEqual(first, resumed)
+    }
+
+    func testLegacyMissingSourceUsesClaudeResumeEvidence() throws {
+        let reference = "11111111-2222-4333-8444-555555555555"
+        let store = CctopSessionIdentityStore(sessionsDir: sessionsURL)
+
+        let legacy = try store.resolve(
+            source: nil, harnessSessionId: nil, legacySessionId: reference
+        )
+        let stamped = try store.resolve(
+            source: Session.ccSource, harnessSessionId: reference, legacySessionId: reference
+        )
+
+        XCTAssertEqual(legacy, stamped)
+    }
+
+    func testConcurrentResolutionCreatesOnePrivateMapping() throws {
+        let reference = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+        let queue = DispatchQueue(label: "cctop.identity-store.tests", attributes: .concurrent)
+        let group = DispatchGroup()
+        let lock = NSLock()
+        var ids: [String] = []
+        var errors: [Error] = []
+
+        for _ in 0..<12 {
+            group.enter()
+            queue.async {
+                defer { group.leave() }
+                do {
+                    let id = try CctopSessionIdentityStore(sessionsDir: self.sessionsURL).resolve(
+                        source: Session.codexSource,
+                        harnessSessionId: reference,
+                        legacySessionId: reference
+                    )
+                    lock.lock()
+                    ids.append(id)
+                    lock.unlock()
+                } catch {
+                    lock.lock()
+                    errors.append(error)
+                    lock.unlock()
+                }
+            }
         }
-    }
+        XCTAssertEqual(group.wait(timeout: .now() + 5), .success)
+        XCTAssertTrue(errors.isEmpty)
+        XCTAssertEqual(Set(ids).count, 1)
 
-    // MARK: - Action identity derivation
-
-    func testActionIDIsDeterministicForTheSameLiveTarget() {
-        let session = Session.mock(
-            harnessSessionId: "raw|ref", pid: 999, pidStartTime: 1_000, source: "cc"
+        let identityDirectory = rootURL.appendingPathComponent("session-identities", isDirectory: true)
+        let mapping = try XCTUnwrap(
+            FileManager.default.contentsOfDirectory(at: identityDirectory, includingPropertiesForKeys: nil)
+                .first { $0.pathExtension == "json" }
         )
-
-        XCTAssertEqual(SessionIdentityPolicy.actionID(for: session), SessionIdentityPolicy.actionID(for: session))
-    }
-
-    func testActionIDDistinguishesProcessGenerationsForTheSameConversation() {
-        let original = Session.mock(harnessSessionId: "conv-1", pid: 111, pidStartTime: 1000)
-        let reusedPID = Session.mock(harnessSessionId: "conv-1", pid: 111, pidStartTime: 2000)
-
-        XCTAssertNotEqual(
-            SessionIdentityPolicy.actionID(for: original),
-            SessionIdentityPolicy.actionID(for: reusedPID)
+        let directoryMode = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: identityDirectory.path)[.posixPermissions] as? NSNumber
         )
-    }
-
-    func testActionIDRotatesWhenConversationChangesInSameProcess() {
-        let before = Session.mock(harnessSessionId: "conv-1", pid: 111, pidStartTime: 1000)
-        let after = Session.mock(harnessSessionId: "conv-2", pid: 111, pidStartTime: 1000)
-
-        XCTAssertNotEqual(
-            SessionIdentityPolicy.actionID(for: before),
-            SessionIdentityPolicy.actionID(for: after)
+        let mappingMode = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: mapping.path)[.posixPermissions] as? NSNumber
         )
+        XCTAssertEqual(directoryMode.intValue & 0o777, 0o700)
+        XCTAssertEqual(mappingMode.intValue & 0o777, 0o600)
     }
 
-    func testActionIDUsesExactReferenceNotSanitizedProjection() {
-        // Distinct raw references whose sanitized forms collide must not share an id.
-        let first = Session.mock(id: "same-sanitized", harnessSessionId: "same|sanitized", pid: 111)
-        let second = Session.mock(id: "same-sanitized", harnessSessionId: "same_sanitized", pid: 111)
-
-        XCTAssertNotEqual(
-            SessionIdentityPolicy.actionID(for: first),
-            SessionIdentityPolicy.actionID(for: second)
+    func testCorruptMappingFailsClosedWithoutReminting() throws {
+        let reference = "11111111-2222-4333-8444-555555555555"
+        let store = CctopSessionIdentityStore(sessionsDir: sessionsURL)
+        _ = try store.resolve(
+            source: Session.codexSource, harnessSessionId: reference, legacySessionId: reference
         )
-    }
-
-    func testActionIDLegacyCodexFallbackMatchesStampedRecord() {
-        // A codex record written before harness_session_id existed must keep its id
-        // once a field-aware hook stamps the (identical) raw reference on the file.
-        let uuid = "11111111-2222-3333-4444-555555555555"
-        let legacy = Session.mock(id: uuid, pid: 4242, source: "codex")
-        let stamped = Session.mock(id: uuid, harnessSessionId: uuid, pid: 4242, source: "codex")
-
-        XCTAssertEqual(
-            SessionIdentityPolicy.actionID(for: legacy),
-            SessionIdentityPolicy.actionID(for: stamped)
+        let identityDirectory = rootURL.appendingPathComponent("session-identities", isDirectory: true)
+        let mapping = try XCTUnwrap(
+            FileManager.default.contentsOfDirectory(at: identityDirectory, includingPropertiesForKeys: nil)
+                .first { $0.pathExtension == "json" }
         )
-    }
+        try Data("{}".utf8).write(to: mapping)
 
-    func testActionIDLegacyProcessFallbackDistinguishesPIDReuse() {
-        let original = Session.mock(id: "conv-1", pid: 111, pidStartTime: 1000)
-        let pidReuser = Session.mock(id: "conv-1", pid: 111, pidStartTime: 2000)
-
-        XCTAssertNotEqual(
-            SessionIdentityPolicy.actionID(for: original),
-            SessionIdentityPolicy.actionID(for: pidReuser)
-        )
-    }
-
-    func testActionIDHasUniformOpaqueFormatAcrossSources() {
-        let sessions = [
-            Session.mock(harnessSessionId: "conv-1", pid: 111, source: "cc"),
-            Session.mock(harnessSessionId: "ses_abc", pid: 222, source: "opencode"),
-            Session.mock(id: "legacy-no-raw", pid: 333, pidStartTime: 1000),
-            Session.mock(id: "no-pid-no-raw", pid: nil),
-        ]
-        for session in sessions {
-            let actionID = SessionIdentityPolicy.actionID(for: session)
-            XCTAssertNotNil(
-                actionID.range(of: "^s-[0-9a-f]{32}$", options: .regularExpression),
-                "unexpected action id shape: \(actionID)"
+        XCTAssertThrowsError(
+            try store.resolve(
+                source: Session.codexSource, harnessSessionId: reference, legacySessionId: reference
             )
-        }
+        )
     }
 }

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -1586,6 +1586,7 @@ final class SessionTests: XCTestCase {
     private func makeFullyPopulatedSession() -> Session {
         Session(
             sessionId: "full-fixture-1",
+            harnessSessionId: "full-fixture-1|raw",
             projectPath: "/Users/test/projects/full-fixture",
             projectName: "full-fixture",
             branch: "feature/full-coverage",
@@ -1634,11 +1635,11 @@ final class SessionTests: XCTestCase {
         return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 
-    // 25 persisted fields + the transient `lifecycle`. If this fails, a stored property was
+    // 26 persisted fields + the transient `lifecycle`. If this fails, a stored property was
     // added or removed: wire it through CodingKeys, init(from:), the memberwise init, and
     // makeFullyPopulatedSession() above, then update this count.
     func testStoredPropertyCountTripwire() {
-        XCTAssertEqual(Mirror(reflecting: makeFullyPopulatedSession()).children.count, 26)
+        XCTAssertEqual(Mirror(reflecting: makeFullyPopulatedSession()).children.count, 27)
     }
 
     // Catches asymmetry between CodingKeys, init(from:), and the synthesized encode: a field
@@ -1677,22 +1678,132 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(rotated.terminal, newTerminal)
     }
 
-    func testExternalDisplayIdentityMatchesOnlyPublishedID() {
-        let target = Session.mock(id: "conversation-target", pid: 111)
-        let decoy = Session.mock(id: "111", pid: 222)
+    func testExternalDisplayIdentityMatchesOnlyPublishedActionID() {
+        let target = Session.mock(id: "abc", harnessSessionId: "abc", pid: 111)
+        let other = Session.mock(id: "def", harnessSessionId: "def", pid: 222)
 
         XCTAssertEqual(
             SessionIdentityPolicy.session(
-                matchingDisplayID: "111",
-                in: [decoy, target]
-            )?.id,
-            target.id
+                matchingDisplayID: SessionIdentityPolicy.actionID(for: target),
+                in: [other, target]
+            )?.sessionId,
+            "abc"
         )
-        XCTAssertNil(
-            SessionIdentityPolicy.session(
-                matchingDisplayID: "conversation-target",
-                in: [decoy, target]
+        // Pre-action-id published values (pid strings, session ids) must not match:
+        // a recycled PID could focus an unrelated session.
+        XCTAssertNil(SessionIdentityPolicy.session(matchingDisplayID: "111", in: [other, target]))
+        XCTAssertNil(SessionIdentityPolicy.session(matchingDisplayID: "abc", in: [other, target]))
+    }
+
+    func testEachVisibleProcessGenerationResolvesByItsPublishedActionID() throws {
+        let now = Date()
+        var working = Session.mock(
+            id: "conv-1", harnessSessionId: "conv-1", status: .working,
+            pid: 111, pidStartTime: 1_000
+        )
+        working.lastActivity = now.addingTimeInterval(-10)
+        var idle = Session.mock(
+            id: "conv-1", harnessSessionId: "conv-1", status: .idle,
+            pid: 999, pidStartTime: 2_000
+        )
+        idle.lastActivity = now.addingTimeInterval(-5)
+
+        let snapshot = DisplayStateWriter.snapshot(
+            sessions: [idle, working],
+            theme: .claude,
+            appRunning: true,
+            appIdentity: nil,
+            now: now
+        )
+        XCTAssertEqual(snapshot.sessions.count, 2)
+
+        let ordered = SessionDisplayPolicy.activeSessions(from: [idle, working], now: now)
+        XCTAssertEqual(snapshot.sessions.map(\.id), ordered.map { SessionIdentityPolicy.actionID(for: $0) })
+        for (published, expected) in zip(snapshot.sessions, ordered) {
+            let resolved = try XCTUnwrap(
+                SessionIdentityPolicy.session(matchingDisplayID: published.id, in: ordered)
             )
+            XCTAssertEqual(resolved.pid, expected.pid)
+        }
+    }
+
+    // MARK: - Action identity derivation
+
+    func testActionIDIsDeterministicForTheSameLiveTarget() {
+        let session = Session.mock(
+            harnessSessionId: "raw|ref", pid: 999, pidStartTime: 1_000, source: "cc"
         )
+
+        XCTAssertEqual(SessionIdentityPolicy.actionID(for: session), SessionIdentityPolicy.actionID(for: session))
+    }
+
+    func testActionIDDistinguishesProcessGenerationsForTheSameConversation() {
+        let original = Session.mock(harnessSessionId: "conv-1", pid: 111, pidStartTime: 1000)
+        let reusedPID = Session.mock(harnessSessionId: "conv-1", pid: 111, pidStartTime: 2000)
+
+        XCTAssertNotEqual(
+            SessionIdentityPolicy.actionID(for: original),
+            SessionIdentityPolicy.actionID(for: reusedPID)
+        )
+    }
+
+    func testActionIDRotatesWhenConversationChangesInSameProcess() {
+        let before = Session.mock(harnessSessionId: "conv-1", pid: 111, pidStartTime: 1000)
+        let after = Session.mock(harnessSessionId: "conv-2", pid: 111, pidStartTime: 1000)
+
+        XCTAssertNotEqual(
+            SessionIdentityPolicy.actionID(for: before),
+            SessionIdentityPolicy.actionID(for: after)
+        )
+    }
+
+    func testActionIDUsesExactReferenceNotSanitizedProjection() {
+        // Distinct raw references whose sanitized forms collide must not share an id.
+        let first = Session.mock(id: "same-sanitized", harnessSessionId: "same|sanitized", pid: 111)
+        let second = Session.mock(id: "same-sanitized", harnessSessionId: "same_sanitized", pid: 111)
+
+        XCTAssertNotEqual(
+            SessionIdentityPolicy.actionID(for: first),
+            SessionIdentityPolicy.actionID(for: second)
+        )
+    }
+
+    func testActionIDLegacyCodexFallbackMatchesStampedRecord() {
+        // A codex record written before harness_session_id existed must keep its id
+        // once a field-aware hook stamps the (identical) raw reference on the file.
+        let uuid = "11111111-2222-3333-4444-555555555555"
+        let legacy = Session.mock(id: uuid, pid: 4242, source: "codex")
+        let stamped = Session.mock(id: uuid, harnessSessionId: uuid, pid: 4242, source: "codex")
+
+        XCTAssertEqual(
+            SessionIdentityPolicy.actionID(for: legacy),
+            SessionIdentityPolicy.actionID(for: stamped)
+        )
+    }
+
+    func testActionIDLegacyProcessFallbackDistinguishesPIDReuse() {
+        let original = Session.mock(id: "conv-1", pid: 111, pidStartTime: 1000)
+        let pidReuser = Session.mock(id: "conv-1", pid: 111, pidStartTime: 2000)
+
+        XCTAssertNotEqual(
+            SessionIdentityPolicy.actionID(for: original),
+            SessionIdentityPolicy.actionID(for: pidReuser)
+        )
+    }
+
+    func testActionIDHasUniformOpaqueFormatAcrossSources() {
+        let sessions = [
+            Session.mock(harnessSessionId: "conv-1", pid: 111, source: "cc"),
+            Session.mock(harnessSessionId: "ses_abc", pid: 222, source: "opencode"),
+            Session.mock(id: "legacy-no-raw", pid: 333, pidStartTime: 1000),
+            Session.mock(id: "no-pid-no-raw", pid: nil),
+        ]
+        for session in sessions {
+            let actionID = SessionIdentityPolicy.actionID(for: session)
+            XCTAssertNotNil(
+                actionID.range(of: "^s-[0-9a-f]{32}$", options: .regularExpression),
+                "unexpected action id shape: \(actionID)"
+            )
+        }
     }
 }

--- a/plugins/opencode/plugin.js
+++ b/plugins/opencode/plugin.js
@@ -80,6 +80,9 @@ export const cctop = async ({ directory }) => {
   const hookBin = findHookBinary();
   if (!hookBin) return {};
 
+  // Keep one process-scoped identity until every callback can route its own opencode
+  // session payload safely. Adopting only session.created/updated would let child and
+  // background events mutate whichever conversation happened to be current in memory.
   const sessionId = `opencode-${process.pid}`;
   let sessionName = null;
 

--- a/plugins/opencode/test/plugin.test.mjs
+++ b/plugins/opencode/test/plugin.test.mjs
@@ -134,7 +134,9 @@ test("maps opencode session events to cctop lifecycle hooks", async () => {
     await plugin.hooks.event({
       event: { type: "session.updated", properties: { info: { title: "opencode session" } } },
     });
-    await plugin.hooks.event({ event: { type: "session.created" } });
+    await plugin.hooks.event({
+      event: { type: "session.created", properties: { info: { id: "ses_top" } } },
+    });
     await plugin.hooks.event({ event: { type: "session.idle" } });
     await plugin.hooks.event({ event: { type: "session.compacted" } });
     await plugin.hooks.event({ event: { type: "session.status", properties: { status: { type: "retry" } } } });
@@ -150,8 +152,41 @@ test("maps opencode session events to cctop lifecycle hooks", async () => {
       ["SessionStart", "SessionStart", "Stop", "PostCompact", "SessionError", "SessionError"],
     );
     assert.equal(calls[1].payload.session_name, "opencode session");
+    assert.equal(calls[1].payload.session_id, `opencode-${process.pid}`);
     assert.equal(calls[4].payload.error, "Retry");
     assert.equal(calls[5].payload.error, "boom");
+  } finally {
+    plugin.restore();
+  }
+});
+
+test("keeps process identity when session events carry conversation ids", async () => {
+  const plugin = await loadPlugin();
+
+  try {
+    await plugin.hooks.event({
+      event: { type: "session.created", properties: { info: { id: "ses_top", title: "top work" } } },
+    });
+    await plugin.hooks.event({
+      event: { type: "session.created", properties: { info: { id: "ses_child", parentID: "ses_top" } } },
+    });
+    await plugin.hooks.event({
+      event: { type: "session.updated", properties: { info: { id: "ses_child", parentID: "ses_top", title: "child" } } },
+    });
+    await plugin.hooks["tool.execute.after"]();
+    await plugin.hooks.event({
+      event: { type: "session.updated", properties: { info: { id: "ses_resumed", title: "older work" } } },
+    });
+    await plugin.hooks["tool.execute.after"]();
+
+    const calls = plugin.readCalls();
+    assert.deepEqual(
+      eventNames(calls),
+      ["SessionStart", "SessionStart", "SessionStart", "PostToolUse", "PostToolUse"],
+    );
+    for (const call of calls) {
+      assert.equal(call.payload.session_id, `opencode-${process.pid}`);
+    }
   } finally {
     plugin.restore();
   }

--- a/plugins/pi/cctop.ts
+++ b/plugins/pi/cctop.ts
@@ -76,10 +76,26 @@ export default function cctop(pi: any) {
   const hookBin = findHookBinary();
   if (!hookBin) return;
 
-  const sessionId = `pi-${process.pid}`;
+  // The synthetic id is only a fallback for pi builds whose extension context does
+  // not expose the session manager. The real session id preserves pi's exact
+  // conversation reference and rotates when the user switches sessions inside
+  // one pi process.
+  let sessionId = `pi-${process.pid}`;
   let sessionName: string | null = null;
   let cwd: string = process.cwd();
   let interactive: boolean | null = null; // null = not yet determined
+
+  function adoptSessionId(ctx: any) {
+    // Each session boundary starts from the process fallback. A missing or failing
+    // lookup must never leak the previous conversation's real id into the new one.
+    sessionId = `pi-${process.pid}`;
+    try {
+      const id = ctx?.sessionManager?.getSessionId?.();
+      if (id) sessionId = id;
+    } catch {
+      // Keep the fresh process fallback
+    }
+  }
 
   function basePayload() {
     return {
@@ -107,6 +123,7 @@ export default function cctop(pi: any) {
     if (!interactive) return;
 
     cwd = ctx?.cwd || process.cwd();
+    adoptSessionId(ctx);
     tryGetSessionName();
     callHook(hookBin, "SessionStart", basePayload());
   });
@@ -171,9 +188,10 @@ export default function cctop(pi: any) {
     callHook(hookBin, "PostCompact", basePayload());
   });
 
-  // Session switch — update name
-  pi.on("session_switch", async () => {
+  // Session switch — adopt the new session's identity and name
+  pi.on("session_switch", async (_event: any, ctx: any) => {
     if (!interactive) return;
+    adoptSessionId(ctx);
     tryGetSessionName();
     callHook(hookBin, "SessionStart", basePayload());
   });

--- a/plugins/pi/test/cctop.test.mjs
+++ b/plugins/pi/test/cctop.test.mjs
@@ -106,6 +106,54 @@ test("registers handlers and emits SessionStart for interactive sessions", async
   }
 });
 
+test("adopts the real pi session id and rotates it on session switch", async () => {
+  const extension = loadExtension();
+
+  try {
+    const ctxFor = (id) => ({
+      hasUI: true,
+      cwd: "/tmp/test-project",
+      sessionManager: { getSessionId: () => id },
+    });
+
+    await extension.emit("session_start", {}, ctxFor("pi-session-aaa"));
+    await extension.emit("tool_execution_end", { isError: false });
+    await extension.emit("session_switch", { reason: "resume" }, ctxFor("pi-session-bbb"));
+
+    const calls = extension.readCalls();
+    assert.deepEqual(eventNames(calls), ["SessionStart", "PostToolUse", "SessionStart"]);
+    assert.equal(calls[0].payload.session_id, "pi-session-aaa");
+    assert.equal(calls[1].payload.session_id, "pi-session-aaa");
+    assert.equal(calls[2].payload.session_id, "pi-session-bbb");
+  } finally {
+    extension.restore();
+  }
+});
+
+test("session switch resets to the process fallback when id lookup is missing or fails", async () => {
+  for (const sessionManager of [
+    {},
+    { getSessionId: () => { throw new Error("unavailable"); } },
+  ]) {
+    const extension = loadExtension();
+    try {
+      await extension.emit("session_start", {}, {
+        hasUI: true,
+        cwd: "/tmp/test-project",
+        sessionManager: { getSessionId: () => "pi-session-aaa" },
+      });
+      await extension.emit("session_switch", { reason: "new" }, { sessionManager });
+
+      const calls = extension.readCalls();
+      assert.deepEqual(eventNames(calls), ["SessionStart", "SessionStart"]);
+      assert.equal(calls[0].payload.session_id, "pi-session-aaa");
+      assert.equal(calls[1].payload.session_id, `pi-${process.pid}`);
+    } finally {
+      extension.restore();
+    }
+  }
+});
+
 test("skips all tracking when ctx.hasUI is false", async () => {
   const extension = loadExtension();
 

--- a/plugins/streamdeck/com.st0012.cctop.sdPlugin/lib/controller.mjs
+++ b/plugins/streamdeck/com.st0012.cctop.sdPlugin/lib/controller.mjs
@@ -144,7 +144,25 @@ export class StreamDeckController {
     }
     if (action !== SESSION_ACTION) return;
     const entry = this.sessionContexts.get(context);
-    const session = entry ? commandSessionForSlot(readDisplayState(), entry.slot) : null;
+    if (!entry) {
+      this.alert(context);
+      return;
+    }
+    const state = readDisplayState();
+    if (state?.app_running === true) {
+      // Send exactly the id this key last rendered — never re-resolve the slot, or a
+      // press could target whichever session shifted into it after the image was drawn.
+      // A stale id is safely ignored by cctop; the pending re-render fixes the key.
+      if (entry.renderedSessionId) {
+        this.launch(focusURL(entry.renderedSessionId), context);
+      } else {
+        this.alert(context);
+      }
+      return;
+    }
+    // Nothing is rendered while cctop is down; a recent graceful-quit snapshot may
+    // still resolve the slot so the press cold-launches cctop into that session.
+    const session = commandSessionForSlot(state, entry.slot);
     const url = session ? focusURL(session.id) : null;
     if (!url) {
       this.alert(context);
@@ -155,6 +173,7 @@ export class StreamDeckController {
 
   renderContext(context, entry, state) {
     const session = displaySessionForSlot(state, entry.slot);
+    entry.renderedSessionId = session?.id ?? null;
     const slotLabel = Number.isInteger(entry.slot) ? entry.slot : "";
     this.send({
       event: "setImage",

--- a/plugins/streamdeck/com.st0012.cctop.sdPlugin/lib/controller.mjs
+++ b/plugins/streamdeck/com.st0012.cctop.sdPlugin/lib/controller.mjs
@@ -148,11 +148,12 @@ export class StreamDeckController {
       this.alert(context);
       return;
     }
-    // Send exactly the id this key last rendered — never re-resolve the slot, or a
+    // Send exactly the permanent id this key last rendered — never re-resolve the slot, or a
     // press could target whichever session shifted into it after the image was drawn.
-    // A stale id is safely ignored by cctop; the pending re-render fixes the key.
-    if (entry.renderedSessionId) {
-      this.launch(focusURL(entry.renderedSessionId), context);
+    // The permanent id may resolve to that session's currently associated target;
+    // it can never retarget the key to an unrelated session that moved into this slot.
+    if (entry.renderedCctopSessionId) {
+      this.launch(focusURL(entry.renderedCctopSessionId), context);
       return;
     }
     const state = readDisplayState();
@@ -163,7 +164,7 @@ export class StreamDeckController {
     // A key first shown while cctop is down has no rendered id. A recent graceful-quit
     // snapshot may still resolve its slot so the press cold-launches that session.
     const session = commandSessionForSlot(state, entry.slot);
-    const url = session ? focusURL(session.id) : null;
+    const url = session ? focusURL(session.cctopSessionId) : null;
     if (!url) {
       this.alert(context);
       return;
@@ -173,7 +174,7 @@ export class StreamDeckController {
 
   renderContext(context, entry, state) {
     const session = displaySessionForSlot(state, entry.slot);
-    entry.renderedSessionId = session?.id ?? null;
+    entry.renderedCctopSessionId = session?.cctopSessionId ?? null;
     const slotLabel = Number.isInteger(entry.slot) ? entry.slot : "";
     this.send({
       event: "setImage",

--- a/plugins/streamdeck/com.st0012.cctop.sdPlugin/lib/controller.mjs
+++ b/plugins/streamdeck/com.st0012.cctop.sdPlugin/lib/controller.mjs
@@ -148,20 +148,20 @@ export class StreamDeckController {
       this.alert(context);
       return;
     }
-    const state = readDisplayState();
-    if (state?.app_running === true) {
-      // Send exactly the id this key last rendered — never re-resolve the slot, or a
-      // press could target whichever session shifted into it after the image was drawn.
-      // A stale id is safely ignored by cctop; the pending re-render fixes the key.
-      if (entry.renderedSessionId) {
-        this.launch(focusURL(entry.renderedSessionId), context);
-      } else {
-        this.alert(context);
-      }
+    // Send exactly the id this key last rendered — never re-resolve the slot, or a
+    // press could target whichever session shifted into it after the image was drawn.
+    // A stale id is safely ignored by cctop; the pending re-render fixes the key.
+    if (entry.renderedSessionId) {
+      this.launch(focusURL(entry.renderedSessionId), context);
       return;
     }
-    // Nothing is rendered while cctop is down; a recent graceful-quit snapshot may
-    // still resolve the slot so the press cold-launches cctop into that session.
+    const state = readDisplayState();
+    if (state?.app_running === true) {
+      this.alert(context);
+      return;
+    }
+    // A key first shown while cctop is down has no rendered id. A recent graceful-quit
+    // snapshot may still resolve its slot so the press cold-launches that session.
     const session = commandSessionForSlot(state, entry.slot);
     const url = session ? focusURL(session.id) : null;
     if (!url) {

--- a/plugins/streamdeck/com.st0012.cctop.sdPlugin/lib/state.mjs
+++ b/plugins/streamdeck/com.st0012.cctop.sdPlugin/lib/state.mjs
@@ -3,7 +3,7 @@ import { readFileSync, watch } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-export const STATE_VERSION = 1;
+export const STATE_VERSION = 2;
 export const STATE_FILE = "display-state.json";
 export const COLD_LAUNCH_GRACE_MS = 5 * 60 * 1000;
 
@@ -24,12 +24,13 @@ function displayStatePath() {
 
 function parseEntry(entry) {
   if (!entry || typeof entry !== "object") return null;
-  if (typeof entry.id !== "string" || entry.id.length === 0) return null;
+  if (typeof entry.cctop_session_id !== "string"
+      || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(entry.cctop_session_id)) return null;
   if (typeof entry.name !== "string" || entry.name.length === 0) return null;
   if (typeof entry.status !== "string" || entry.status.length === 0) return null;
   if (typeof entry.color !== "string" || !/^#[0-9a-f]{6}$/i.test(entry.color)) return null;
   return {
-    id: entry.id,
+    cctopSessionId: entry.cctop_session_id,
     name: entry.name,
     status: entry.status,
     color: entry.color,
@@ -60,8 +61,6 @@ export function parseDisplayState(text) {
   }
 
   const sessions = raw.sessions.slice(0, 32).map(parseEntry);
-  const ids = sessions.filter(Boolean).map((entry) => entry.id);
-  if (new Set(ids).size !== ids.length) return emptyState();
 
   return {
     version: STATE_VERSION,

--- a/plugins/streamdeck/test/protocol.test.mjs
+++ b/plugins/streamdeck/test/protocol.test.mjs
@@ -226,6 +226,27 @@ test("a press sends the id the key rendered, not the slot's later occupant", asy
   assert.deepEqual(launches.map((launch) => launch.args[0]), ["cctop://focus?sid=first%2Fid%3F"]);
 });
 
+test("a cold-launch press preserves the id rendered before sessions reordered", async () => {
+  writeState();
+  const { controller } = makeController();
+  controller.handleMessage(willAppear("key-1", { row: 0, column: 0 }, { slot: 1 }));
+
+  // cctop quits and publishes a reordered graceful snapshot before the key refreshes.
+  writeState({
+    app_running: false,
+    app_pid: null,
+    app_start_time: null,
+    sessions: [
+      { id: "second", name: "second", status: "working", color: "#DD5353" },
+      { id: "first/id?", name: "first", status: "idle", color: "#7DAEA3" },
+    ],
+  });
+  controller.handleMessage({ event: "keyDown", action: SESSION_ACTION, context: "key-1" });
+  await new Promise(setImmediate);
+
+  assert.deepEqual(launches.map((launch) => launch.args[0]), ["cctop://focus?sid=first%2Fid%3F"]);
+});
+
 test("recent graceful state can cold-launch but renders unavailable while stopped", async () => {
   writeState({ app_running: false, app_pid: null, app_start_time: null });
   const { controller, socket } = makeController();

--- a/plugins/streamdeck/test/protocol.test.mjs
+++ b/plugins/streamdeck/test/protocol.test.mjs
@@ -37,6 +37,8 @@ after(() => {
 beforeEach(() => launches.splice(0));
 
 const MK2 = { id: "mk2", name: "MK.2", size: { columns: 5, rows: 3 }, type: 0 };
+const ID_FIRST = "11111111-2222-4333-8444-555555555555";
+const ID_SECOND = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
 const currentProcessStartTime = Date.parse(childProcess.execFileSync(
   "/bin/ps",
   ["-p", String(process.pid), "-o", "lstart="],
@@ -53,14 +55,14 @@ class RecordingSocket {
 
 function writeState(overrides = {}) {
   const state = {
-    version: 1,
+    version: 2,
     generated_at: new Date().toISOString(),
     app_running: true,
     app_pid: process.pid,
     app_start_time: currentProcessStartTime,
     sessions: [
-      { id: "first/id?", name: "first", status: "working", color: "#7EAA6E" },
-      { id: "second", name: "second", status: "idle", color: "#7DAEA3" },
+      { cctop_session_id: ID_FIRST, name: "first", status: "working", color: "#7EAA6E" },
+      { cctop_session_id: ID_SECOND, name: "second", status: "idle", color: "#7DAEA3" },
     ],
     ...overrides,
   };
@@ -184,7 +186,7 @@ test("a session key asks Launch Services to deliver the exact encoded cctop comm
 
   assert.deepEqual(launches, [{
     file: "/usr/bin/open",
-    args: ["cctop://focus?sid=first%2Fid%3F"],
+    args: [`cctop://focus?sid=${ID_FIRST}`],
     options: { timeout: 5_000 },
   }]);
   assert.equal(messages(socket, "openUrl").length, 0);
@@ -217,13 +219,31 @@ test("a press sends the id the key rendered, not the slot's later occupant", asy
 
   // Sessions reorder after the key image was drawn; no refresh has run yet.
   writeState({ sessions: [
-    { id: "second", name: "second", status: "working", color: "#DD5353" },
-    { id: "first/id?", name: "first", status: "idle", color: "#7DAEA3" },
+    { cctop_session_id: ID_SECOND, name: "second", status: "working", color: "#DD5353" },
+    { cctop_session_id: ID_FIRST, name: "first", status: "idle", color: "#7DAEA3" },
   ] });
   controller.handleMessage({ event: "keyDown", action: SESSION_ACTION, context: "key-1" });
   await new Promise(setImmediate);
 
-  assert.deepEqual(launches.map((launch) => launch.args[0]), ["cctop://focus?sid=first%2Fid%3F"]);
+  assert.deepEqual(launches.map((launch) => launch.args[0]), [`cctop://focus?sid=${ID_FIRST}`]);
+});
+
+test("two visible slots may share one permanent session id without shifting", async () => {
+  writeState({ sessions: [
+    { cctop_session_id: ID_FIRST, name: "first target", status: "working", color: "#7EAA6E" },
+    { cctop_session_id: ID_FIRST, name: "second target", status: "idle", color: "#7DAEA3" },
+  ] });
+  const { controller, socket } = makeController();
+  controller.handleMessage(willAppear("key-1", { row: 0, column: 0 }, { slot: 1 }));
+  controller.handleMessage(willAppear("key-2", { row: 0, column: 1 }, { slot: 2 }));
+
+  const images = messages(socket, "setImage").map((message) => decodeURIComponent(message.payload.image));
+  assert.ok(images[0].includes("first"));
+  assert.ok(images[1].includes("second"));
+
+  controller.handleMessage({ event: "keyDown", action: SESSION_ACTION, context: "key-2" });
+  await new Promise(setImmediate);
+  assert.deepEqual(launches.map((launch) => launch.args[0]), [`cctop://focus?sid=${ID_FIRST}`]);
 });
 
 test("a cold-launch press preserves the id rendered before sessions reordered", async () => {
@@ -237,14 +257,14 @@ test("a cold-launch press preserves the id rendered before sessions reordered", 
     app_pid: null,
     app_start_time: null,
     sessions: [
-      { id: "second", name: "second", status: "working", color: "#DD5353" },
-      { id: "first/id?", name: "first", status: "idle", color: "#7DAEA3" },
+      { cctop_session_id: ID_SECOND, name: "second", status: "working", color: "#DD5353" },
+      { cctop_session_id: ID_FIRST, name: "first", status: "idle", color: "#7DAEA3" },
     ],
   });
   controller.handleMessage({ event: "keyDown", action: SESSION_ACTION, context: "key-1" });
   await new Promise(setImmediate);
 
-  assert.deepEqual(launches.map((launch) => launch.args[0]), ["cctop://focus?sid=first%2Fid%3F"]);
+  assert.deepEqual(launches.map((launch) => launch.args[0]), [`cctop://focus?sid=${ID_FIRST}`]);
 });
 
 test("recent graceful state can cold-launch but renders unavailable while stopped", async () => {
@@ -256,7 +276,7 @@ test("recent graceful state can cold-launch but renders unavailable while stoppe
 
   controller.handleMessage({ event: "keyDown", action: SESSION_ACTION, context: "key-1" });
   await new Promise(setImmediate);
-  assert.equal(launches[0].args[0], "cctop://focus?sid=first%2Fid%3F");
+  assert.equal(launches[0].args[0], `cctop://focus?sid=${ID_FIRST}`);
 });
 
 test("empty or unusable slots fail safely without launching cctop", () => {
@@ -282,8 +302,8 @@ test("settings changes, reordering, and disappearance update existing contexts",
   assert.ok(decodeURIComponent(messages(socket, "setImage").at(-1).payload.image).includes("second"));
 
   writeState({ sessions: [
-    { id: "second", name: "second now first", status: "working", color: "#DD5353" },
-    { id: "first/id?", name: "first now second", status: "idle", color: "#7DAEA3" },
+    { cctop_session_id: ID_SECOND, name: "second now first", status: "working", color: "#DD5353" },
+    { cctop_session_id: ID_FIRST, name: "first now second", status: "idle", color: "#7DAEA3" },
   ] });
   controller.refresh();
   const reorderedImage = decodeURIComponent(messages(socket, "setImage").at(-1).payload.image);

--- a/plugins/streamdeck/test/protocol.test.mjs
+++ b/plugins/streamdeck/test/protocol.test.mjs
@@ -210,6 +210,22 @@ test("toggle uses the same direct cctop command boundary", async () => {
   assert.equal(messages(socket, "openUrl").length, 0);
 });
 
+test("a press sends the id the key rendered, not the slot's later occupant", async () => {
+  writeState();
+  const { controller } = makeController();
+  controller.handleMessage(willAppear("key-1", { row: 0, column: 0 }, { slot: 1 }));
+
+  // Sessions reorder after the key image was drawn; no refresh has run yet.
+  writeState({ sessions: [
+    { id: "second", name: "second", status: "working", color: "#DD5353" },
+    { id: "first/id?", name: "first", status: "idle", color: "#7DAEA3" },
+  ] });
+  controller.handleMessage({ event: "keyDown", action: SESSION_ACTION, context: "key-1" });
+  await new Promise(setImmediate);
+
+  assert.deepEqual(launches.map((launch) => launch.args[0]), ["cctop://focus?sid=first%2Fid%3F"]);
+});
+
 test("recent graceful state can cold-launch but renders unavailable while stopped", async () => {
   writeState({ app_running: false, app_pid: null, app_start_time: null });
   const { controller, socket } = makeController();

--- a/plugins/streamdeck/test/state.test.mjs
+++ b/plugins/streamdeck/test/state.test.mjs
@@ -15,6 +15,8 @@ import {
 } from "../com.st0012.cctop.sdPlugin/lib/state.mjs";
 
 const originalHome = process.env.HOME;
+const ID_ONE = "11111111-2222-4333-8444-555555555555";
+const ID_TWO = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
 const testHome = mkdtempSync(join(tmpdir(), "cctop-streamdeck-state-"));
 const currentProcessStartTime = Date.parse(execFileSync(
   "/bin/ps",
@@ -27,14 +29,14 @@ after(() => { process.env.HOME = originalHome; });
 
 function validState(overrides = {}) {
   return {
-    version: 1,
+    version: 2,
     generated_at: new Date().toISOString(),
     app_running: true,
     app_pid: process.pid,
     app_start_time: currentProcessStartTime,
     sessions: [
-      { id: "one", name: "alpha", status: "working", color: "#7EAA6E" },
-      { id: "two", name: "beta", status: "idle", color: "#7DAEA3" },
+      { cctop_session_id: ID_ONE, name: "alpha", status: "working", color: "#7EAA6E" },
+      { cctop_session_id: ID_TWO, name: "beta", status: "idle", color: "#7DAEA3" },
     ],
     ...overrides,
   };
@@ -45,33 +47,38 @@ test("parses the versioned app projection", () => {
   assert.equal(state.app_running, true);
   assert.equal(state.app_pid, process.pid);
   assert.equal(state.app_start_time, currentProcessStartTime);
-  assert.deepEqual(state.sessions.map((session) => session.id), ["one", "two"]);
+  assert.deepEqual(state.sessions.map((session) => session.cctopSessionId), [ID_ONE, ID_TWO]);
 });
 
-test("missing, corrupt, wrong-version, and duplicate state is unavailable", () => {
+test("missing, corrupt, and wrong-version state is unavailable", () => {
   assert.deepEqual(parseDisplayState("{not json"), emptyState());
-  assert.deepEqual(parseDisplayState(JSON.stringify(validState({ version: 2 }))), emptyState());
+  assert.deepEqual(parseDisplayState(JSON.stringify(validState({ version: 1 }))), emptyState());
   assert.deepEqual(parseDisplayState(JSON.stringify(validState({ app_start_time: null }))), emptyState());
-  assert.deepEqual(parseDisplayState(JSON.stringify(validState({
+});
+
+test("duplicate logical session ids preserve visible slots", () => {
+  const state = parseDisplayState(JSON.stringify(validState({
     sessions: [validState().sessions[0], validState().sessions[0]],
-  }))), emptyState());
+  })));
+  assert.equal(state.sessions.length, 2);
+  assert.deepEqual(state.sessions.map((session) => session.cctopSessionId), [ID_ONE, ID_ONE]);
 });
 
 test("a malformed entry stays an empty slot instead of shifting later sessions", () => {
   const state = parseDisplayState(JSON.stringify(validState({
     sessions: [validState().sessions[0], { name: "missing identity" }, validState().sessions[1]],
   })));
-  assert.equal(state.sessions[0].id, "one");
+  assert.equal(state.sessions[0].cctopSessionId, ID_ONE);
   assert.equal(state.sessions[1], null);
-  assert.equal(state.sessions[2].id, "two");
+  assert.equal(state.sessions[2].cctopSessionId, ID_TWO);
   assert.equal(displaySessionForSlot(state, 2), null);
-  assert.equal(displaySessionForSlot(state, 3).id, "two");
+  assert.equal(displaySessionForSlot(state, 3).cctopSessionId, ID_TWO);
 });
 
 test("live process state renders and targets its exact slot", () => {
   const state = parseDisplayState(JSON.stringify(validState()));
-  assert.equal(displaySessionForSlot(state, 1).id, "one");
-  assert.equal(commandSessionForSlot(state, 2).id, "two");
+  assert.equal(displaySessionForSlot(state, 1).cctopSessionId, ID_ONE);
+  assert.equal(commandSessionForSlot(state, 2).cctopSessionId, ID_TWO);
   assert.equal(commandSessionForSlot(state, 3), null);
   assert.equal(commandSessionForSlot(state, 0), null);
 });
@@ -89,7 +96,7 @@ test("recent graceful state is command-only and expires", () => {
     app_start_time: null,
   })));
   assert.equal(displaySessionForSlot(recent, 1), null);
-  assert.equal(commandSessionForSlot(recent, 1).id, "one");
+  assert.equal(commandSessionForSlot(recent, 1).cctopSessionId, ID_ONE);
 
   const expired = parseDisplayState(JSON.stringify(validState({
     generated_at: new Date(Date.now() - COLD_LAUNCH_GRACE_MS - 1_000).toISOString(),
@@ -111,7 +118,7 @@ test("the plugin does not derive display state from cctop session sources", () =
 test("the reader rejects a reused PID with a different publisher identity", () => {
   const statePath = join(testHome, ".cctop", "display-state.json");
   writeFileSync(statePath, JSON.stringify(validState()));
-  assert.equal(readDisplayState().sessions[0].id, "one");
+  assert.equal(readDisplayState().sessions[0].cctopSessionId, ID_ONE);
 
   writeFileSync(statePath, JSON.stringify(validState({
     app_start_time: currentProcessStartTime - 60,


### PR DESCRIPTION
## Problem

Stream Deck session routing was coupled to live process identity. A resumed conversation could receive a different control identity, while treating that live focus target as the session itself made persistence and multi-target behavior unclear.

## Solution

cctop now assigns each observed session an opaque local UUID and persists source-scoped resume mappings only where the client provides reliable evidence: Codex, UUID-backed Claude sessions, and UUID-backed pi sessions. OpenCode and synthetic pi observations remain record-local and are documented as current limitations.

Stream Deck publishes and caches the permanent session ID, while cctop separately resolves it to the first current focus target in canonical panel order. Legacy visible records migrate under existing locks, rows never shift during migration, SessionEnd matches exact raw/source identity before an unambiguous legacy fallback, and pi resets its fallback at each session boundary.

## Current limits

- Multiple clients or simultaneous focus targets for one logical session are not reconciled yet; current focus resolution chooses the first canonical current target.
- OpenCode and synthetic pi observations may receive a new cctop ID after reopening.
- IDs are local to one machine and are not synchronized.
- Panel identity, notifications, hiding, cleanup, history, and other saved preferences do not use cctop_session_id yet.

## Follow-up

- https://github.com/st0012/cctop/issues/224

## Verification

- `make all`
- Exact worktree app/hook E2E with a real Claude CLI session retaining its cctop ID across an app restart
- Rendered-ID and cold-launch press-race coverage against the bundled Stream Deck sources