### PR TITLE
Stabilize Codex session classification during read failures

### DIFF
--- a/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadArchiveLookup.swift
@@ -36,15 +36,21 @@ final class CodexThreadArchiveLookup {
     }
 
     /// Returns all Codex thread metadata cctop needs for `threadIDs` using one database pass.
-    /// Missing or unreadable state is unknown, so callers should fail OPEN when this returns `nil`.
+    /// `.missing` means no configured database exists, `.available` may identify per-ID unknowns
+    /// from a partial read, and `.unreadable` means no authoritative state could be loaded.
+    func stateSnapshot(matching threadIDs: Set<String>) -> CodexThreadStateSnapshot {
+        resolvedStateSnapshot(matching: threadIDs)
+    }
+
     func stateIndex(matching threadIDs: Set<String>) -> CodexThreadStateIndex? {
         guard !threadIDs.isEmpty else { return CodexThreadStateIndex() }
-        guard let snapshot = stateSnapshot(matching: threadIDs) else { return nil }
-        switch snapshot {
+        switch stateSnapshot(matching: threadIDs) {
         case .missing:
             return nil
         case .available(let index):
             return index
+        case .unreadable:
+            return nil
         }
     }
 
@@ -53,13 +59,14 @@ final class CodexThreadArchiveLookup {
     /// should fail OPEN when this returns `nil`.
     func existingThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
         guard !threadIDs.isEmpty else { return [] }
-        guard let snapshot = stateSnapshot(matching: threadIDs) else { return nil }
-        switch snapshot {
+        switch stateSnapshot(matching: threadIDs) {
         case .missing:
             return nil
         case .available(let index):
             guard index.unknownThreadIDs.isDisjoint(with: threadIDs) else { return nil }
             return index.existingThreadIDs.intersection(threadIDs)
+        case .unreadable:
+            return nil
         }
     }
 
@@ -69,13 +76,14 @@ final class CodexThreadArchiveLookup {
     /// archived". A missing database returns `[]` (no Codex state ⇒ nothing archived), not `nil`.
     func archivedThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
         guard !threadIDs.isEmpty else { return [] }
-        guard let snapshot = stateSnapshot(matching: threadIDs) else { return nil }
-        switch snapshot {
+        switch stateSnapshot(matching: threadIDs) {
         case .missing:
             return []
         case .available(let index):
             guard index.unknownThreadIDs.isDisjoint(with: threadIDs) else { return nil }
             return index.archivedThreadIDs.intersection(threadIDs)
+        case .unreadable:
+            return nil
         }
     }
 
@@ -83,12 +91,13 @@ final class CodexThreadArchiveLookup {
     /// subagent-owned. This is display-only metadata, so callers fail OPEN on uncertainty.
     func internalHelperThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
         guard !threadIDs.isEmpty else { return [] }
-        guard let snapshot = stateSnapshot(matching: threadIDs) else { return nil }
-        switch snapshot {
+        switch stateSnapshot(matching: threadIDs) {
         case .missing:
             return []
         case .available(let index):
             return index.internalHelperThreadIDs.intersection(threadIDs)
+        case .unreadable:
+            return nil
         }
     }
 
@@ -97,12 +106,13 @@ final class CodexThreadArchiveLookup {
     /// returns `nil` and callers should preserve any existing label.
     func projectNames(matching threadIDs: Set<String>) -> [String: String]? {
         guard !threadIDs.isEmpty else { return [:] }
-        guard let snapshot = stateSnapshot(matching: threadIDs) else { return nil }
-        switch snapshot {
+        switch stateSnapshot(matching: threadIDs) {
         case .missing:
             return [:]
         case .available(let index):
             return index.projectNamesByThreadID.filter { threadIDs.contains($0.key) }
+        case .unreadable:
+            return nil
         }
     }
 
@@ -110,12 +120,13 @@ final class CodexThreadArchiveLookup {
     /// alone also covers user-run `codex exec`, so verify the rollout originator before hiding.
     func execHelperThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
         guard !threadIDs.isEmpty else { return [] }
-        guard let snapshot = stateSnapshot(matching: threadIDs) else { return nil }
-        switch snapshot {
+        switch stateSnapshot(matching: threadIDs) {
         case .missing:
             return []
         case .available(let index):
             return index.execHelperThreadIDs.intersection(threadIDs)
+        case .unreadable:
+            return nil
         }
     }
 
@@ -254,7 +265,8 @@ final class CodexThreadArchiveLookup {
 }
 
 private extension CodexThreadArchiveLookup {
-    func stateSnapshot(matching threadIDs: Set<String>) -> CodexThreadStateSnapshot? {
+    func resolvedStateSnapshot(matching threadIDs: Set<String>) -> CodexThreadStateSnapshot {
+        guard !threadIDs.isEmpty else { return .available(CodexThreadStateIndex()) }
         var remainingThreadIDs = Set(threadIDs)
         var mergedIndex = CodexThreadStateIndex()
         var foundReadableDatabase = false
@@ -262,7 +274,7 @@ private extension CodexThreadArchiveLookup {
         for path in resolvedStateDatabasePaths() where !remainingThreadIDs.isEmpty {
             guard let snapshot = stateSnapshot(at: path, matching: remainingThreadIDs) else {
                 mergedIndex.unknownThreadIDs.formUnion(remainingThreadIDs)
-                return foundReadableDatabase ? .available(mergedIndex) : nil
+                return foundReadableDatabase ? .available(mergedIndex) : .unreadable
             }
             guard case .available(let index) = snapshot else {
                 continue

--- a/menubar/CctopMenubar/Services/CodexThreadStateTypes.swift
+++ b/menubar/CctopMenubar/Services/CodexThreadStateTypes.swift
@@ -160,9 +160,11 @@ private struct CodexThreadSpawnSource: Decodable {
 
 /// Read-side seam over Codex's local thread state. `CodexThreadArchiveLookup` is the live
 /// SQLite-backed implementation; tests substitute in-memory stubs so classification and archive
-/// logic can run without a database on disk. `nil` means the lookup could not prove an answer,
-/// either because the store was unreadable or because absence is intentionally treated as unknown.
+/// logic can run without a database on disk. `stateSnapshot` distinguishes confirmed database
+/// absence from a transient unreadable store; the narrower optional methods retain their existing
+/// caller-specific fail-open/fail-safe meanings.
 protocol CodexThreadStateProviding {
+    func stateSnapshot(matching threadIDs: Set<String>) -> CodexThreadStateSnapshot
     func stateIndex(matching threadIDs: Set<String>) -> CodexThreadStateIndex?
     func existingThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
     func archivedThreadIDs(matching threadIDs: Set<String>) -> Set<String>?
@@ -191,6 +193,7 @@ struct CodexThreadStateLoadResult {
 enum CodexThreadStateSnapshot {
     case missing
     case available(CodexThreadStateIndex)
+    case unreadable
 }
 
 struct CodexThreadStateIndex {
@@ -234,6 +237,59 @@ struct CodexThreadStateIndex {
     }
 }
 
+/// Display classification remembers authoritative per-thread facts across transient state-store
+/// failures. Coverage is separate from positive sets because a successfully absent thread is a
+/// meaningful "missing" classification. The memory is pruned to the current request every pass.
+struct CodexThreadClassificationMemory {
+    private var index = CodexThreadStateIndex()
+    private var resolvedThreadIDs: Set<String> = []
+
+    mutating func effectiveIndex(
+        from snapshot: CodexThreadStateSnapshot,
+        matching threadIDs: Set<String>
+    ) -> CodexThreadStateIndex? {
+        switch snapshot {
+        case .missing:
+            index = CodexThreadStateIndex()
+            resolvedThreadIDs = []
+            return nil
+        case .unreadable:
+            return retainKnownState(matching: threadIDs)
+        case .available(let authoritative):
+            return replaceResolvedState(authoritative, matching: threadIDs)
+        }
+    }
+
+    private mutating func retainKnownState(matching threadIDs: Set<String>) -> CodexThreadStateIndex {
+        let retainedThreadIDs = resolvedThreadIDs.intersection(threadIDs)
+        var effective = index.filtered(to: retainedThreadIDs)
+        effective.unknownThreadIDs = threadIDs.subtracting(retainedThreadIDs)
+        index = effective.filtered(to: retainedThreadIDs)
+        index.unknownThreadIDs = []
+        resolvedThreadIDs = retainedThreadIDs
+        return effective
+    }
+
+    private mutating func replaceResolvedState(
+        _ authoritative: CodexThreadStateIndex,
+        matching threadIDs: Set<String>
+    ) -> CodexThreadStateIndex {
+        let unknownThreadIDs = authoritative.unknownThreadIDs.intersection(threadIDs)
+        let resolvedNow = threadIDs.subtracting(unknownThreadIDs)
+        let retainedThreadIDs = unknownThreadIDs.intersection(resolvedThreadIDs)
+        let effectiveResolvedThreadIDs = resolvedNow.union(retainedThreadIDs)
+
+        var effective = authoritative.filtered(to: resolvedNow)
+        effective.merge(index.filtered(to: retainedThreadIDs))
+        effective.unknownThreadIDs = unknownThreadIDs.subtracting(retainedThreadIDs)
+
+        index = effective.filtered(to: effectiveResolvedThreadIDs)
+        index.unknownThreadIDs = []
+        resolvedThreadIDs = effectiveResolvedThreadIDs
+        return effective
+    }
+}
+
 struct CodexThreadStateRolloutTracker {
     var paths: Set<String> = []
     var fingerprints: [String: CodexThreadStateRolloutFileFingerprint] = [:]
@@ -266,6 +322,11 @@ struct CodexThreadStateFileFingerprint: Equatable, Hashable {
 let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
 extension CodexThreadStateProviding {
+    func stateSnapshot(matching threadIDs: Set<String>) -> CodexThreadStateSnapshot {
+        guard let index = stateIndex(matching: threadIDs) else { return .unreadable }
+        return .available(index)
+    }
+
     func stateIndex(matching threadIDs: Set<String>) -> CodexThreadStateIndex? {
         guard !threadIDs.isEmpty else { return CodexThreadStateIndex() }
         guard let existingThreadIDs = existingThreadIDs(matching: threadIDs) else { return nil }

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -315,19 +315,25 @@ extension SessionManager {
         now: Date
     ) -> SessionClassificationSnapshot {
         let externallyClassifiableSessions = sessions.filter { !$0.hidden && !$0.shouldAutoHide }
-        let archivedCodexThreadIDs = archivedCodexDesktopThreadIDs(in: externallyClassifiableSessions, codexThreads: codexThreads)
-        let missingCodexDesktopThreadIDs = missingCodexDesktopThreadIDs(
-            in: externallyClassifiableSessions,
-            codexThreads: codexThreads,
-            now: now
-        )
         let codexDelegationIndex = codexThreads.stateIndex(
             matching: codexThreadIDs(in: sessions)
+        )
+        let archivedCodexThreadIDs = archivedCodexDesktopThreadIDs(
+            in: externallyClassifiableSessions,
+            index: codexDelegationIndex
+        )
+        let missingCodexDesktopThreadIDs = missingCodexDesktopThreadIDs(
+            in: externallyClassifiableSessions,
+            index: codexDelegationIndex,
+            now: now
         )
         let codexInternalHelperThreadIDs = codexDelegationIndex?.internalHelperThreadIDs ?? []
         let uncertainCodexDelegationThreadIDs = codexDelegationIndex?.uncertainDelegationThreadIDs ?? []
         let contradictoryCodexDelegationThreadIDs = codexDelegationIndex?.contradictoryDelegationThreadIDs ?? []
-        let codexExecHelperThreadIDs = codexExecHelperThreadIDs(in: externallyClassifiableSessions, codexThreads: codexThreads)
+        let codexExecHelperThreadIDs = codexExecHelperThreadIDs(
+            in: externallyClassifiableSessions,
+            index: codexDelegationIndex
+        )
         let archivedClaudeSessionIDs = claudeMetadata?.archivedSessionIDs ?? []
 
         let evidence = SessionClassificationEvidence(
@@ -393,7 +399,7 @@ extension SessionManager {
 
     func deriveSessionClassification(from decoded: [(url: URL, session: Session)]) -> SessionClassificationSnapshot {
         let now = dataSources.now()
-        let codexThreads = Self.batchedCodexThreadState(
+        let codexThreads = batchedCodexThreadState(
             in: decoded.map(\.session),
             codexThreads: dataSources.codexThreads
         )
@@ -459,15 +465,17 @@ extension SessionManager {
         }
     }
 
-    private nonisolated static func batchedCodexThreadState(
+    private func batchedCodexThreadState(
         in sessions: [Session],
         codexThreads: any CodexThreadStateProviding
     ) -> FrozenCodexThreadState {
-        let threadIDs = codexThreadIDs(in: sessions)
-        guard !threadIDs.isEmpty else {
-            return FrozenCodexThreadState(index: CodexThreadStateIndex())
-        }
-        return FrozenCodexThreadState(index: codexThreads.stateIndex(matching: threadIDs))
+        let threadIDs = Self.codexThreadIDs(in: sessions)
+        let snapshot = codexThreads.stateSnapshot(matching: threadIDs)
+        let effectiveIndex = codexThreadClassificationMemory.effectiveIndex(
+            from: snapshot,
+            matching: threadIDs
+        )
+        return FrozenCodexThreadState(index: effectiveIndex)
     }
 
     private nonisolated static func codexThreadIDs(in sessions: [Session]) -> Set<String> {
@@ -478,18 +486,12 @@ extension SessionManager {
         )
     }
 
-    /// Batch snapshot for the display path. This never deletes files, so unreadable external state
-    /// fails OPEN: at worst an archived session shows for one pass.
-    nonisolated static func archivedCodexDesktopThreadIDs(
+    private nonisolated static func archivedCodexDesktopThreadIDs(
         in sessions: [Session],
-        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup()
+        index: CodexThreadStateIndex?
     ) -> Set<String> {
-        let threadIDs = Set(
-            sessions
-                .filter(\.isCodexDesktopHost)
-                .map(\.sessionId)
-        )
-        return codexThreads.archivedThreadIDs(matching: threadIDs) ?? []
+        let threadIDs = Set(sessions.filter(\.isCodexDesktopHost).map(\.sessionId))
+        return index?.archivedThreadIDs.intersection(threadIDs) ?? []
     }
 
     nonisolated static func isArchivedCodexDesktopSession(
@@ -501,15 +503,16 @@ extension SessionManager {
 
     /// Codex Desktop sessions should correspond to a Codex thread row. If the thread store is
     /// readable and the row is gone, the app should not publish the stale hook session.
-    nonisolated static func missingCodexDesktopThreadIDs(
+    private nonisolated static func missingCodexDesktopThreadIDs(
         in sessions: [Session],
-        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup(),
-        now: Date = Date()
+        index: CodexThreadStateIndex?,
+        now: Date
     ) -> Set<String> {
+        guard let index else { return [] }
         let codexDesktopSessions = sessions.filter { $0.source == Session.codexSource && $0.isCodexDesktopHost }
         let threadIDs = Set(codexDesktopSessions.map(\.sessionId))
-        guard let existingThreadIDs = codexThreads.existingThreadIDs(matching: threadIDs) else { return [] }
-        let missingThreadIDs = threadIDs.subtracting(existingThreadIDs)
+        let resolvedThreadIDs = threadIDs.subtracting(index.unknownThreadIDs)
+        let missingThreadIDs = resolvedThreadIDs.subtracting(index.existingThreadIDs)
         let freshMissingThreadIDs = Set(codexDesktopSessions.compactMap { session -> String? in
             guard missingThreadIDs.contains(session.sessionId),
                   now.timeIntervalSince(session.lastActivity) <= Self.codexMissingThreadGraceSeconds else {
@@ -538,12 +541,12 @@ extension SessionManager {
 
     /// Codex Desktop can launch short-lived `codex exec` helper threads. They are useful as
     /// rollout artifacts but should not appear as user-visible cctop sessions.
-    nonisolated static func codexExecHelperThreadIDs(
+    private nonisolated static func codexExecHelperThreadIDs(
         in sessions: [Session],
-        codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup()
+        index: CodexThreadStateIndex?
     ) -> Set<String> {
         let threadIDs = codexThreadIDs(in: sessions)
-        return codexThreads.execHelperThreadIDs(matching: threadIDs) ?? []
+        return index?.execHelperThreadIDs.intersection(threadIDs) ?? []
     }
 
     nonisolated static func isCodexExecHelperSession(

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -23,6 +23,7 @@ class SessionManager: ObservableObject {
     private(set) var cleanupSources: [SessionCleanupSource] = []
     private(set) var cleanupActiveProjectPaths: Set<String> = []
     private var currentClassificationCleanupSources: [SessionCleanupSource] = []
+    var codexThreadClassificationMemory = CodexThreadClassificationMemory()
 
     private let sessionsDir: URL
     private var source: DispatchSourceFileSystemObject?

--- a/menubar/CctopMenubarTests/CodexThreadArchiveLookupTests.swift
+++ b/menubar/CctopMenubarTests/CodexThreadArchiveLookupTests.swift
@@ -214,11 +214,19 @@ final class CodexThreadArchiveLookupTests: XCTestCase {
         defer { try? FileManager.default.removeItem(atPath: root) }
 
         let missing = (root as NSString).appendingPathComponent("missing.sqlite")
-        XCTAssertEqual(CodexThreadArchiveLookup(stateDatabasePath: missing).archivedThreadIDs(matching: ["x"]), [])
+        let missingLookup = CodexThreadArchiveLookup(stateDatabasePath: missing)
+        guard case .missing = missingLookup.stateSnapshot(matching: ["x"]) else {
+            return XCTFail("Expected an explicitly missing Codex state snapshot")
+        }
+        XCTAssertEqual(missingLookup.archivedThreadIDs(matching: ["x"]), [])
 
         let corrupt = (root as NSString).appendingPathComponent("corrupt.sqlite")
         try Data("this is not a sqlite database".utf8).write(to: URL(fileURLWithPath: corrupt))
-        XCTAssertNil(CodexThreadArchiveLookup(stateDatabasePath: corrupt).archivedThreadIDs(matching: ["x"]))
+        let unreadableLookup = CodexThreadArchiveLookup(stateDatabasePath: corrupt)
+        guard case .unreadable = unreadableLookup.stateSnapshot(matching: ["x"]) else {
+            return XCTFail("Expected an explicitly unreadable Codex state snapshot")
+        }
+        XCTAssertNil(unreadableLookup.archivedThreadIDs(matching: ["x"]))
     }
 
     func testCodexThreadLookupFallsBackToLaterCandidateWhenPreferredDatabaseDoesNotContainThread() throws {
@@ -292,7 +300,9 @@ final class CodexThreadArchiveLookupTests: XCTestCase {
         try Data("this is not a sqlite database".utf8).write(to: URL(fileURLWithPath: fallbackDB))
 
         let lookup = CodexThreadArchiveLookup(stateDatabasePaths: { [preferredDB, fallbackDB] })
-        let index = try XCTUnwrap(lookup.stateIndex(matching: ["desktop-thread", "cli-thread"]))
+        guard case .available(let index) = lookup.stateSnapshot(matching: ["desktop-thread", "cli-thread"]) else {
+            return XCTFail("Expected a partial available snapshot")
+        }
 
         XCTAssertEqual(index.existingThreadIDs, ["desktop-thread"])
         XCTAssertEqual(index.archivedThreadIDs, ["desktop-thread"])

--- a/menubar/CctopMenubarTests/SessionLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/SessionLifecycleTests.swift
@@ -1035,6 +1035,110 @@ final class SessionLifecycleTests: XCTestCase {
         XCTAssertEqual(classification.cleanupSources.map(\.sessionId), [])
     }
 
+    @MainActor
+    func testCodexClassificationDoesNotOscillateAcrossTransientUnreadableSnapshot() throws {
+        let root = NSTemporaryDirectory() + "cctop-codex-classification-retention-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let initialIDs = Set(["archived", "missing", "internal", "exec-helper", "visible"])
+        var initial = CodexThreadStateIndex()
+        initial.existingThreadIDs = initialIDs.subtracting(["missing"])
+        initial.archivedThreadIDs = ["archived"]
+        initial.internalHelperThreadIDs = ["internal"]
+        initial.execHelperThreadIDs = ["exec-helper"]
+
+        let changedIDs = initialIDs.union(["new"])
+        var changed = CodexThreadStateIndex()
+        changed.existingThreadIDs = changedIDs
+
+        let codexState = SequencedCodexClassificationState(
+            snapshots: [.available(initial), .unreadable, .available(changed)]
+        )
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
+        sources.codexThreads = codexState
+        sources.desktopAppConnection = DesktopAppConnectionLookup { _ in true }
+        sources.processAlive = { _ in true }
+        sources.now = { now }
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        func record(_ sessionID: String, desktop: Bool = true) -> (url: URL, session: Session) {
+            var session = desktop
+                ? codexDesktopSession(sessionId: sessionID, projectPath: "/tmp/\(sessionID)")
+                : codexTerminalSession(sessionId: sessionID, projectPath: "/tmp/\(sessionID)")
+            session.lastActivity = now.addingTimeInterval(-SessionManager.codexMissingThreadGraceSeconds - 1)
+            return (
+                URL(fileURLWithPath: (sessionsDir as NSString).appendingPathComponent("codex-\(sessionID).json")),
+                session
+            )
+        }
+
+        let initialRecords = [
+            record("archived"),
+            record("missing"),
+            record("internal", desktop: false),
+            record("exec-helper"),
+            record("visible"),
+        ]
+        let first = manager.deriveSessionClassification(from: initialRecords)
+        XCTAssertEqual(first.displayCandidates.map(\.session.sessionId), ["visible"])
+
+        let second = manager.deriveSessionClassification(from: initialRecords + [record("new")])
+        XCTAssertEqual(second.displayCandidates.map(\.session.sessionId), ["visible", "new"])
+        XCTAssertEqual(second.archivedCodexThreadIDs, ["archived"])
+        XCTAssertEqual(second.missingCodexDesktopThreadIDs, ["missing"])
+        XCTAssertEqual(second.codexInternalHelperThreadIDs, ["internal"])
+        XCTAssertEqual(second.codexExecHelperThreadIDs, ["exec-helper"])
+
+        let third = manager.deriveSessionClassification(from: initialRecords + [record("new")])
+        XCTAssertEqual(
+            third.displayCandidates.map(\.session.sessionId),
+            ["archived", "missing", "internal", "exec-helper", "visible", "new"]
+        )
+        XCTAssertEqual(third.archivedCodexThreadIDs, [])
+        XCTAssertEqual(third.missingCodexDesktopThreadIDs, [])
+        XCTAssertEqual(third.codexInternalHelperThreadIDs, [])
+        XCTAssertEqual(third.codexExecHelperThreadIDs, [])
+        XCTAssertEqual(codexState.requests, [initialIDs, changedIDs, changedIDs])
+    }
+
+    func testCodexClassificationMemoryCarriesOnlyUnknownIDsAndClearsOnMissing() throws {
+        let initialIDs = Set(["changed", "retained", "known-missing"])
+        var initial = CodexThreadStateIndex()
+        initial.existingThreadIDs = ["changed", "retained"]
+        initial.archivedThreadIDs = ["changed"]
+        initial.internalHelperThreadIDs = ["retained"]
+
+        var memory = CodexThreadClassificationMemory()
+        _ = memory.effectiveIndex(from: .available(initial), matching: initialIDs)
+
+        let partialIDs = initialIDs.union(["new"])
+        var partial = CodexThreadStateIndex()
+        partial.existingThreadIDs = ["changed"]
+        partial.unknownThreadIDs = ["retained", "known-missing", "new"]
+        let effective = try XCTUnwrap(memory.effectiveIndex(from: .available(partial), matching: partialIDs))
+
+        XCTAssertEqual(effective.existingThreadIDs, ["changed", "retained"])
+        XCTAssertEqual(effective.archivedThreadIDs, [])
+        XCTAssertEqual(effective.internalHelperThreadIDs, ["retained"])
+        XCTAssertEqual(effective.unknownThreadIDs, ["new"])
+
+        XCTAssertNil(memory.effectiveIndex(from: .missing, matching: partialIDs))
+        let afterMissing = try XCTUnwrap(memory.effectiveIndex(from: .unreadable, matching: partialIDs))
+        XCTAssertEqual(afterMissing.existingThreadIDs, [])
+        XCTAssertEqual(afterMissing.internalHelperThreadIDs, [])
+        XCTAssertEqual(afterMissing.unknownThreadIDs, partialIDs)
+    }
+
     // MARK: - Lifecycle derivation via injected process liveness
 
     // Lifecycle used to be testable only by fabricating PIDs that could not exist; with liveness
@@ -1092,6 +1196,45 @@ final class SessionLifecycleTests: XCTestCase {
         var working = session
         working.status = .working
         XCTAssertEqual(SessionManager.adjustIdleTimeout(working, now: pastTimeout).status, .working)
+    }
+}
+
+private final class SequencedCodexClassificationState: CodexThreadStateProviding {
+    private var snapshots: [CodexThreadStateSnapshot]
+    private(set) var requests: [Set<String>] = []
+
+    init(snapshots: [CodexThreadStateSnapshot]) {
+        self.snapshots = snapshots
+    }
+
+    func stateSnapshot(matching threadIDs: Set<String>) -> CodexThreadStateSnapshot {
+        guard !threadIDs.isEmpty else { return .available(CodexThreadStateIndex()) }
+        requests.append(threadIDs)
+        return snapshots.removeFirst()
+    }
+
+    func stateIndex(matching threadIDs: Set<String>) -> CodexThreadStateIndex? {
+        nil
+    }
+
+    func existingThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        nil
+    }
+
+    func archivedThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        nil
+    }
+
+    func internalHelperThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        nil
+    }
+
+    func execHelperThreadIDs(matching threadIDs: Set<String>) -> Set<String>? {
+        nil
+    }
+
+    func projectNames(matching threadIDs: Set<String>) -> [String: String]? {
+        nil
     }
 }
 


### PR DESCRIPTION
## Summary

- retain the last authoritative Codex classification for known sessions when the state database is transiently unreadable
- keep genuinely new sessions visible and replace retained facts on the next successful snapshot
- distinguish missing, partial, and unreadable database state without changing deletion safety or polling behavior

Fixes #225