### PR TITLE
Migrate manually hidden sessions to permanent identity

### DIFF
--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -199,7 +199,11 @@ so later observations can join the hidden set. A complete inventory retires the
 legacy keys, including process/PID keys, rather than rebinding them to a current
 session. Until an exact Codex or desktop match receives a valid permanent ID,
 that durable legacy key remains a fail-closed display fallback and its finished
-session record is retained. Process/PID keys never participate in this fallback.
+session record is retained. A retained finished non-desktop dedup winner remains
+available to Cleanup without entering Recent Projects. Unreadable pre-PID files
+also survive cleanup while any durable legacy key remains unresolved because
+they cannot yet be proven unrelated. Process/PID keys never participate in this
+fallback.
 
 ### `is_subagent`
 

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -199,8 +199,8 @@ so later observations can join the hidden set. A complete inventory retires the
 legacy keys, including process/PID keys, rather than rebinding them to a current
 session. Until an exact Codex or desktop match receives a valid permanent ID,
 that durable legacy key remains a fail-closed display fallback and its finished
-session record is retained. A retained finished non-desktop dedup winner remains
-available to Cleanup without entering Recent Projects. Unreadable pre-PID files
+session record is retained. Retained finished non-desktop dedup winners and archived
+desktop records remain available to Cleanup without entering Recent Projects. Unreadable pre-PID files
 also survive cleanup while any durable legacy key remains unresolved because
 they cannot yet be proven unrelated. Process/PID keys never participate in this
 fallback.

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -197,7 +197,9 @@ values. If identity drift produced several exact matches, all remain hidden.
 Legacy keys survive partial reads even after their known permanent IDs migrate,
 so later observations can join the hidden set. A complete inventory retires the
 legacy keys, including process/PID keys, rather than rebinding them to a current
-session.
+session. Until an exact Codex or desktop match receives a valid permanent ID,
+that durable legacy key remains a fail-closed display fallback and its finished
+session record is retained. Process/PID keys never participate in this fallback.
 
 ### `is_subagent`
 

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -191,6 +191,14 @@ Cleanup tracking. There is no in-app restore. cctop prunes the preference only
 after a complete local inventory proves the session record is gone; partial or
 unreadable inventories retain it to avoid unexpectedly revealing the session.
 
+Upgrades from the initial manual-hiding implementation migrate exact legacy
+Codex and desktop conversation matches to their permanent `cctop_session_id`
+values. If identity drift produced several exact matches, all remain hidden.
+Legacy keys survive partial reads even after their known permanent IDs migrate,
+so later observations can join the hidden set. A complete inventory retires the
+legacy keys, including process/PID keys, rather than rebinding them to a current
+session.
+
 ### `is_subagent`
 
 Type: `boolean`

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -190,20 +190,19 @@ Stream Deck output while the full record remains available for lifecycle and
 Cleanup tracking. There is no in-app restore. cctop prunes the preference only
 after a complete local inventory proves the session record is gone; partial or
 unreadable inventories retain it to avoid unexpectedly revealing the session.
+Finished manually hidden records remain exempt from lifecycle cleanup, including
+after legacy preferences migrate, so their permanent identity evidence stays
+available until the record is removed externally.
 
-Upgrades from the initial manual-hiding implementation migrate exact legacy
-Codex and desktop conversation matches to their permanent `cctop_session_id`
-values. If identity drift produced several exact matches, all remain hidden.
-Legacy keys survive partial reads even after their known permanent IDs migrate,
-so later observations can join the hidden set. A complete inventory retires the
-legacy keys, including process/PID keys, rather than rebinding them to a current
-session. Until an exact Codex or desktop match receives a valid permanent ID,
-that durable legacy key remains a fail-closed display fallback and its finished
-session record is retained. Retained finished non-desktop dedup winners and archived
-desktop records remain available to Cleanup without entering Recent Projects. Unreadable pre-PID files
-also survive cleanup while any durable legacy key remains unresolved because
-they cannot yet be proven unrelated. Process/PID keys never participate in this
-fallback.
+Upgrades migrate an exact, unambiguous legacy Codex or desktop key to its
+permanent `cctop_session_id` before building the visible projection. Partial
+inventories retain the legacy key after adding a known permanent ID; missing or
+ambiguous matches also remain unresolved so later observations stay hidden.
+Complete inventories retire migrated and proven-missing keys. Process/PID keys
+are retired rather than rebound. Retained finished non-desktop winners and
+archived desktop records remain available to Cleanup without entering Recent
+Projects. Unreadable pre-PID files survive while stored manual-hide evidence
+prevents proving them unrelated.
 
 ### `is_subagent`
 

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -194,15 +194,17 @@ Finished manually hidden records remain exempt from lifecycle cleanup, including
 after legacy preferences migrate, so their permanent identity evidence stays
 available until the record is removed externally.
 
-Upgrades migrate an exact, unambiguous legacy Codex or desktop key to its
-permanent `cctop_session_id` before building the visible projection. Partial
-inventories retain the legacy key after adding a known permanent ID; missing or
-ambiguous matches also remain unresolved so later observations stay hidden.
-Complete inventories retire migrated and proven-missing keys. Process/PID keys
-are retired rather than rebound. Retained finished non-desktop winners and
-archived desktop records remain available to Cleanup without entering Recent
-Projects. Unreadable pre-PID files survive while stored manual-hide evidence
-prevents proving them unrelated.
+Upgrades migrate an unambiguous legacy Codex or desktop key to its permanent
+`cctop_session_id` before building the visible projection. The canonical source
+and session UUID in the key can adopt the sole permanent ID already stamped on
+a peer even after the exact legacy observation disappears. Partial inventories
+retain the fallback; zero or multiple matching permanent IDs keep every current
+candidate hidden and the visibility projections frozen. Complete inventories
+retire disk-confirmed migrations and proven-missing keys. Process/PID keys are
+retired rather than rebound. Retained finished winners and archived desktop
+records remain available to Cleanup without entering Recent Projects. Unreadable
+pre-PID files survive while stored manual-hide evidence prevents proving them
+unrelated.
 
 ### `is_subagent`
 

--- a/menubar/CctopMenubar/Services/CctopSessionIdentityStore.swift
+++ b/menubar/CctopMenubar/Services/CctopSessionIdentityStore.swift
@@ -20,8 +20,25 @@ struct CctopSessionIdentityStore {
         self.sessionsDir = sessionsDir
     }
 
+    /// Returns an already-persisted durable identity without creating mapping state.
+    func existingIdentity(
+        source: String?,
+        harnessSessionId: String?,
+        legacySessionId: String
+    ) throws -> String? {
+        guard let evidence = Self.durableEvidence(
+            source: source,
+            harnessSessionId: harnessSessionId,
+            legacySessionId: legacySessionId
+        ) else {
+            return nil
+        }
+        let mappingURL = identityDirectory.appendingPathComponent(Self.mappingFileName(for: evidence))
+        guard FileManager.default.fileExists(atPath: mappingURL.path) else { return nil }
+        return try readMapping(at: mappingURL)
+    }
+
     // Resolution intentionally keeps mapping validation and creation under one flock.
-    // swiftlint:disable:next function_body_length
     func resolve(
         source: String?,
         harnessSessionId: String?,
@@ -47,13 +64,7 @@ struct CctopSessionIdentityStore {
         var resolved: String?
         try withSessionLock(sessionPath: mappingURL.path) {
             if FileManager.default.fileExists(atPath: mappingURL.path) {
-                let decoder = JSONDecoder()
-                decoder.keyDecodingStrategy = .convertFromSnakeCase
-                let mapping = try decoder.decode(Mapping.self, from: Data(contentsOf: mappingURL))
-                guard Session.isValidCctopSessionId(mapping.cctopSessionId) else {
-                    throw StoreError.corruptMapping(mappingURL.lastPathComponent)
-                }
-                resolved = mapping.cctopSessionId
+                resolved = try readMapping(at: mappingURL)
                 return
             }
 
@@ -126,6 +137,16 @@ struct CctopSessionIdentityStore {
         let canonical = "v1:\(evidence.utf8.count):\(evidence)"
         let digest = SHA256.hash(data: Data(canonical.utf8))
         return "v1-\(digest.map { String(format: "%02x", $0) }.joined()).json"
+    }
+
+    private func readMapping(at url: URL) throws -> String {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let mapping = try decoder.decode(Mapping.self, from: Data(contentsOf: url))
+        guard Session.isValidCctopSessionId(mapping.cctopSessionId) else {
+            throw StoreError.corruptMapping(url.lastPathComponent)
+        }
+        return mapping.cctopSessionId
     }
 
     private func writeMapping(_ mapping: Mapping, to url: URL) throws {

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -161,22 +161,34 @@ struct ManualSessionVisibilityStore {
         save(sessionIDs)
     }
 
-    /// Upgrade exact, unambiguous durable matches and retain partial or ambiguous keys as fallback.
+    /// Upgrade exact, unambiguous durable matches, but retire their fallback only after
+    /// the persisted inventory confirms the same identity. Retain partial or ambiguous keys.
     /// Process-scoped `active:<pid>` keys are retired rather than rebound to a new process generation.
     @discardableResult
-    func migrateLegacyStableKeys(using sessions: [Session], inventoryComplete: Bool) -> Set<String> {
+    func migrateLegacyStableKeys(
+        using sessions: [Session],
+        persistedSessions: [Session],
+        inventoryComplete: Bool
+    ) -> Set<String> {
         let legacyKeys = legacyStableKeys
         guard !legacyKeys.isEmpty else { return hiddenSessionIDs }
+
+        // A disk-stamped peer may supply a hide candidate when the legacy key itself
+        // contains the same durable source and session UUID evidence.
+        let persistedMatches = Self.persistedLegacyMigrationMatches(in: persistedSessions, legacyKeys: legacyKeys)
 
         var unresolvedMatchedKeys: Set<String> = []
         var sessionIDsByKey: [String: Set<String>] = [:]
         for session in sessions {
             let key = SessionIdentityPolicy.stableKey(for: session)
             guard legacyKeys.contains(key) else { continue }
-            if let cctopSessionID = SessionIdentityPolicy.logicalIdentity(for: session).cctopSessionID {
-                sessionIDsByKey[key, default: []].insert(cctopSessionID)
-            } else {
+            let matches = Self.legacyMigrationCandidateIDs(
+                for: session, persistedSessionIDsByEvidence: persistedMatches.sessionIDsByEvidence
+            )
+            if matches.isEmpty {
                 unresolvedMatchedKeys.insert(key)
+            } else {
+                sessionIDsByKey[key, default: []].formUnion(matches)
             }
         }
 
@@ -188,13 +200,24 @@ struct ManualSessionVisibilityStore {
                 continue
             }
 
-            let matches = sessionIDsByKey[key] ?? []
+            let legacyEvidence = Self.durableEvidence(forLegacyKey: key)
+            let persistedEvidenceSessionIDs = legacyEvidence.map { persistedMatches.sessionIDsByEvidence[$0] ?? [] } ?? []
+            var matches = sessionIDsByKey[key] ?? []
+            matches.formUnion(persistedEvidenceSessionIDs)
             let isUnambiguous = matches.count == 1 && !unresolvedMatchedKeys.contains(key)
-            if isUnambiguous, let match = matches.first {
-                migratedSessionIDs.insert(match)
-            }
-            let isProvenMissing = matches.isEmpty && !unresolvedMatchedKeys.contains(key)
-            if inventoryComplete && (isUnambiguous || isProvenMissing) {
+            if isUnambiguous, let match = matches.first { migratedSessionIDs.insert(match) }
+            let persistedSessionIDs = persistedMatches.sessionIDsByKey[key] ?? []
+            let persistedConfirmationIDs = persistedSessionIDs.isEmpty ? persistedEvidenceSessionIDs : persistedSessionIDs
+            let hasUnresolvedPersistedEvidence = legacyEvidence
+                .map(persistedMatches.unresolvedEvidence.contains) ?? false
+            let hasPersistedEvidence = !persistedEvidenceSessionIDs.isEmpty || hasUnresolvedPersistedEvidence
+            let isPersistedUnambiguous = isUnambiguous && persistedConfirmationIDs == matches
+                && !persistedMatches.unresolvedMatchedKeys.contains(key)
+                && !hasUnresolvedPersistedEvidence
+            let isProvenMissing = matches.isEmpty && !unresolvedMatchedKeys.contains(key) && persistedSessionIDs.isEmpty
+                && !persistedMatches.unresolvedMatchedKeys.contains(key)
+                && !hasPersistedEvidence
+            if inventoryComplete && (isPersistedUnambiguous || isProvenMissing) {
                 remainingLegacyKeys.remove(key)
             }
         }
@@ -202,6 +225,79 @@ struct ManualSessionVisibilityStore {
         if migratedSessionIDs != hiddenSessionIDs { save(migratedSessionIDs) }
         saveLegacy(remainingLegacyKeys)
         return migratedSessionIDs
+    }
+
+    private static func persistedLegacyMigrationMatches(
+        in sessions: [Session],
+        legacyKeys: Set<String>
+    ) -> (
+        sessionIDsByEvidence: [String: Set<String>],
+        unresolvedEvidence: Set<String>,
+        unresolvedMatchedKeys: Set<String>,
+        sessionIDsByKey: [String: Set<String>]
+    ) {
+        var sessionIDsByEvidence: [String: Set<String>] = [:]
+        var unresolvedEvidence: Set<String> = []
+        var unresolvedMatchedKeys: Set<String> = []
+        var sessionIDsByKey: [String: Set<String>] = [:]
+        for session in sessions {
+            let cctopSessionID = SessionIdentityPolicy.logicalIdentity(for: session).cctopSessionID
+            if let evidence = CctopSessionIdentityStore.durableEvidence(
+                source: session.source,
+                harnessSessionId: session.harnessSessionId,
+                legacySessionId: session.sessionId
+            ) {
+                if let cctopSessionID {
+                    sessionIDsByEvidence[evidence, default: []].insert(cctopSessionID)
+                } else {
+                    unresolvedEvidence.insert(evidence)
+                }
+            }
+
+            let key = SessionIdentityPolicy.stableKey(for: session)
+            guard legacyKeys.contains(key) else { continue }
+            if let cctopSessionID {
+                sessionIDsByKey[key, default: []].insert(cctopSessionID)
+            } else {
+                unresolvedMatchedKeys.insert(key)
+            }
+        }
+        return (sessionIDsByEvidence, unresolvedEvidence, unresolvedMatchedKeys, sessionIDsByKey)
+    }
+
+    private static func legacyMigrationCandidateIDs(
+        for session: Session,
+        persistedSessionIDsByEvidence: [String: Set<String>]
+    ) -> Set<String> {
+        var matches: Set<String> = []
+        if let cctopSessionID = SessionIdentityPolicy.logicalIdentity(for: session).cctopSessionID {
+            matches.insert(cctopSessionID)
+        }
+        if let evidence = CctopSessionIdentityStore.durableEvidence(
+            source: session.source,
+            harnessSessionId: session.harnessSessionId,
+            legacySessionId: session.sessionId
+        ) {
+            matches.formUnion(persistedSessionIDsByEvidence[evidence] ?? [])
+        }
+        return matches
+    }
+
+    static func durableEvidence(forLegacyKey key: String) -> String? {
+        let components = key.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        guard components.count == 2 else { return nil }
+        let source: String
+        switch components[0] {
+        case "codex": source = Session.codexSource
+        case "desktop": source = Session.ccSource
+        default: return nil
+        }
+        let sessionID = String(components[1])
+        return CctopSessionIdentityStore.durableEvidence(
+            source: source,
+            harnessSessionId: sessionID,
+            legacySessionId: sessionID
+        )
     }
 
     /// Remove IDs only after the caller has completed an authoritative local inventory.

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -141,6 +141,12 @@ struct ManualSessionVisibilityStore {
         !hiddenSessionIDs.isEmpty || !legacyStableKeys.isEmpty
     }
 
+    /// Exact durable legacy keys that still need a permanent identity before they can be retired.
+    /// Process-scoped keys never participate in display fallback because a PID can be reused.
+    var unresolvedDurableLegacyKeys: Set<String> {
+        legacyStableKeys.filter(Self.isDurableLegacyKey)
+    }
+
     func isHidden(_ session: Session) -> Bool {
         guard let cctopSessionID = session.cctopSessionId,
               Session.isValidCctopSessionId(cctopSessionID) else { return false }
@@ -214,6 +220,10 @@ struct ManualSessionVisibilityStore {
 
     private var legacyStableKeys: Set<String> {
         Set(defaults.stringArray(forKey: Self.legacyDefaultsKey) ?? [])
+    }
+
+    private static func isDurableLegacyKey(_ key: String) -> Bool {
+        key.hasPrefix("codex:") || key.hasPrefix("desktop:")
     }
 
     private func saveLegacy(_ keys: Set<String>) {

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -124,6 +124,7 @@ enum SessionIdentityPolicy {
 /// The stored payload is intentionally limited to opaque cctop-owned session IDs.
 struct ManualSessionVisibilityStore {
     static let defaultsKey = "manuallyHiddenCctopSessionIDs"
+    static let legacyDefaultsKey = "manuallyHiddenSessionStableKeys"
     static let live = ManualSessionVisibilityStore(defaults: .standard)
 
     private let defaults: UserDefaults
@@ -134,6 +135,10 @@ struct ManualSessionVisibilityStore {
 
     var hiddenSessionIDs: Set<String> {
         Set((defaults.stringArray(forKey: Self.defaultsKey) ?? []).filter(Session.isValidCctopSessionId))
+    }
+
+    var hasStoredVisibilityPreferences: Bool {
+        !hiddenSessionIDs.isEmpty || !legacyStableKeys.isEmpty
     }
 
     func isHidden(_ session: Session) -> Bool {
@@ -150,6 +155,47 @@ struct ManualSessionVisibilityStore {
         save(sessionIDs)
     }
 
+    /// Upgrade exact durable legacy matches to permanent IDs, retaining their keys until inventory is complete.
+    /// Process-scoped `active:<pid>` keys are never rebound to a new process generation.
+    @discardableResult
+    func migrateLegacyStableKeys(using sessions: [Session], inventoryComplete: Bool) -> Set<String> {
+        let legacyKeys = legacyStableKeys
+        guard !legacyKeys.isEmpty else { return hiddenSessionIDs }
+
+        var matchedKeys: Set<String> = []
+        var sessionIDsByKey: [String: Set<String>] = [:]
+        for session in sessions {
+            let key = SessionIdentityPolicy.stableKey(for: session)
+            guard legacyKeys.contains(key) else { continue }
+            matchedKeys.insert(key)
+            if let cctopSessionID = session.cctopSessionId,
+               Session.isValidCctopSessionId(cctopSessionID) {
+                sessionIDsByKey[key, default: []].insert(cctopSessionID)
+            }
+        }
+
+        var migratedSessionIDs = hiddenSessionIDs
+        var remainingLegacyKeys = legacyKeys
+        for key in legacyKeys.sorted() {
+            if key.hasPrefix("active:") {
+                if inventoryComplete { remainingLegacyKeys.remove(key) }
+                continue
+            }
+            guard matchedKeys.contains(key) else {
+                if inventoryComplete { remainingLegacyKeys.remove(key) }
+                continue
+            }
+            guard key.hasPrefix("codex:") || key.hasPrefix("desktop:"),
+                  let matches = sessionIDsByKey[key], !matches.isEmpty else { continue }
+            migratedSessionIDs.formUnion(matches)
+            if inventoryComplete { remainingLegacyKeys.remove(key) }
+        }
+
+        if migratedSessionIDs != hiddenSessionIDs { save(migratedSessionIDs) }
+        saveLegacy(remainingLegacyKeys)
+        return migratedSessionIDs
+    }
+
     /// Remove IDs only after the caller has completed an authoritative local inventory.
     func prune(retaining validSessionIDs: Set<String>) {
         let current = hiddenSessionIDs
@@ -163,6 +209,19 @@ struct ManualSessionVisibilityStore {
             defaults.removeObject(forKey: Self.defaultsKey)
         } else {
             defaults.set(sessionIDs.sorted(), forKey: Self.defaultsKey)
+        }
+    }
+
+    private var legacyStableKeys: Set<String> {
+        Set(defaults.stringArray(forKey: Self.legacyDefaultsKey) ?? [])
+    }
+
+    private func saveLegacy(_ keys: Set<String>) {
+        guard keys != legacyStableKeys else { return }
+        if keys.isEmpty {
+            defaults.removeObject(forKey: Self.legacyDefaultsKey)
+        } else {
+            defaults.set(keys.sorted(), forKey: Self.legacyDefaultsKey)
         }
     }
 }

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -169,6 +169,7 @@ struct ManualSessionVisibilityStore {
         guard !legacyKeys.isEmpty else { return hiddenSessionIDs }
 
         var matchedKeys: Set<String> = []
+        var unresolvedMatchedKeys: Set<String> = []
         var sessionIDsByKey: [String: Set<String>] = [:]
         for session in sessions {
             let key = SessionIdentityPolicy.stableKey(for: session)
@@ -177,6 +178,8 @@ struct ManualSessionVisibilityStore {
             if let cctopSessionID = session.cctopSessionId,
                Session.isValidCctopSessionId(cctopSessionID) {
                 sessionIDsByKey[key, default: []].insert(cctopSessionID)
+            } else {
+                unresolvedMatchedKeys.insert(key)
             }
         }
 
@@ -194,7 +197,9 @@ struct ManualSessionVisibilityStore {
             guard key.hasPrefix("codex:") || key.hasPrefix("desktop:"),
                   let matches = sessionIDsByKey[key], !matches.isEmpty else { continue }
             migratedSessionIDs.formUnion(matches)
-            if inventoryComplete { remainingLegacyKeys.remove(key) }
+            if inventoryComplete && !unresolvedMatchedKeys.contains(key) {
+                remainingLegacyKeys.remove(key)
+            }
         }
 
         if migratedSessionIDs != hiddenSessionIDs { save(migratedSessionIDs) }

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -137,12 +137,12 @@ struct ManualSessionVisibilityStore {
         Set((defaults.stringArray(forKey: Self.defaultsKey) ?? []).filter(Session.isValidCctopSessionId))
     }
 
-    var hasStoredVisibilityPreferences: Bool {
-        !hiddenSessionIDs.isEmpty || !legacyStableKeys.isEmpty
+    var hasStoredHideEvidence: Bool {
+        !hiddenSessionIDs.isEmpty || !unresolvedDurableLegacyKeys.isEmpty
     }
 
-    /// Exact durable legacy keys that still need a permanent identity before they can be retired.
-    /// Process-scoped keys never participate in display fallback because a PID can be reused.
+    /// Durable legacy keys retained as display fallback until a complete, unambiguous inventory.
+    /// A partial inventory may already have contributed a permanent ID. Process keys never participate.
     var unresolvedDurableLegacyKeys: Set<String> {
         legacyStableKeys.filter(Self.isDurableLegacyKey)
     }
@@ -161,22 +161,19 @@ struct ManualSessionVisibilityStore {
         save(sessionIDs)
     }
 
-    /// Upgrade exact durable legacy matches to permanent IDs, retaining their keys until inventory is complete.
-    /// Process-scoped `active:<pid>` keys are never rebound to a new process generation.
+    /// Upgrade exact, unambiguous durable matches and retain partial or ambiguous keys as fallback.
+    /// Process-scoped `active:<pid>` keys are retired rather than rebound to a new process generation.
     @discardableResult
     func migrateLegacyStableKeys(using sessions: [Session], inventoryComplete: Bool) -> Set<String> {
         let legacyKeys = legacyStableKeys
         guard !legacyKeys.isEmpty else { return hiddenSessionIDs }
 
-        var matchedKeys: Set<String> = []
         var unresolvedMatchedKeys: Set<String> = []
         var sessionIDsByKey: [String: Set<String>] = [:]
         for session in sessions {
             let key = SessionIdentityPolicy.stableKey(for: session)
             guard legacyKeys.contains(key) else { continue }
-            matchedKeys.insert(key)
-            if let cctopSessionID = session.cctopSessionId,
-               Session.isValidCctopSessionId(cctopSessionID) {
+            if let cctopSessionID = SessionIdentityPolicy.logicalIdentity(for: session).cctopSessionID {
                 sessionIDsByKey[key, default: []].insert(cctopSessionID)
             } else {
                 unresolvedMatchedKeys.insert(key)
@@ -186,18 +183,18 @@ struct ManualSessionVisibilityStore {
         var migratedSessionIDs = hiddenSessionIDs
         var remainingLegacyKeys = legacyKeys
         for key in legacyKeys.sorted() {
-            if key.hasPrefix("active:") {
+            guard Self.isDurableLegacyKey(key) else {
                 if inventoryComplete { remainingLegacyKeys.remove(key) }
                 continue
             }
-            guard matchedKeys.contains(key) else {
-                if inventoryComplete { remainingLegacyKeys.remove(key) }
-                continue
+
+            let matches = sessionIDsByKey[key] ?? []
+            let isUnambiguous = matches.count == 1 && !unresolvedMatchedKeys.contains(key)
+            if isUnambiguous, let match = matches.first {
+                migratedSessionIDs.insert(match)
             }
-            guard key.hasPrefix("codex:") || key.hasPrefix("desktop:"),
-                  let matches = sessionIDsByKey[key], !matches.isEmpty else { continue }
-            migratedSessionIDs.formUnion(matches)
-            if inventoryComplete && !unresolvedMatchedKeys.contains(key) {
+            let isProvenMissing = matches.isEmpty && !unresolvedMatchedKeys.contains(key)
+            if inventoryComplete && (isUnambiguous || isProvenMissing) {
                 remainingLegacyKeys.remove(key)
             }
         }

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -171,21 +171,31 @@ struct SessionClassificationSnapshot {
         })
     }
 
-    func unresolvedLegacyFinishedCleanupSources(
+    func unresolvedLegacyCleanupSources(
         winners: [DedupCandidate],
         legacyKeys: Set<String>
     ) -> [SessionCleanupSource] {
-        winners.compactMap { candidate in
-            let session = candidate.session
-            guard candidate.lifecycleRank == SessionLifecycle.finished.rawValue,
-                  session.hostClass != .desktop,
-                  !Session.isValidCctopSessionId(session.cctopSessionId),
+        let archivedSources = records.compactMap { record -> SessionCleanupSource? in
+            let session = record.candidate.session
+            guard case .hidden(let reason) = record.disposition,
+                  reason.emitsCleanupSource,
                   legacyKeys.contains(SessionIdentityPolicy.stableKey(for: session)),
                   session.hasCleanupSourcePath else {
                 return nil
             }
             return SessionCleanupSource(session: session)
         }
+        let finishedNonDesktopSources = winners.compactMap { candidate -> SessionCleanupSource? in
+            let session = candidate.session
+            guard candidate.lifecycleRank == SessionLifecycle.finished.rawValue,
+                  session.hostClass != .desktop,
+                  legacyKeys.contains(SessionIdentityPolicy.stableKey(for: session)),
+                  session.hasCleanupSourcePath else {
+                return nil
+            }
+            return SessionCleanupSource(session: session)
+        }
+        return archivedSources + finishedNonDesktopSources
     }
 
     /// Archived desktop conversations stay hidden and resumable in Recent, but a known

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -214,6 +214,46 @@ private extension Session {
 }
 
 extension SessionManager {
+    func archiveAndRemoveFinishedNonDesktop(
+        _ candidates: [DedupCandidate],
+        winners: [DedupCandidate],
+        unresolvedLegacyKeys: Set<String>
+    ) {
+        let winnerPaths = Set(winners.map(\.path))
+        for candidate in candidates {
+            guard !hasUnresolvedLegacyIdentity(candidate.session, keys: unresolvedLegacyKeys) else { continue }
+            // A finished dedup winner is a real completed non-desktop session, so keep today's
+            // Recent Projects behavior. A finished duplicate loser is stale migration debris;
+            // remove it without archiving so it cannot later surface as a separate session.
+            if winnerPaths.contains(candidate.path) {
+                archiveAndRemove(candidate)
+            } else {
+                removeStaleDuplicate(candidate)
+            }
+        }
+    }
+
+    func hasUnresolvedLegacyIdentity(_ session: Session, keys: Set<String>) -> Bool {
+        !Session.isValidCctopSessionId(session.cctopSessionId)
+            && keys.contains(SessionIdentityPolicy.stableKey(for: session))
+    }
+
+    private func archiveAndRemove(_ candidate: DedupCandidate) {
+        let session = candidate.session
+        // A dead non-desktop process holds no lock, so removing its .json needs no flock. Remove
+        // the .json ONLY — never the .lock (unlinking a lock a hook still holds splits the inode).
+        if historyManager.archiveSession(session) {
+            try? FileManager.default.removeItem(atPath: candidate.path)
+        } else {
+            sessionManagerLogger.warning("skipping removal of \(session.sessionId, privacy: .public) — archive failed")
+        }
+    }
+
+    private func removeStaleDuplicate(_ candidate: DedupCandidate) {
+        sessionManagerLogger.info("removing stale duplicate session file \(candidate.path, privacy: .public)")
+        try? FileManager.default.removeItem(atPath: candidate.path)
+    }
+
     nonisolated static func desktopAppRunningByBundleID(
         in sessions: [Session],
         lookup: DesktopAppConnectionLookup

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -171,6 +171,23 @@ struct SessionClassificationSnapshot {
         })
     }
 
+    func unresolvedLegacyFinishedCleanupSources(
+        winners: [DedupCandidate],
+        legacyKeys: Set<String>
+    ) -> [SessionCleanupSource] {
+        winners.compactMap { candidate in
+            let session = candidate.session
+            guard candidate.lifecycleRank == SessionLifecycle.finished.rawValue,
+                  session.hostClass != .desktop,
+                  !Session.isValidCctopSessionId(session.cctopSessionId),
+                  legacyKeys.contains(SessionIdentityPolicy.stableKey(for: session)),
+                  session.hasCleanupSourcePath else {
+                return nil
+            }
+            return SessionCleanupSource(session: session)
+        }
+    }
+
     /// Archived desktop conversations stay hidden and resumable in Recent, but a known
     /// project path can still seed worktree cleanup while preserving the session file.
     /// Non-desktop cleanup rows come from history.
@@ -236,6 +253,29 @@ extension SessionManager {
     func hasUnresolvedLegacyIdentity(_ session: Session, keys: Set<String>) -> Bool {
         !Session.isValidCctopSessionId(session.cctopSessionId)
             && keys.contains(SessionIdentityPolicy.stableKey(for: session))
+    }
+
+    func sweepLegacyUUIDFileIfNeeded(_ url: URL, unresolvedLegacyKeys: Set<String>) -> Bool {
+        guard Self.isLegacyUUIDFilename(url.deletingPathExtension().lastPathComponent) else { return false }
+        if unresolvedLegacyKeys.isEmpty {
+            try? FileManager.default.removeItem(at: url) // Pre-PID legacy file; no live writer to race.
+        } else if let data = try? Data(contentsOf: url),
+                  let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data),
+                  !hasUnresolvedLegacyIdentity(session, keys: unresolvedLegacyKeys) {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return true
+    }
+
+    func mergingCleanupSources(
+        _ retained: [SessionCleanupSource],
+        with replacements: [SessionCleanupSource]
+    ) -> [SessionCleanupSource] {
+        retained.filter { source in
+            !replacements.contains {
+                $0.sessionId == source.sessionId && $0.projectPath == source.projectPath
+            }
+        } + replacements
     }
 
     private func archiveAndRemove(_ candidate: DedupCandidate) {

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -163,11 +163,11 @@ struct SessionClassificationSnapshot {
         }
     }
 
-    func manualHiddenFinishedProjectPaths(_ hiddenSessionIDs: Set<String>) -> Set<String> {
-        Set(finishedNonDesktopCandidates.compactMap { candidate in
-            guard let cctopSessionID = candidate.session.cctopSessionId,
+    func manualHiddenProjectPaths(_ hiddenSessionIDs: Set<String>) -> Set<String> {
+        Set(records.compactMap { record in
+            guard let cctopSessionID = record.candidate.session.cctopSessionId,
                   hiddenSessionIDs.contains(cctopSessionID) else { return nil }
-            return candidate.session.projectPath
+            return record.candidate.session.projectPath
         })
     }
 
@@ -214,15 +214,19 @@ private extension Session {
 }
 
 extension SessionManager {
-    func retainedFinishedNonDesktopCleanupSources(
+    func retainedFinishedCleanupSources(
         winners: [DedupCandidate],
-        unresolvedLegacyKeys: Set<String>
+        unresolvedLegacyKeys: Set<String>,
+        unresolvedLegacyEvidence: Set<String>
     ) -> [SessionCleanupSource] {
         winners.compactMap { candidate in
             let session = candidate.session
             guard candidate.lifecycleRank == SessionLifecycle.finished.rawValue,
-                  session.hostClass != .desktop,
-                  shouldRetainManualHideEvidence(session, unresolvedLegacyKeys: unresolvedLegacyKeys),
+                  shouldRetainFinishedManualHideEvidence(
+                      session,
+                      legacyKeys: unresolvedLegacyKeys,
+                      legacyEvidence: unresolvedLegacyEvidence
+                  ),
                   session.hasCleanupSourcePath else {
                 return nil
             }
@@ -233,40 +237,111 @@ extension SessionManager {
     func archiveAndRemoveFinishedNonDesktop(
         _ candidates: [DedupCandidate],
         winners: [DedupCandidate],
-        unresolvedLegacyKeys: Set<String>
-    ) {
+        unresolvedLegacyKeys: Set<String>,
+        unresolvedLegacyEvidence: Set<String>
+    ) -> [SessionCleanupSource] {
         let winnerPaths = Set(winners.map(\.path))
+        var newlyArchivedCleanupSources: [SessionCleanupSource] = []
         for candidate in candidates {
-            guard !shouldRetainManualHideEvidence(
+            guard !shouldRetainFinishedManualHideEvidence(
                 candidate.session,
-                unresolvedLegacyKeys: unresolvedLegacyKeys
+                legacyKeys: unresolvedLegacyKeys,
+                legacyEvidence: unresolvedLegacyEvidence
             ) else { continue }
             // A finished dedup winner is a real completed non-desktop session, so keep today's
             // Recent Projects behavior. A finished duplicate loser is stale migration debris;
             // remove it without archiving so it cannot later surface as a separate session.
             if winnerPaths.contains(candidate.path) {
-                archiveAndRemove(candidate)
+                if let cleanupSource = archiveAndRemove(candidate) {
+                    newlyArchivedCleanupSources.append(cleanupSource)
+                }
             } else {
                 removeStaleDuplicate(candidate)
             }
         }
+        return newlyArchivedCleanupSources
     }
 
-    func shouldRetainManualHideEvidence(_ session: Session, unresolvedLegacyKeys: Set<String>) -> Bool {
+    func shouldRetainFinishedManualHideEvidence(
+        _ session: Session,
+        legacyKeys: Set<String>,
+        legacyEvidence: Set<String>
+    ) -> Bool {
+        shouldRetainManualHideEvidence(session, legacyKeys: legacyKeys, legacyEvidence: legacyEvidence)
+            || hasExistingMappedManualHide(session)
+    }
+
+    func hasExistingMappedManualHide(_ session: Session) -> Bool {
+        guard !Session.isValidCctopSessionId(session.cctopSessionId) else { return false }
+        let hiddenSessionIDs = dataSources.manualSessionVisibility.hiddenSessionIDs
+        guard !hiddenSessionIDs.isEmpty,
+              let existingID = try? CctopSessionIdentityStore(sessionsDir: dataSources.sessionsDir).existingIdentity(
+                  source: session.source,
+                  harnessSessionId: session.harnessSessionId,
+                  legacySessionId: session.sessionId
+              ) else {
+            return false
+        }
+        return hiddenSessionIDs.contains(existingID)
+    }
+
+    func shouldRetainManualHideEvidence(
+        _ session: Session,
+        legacyKeys: Set<String>,
+        legacyEvidence: Set<String>
+    ) -> Bool {
         dataSources.manualSessionVisibility.isHidden(session)
-            || unresolvedLegacyKeys.contains(SessionIdentityPolicy.stableKey(for: session))
+            || legacyKeys.contains(SessionIdentityPolicy.stableKey(for: session))
+            || CctopSessionIdentityStore.durableEvidence(
+                source: session.source,
+                harnessSessionId: session.harnessSessionId,
+                legacySessionId: session.sessionId
+            ).map(legacyEvidence.contains) == true
     }
 
-    func sweepLegacyUUIDFileIfNeeded(_ url: URL, unresolvedLegacyKeys: Set<String>) -> Bool {
+    func sweepLegacyUUIDFileIfNeeded(
+        _ url: URL,
+        unresolvedLegacyKeys: Set<String>,
+        unresolvedLegacyEvidence: Set<String>
+    ) -> Bool {
         guard Self.isLegacyUUIDFilename(url.deletingPathExtension().lastPathComponent) else { return false }
         if !dataSources.manualSessionVisibility.hasStoredHideEvidence {
             try? FileManager.default.removeItem(at: url) // Pre-PID legacy file; no live writer to race.
         } else if let data = try? Data(contentsOf: url),
                   let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data),
-                  !shouldRetainManualHideEvidence(session, unresolvedLegacyKeys: unresolvedLegacyKeys) {
+                  !shouldRetainFinishedManualHideEvidence(
+                      session,
+                      legacyKeys: unresolvedLegacyKeys,
+                      legacyEvidence: unresolvedLegacyEvidence
+                  ) {
             try? FileManager.default.removeItem(at: url)
         }
         return true
+    }
+
+    func unresolvedManualHideEvidence(in sessions: [Session], legacyKeys: Set<String>) -> Set<String> {
+        var evidence = Set(legacyKeys.compactMap {
+            ManualSessionVisibilityStore.durableEvidence(forLegacyKey: $0)
+        })
+        evidence.formUnion(sessions
+            .filter { legacyKeys.contains(SessionIdentityPolicy.stableKey(for: $0)) }
+            .compactMap {
+                CctopSessionIdentityStore.durableEvidence(
+                    source: $0.source,
+                    harnessSessionId: $0.harnessSessionId,
+                    legacySessionId: $0.sessionId
+                )
+            })
+        return evidence
+    }
+
+    func unresolvedManualHideEvidence(in files: [URL], legacyKeys: Set<String>) -> Set<String> {
+        unresolvedManualHideEvidence(
+            in: files.compactMap { url in
+                (try? Data(contentsOf: url)).flatMap { try? JSONDecoder.sessionDecoder.decode(Session.self, from: $0) }
+            },
+            legacyKeys: legacyKeys
+        )
     }
 
     func mergingCleanupSources(
@@ -280,14 +355,16 @@ extension SessionManager {
         } + replacements
     }
 
-    private func archiveAndRemove(_ candidate: DedupCandidate) {
+    private func archiveAndRemove(_ candidate: DedupCandidate) -> SessionCleanupSource? {
         let session = candidate.session
         // A dead non-desktop process holds no lock, so removing its .json needs no flock. Remove
         // the .json ONLY — never the .lock (unlinking a lock a hook still holds splits the inode).
         if historyManager.archiveSession(session) {
             try? FileManager.default.removeItem(atPath: candidate.path)
+            return session.hasCleanupSourcePath ? SessionCleanupSource(session: session) : nil
         } else {
             sessionManagerLogger.warning("skipping removal of \(session.sessionId, privacy: .public) — archive failed")
+            return nil
         }
     }
 

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -171,33 +171,6 @@ struct SessionClassificationSnapshot {
         })
     }
 
-    func unresolvedLegacyCleanupSources(
-        winners: [DedupCandidate],
-        legacyKeys: Set<String>
-    ) -> [SessionCleanupSource] {
-        let archivedSources = records.compactMap { record -> SessionCleanupSource? in
-            let session = record.candidate.session
-            guard case .hidden(let reason) = record.disposition,
-                  reason.emitsCleanupSource,
-                  legacyKeys.contains(SessionIdentityPolicy.stableKey(for: session)),
-                  session.hasCleanupSourcePath else {
-                return nil
-            }
-            return SessionCleanupSource(session: session)
-        }
-        let finishedNonDesktopSources = winners.compactMap { candidate -> SessionCleanupSource? in
-            let session = candidate.session
-            guard candidate.lifecycleRank == SessionLifecycle.finished.rawValue,
-                  session.hostClass != .desktop,
-                  legacyKeys.contains(SessionIdentityPolicy.stableKey(for: session)),
-                  session.hasCleanupSourcePath else {
-                return nil
-            }
-            return SessionCleanupSource(session: session)
-        }
-        return archivedSources + finishedNonDesktopSources
-    }
-
     /// Archived desktop conversations stay hidden and resumable in Recent, but a known
     /// project path can still seed worktree cleanup while preserving the session file.
     /// Non-desktop cleanup rows come from history.
@@ -241,6 +214,22 @@ private extension Session {
 }
 
 extension SessionManager {
+    func retainedFinishedNonDesktopCleanupSources(
+        winners: [DedupCandidate],
+        unresolvedLegacyKeys: Set<String>
+    ) -> [SessionCleanupSource] {
+        winners.compactMap { candidate in
+            let session = candidate.session
+            guard candidate.lifecycleRank == SessionLifecycle.finished.rawValue,
+                  session.hostClass != .desktop,
+                  shouldRetainManualHideEvidence(session, unresolvedLegacyKeys: unresolvedLegacyKeys),
+                  session.hasCleanupSourcePath else {
+                return nil
+            }
+            return SessionCleanupSource(session: session)
+        }
+    }
+
     func archiveAndRemoveFinishedNonDesktop(
         _ candidates: [DedupCandidate],
         winners: [DedupCandidate],
@@ -248,7 +237,10 @@ extension SessionManager {
     ) {
         let winnerPaths = Set(winners.map(\.path))
         for candidate in candidates {
-            guard !hasUnresolvedLegacyIdentity(candidate.session, keys: unresolvedLegacyKeys) else { continue }
+            guard !shouldRetainManualHideEvidence(
+                candidate.session,
+                unresolvedLegacyKeys: unresolvedLegacyKeys
+            ) else { continue }
             // A finished dedup winner is a real completed non-desktop session, so keep today's
             // Recent Projects behavior. A finished duplicate loser is stale migration debris;
             // remove it without archiving so it cannot later surface as a separate session.
@@ -260,18 +252,18 @@ extension SessionManager {
         }
     }
 
-    func hasUnresolvedLegacyIdentity(_ session: Session, keys: Set<String>) -> Bool {
-        !Session.isValidCctopSessionId(session.cctopSessionId)
-            && keys.contains(SessionIdentityPolicy.stableKey(for: session))
+    func shouldRetainManualHideEvidence(_ session: Session, unresolvedLegacyKeys: Set<String>) -> Bool {
+        dataSources.manualSessionVisibility.isHidden(session)
+            || unresolvedLegacyKeys.contains(SessionIdentityPolicy.stableKey(for: session))
     }
 
     func sweepLegacyUUIDFileIfNeeded(_ url: URL, unresolvedLegacyKeys: Set<String>) -> Bool {
         guard Self.isLegacyUUIDFilename(url.deletingPathExtension().lastPathComponent) else { return false }
-        if unresolvedLegacyKeys.isEmpty {
+        if !dataSources.manualSessionVisibility.hasStoredHideEvidence {
             try? FileManager.default.removeItem(at: url) // Pre-PID legacy file; no live writer to race.
         } else if let data = try? Data(contentsOf: url),
                   let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data),
-                  !hasUnresolvedLegacyIdentity(session, keys: unresolvedLegacyKeys) {
+                  !shouldRetainManualHideEvidence(session, unresolvedLegacyKeys: unresolvedLegacyKeys) {
             try? FileManager.default.removeItem(at: url)
         }
         return true

--- a/menubar/CctopMenubar/Services/SessionManager+Loading.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Loading.swift
@@ -137,13 +137,13 @@ extension SessionManager {
         )
     }
 
-    func identifiedPublishableSessions(
+    func identifiedPublishableCandidates(
         winners: [DedupCandidate],
         knownRecords: [(url: URL, session: Session)]
-    ) -> [Session] {
+    ) -> [DedupCandidate] {
         let publishableWinners = winners.filter { $0.session.lifecycle != .finished }
         let identified = assigningCctopSessionIdentities(to: publishableWinners, knownRecords: knownRecords)
-        let identifiedCandidates = zip(publishableWinners, identified).map { candidate, session in
+        return zip(publishableWinners, identified).map { candidate, session in
             DedupCandidate(
                 session: session,
                 lifecycleRank: candidate.lifecycleRank,
@@ -151,64 +151,30 @@ extension SessionManager {
                 path: candidate.path
             )
         }
-        return SessionIdentityPolicy.dedupedCandidatesByLogicalIdentity(identifiedCandidates).map(\.session)
     }
 
-    func identifyingRecentDesktopRecords(
+    func identifyingPersistedRecords(
         in classification: SessionClassificationSnapshot,
         knownRecords: [(url: URL, session: Session)]
     ) -> SessionClassificationSnapshot {
+        let legacyKeys = dataSources.manualSessionVisibility.unresolvedDurableLegacyKeys
         let indices = classification.records.indices.filter { index in
             let record = classification.records[index]
-            guard !Session.isValidCctopSessionId(record.candidate.session.cctopSessionId),
-                  case .hidden(let reason) = record.disposition else { return false }
+            let session = record.candidate.session
+            guard case .legacy(let stableKey) = SessionIdentityPolicy.logicalIdentity(for: session) else { return false }
+            if legacyKeys.contains(stableKey) { return true }
+            guard case .hidden(let reason) = record.disposition else { return false }
             switch reason {
             case .archivedCodexDesktop, .archivedClaudeDesktop:
                 return CctopSessionIdentityStore.durableEvidence(
-                    source: record.candidate.session.source,
-                    harnessSessionId: record.candidate.session.harnessSessionId,
-                    legacySessionId: record.candidate.session.sessionId
+                    source: session.source,
+                    harnessSessionId: session.harnessSessionId,
+                    legacySessionId: session.sessionId
                 ) != nil
             case .persistedHidden, .autoHidden, .missingCodexDesktopThread, .codexInternalHelper, .codexExecHelper,
                  .orphanedEndedClaudeDesktop, .claudeDesktopStartupPlaceholder:
                 return false
             }
-        }
-        guard !indices.isEmpty else { return classification }
-
-        let identified = assigningCctopSessionIdentities(
-            to: indices.map { classification.records[$0].candidate },
-            knownRecords: knownRecords
-        )
-        var records = classification.records
-        for (index, session) in zip(indices, identified) {
-            let record = records[index]
-            let candidate = record.candidate
-            records[index] = ClassifiedSessionRecord(
-                url: record.url,
-                candidate: DedupCandidate(
-                    session: session,
-                    lifecycleRank: candidate.lifecycleRank,
-                    mtime: candidate.mtime,
-                    path: candidate.path
-                ),
-                disposition: record.disposition
-            )
-        }
-        return SessionClassificationSnapshot(records: records, evidence: classification.evidence)
-    }
-
-    func identifyingLegacyManualHiddenRecords(
-        in classification: SessionClassificationSnapshot,
-        knownRecords: [(url: URL, session: Session)]
-    ) -> SessionClassificationSnapshot {
-        let legacyKeys = dataSources.manualSessionVisibility.unresolvedDurableLegacyKeys
-        guard !legacyKeys.isEmpty else { return classification }
-
-        let indices = classification.records.indices.filter { index in
-            let session = classification.records[index].candidate.session
-            return !Session.isValidCctopSessionId(session.cctopSessionId)
-                && legacyKeys.contains(SessionIdentityPolicy.stableKey(for: session))
         }
         guard !indices.isEmpty else { return classification }
 

--- a/menubar/CctopMenubar/Services/SessionManager+Loading.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Loading.swift
@@ -198,6 +198,42 @@ extension SessionManager {
         return SessionClassificationSnapshot(records: records, evidence: classification.evidence)
     }
 
+    func identifyingLegacyManualHiddenRecords(
+        in classification: SessionClassificationSnapshot,
+        knownRecords: [(url: URL, session: Session)]
+    ) -> SessionClassificationSnapshot {
+        let legacyKeys = dataSources.manualSessionVisibility.unresolvedDurableLegacyKeys
+        guard !legacyKeys.isEmpty else { return classification }
+
+        let indices = classification.records.indices.filter { index in
+            let session = classification.records[index].candidate.session
+            return !Session.isValidCctopSessionId(session.cctopSessionId)
+                && legacyKeys.contains(SessionIdentityPolicy.stableKey(for: session))
+        }
+        guard !indices.isEmpty else { return classification }
+
+        let identified = assigningCctopSessionIdentities(
+            to: indices.map { classification.records[$0].candidate },
+            knownRecords: knownRecords
+        )
+        var records = classification.records
+        for (index, session) in zip(indices, identified) {
+            let record = records[index]
+            let candidate = record.candidate
+            records[index] = ClassifiedSessionRecord(
+                url: record.url,
+                candidate: DedupCandidate(
+                    session: session,
+                    lifecycleRank: candidate.lifecycleRank,
+                    mtime: candidate.mtime,
+                    path: candidate.path
+                ),
+                disposition: record.disposition
+            )
+        }
+        return SessionClassificationSnapshot(records: records, evidence: classification.evidence)
+    }
+
     private func scheduleRecordLocalCctopSessionIdentityStamp(url: URL, snapshot: Session) {
         guard pendingIdentityMigrationPaths.insert(url.path).inserted else { return }
         cctopIdentityMigrationQueue.async { [weak self] in

--- a/menubar/CctopMenubar/Services/SessionManager+Loading.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Loading.swift
@@ -113,7 +113,6 @@ extension SessionManager {
                 session.cctopSessionId = cctopSessionId
                 records[index].session = session
                 idsByEvidence[evidence, default: []].insert(cctopSessionId)
-                cacheMigratedSession(session, at: records[index].url.path)
                 scheduleCctopSessionIdentityStamp(
                     url: records[index].url,
                     snapshot: records[index].session
@@ -127,14 +126,6 @@ extension SessionManager {
             }
         }
         return records.map(\.session)
-    }
-
-    private func cacheMigratedSession(_ session: Session, at path: String) {
-        guard let cached = sessionFileCache[path] else { return }
-        sessionFileCache[path] = SessionFileCacheEntry(
-            fingerprint: cached.fingerprint,
-            session: session
-        )
     }
 
     func identifiedPublishableCandidates(
@@ -162,6 +153,7 @@ extension SessionManager {
             let record = classification.records[index]
             let session = record.candidate.session
             guard case .legacy(let stableKey) = SessionIdentityPolicy.logicalIdentity(for: session) else { return false }
+            if hasExistingMappedManualHide(session) { return true }
             if legacyKeys.contains(stableKey) { return true }
             guard case .hidden(let reason) = record.disposition else { return false }
             switch reason {

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -107,24 +107,28 @@ class SessionManager: ObservableObject {
         let identifiedCandidates = identifiedPublishableCandidates(winners: winners, knownRecords: allDecoded)
         let identifiedInventory = classification.records.map(\.candidate.session) + identifiedCandidates.map(\.session)
         let hiddenSessionIDs = dataSources.manualSessionVisibility.migrateLegacyStableKeys(
-            using: identifiedInventory,
-            inventoryComplete: inventoryComplete
+            using: identifiedInventory, persistedSessions: allDecoded.map(\.session), inventoryComplete: inventoryComplete
         )
         let unresolvedLegacyKeys = dataSources.manualSessionVisibility.unresolvedDurableLegacyKeys
-        let retainedFinishedCleanupSources = retainedFinishedNonDesktopCleanupSources(
+        let unresolvedLegacyEvidence = unresolvedManualHideEvidence(in: identifiedInventory, legacyKeys: unresolvedLegacyKeys)
+        let retainedFinishedCleanupSources = retainedFinishedCleanupSources(
             winners: winners,
-            unresolvedLegacyKeys: unresolvedLegacyKeys
+            unresolvedLegacyKeys: unresolvedLegacyKeys,
+            unresolvedLegacyEvidence: unresolvedLegacyEvidence
         )
         let observedCleanupSources = classification.cleanupSources + retainedFinishedCleanupSources
         let visibleCandidates = identifiedCandidates.filter { candidate in
             let session = candidate.session
             let hiddenByPermanentID = session.cctopSessionId.map(hiddenSessionIDs.contains) ?? false
             let hiddenByLegacyKey = unresolvedLegacyKeys.contains(SessionIdentityPolicy.stableKey(for: session))
-            return !hiddenByPermanentID && !hiddenByLegacyKey
+            let hiddenByLegacyEvidence = CctopSessionIdentityStore.durableEvidence(
+                source: session.source,
+                harnessSessionId: session.harnessSessionId,
+                legacySessionId: session.sessionId
+            ).map(unresolvedLegacyEvidence.contains) ?? false
+            return !hiddenByPermanentID && !hiddenByLegacyKey && !hiddenByLegacyEvidence
         }
-        let identifiedSessions = SessionIdentityPolicy
-            .dedupedCandidatesByLogicalIdentity(visibleCandidates)
-            .map(\.session)
+        let identifiedSessions = SessionIdentityPolicy.dedupedCandidatesByLogicalIdentity(visibleCandidates).map(\.session)
         let loadedSessions = identifiedSessions.map { adjustDisplayStatus($0) }
         let orderedSessions = SessionDisplayPolicy.reconcilingActiveOrder(in: loadedSessions, preserving: oldSessions, now: now)
         let newSessions = orderedSessions
@@ -147,13 +151,14 @@ class SessionManager: ObservableObject {
         // Non-desktop finished sessions keep today's behavior: archive to Recent Projects and
         // remove now (no Recent-Projects lag). Desktop files are retained while dormant and reaped
         // only by the slow, lock-held GC. No dormant file is ever deleted on this fast path.
-        archiveAndRemoveFinishedNonDesktop(
+        let newlyArchivedCleanupSources = archiveAndRemoveFinishedNonDesktop(
             classification.finishedNonDesktopCandidates,
             winners: winners,
-            unresolvedLegacyKeys: unresolvedLegacyKeys
+            unresolvedLegacyKeys: unresolvedLegacyKeys,
+            unresolvedLegacyEvidence: unresolvedLegacyEvidence
         )
         let activeProjectPaths = classification.protectedProjectPathsForCleanup
-        let recentExcludedPaths = activeProjectPaths.union(classification.manualHiddenFinishedProjectPaths(hiddenSessionIDs))
+        let recentExcludedPaths = activeProjectPaths.union(classification.manualHiddenProjectPaths(hiddenSessionIDs))
         let shouldFreezeVisibilityProjections = !unresolvedLegacyKeys.isEmpty
             || (!inventoryComplete && !hiddenSessionIDs.isEmpty)
         if !shouldFreezeVisibilityProjections {
@@ -167,7 +172,7 @@ class SessionManager: ObservableObject {
         } else { // Freeze existing items, add unresolved finished evidence, and only grow path protection.
             let frozenCleanupSources = mergingCleanupSources(
                 currentClassificationCleanupSources,
-                with: observedCleanupSources
+                with: observedCleanupSources + newlyArchivedCleanupSources
             )
             let frozenActiveProjectPaths = cleanupActiveProjectPaths.union(activeProjectPaths)
             if frozenCleanupSources != currentClassificationCleanupSources
@@ -300,30 +305,24 @@ class SessionManager: ObservableObject {
         }
     }
 
-    /// Pass 2: reap finished desktop files (non-desktop is handled on the fast path). Acquires
-    /// the per-session lock, re-validates under it, and unlinks the `.json` ONLY (never the `.lock`).
-    /// A decode failure is never treated as finished. Also sweeps pre-PID legacy files.
+    /// Reap finished desktop and pre-PID legacy files after lock-held lifecycle validation.
     func garbageCollectFinished() {
         let fm = FileManager.default
         guard let files = try? fm.contentsOfDirectory(at: sessionsDir, includingPropertiesForKeys: nil) else { return }
         let now = dataSources.now()
-        let unresolvedLegacyKeys = dataSources.manualSessionVisibility.unresolvedDurableLegacyKeys
+        let legacyKeys = dataSources.manualSessionVisibility.unresolvedDurableLegacyKeys
         let jsonFiles = files.filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasSuffix(".tmp") }
+        let legacyEvidence = unresolvedManualHideEvidence(in: jsonFiles, legacyKeys: legacyKeys)
         preloadDesktopArchiveStateForFinishedSessions(in: jsonFiles, now: now)
         var removedAny = false
         for url in jsonFiles {
-            if sweepLegacyUUIDFileIfNeeded(url, unresolvedLegacyKeys: unresolvedLegacyKeys) { continue }
-            withSessionLockForMaintenance(
-                sessionPath: url.path,
-                sessionId: url.deletingPathExtension().lastPathComponent,
-                action: "desktop GC"
-            ) {
+            if sweepLegacyUUIDFileIfNeeded(url, unresolvedLegacyKeys: legacyKeys, unresolvedLegacyEvidence: legacyEvidence) { continue }
+            withSessionLockForMaintenance(sessionPath: url.path, sessionId: url.deletingPathExtension().lastPathComponent, action: "desktop GC") {
                 guard let data = try? Data(contentsOf: url),
                       let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data) else {
                     return   // decode failure → never treat as finished
                 }
                 guard !session.hidden, !session.shouldAutoHide else { return }
-                guard !shouldRetainManualHideEvidence(session, unresolvedLegacyKeys: unresolvedLegacyKeys) else { return }
                 let hostClass = session.hostClass
                 guard hostClass == .desktop else { return }   // non-desktop handled on the fast path
                 let life = SessionLifecyclePolicy.lifecycle(
@@ -335,9 +334,12 @@ class SessionManager: ObservableObject {
                     desktopAppRunning: Self.desktopAppRunning(for: session, lookup: dataSources.desktopAppConnection)
                 )
                 guard life == .finished else { return }
-                // Re-read external desktop archive state under the lock, right before deleting. A
-                // session archived after the directory scan must keep its .json so a later unarchive
-                // can restore it. Provider-level caches keep this fresh guard cheap.
+                guard !shouldRetainFinishedManualHideEvidence(
+                    session,
+                    legacyKeys: legacyKeys,
+                    legacyEvidence: legacyEvidence
+                ) else { return }
+                // Re-check external archive state under the lock so a concurrent archive retains its file.
                 guard !Self.isArchivedDesktopSession(
                     session,
                     codexThreads: dataSources.codexThreads,
@@ -347,10 +349,8 @@ class SessionManager: ObservableObject {
                 removedAny = true
             }
         }
-        if removedAny {
-            if historyManager.rebuildRecentProjects(excludingActive: cleanupActiveProjectPaths) {
-                refreshCleanupSources(from: currentClassificationCleanupSources, activeProjectPaths: cleanupActiveProjectPaths)
-            }
+        if removedAny, historyManager.rebuildRecentProjects(excludingActive: cleanupActiveProjectPaths) {
+            refreshCleanupSources(from: currentClassificationCleanupSources, activeProjectPaths: cleanupActiveProjectPaths)
         }
     }
 

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -64,7 +64,7 @@ class SessionManager: ObservableObject {
 
     // swiftlint:disable:next function_body_length
     func loadSessions() {
-        let hasStoredVisibilityPreferences = dataSources.manualSessionVisibility.hasStoredVisibilityPreferences
+        let hasStoredHideEvidence = dataSources.manualSessionVisibility.hasStoredHideEvidence
         guard let files = try? FileManager.default.contentsOfDirectory(
             at: sessionsDir,
             includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey]
@@ -74,7 +74,7 @@ class SessionManager: ObservableObject {
             lastLoadLogSignature = nil
             sessionFileCache.removeAll()
             sessions = []
-            if !hasStoredVisibilityPreferences {
+            if !hasStoredHideEvidence {
                 publishRecentResumeTargets(historyManager.recentProjects.map(RecentResumeTarget.project))
             }
             return
@@ -85,11 +85,10 @@ class SessionManager: ObservableObject {
         let jsonFiles = sessionJSONFiles(in: files)
         let allDecoded = decodedSessions(from: jsonFiles)
         let inventoryComplete = allDecoded.count == jsonFiles.count
-        var classification = identifyingRecentDesktopRecords(
+        let classification = identifyingPersistedRecords(
             in: deriveSessionClassification(from: allDecoded),
             knownRecords: allDecoded
         )
-        classification = identifyingLegacyManualHiddenRecords(in: classification, knownRecords: allDecoded)
         let hidden = classification.records.filter { $0.disposition == .hidden(.persistedHidden) }
         let autoHidden = classification.autoHiddenSessions
         let displayCandidates = classification.displayCandidates
@@ -105,24 +104,30 @@ class SessionManager: ObservableObject {
         // Publish active + dormant; finished are hidden (swept below / by GC).
         let winners = SessionIdentityPolicy.dedupedCandidatesByStableKey(displayCandidates)
         let now = dataSources.now()
-        let identifiedSessions = identifiedPublishableSessions(winners: winners, knownRecords: allDecoded)
-        let identifiedInventory = classification.records.map(\.candidate.session) + identifiedSessions
+        let identifiedCandidates = identifiedPublishableCandidates(winners: winners, knownRecords: allDecoded)
+        let identifiedInventory = classification.records.map(\.candidate.session) + identifiedCandidates.map(\.session)
         let hiddenSessionIDs = dataSources.manualSessionVisibility.migrateLegacyStableKeys(
             using: identifiedInventory,
             inventoryComplete: inventoryComplete
         )
         let unresolvedLegacyKeys = dataSources.manualSessionVisibility.unresolvedDurableLegacyKeys
-        let unresolvedLegacyCleanupSources = classification.unresolvedLegacyCleanupSources(
+        let retainedFinishedCleanupSources = retainedFinishedNonDesktopCleanupSources(
             winners: winners,
-            legacyKeys: unresolvedLegacyKeys
+            unresolvedLegacyKeys: unresolvedLegacyKeys
         )
-        let loadedSessions = identifiedSessions.map { adjustDisplayStatus($0) }
-        let orderedSessions = SessionDisplayPolicy.reconcilingActiveOrder(in: loadedSessions, preserving: oldSessions, now: now)
-        let newSessions = orderedSessions.filter { session in
+        let observedCleanupSources = classification.cleanupSources + retainedFinishedCleanupSources
+        let visibleCandidates = identifiedCandidates.filter { candidate in
+            let session = candidate.session
             let hiddenByPermanentID = session.cctopSessionId.map(hiddenSessionIDs.contains) ?? false
             let hiddenByLegacyKey = unresolvedLegacyKeys.contains(SessionIdentityPolicy.stableKey(for: session))
             return !hiddenByPermanentID && !hiddenByLegacyKey
         }
+        let identifiedSessions = SessionIdentityPolicy
+            .dedupedCandidatesByLogicalIdentity(visibleCandidates)
+            .map(\.session)
+        let loadedSessions = identifiedSessions.map { adjustDisplayStatus($0) }
+        let orderedSessions = SessionDisplayPolicy.reconcilingActiveOrder(in: loadedSessions, preserving: oldSessions, now: now)
+        let newSessions = orderedSessions
         let displaySignature = SessionDisplayPolicy.signature(for: newSessions, now: now)
         syncTransitionNotifications(for: newSessions, oldSessions: oldSessions)
         // Only publish when data actually changed, or when the presentation bucket changed
@@ -149,19 +154,20 @@ class SessionManager: ObservableObject {
         )
         let activeProjectPaths = classification.protectedProjectPathsForCleanup
         let recentExcludedPaths = activeProjectPaths.union(classification.manualHiddenFinishedProjectPaths(hiddenSessionIDs))
-        if (inventoryComplete && unresolvedLegacyKeys.isEmpty)
-            || !dataSources.manualSessionVisibility.hasStoredVisibilityPreferences {
+        let shouldFreezeVisibilityProjections = !unresolvedLegacyKeys.isEmpty
+            || (!inventoryComplete && !hiddenSessionIDs.isEmpty)
+        if !shouldFreezeVisibilityProjections {
             _ = historyManager.rebuildRecentProjects(excludingActive: recentExcludedPaths)
             publishRecentResumeTargets(RecentResumeTarget.build(
                 projects: historyManager.recentProjects,
                 classification: classification,
                 excludingDesktopSessionIDs: hiddenSessionIDs
             ))
-            refreshCleanupSources(from: classification.cleanupSources, activeProjectPaths: activeProjectPaths)
+            refreshCleanupSources(from: observedCleanupSources, activeProjectPaths: activeProjectPaths)
         } else { // Freeze existing items, add unresolved finished evidence, and only grow path protection.
             let frozenCleanupSources = mergingCleanupSources(
                 currentClassificationCleanupSources,
-                with: unresolvedLegacyCleanupSources
+                with: observedCleanupSources
             )
             let frozenActiveProjectPaths = cleanupActiveProjectPaths.union(activeProjectPaths)
             if frozenCleanupSources != currentClassificationCleanupSources
@@ -317,7 +323,7 @@ class SessionManager: ObservableObject {
                     return   // decode failure → never treat as finished
                 }
                 guard !session.hidden, !session.shouldAutoHide else { return }
-                guard !hasUnresolvedLegacyIdentity(session, keys: unresolvedLegacyKeys) else { return }
+                guard !shouldRetainManualHideEvidence(session, unresolvedLegacyKeys: unresolvedLegacyKeys) else { return }
                 let hostClass = session.hostClass
                 guard hostClass == .desktop else { return }   // non-desktop handled on the fast path
                 let life = SessionLifecyclePolicy.lifecycle(

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -106,12 +106,16 @@ class SessionManager: ObservableObject {
         let winners = SessionIdentityPolicy.dedupedCandidatesByStableKey(displayCandidates)
         let now = dataSources.now()
         let identifiedSessions = identifiedPublishableSessions(winners: winners, knownRecords: allDecoded)
-        let identifiedInventory = allDecoded.map(\.session) + classification.records.map(\.candidate.session) + identifiedSessions
+        let identifiedInventory = classification.records.map(\.candidate.session) + identifiedSessions
         let hiddenSessionIDs = dataSources.manualSessionVisibility.migrateLegacyStableKeys(
             using: identifiedInventory,
             inventoryComplete: inventoryComplete
         )
         let unresolvedLegacyKeys = dataSources.manualSessionVisibility.unresolvedDurableLegacyKeys
+        let unresolvedLegacyCleanupSources = classification.unresolvedLegacyFinishedCleanupSources(
+            winners: winners,
+            legacyKeys: unresolvedLegacyKeys
+        )
         let loadedSessions = identifiedSessions.map { adjustDisplayStatus($0) }
         let orderedSessions = SessionDisplayPolicy.reconcilingActiveOrder(in: loadedSessions, preserving: oldSessions, now: now)
         let newSessions = orderedSessions.filter { session in
@@ -154,11 +158,16 @@ class SessionManager: ObservableObject {
                 excludingDesktopSessionIDs: hiddenSessionIDs
             ))
             refreshCleanupSources(from: classification.cleanupSources, activeProjectPaths: activeProjectPaths)
-        } else if !activeProjectPaths.isSubset(of: cleanupActiveProjectPaths) { // Freeze items; only grow path protection.
-            refreshCleanupSources(
-                from: currentClassificationCleanupSources,
-                activeProjectPaths: cleanupActiveProjectPaths.union(activeProjectPaths)
+        } else { // Freeze existing items, add unresolved finished evidence, and only grow path protection.
+            let frozenCleanupSources = mergingCleanupSources(
+                currentClassificationCleanupSources,
+                with: unresolvedLegacyCleanupSources
             )
+            let frozenActiveProjectPaths = cleanupActiveProjectPaths.union(activeProjectPaths)
+            if frozenCleanupSources != currentClassificationCleanupSources
+                || frozenActiveProjectPaths != cleanupActiveProjectPaths {
+                refreshCleanupSources(from: frozenCleanupSources, activeProjectPaths: frozenActiveProjectPaths)
+            }
         }
 
         // Prune permanent IDs only after a complete inventory; partial reads retain them to avoid revealing sessions.
@@ -297,10 +306,7 @@ class SessionManager: ObservableObject {
         preloadDesktopArchiveStateForFinishedSessions(in: jsonFiles, now: now)
         var removedAny = false
         for url in jsonFiles {
-            if Self.isLegacyUUIDFilename(url.deletingPathExtension().lastPathComponent) {
-                try? fm.removeItem(at: url)   // pre-PID legacy file; no live writer to race
-                continue
-            }
+            if sweepLegacyUUIDFileIfNeeded(url, unresolvedLegacyKeys: unresolvedLegacyKeys) { continue }
             withSessionLockForMaintenance(
                 sessionPath: url.path,
                 sessionId: url.deletingPathExtension().lastPathComponent,

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -112,7 +112,7 @@ class SessionManager: ObservableObject {
             inventoryComplete: inventoryComplete
         )
         let unresolvedLegacyKeys = dataSources.manualSessionVisibility.unresolvedDurableLegacyKeys
-        let unresolvedLegacyCleanupSources = classification.unresolvedLegacyFinishedCleanupSources(
+        let unresolvedLegacyCleanupSources = classification.unresolvedLegacyCleanupSources(
             winners: winners,
             legacyKeys: unresolvedLegacyKeys
         )

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -64,7 +64,7 @@ class SessionManager: ObservableObject {
 
     // swiftlint:disable:next function_body_length
     func loadSessions() {
-        let hiddenSessionIDs = dataSources.manualSessionVisibility.hiddenSessionIDs
+        let hasStoredVisibilityPreferences = dataSources.manualSessionVisibility.hasStoredVisibilityPreferences
         guard let files = try? FileManager.default.contentsOfDirectory(
             at: sessionsDir,
             includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey]
@@ -74,7 +74,9 @@ class SessionManager: ObservableObject {
             lastLoadLogSignature = nil
             sessionFileCache.removeAll()
             sessions = []
-            if hiddenSessionIDs.isEmpty { publishRecentResumeTargets(historyManager.recentProjects.map(RecentResumeTarget.project)) }
+            if !hasStoredVisibilityPreferences {
+                publishRecentResumeTargets(historyManager.recentProjects.map(RecentResumeTarget.project))
+            }
             return
         }
 
@@ -100,6 +102,11 @@ class SessionManager: ObservableObject {
         let winners = SessionIdentityPolicy.dedupedCandidatesByStableKey(displayCandidates)
         let now = dataSources.now()
         let identifiedSessions = identifiedPublishableSessions(winners: winners, knownRecords: allDecoded)
+        let identifiedInventory = allDecoded.map(\.session) + classification.records.map(\.candidate.session) + identifiedSessions
+        let hiddenSessionIDs = dataSources.manualSessionVisibility.migrateLegacyStableKeys(
+            using: identifiedInventory,
+            inventoryComplete: inventoryComplete
+        )
         let loadedSessions = identifiedSessions.map { adjustDisplayStatus($0) }
         let orderedSessions = SessionDisplayPolicy.reconcilingActiveOrder(in: loadedSessions, preserving: oldSessions, now: now)
         let newSessions = orderedSessions.filter { !($0.cctopSessionId.map(hiddenSessionIDs.contains) ?? false) }
@@ -125,7 +132,7 @@ class SessionManager: ObservableObject {
         archiveAndRemoveFinishedNonDesktop(classification.finishedNonDesktopCandidates, winners: winners)
         let activeProjectPaths = classification.protectedProjectPathsForCleanup
         let recentExcludedPaths = activeProjectPaths.union(classification.manualHiddenFinishedProjectPaths(hiddenSessionIDs))
-        if inventoryComplete || hiddenSessionIDs.isEmpty {
+        if inventoryComplete || !dataSources.manualSessionVisibility.hasStoredVisibilityPreferences {
             _ = historyManager.rebuildRecentProjects(excludingActive: recentExcludedPaths)
             publishRecentResumeTargets(RecentResumeTarget.build(
                 projects: historyManager.recentProjects,
@@ -142,7 +149,6 @@ class SessionManager: ObservableObject {
 
         // Prune permanent IDs only after a complete inventory; partial reads retain them to avoid revealing sessions.
         if inventoryComplete {
-            let identifiedInventory = allDecoded.map(\.session) + classification.records.map(\.candidate.session) + identifiedSessions
             let validSessionIDs = Set(identifiedInventory.compactMap(\.cctopSessionId).filter(Session.isValidCctopSessionId))
             dataSources.manualSessionVisibility.prune(retaining: validSessionIDs)
         }

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -85,7 +85,11 @@ class SessionManager: ObservableObject {
         let jsonFiles = sessionJSONFiles(in: files)
         let allDecoded = decodedSessions(from: jsonFiles)
         let inventoryComplete = allDecoded.count == jsonFiles.count
-        let classification = identifyingRecentDesktopRecords(in: deriveSessionClassification(from: allDecoded), knownRecords: allDecoded)
+        var classification = identifyingRecentDesktopRecords(
+            in: deriveSessionClassification(from: allDecoded),
+            knownRecords: allDecoded
+        )
+        classification = identifyingLegacyManualHiddenRecords(in: classification, knownRecords: allDecoded)
         let hidden = classification.records.filter { $0.disposition == .hidden(.persistedHidden) }
         let autoHidden = classification.autoHiddenSessions
         let displayCandidates = classification.displayCandidates
@@ -107,9 +111,14 @@ class SessionManager: ObservableObject {
             using: identifiedInventory,
             inventoryComplete: inventoryComplete
         )
+        let unresolvedLegacyKeys = dataSources.manualSessionVisibility.unresolvedDurableLegacyKeys
         let loadedSessions = identifiedSessions.map { adjustDisplayStatus($0) }
         let orderedSessions = SessionDisplayPolicy.reconcilingActiveOrder(in: loadedSessions, preserving: oldSessions, now: now)
-        let newSessions = orderedSessions.filter { !($0.cctopSessionId.map(hiddenSessionIDs.contains) ?? false) }
+        let newSessions = orderedSessions.filter { session in
+            let hiddenByPermanentID = session.cctopSessionId.map(hiddenSessionIDs.contains) ?? false
+            let hiddenByLegacyKey = unresolvedLegacyKeys.contains(SessionIdentityPolicy.stableKey(for: session))
+            return !hiddenByPermanentID && !hiddenByLegacyKey
+        }
         let displaySignature = SessionDisplayPolicy.signature(for: newSessions, now: now)
         syncTransitionNotifications(for: newSessions, oldSessions: oldSessions)
         // Only publish when data actually changed, or when the presentation bucket changed
@@ -129,10 +138,15 @@ class SessionManager: ObservableObject {
         // Non-desktop finished sessions keep today's behavior: archive to Recent Projects and
         // remove now (no Recent-Projects lag). Desktop files are retained while dormant and reaped
         // only by the slow, lock-held GC. No dormant file is ever deleted on this fast path.
-        archiveAndRemoveFinishedNonDesktop(classification.finishedNonDesktopCandidates, winners: winners)
+        archiveAndRemoveFinishedNonDesktop(
+            classification.finishedNonDesktopCandidates,
+            winners: winners,
+            unresolvedLegacyKeys: unresolvedLegacyKeys
+        )
         let activeProjectPaths = classification.protectedProjectPathsForCleanup
         let recentExcludedPaths = activeProjectPaths.union(classification.manualHiddenFinishedProjectPaths(hiddenSessionIDs))
-        if inventoryComplete || !dataSources.manualSessionVisibility.hasStoredVisibilityPreferences {
+        if (inventoryComplete && unresolvedLegacyKeys.isEmpty)
+            || !dataSources.manualSessionVisibility.hasStoredVisibilityPreferences {
             _ = historyManager.rebuildRecentProjects(excludingActive: recentExcludedPaths)
             publishRecentResumeTargets(RecentResumeTarget.build(
                 projects: historyManager.recentProjects,
@@ -211,36 +225,6 @@ class SessionManager: ObservableObject {
         return "maintenance"
     }
 
-    private func archiveAndRemoveFinishedNonDesktop(_ candidates: [DedupCandidate], winners: [DedupCandidate]) {
-        let winnerPaths = Set(winners.map(\.path))
-        for candidate in candidates {
-            // A finished dedup winner is a real completed non-desktop session, so keep today's
-            // Recent Projects behavior. A finished duplicate loser is stale migration debris;
-            // remove it without archiving so it cannot later surface as a separate session.
-            if winnerPaths.contains(candidate.path) {
-                archiveAndRemove(candidate)
-            } else {
-                removeStaleDuplicate(candidate)
-            }
-        }
-    }
-
-    private func archiveAndRemove(_ candidate: DedupCandidate) {
-        let session = candidate.session
-        // A dead non-desktop process holds no lock, so removing its .json needs no flock. Remove
-        // the .json ONLY — never the .lock (unlinking a lock a hook still holds splits the inode).
-        if historyManager.archiveSession(session) {
-            try? FileManager.default.removeItem(atPath: candidate.path)
-        } else {
-            sessionManagerLogger.warning("skipping removal of \(session.sessionId, privacy: .public) — archive failed")
-        }
-    }
-
-    private func removeStaleDuplicate(_ candidate: DedupCandidate) {
-        sessionManagerLogger.info("removing stale duplicate session file \(candidate.path, privacy: .public)")
-        try? FileManager.default.removeItem(atPath: candidate.path)
-    }
-
     private func clearReconnectedDesktopSessions(_ candidates: [DedupCandidate], now: Date) {
         for candidate in candidates {
             guard candidate.session.hostClass == .desktop,
@@ -308,6 +292,7 @@ class SessionManager: ObservableObject {
         let fm = FileManager.default
         guard let files = try? fm.contentsOfDirectory(at: sessionsDir, includingPropertiesForKeys: nil) else { return }
         let now = dataSources.now()
+        let unresolvedLegacyKeys = dataSources.manualSessionVisibility.unresolvedDurableLegacyKeys
         let jsonFiles = files.filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasSuffix(".tmp") }
         preloadDesktopArchiveStateForFinishedSessions(in: jsonFiles, now: now)
         var removedAny = false
@@ -326,6 +311,7 @@ class SessionManager: ObservableObject {
                     return   // decode failure → never treat as finished
                 }
                 guard !session.hidden, !session.shouldAutoHide else { return }
+                guard !hasUnresolvedLegacyIdentity(session, keys: unresolvedLegacyKeys) else { return }
                 let hostClass = session.hostClass
                 guard hostClass == .desktop else { return }   // non-desktop handled on the fast path
                 let life = SessionLifecyclePolicy.lifecycle(

--- a/menubar/CctopMenubarTests/SessionLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/SessionLifecycleTests.swift
@@ -166,6 +166,7 @@ final class SessionLifecycleTests: XCTestCase {
             ]
         )
         var sources = SessionDataSources.live()
+        sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-batched-codex-state")
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = codexThreads
         sources.desktopAppConnection = DesktopAppConnectionLookup { _ in false }
@@ -826,6 +827,7 @@ final class SessionLifecycleTests: XCTestCase {
         try claude.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("\(claudeID).json"))
 
         var sources = SessionDataSources.live()
+        sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-recent-desktop-targets")
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState(archived: [codexID])
         sources.claudeDesktopSessions = StubClaudeDesktopState(snapshot: ClaudeDesktopSessionMetadataSnapshot(
@@ -1067,6 +1069,7 @@ final class SessionLifecycleTests: XCTestCase {
             snapshots: [.available(initial), .unreadable, .available(changed)]
         )
         var sources = SessionDataSources.live()
+        sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-classification-retention")
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = codexState
         sources.desktopAppConnection = DesktopAppConnectionLookup { _ in true }

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -104,7 +104,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(atPath: root) }
 
-        let threadID = "legacy-hidden-thread"
+        let identityBlockerPath = (root as NSString).appendingPathComponent("session-identities")
+        try Data("not a directory".utf8).write(to: URL(fileURLWithPath: identityBlockerPath))
+        let threadID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+        let currentObservationID = "current-observation"
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
         var session = Session(
             sessionId: threadID,
@@ -112,12 +115,13 @@ final class SessionManagerVisibilityTests: XCTestCase {
             branch: "main",
             terminal: TerminalInfo(program: "zsh")
         )
-        session.cctopSessionId = cctopSessionID
+        session.cctopSessionId = nil
         session.harnessSessionId = threadID
         session.source = Session.codexSource
         session.pid = 4_204
-        session.status = .working
-        try session.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json"))
+        session.status = .waitingInput
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
+        try session.writeToFile(path: sessionPath)
         let brokenPath = (sessionsDir as NSString).appendingPathComponent("unrelated-broken.json")
         try Data("not valid session json".utf8).write(to: URL(fileURLWithPath: brokenPath))
 
@@ -129,11 +133,48 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         var sources = SessionDataSources.live()
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
-        sources.codexThreads = StubCodexThreadState(existing: [threadID], archived: [])
+        sources.codexThreads = StubCodexThreadState(existing: [threadID, currentObservationID], archived: [])
         sources.processAlive = { _ in true }
         sources.manualSessionVisibility = visibility
+        var postedNotificationIDs: [String] = []
+        sources.notificationsEnabled = { true }
+        sources.notificationClient = SessionNotificationClient(
+            add: { request, completion in
+                postedNotificationIDs.append(request.identifier)
+                completion(nil)
+            },
+            removePending: { _ in },
+            removeDelivered: { _ in }
+        )
         let historyManager = HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
         let manager = SessionManager(historyManager: historyManager, dataSources: sources, startMonitoring: false)
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(postedNotificationIDs.isEmpty)
+        XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
+        XCTAssertNil(try Session.fromFile(path: sessionPath).cctopSessionId)
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:\(threadID)"]
+        )
+
+        try FileManager.default.removeItem(atPath: identityBlockerPath)
+        var current = Session(
+            sessionId: currentObservationID,
+            projectPath: "/tmp/legacy-hidden",
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        current.cctopSessionId = cctopSessionID
+        current.harnessSessionId = threadID
+        current.source = Session.codexSource
+        current.pid = 4_205
+        current.status = .waitingInput
+        try current.writeToFile(
+            path: (sessionsDir as NSString).appendingPathComponent("codex-\(currentObservationID).json")
+        )
+
+        manager.loadSessions()
 
         XCTAssertTrue(manager.sessions.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [cctopSessionID])
@@ -141,6 +182,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
             ["codex:\(threadID)"]
         )
+        XCTAssertTrue(postedNotificationIDs.isEmpty)
 
         try FileManager.default.removeItem(atPath: brokenPath)
         manager.loadSessions()
@@ -151,58 +193,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let reloaded = SessionManager(historyManager: historyManager, dataSources: sources, startMonitoring: false)
         XCTAssertTrue(reloaded.sessions.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [cctopSessionID])
-    }
-
-    @MainActor
-    func testUnresolvedLegacyCodexManualHideFailsClosedBeforeIdentityResolution() throws {
-        let root = NSTemporaryDirectory() + "cctop-unresolved-legacy-live-\(UUID().uuidString)"
-        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
-        let historyDir = (root as NSString).appendingPathComponent("history")
-        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(atPath: root) }
-
-        let identityBlockerPath = (root as NSString).appendingPathComponent("session-identities")
-        try Data("not a directory".utf8).write(to: URL(fileURLWithPath: identityBlockerPath))
-        let threadID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
-        var session = Session(
-            sessionId: threadID,
-            projectPath: (root as NSString).appendingPathComponent("project"),
-            branch: "main",
-            terminal: TerminalInfo(program: "zsh")
-        )
-        session.cctopSessionId = nil
-        session.harnessSessionId = threadID
-        session.source = Session.codexSource
-        session.pid = 4_204
-        session.status = .working
-        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
-        try session.writeToFile(path: sessionPath)
-
-        let suiteName = "cctop-unresolved-legacy-live-\(UUID().uuidString)"
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
-        let visibility = ManualSessionVisibilityStore(defaults: defaults)
-
-        var sources = SessionDataSources.live()
-        sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
-        sources.codexThreads = StubCodexThreadState(existing: [threadID], archived: [])
-        sources.processAlive = { _ in true }
-        sources.manualSessionVisibility = visibility
-        let manager = SessionManager(
-            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
-            dataSources: sources,
-            startMonitoring: false
-        )
-
-        XCTAssertTrue(manager.sessions.isEmpty)
-        XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
-        XCTAssertNil(try Session.fromFile(path: sessionPath).cctopSessionId)
-        XCTAssertEqual(
-            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
-            ["codex:\(threadID)"]
-        )
+        XCTAssertTrue(postedNotificationIDs.isEmpty)
     }
 
     @MainActor
@@ -223,6 +214,16 @@ final class SessionManagerVisibilityTests: XCTestCase {
         session.harnessSessionId = threadID
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
         try session.writeToFile(path: sessionPath)
+        let unrelatedThreadID = "cccccccc-dddd-4eee-8fff-000000000001"
+        let unrelatedProjectPath = (root as NSString).appendingPathComponent("unrelated-project")
+        let unrelated = codexDesktopSession(
+            sessionId: unrelatedThreadID,
+            projectPath: unrelatedProjectPath
+        )
+        let unrelatedCctopSessionID = try XCTUnwrap(unrelated.cctopSessionId)
+        try unrelated.writeToFile(
+            path: (sessionsDir as NSString).appendingPathComponent("codex-\(unrelatedThreadID).json")
+        )
 
         let suiteName = "cctop-unresolved-legacy-archived-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -232,7 +233,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         var sources = SessionDataSources.live()
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
-        sources.codexThreads = StubCodexThreadState(existing: [threadID], archived: [threadID])
+        sources.codexThreads = StubCodexThreadState(
+            existing: [threadID, unrelatedThreadID],
+            archived: [threadID, unrelatedThreadID]
+        )
         sources.desktopAppConnection = DesktopAppConnectionLookup { _ in true }
         sources.processAlive = { _ in true }
         sources.manualSessionVisibility = visibility
@@ -248,6 +252,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
             manager.cleanupSources.filter { $0.sessionId == threadID }.map(\.projectPath),
             [projectPath]
         )
+        XCTAssertEqual(
+            manager.cleanupSources.filter { $0.sessionId == unrelatedThreadID }.map(\.projectPath),
+            [unrelatedProjectPath]
+        )
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
         XCTAssertEqual(
@@ -255,34 +263,51 @@ final class SessionManagerVisibilityTests: XCTestCase {
             ["codex:\(threadID)"]
         )
 
+        let brokenPath = (sessionsDir as NSString).appendingPathComponent("broken.json")
+        try FileManager.default.removeItem(atPath: identityBlockerPath)
+        try Data("not valid session json".utf8).write(to: URL(fileURLWithPath: brokenPath))
         manager.loadSessions()
 
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 1)
+        XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == unrelatedThreadID }.count, 1)
+        XCTAssertEqual(visibility.hiddenSessionIDs.count, 1)
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:\(threadID)"]
+        )
+
+        try FileManager.default.removeItem(atPath: brokenPath)
+        manager.loadSessions()
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
+        XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 1)
+        XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == unrelatedThreadID }.count, 1)
+        XCTAssertEqual(manager.recentResumeTargets.compactMap(\.cctopSessionId), [unrelatedCctopSessionID])
     }
 
     @MainActor
-    func testPartialInventoryKeepsIdentifiedArchivedLegacyHideInCleanup() throws {
-        let root = NSTemporaryDirectory() + "cctop-partial-legacy-archived-\(UUID().uuidString)"
+    func testProcessScopedLegacyKeyDoesNotFreezeArchivedProjectionsDuringPartialInventory() throws {
+        let root = NSTemporaryDirectory() + "cctop-process-key-partial-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")
         let historyDir = (root as NSString).appendingPathComponent("history")
         try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(atPath: root) }
 
-        let threadID = "cccccccc-dddd-4eee-8fff-000000000000"
+        let threadID = "dddddddd-eeee-4fff-8000-111111111111"
         let projectPath = (root as NSString).appendingPathComponent("project")
         let session = codexDesktopSession(sessionId: threadID, projectPath: projectPath)
-        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
-        try session.writeToFile(path: sessionPath)
+        try session.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json"))
         try Data("not valid session json".utf8).write(
             to: URL(fileURLWithPath: (sessionsDir as NSString).appendingPathComponent("broken.json"))
         )
 
-        let suiteName = "cctop-partial-legacy-archived-\(UUID().uuidString)"
+        let suiteName = "cctop-process-key-partial-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        defaults.set(["active:42"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
 
         var sources = SessionDataSources.live()
@@ -298,12 +323,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
 
         XCTAssertTrue(manager.sessions.isEmpty)
-        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(manager.recentResumeTargets.compactMap(\.cctopSessionId), [session.cctopSessionId])
         XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.map(\.projectPath), [projectPath])
-        XCTAssertTrue(visibility.isHidden(session))
         XCTAssertEqual(
             defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
-            ["codex:\(threadID)"]
+            ["active:42"]
         )
     }
 
@@ -387,9 +411,23 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try FileManager.default.removeItem(atPath: identityBlockerPath)
         manager.loadSessions()
 
-        XCTAssertFalse(FileManager.default.fileExists(atPath: sessionPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
-        XCTAssertEqual(visibility.hiddenSessionIDs.count, 1)
+        let migratedSessionIDs = visibility.hiddenSessionIDs
+        XCTAssertEqual(migratedSessionIDs.count, 1)
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 1)
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
+
+        manager.loadSessions()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
+        XCTAssertEqual(visibility.hiddenSessionIDs, migratedSessionIDs)
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 1)
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
     }
 
     @MainActor
@@ -814,52 +852,27 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(manager.historyManager.recentProjects.map(\.projectPath), [projectPath])
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertTrue(visibility.isHidden(hidden))
-    }
 
-    @MainActor
-    func testUnresolvedLegacyManualHideKeepsRecentEmptyWhenSessionDirectoryReadFails() throws {
-        let root = NSTemporaryDirectory() + "cctop-legacy-hide-recent-directory-\(UUID().uuidString)"
-        let sessionsPath = (root as NSString).appendingPathComponent("sessions")
-        let historyDir = (root as NSString).appendingPathComponent("history")
-        try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(atPath: root) }
-
-        let projectPath = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .path
         let threadID = "legacy-hidden-directory-session"
-        var history = Session(
-            sessionId: "ended-legacy-hidden-directory-project",
-            projectPath: projectPath,
-            branch: "main",
-            terminal: TerminalInfo(program: "zsh")
-        )
-        history.endedAt = Date(timeIntervalSince1970: 2_000)
-        try history.writeToFile(path: (historyDir as NSString).appendingPathComponent("history.json"))
-        try Data("not a directory".utf8).write(to: URL(fileURLWithPath: sessionsPath))
+        let legacySuiteName = "cctop-legacy-hide-recent-directory-\(UUID().uuidString)"
+        let legacyDefaults = try XCTUnwrap(UserDefaults(suiteName: legacySuiteName))
+        defer { legacyDefaults.removePersistentDomain(forName: legacySuiteName) }
+        legacyDefaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        let legacyVisibility = ManualSessionVisibilityStore(defaults: legacyDefaults)
 
-        let suiteName = "cctop-legacy-hide-recent-directory-\(UUID().uuidString)"
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
-        let visibility = ManualSessionVisibilityStore(defaults: defaults)
-
-        let manager = makeManager(
+        let legacyManager = makeManager(
             sessionsDir: sessionsPath,
             historyDir: historyDir,
-            manualSessionVisibility: visibility
+            manualSessionVisibility: legacyVisibility
         )
 
-        XCTAssertEqual(manager.historyManager.recentProjects.map(\.projectPath), [projectPath])
-        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(legacyManager.historyManager.recentProjects.map(\.projectPath), [projectPath])
+        XCTAssertTrue(legacyManager.recentResumeTargets.isEmpty)
         XCTAssertEqual(
-            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            legacyDefaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
             ["codex:\(threadID)"]
         )
-        XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
+        XCTAssertTrue(legacyVisibility.hiddenSessionIDs.isEmpty)
     }
 
     @MainActor
@@ -2378,7 +2391,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
     }
 
     @MainActor
-    func testGarbageCollectRetainsUnresolvedLegacyDesktopEvidence() throws {
+    func testGarbageCollectRetainsLegacyDesktopEvidenceBeforeAndAfterMigration() throws {
         let root = NSTemporaryDirectory() + "cctop-unresolved-legacy-desktop-gc-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")
         let historyDir = (root as NSString).appendingPathComponent("history")
@@ -2386,10 +2399,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(atPath: root) }
 
-        try Data("not a directory".utf8).write(
-            to: URL(fileURLWithPath: (root as NSString).appendingPathComponent("session-identities"))
-        )
+        let identityBlockerPath = (root as NSString).appendingPathComponent("session-identities")
+        try Data("not a directory".utf8).write(to: URL(fileURLWithPath: identityBlockerPath))
         let threadID = "66666666-7777-4888-8999-aaaaaaaaaaaa"
+        let cctopSessionID = "66666666-7777-4888-8999-bbbbbbbbbbbb"
         let old = Date(timeIntervalSinceNow: -SessionManager.lifecycleWindows.retention - 86_400)
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("\(threadID).json")
         var session = codexDesktopSession(sessionId: threadID, projectPath: "/tmp/unresolved-legacy-desktop")
@@ -2426,7 +2439,22 @@ final class SessionManagerVisibilityTests: XCTestCase {
             ["codex:\(threadID)"]
         )
 
-        defaults.removeObject(forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        session.cctopSessionId = cctopSessionID
+        try session.writeToFile(path: sessionPath)
+        try FileManager.default.removeItem(atPath: identityBlockerPath)
+        manager.loadSessions()
+
+        XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
+        XCTAssertEqual(visibility.hiddenSessionIDs, [cctopSessionID])
+        manager.garbageCollectFinished()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
+        manager.loadSessions()
+        XCTAssertEqual(visibility.hiddenSessionIDs, [cctopSessionID])
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+
+        defaults.removeObject(forKey: ManualSessionVisibilityStore.defaultsKey)
         manager.garbageCollectFinished()
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: sessionPath))
@@ -2449,6 +2477,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let suiteName = "cctop-unreadable-legacy-uuid-gc-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
+        let cctopSessionID = "77777777-8888-4999-8aaa-cccccccccccc"
         defaults.set(["codex:unresolved"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
         let manager = makeManager(
@@ -2461,7 +2490,13 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
 
+        defaults.set([cctopSessionID], forKey: ManualSessionVisibilityStore.defaultsKey)
         defaults.removeObject(forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        manager.garbageCollectFinished()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
+
+        defaults.removeObject(forKey: ManualSessionVisibilityStore.defaultsKey)
         manager.garbageCollectFinished()
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: sessionPath))

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -154,6 +154,138 @@ final class SessionManagerVisibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testUnresolvedLegacyCodexManualHideFailsClosedBeforeIdentityResolution() throws {
+        let root = NSTemporaryDirectory() + "cctop-unresolved-legacy-live-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let identityBlockerPath = (root as NSString).appendingPathComponent("session-identities")
+        try Data("not a directory".utf8).write(to: URL(fileURLWithPath: identityBlockerPath))
+        let threadID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+        var session = Session(
+            sessionId: threadID,
+            projectPath: (root as NSString).appendingPathComponent("project"),
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        session.cctopSessionId = nil
+        session.harnessSessionId = threadID
+        session.source = Session.codexSource
+        session.pid = 4_204
+        session.status = .working
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
+        try session.writeToFile(path: sessionPath)
+
+        let suiteName = "cctop-unresolved-legacy-live-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
+        sources.codexThreads = StubCodexThreadState(existing: [threadID], archived: [])
+        sources.processAlive = { _ in true }
+        sources.manualSessionVisibility = visibility
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
+        XCTAssertNil(try Session.fromFile(path: sessionPath).cctopSessionId)
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:\(threadID)"]
+        )
+    }
+
+    @MainActor
+    func testUnresolvedLegacyFinishedSessionKeepsEvidenceAndRecentFrozen() throws {
+        let root = NSTemporaryDirectory() + "cctop-unresolved-legacy-finished-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let identityBlockerPath = (root as NSString).appendingPathComponent("session-identities")
+        try Data("not a directory".utf8).write(to: URL(fileURLWithPath: identityBlockerPath))
+        let projectPath = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .path
+        var history = Session(
+            sessionId: "previous-finished-project",
+            projectPath: projectPath,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        history.endedAt = Date(timeIntervalSince1970: 2_000)
+        try history.writeToFile(path: (historyDir as NSString).appendingPathComponent("history.json"))
+
+        let threadID = "11111111-2222-4333-8444-555555555555"
+        var finished = Session(
+            sessionId: threadID,
+            projectPath: projectPath,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        finished.cctopSessionId = nil
+        finished.harnessSessionId = threadID
+        finished.source = Session.codexSource
+        finished.pid = 4_205
+        finished.status = .working
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
+        try finished.writeToFile(path: sessionPath)
+
+        let suiteName = "cctop-unresolved-legacy-finished-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
+        sources.codexThreads = StubCodexThreadState(existing: [threadID], archived: [])
+        sources.processAlive = { _ in false }
+        sources.manualSessionVisibility = visibility
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
+        XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:\(threadID)"]
+        )
+
+        manager.loadSessions()
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
+
+        try FileManager.default.removeItem(atPath: identityBlockerPath)
+        manager.loadSessions()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: sessionPath))
+        XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
+        XCTAssertEqual(visibility.hiddenSessionIDs.count, 1)
+    }
+
+    @MainActor
     func testManualHideImmediatelyRemovesEveryProjectionSharingPermanentIdentity() throws {
         let root = NSTemporaryDirectory() + "cctop-manual-hide-shared-id-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")
@@ -2136,6 +2268,56 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [])
         manager.garbageCollectFinished()
         XCTAssertFalse(FileManager.default.fileExists(atPath: sessionPath))
+    }
+
+    @MainActor
+    func testGarbageCollectRetainsUnresolvedLegacyDesktopEvidence() throws {
+        let root = NSTemporaryDirectory() + "cctop-unresolved-legacy-desktop-gc-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        try Data("not a directory".utf8).write(
+            to: URL(fileURLWithPath: (root as NSString).appendingPathComponent("session-identities"))
+        )
+        let threadID = "66666666-7777-4888-8999-aaaaaaaaaaaa"
+        let old = Date(timeIntervalSinceNow: -SessionManager.lifecycleWindows.retention - 86_400)
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
+        var session = codexDesktopSession(sessionId: threadID, projectPath: "/tmp/unresolved-legacy-desktop")
+        session.cctopSessionId = nil
+        session.harnessSessionId = threadID
+        session.lastActivity = old
+        session.disconnectedAt = old
+        try session.writeToFile(path: sessionPath)
+
+        let suiteName = "cctop-unresolved-legacy-desktop-gc-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
+        sources.codexThreads = StubCodexThreadState(existing: [threadID], archived: [])
+        sources.desktopAppConnection = DesktopAppConnectionLookup { _ in false }
+        sources.processAlive = { _ in false }
+        sources.manualSessionVisibility = visibility
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        manager.garbageCollectFinished()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
+        XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:\(threadID)"]
+        )
     }
 
     // GC keeps a finished Claude Desktop file while its session metadata is archived, then reaps

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -206,6 +206,108 @@ final class SessionManagerVisibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testUnresolvedArchivedCodexLegacyHideKeepsCleanupAvailable() throws {
+        let root = NSTemporaryDirectory() + "cctop-unresolved-legacy-archived-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let identityBlockerPath = (root as NSString).appendingPathComponent("session-identities")
+        try Data("not a directory".utf8).write(to: URL(fileURLWithPath: identityBlockerPath))
+        let threadID = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff"
+        let projectPath = (root as NSString).appendingPathComponent("project")
+        var session = codexDesktopSession(sessionId: threadID, projectPath: projectPath)
+        session.cctopSessionId = nil
+        session.harnessSessionId = threadID
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
+        try session.writeToFile(path: sessionPath)
+
+        let suiteName = "cctop-unresolved-legacy-archived-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
+        sources.codexThreads = StubCodexThreadState(existing: [threadID], archived: [threadID])
+        sources.desktopAppConnection = DesktopAppConnectionLookup { _ in true }
+        sources.processAlive = { _ in true }
+        sources.manualSessionVisibility = visibility
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(
+            manager.cleanupSources.filter { $0.sessionId == threadID }.map(\.projectPath),
+            [projectPath]
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
+        XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:\(threadID)"]
+        )
+
+        manager.loadSessions()
+
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 1)
+    }
+
+    @MainActor
+    func testPartialInventoryKeepsIdentifiedArchivedLegacyHideInCleanup() throws {
+        let root = NSTemporaryDirectory() + "cctop-partial-legacy-archived-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let threadID = "cccccccc-dddd-4eee-8fff-000000000000"
+        let projectPath = (root as NSString).appendingPathComponent("project")
+        let session = codexDesktopSession(sessionId: threadID, projectPath: projectPath)
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
+        try session.writeToFile(path: sessionPath)
+        try Data("not valid session json".utf8).write(
+            to: URL(fileURLWithPath: (sessionsDir as NSString).appendingPathComponent("broken.json"))
+        )
+
+        let suiteName = "cctop-partial-legacy-archived-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
+        sources.codexThreads = StubCodexThreadState(existing: [threadID], archived: [threadID])
+        sources.desktopAppConnection = DesktopAppConnectionLookup { _ in true }
+        sources.processAlive = { _ in true }
+        sources.manualSessionVisibility = visibility
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: URL(fileURLWithPath: historyDir)),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.map(\.projectPath), [projectPath])
+        XCTAssertTrue(visibility.isHidden(session))
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:\(threadID)"]
+        )
+    }
+
+    @MainActor
     func testUnresolvedLegacyFinishedSessionKeepsEvidenceAndRecentFrozen() throws {
         let root = NSTemporaryDirectory() + "cctop-unresolved-legacy-finished-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -96,6 +96,64 @@ final class SessionManagerVisibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testLegacyCodexManualHideMigratesBeforePublishingAndSurvivesReloads() throws {
+        let root = NSTemporaryDirectory() + "cctop-legacy-manual-hide-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let threadID = "legacy-hidden-thread"
+        let cctopSessionID = "11111111-1111-4111-8111-111111111111"
+        var session = Session(
+            sessionId: threadID,
+            projectPath: "/tmp/legacy-hidden",
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        session.cctopSessionId = cctopSessionID
+        session.harnessSessionId = threadID
+        session.source = Session.codexSource
+        session.pid = 4_204
+        session.status = .working
+        try session.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json"))
+        let brokenPath = (sessionsDir as NSString).appendingPathComponent("unrelated-broken.json")
+        try Data("not valid session json".utf8).write(to: URL(fileURLWithPath: brokenPath))
+
+        let suiteName = "cctop-legacy-manual-hide-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
+        sources.codexThreads = StubCodexThreadState(existing: [threadID], archived: [])
+        sources.processAlive = { _ in true }
+        sources.manualSessionVisibility = visibility
+        let historyManager = HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
+        let manager = SessionManager(historyManager: historyManager, dataSources: sources, startMonitoring: false)
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertEqual(visibility.hiddenSessionIDs, [cctopSessionID])
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:\(threadID)"]
+        )
+
+        try FileManager.default.removeItem(atPath: brokenPath)
+        manager.loadSessions()
+        XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
+        manager.loadSessions()
+        XCTAssertTrue(manager.sessions.isEmpty)
+
+        let reloaded = SessionManager(historyManager: historyManager, dataSources: sources, startMonitoring: false)
+        XCTAssertTrue(reloaded.sessions.isEmpty)
+        XCTAssertEqual(visibility.hiddenSessionIDs, [cctopSessionID])
+    }
+
+    @MainActor
     func testManualHideImmediatelyRemovesEveryProjectionSharingPermanentIdentity() throws {
         let root = NSTemporaryDirectory() + "cctop-manual-hide-shared-id-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")
@@ -517,6 +575,52 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(manager.historyManager.recentProjects.map(\.projectPath), [projectPath])
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertTrue(visibility.isHidden(hidden))
+    }
+
+    @MainActor
+    func testUnresolvedLegacyManualHideKeepsRecentEmptyWhenSessionDirectoryReadFails() throws {
+        let root = NSTemporaryDirectory() + "cctop-legacy-hide-recent-directory-\(UUID().uuidString)"
+        let sessionsPath = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let projectPath = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .path
+        let threadID = "legacy-hidden-directory-session"
+        var history = Session(
+            sessionId: "ended-legacy-hidden-directory-project",
+            projectPath: projectPath,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        history.endedAt = Date(timeIntervalSince1970: 2_000)
+        try history.writeToFile(path: (historyDir as NSString).appendingPathComponent("history.json"))
+        try Data("not a directory".utf8).write(to: URL(fileURLWithPath: sessionsPath))
+
+        let suiteName = "cctop-legacy-hide-recent-directory-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+
+        let manager = makeManager(
+            sessionsDir: sessionsPath,
+            historyDir: historyDir,
+            manualSessionVisibility: visibility
+        )
+
+        XCTAssertEqual(manager.historyManager.recentProjects.map(\.projectPath), [projectPath])
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:\(threadID)"]
+        )
+        XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
     }
 
     @MainActor

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -264,6 +264,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         XCTAssertTrue(manager.sessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(
+            manager.cleanupSources.filter { $0.sessionId == threadID }.map(\.projectPath),
+            [projectPath]
+        )
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
         XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
@@ -274,6 +278,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         manager.loadSessions()
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 1)
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
 
@@ -2284,7 +2289,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         let threadID = "66666666-7777-4888-8999-aaaaaaaaaaaa"
         let old = Date(timeIntervalSinceNow: -SessionManager.lifecycleWindows.retention - 86_400)
-        let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent("\(threadID).json")
         var session = codexDesktopSession(sessionId: threadID, projectPath: "/tmp/unresolved-legacy-desktop")
         session.cctopSessionId = nil
         session.harnessSessionId = threadID
@@ -2318,6 +2323,46 @@ final class SessionManagerVisibilityTests: XCTestCase {
             defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
             ["codex:\(threadID)"]
         )
+
+        defaults.removeObject(forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        manager.garbageCollectFinished()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: sessionPath))
+    }
+
+    @MainActor
+    func testGarbageCollectRetainsUnreadableLegacyUUIDWhileDurableKeyIsUnresolved() throws {
+        let root = NSTemporaryDirectory() + "cctop-unreadable-legacy-uuid-gc-\(UUID().uuidString)"
+        let sessionsDir = (root as NSString).appendingPathComponent("sessions")
+        let historyDir = (root as NSString).appendingPathComponent("history")
+        try FileManager.default.createDirectory(atPath: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let sessionPath = (sessionsDir as NSString).appendingPathComponent(
+            "77777777-8888-4999-8aaa-bbbbbbbbbbbb.json"
+        )
+        try Data("not valid session json".utf8).write(to: URL(fileURLWithPath: sessionPath))
+
+        let suiteName = "cctop-unreadable-legacy-uuid-gc-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(["codex:unresolved"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            manualSessionVisibility: visibility
+        )
+
+        manager.garbageCollectFinished()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
+
+        defaults.removeObject(forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        manager.garbageCollectFinished()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: sessionPath))
     }
 
     // GC keeps a finished Claude Desktop file while its session metadata is archived, then reaps

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -108,7 +108,9 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try Data("not a directory".utf8).write(to: URL(fileURLWithPath: identityBlockerPath))
         let threadID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
         let currentObservationID = "current-observation"
+        let conflictingObservationID = "conflicting-observation"
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
+        let conflictingCctopSessionID = "22222222-2222-4222-8222-222222222222"
         var session = Session(
             sessionId: threadID,
             projectPath: "/tmp/legacy-hidden",
@@ -122,8 +124,25 @@ final class SessionManagerVisibilityTests: XCTestCase {
         session.status = .waitingInput
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
         try session.writeToFile(path: sessionPath)
-        let brokenPath = (sessionsDir as NSString).appendingPathComponent("unrelated-broken.json")
-        try Data("not valid session json".utf8).write(to: URL(fileURLWithPath: brokenPath))
+        var current = Session(
+            sessionId: currentObservationID,
+            projectPath: "/tmp/legacy-hidden",
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        current.cctopSessionId = cctopSessionID
+        current.harnessSessionId = threadID
+        current.source = Session.codexSource
+        current.pid = 4_205
+        current.status = .waitingInput
+        try current.writeToFile(
+            path: (sessionsDir as NSString).appendingPathComponent("codex-\(currentObservationID).json")
+        )
+        var conflicting = current
+        conflicting.sessionId = conflictingObservationID
+        conflicting.cctopSessionId = conflictingCctopSessionID
+        let conflictingPath = (sessionsDir as NSString).appendingPathComponent("codex-\(conflictingObservationID).json")
+        try conflicting.writeToFile(path: conflictingPath)
 
         let suiteName = "cctop-legacy-manual-hide-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -133,7 +152,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         var sources = SessionDataSources.live()
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
-        sources.codexThreads = StubCodexThreadState(existing: [threadID, currentObservationID], archived: [])
+        sources.codexThreads = StubCodexThreadState(
+            existing: [threadID, currentObservationID, conflictingObservationID],
+            archived: []
+        )
         sources.processAlive = { _ in true }
         sources.manualSessionVisibility = visibility
         var postedNotificationIDs: [String] = []
@@ -158,22 +180,19 @@ final class SessionManagerVisibilityTests: XCTestCase {
             ["codex:\(threadID)"]
         )
 
-        try FileManager.default.removeItem(atPath: identityBlockerPath)
-        var current = Session(
-            sessionId: currentObservationID,
-            projectPath: "/tmp/legacy-hidden",
-            branch: "main",
-            terminal: TerminalInfo(program: "zsh")
-        )
-        current.cctopSessionId = cctopSessionID
-        current.harnessSessionId = threadID
-        current.source = Session.codexSource
-        current.pid = 4_205
-        current.status = .waitingInput
-        try current.writeToFile(
-            path: (sessionsDir as NSString).appendingPathComponent("codex-\(currentObservationID).json")
+        try FileManager.default.removeItem(atPath: conflictingPath)
+        manager.loadSessions()
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(postedNotificationIDs.isEmpty)
+        XCTAssertEqual(visibility.hiddenSessionIDs, [cctopSessionID])
+        XCTAssertNil(try Session.fromFile(path: sessionPath).cctopSessionId)
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:\(threadID)"]
         )
 
+        try FileManager.default.removeItem(atPath: identityBlockerPath)
         manager.loadSessions()
 
         XCTAssertTrue(manager.sessions.isEmpty)
@@ -183,8 +202,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
             ["codex:\(threadID)"]
         )
         XCTAssertTrue(postedNotificationIDs.isEmpty)
+        waitForIdentityMigrationQueue(manager)
 
-        try FileManager.default.removeItem(atPath: brokenPath)
         manager.loadSessions()
         XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
         manager.loadSessions()
@@ -208,14 +227,28 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let identityBlockerPath = (root as NSString).appendingPathComponent("session-identities")
         try Data("not a directory".utf8).write(to: URL(fileURLWithPath: identityBlockerPath))
         let threadID = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff"
-        let projectPath = (root as NSString).appendingPathComponent("project")
+        let projectPath = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .path
         var session = codexDesktopSession(sessionId: threadID, projectPath: projectPath)
         session.cctopSessionId = nil
         session.harnessSessionId = threadID
+        session.endedAt = Date(timeIntervalSince1970: 2_100)
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
         try session.writeToFile(path: sessionPath)
         let unrelatedThreadID = "cccccccc-dddd-4eee-8fff-000000000001"
         let unrelatedProjectPath = (root as NSString).appendingPathComponent("unrelated-project")
+        try FileManager.default.createDirectory(atPath: unrelatedProjectPath, withIntermediateDirectories: true)
+        var previous = Session(
+            sessionId: "previous-hidden-project",
+            projectPath: projectPath,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        previous.endedAt = Date(timeIntervalSince1970: 2_000)
+        try previous.writeToFile(path: (historyDir as NSString).appendingPathComponent("previous-hidden-project.json"))
         let unrelated = codexDesktopSession(
             sessionId: unrelatedThreadID,
             projectPath: unrelatedProjectPath
@@ -276,6 +309,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
             ["codex:\(threadID)"]
         )
+        waitForIdentityMigrationQueue(manager)
 
         try FileManager.default.removeItem(atPath: brokenPath)
         manager.loadSessions()
@@ -285,6 +319,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 1)
         XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == unrelatedThreadID }.count, 1)
         XCTAssertEqual(manager.recentResumeTargets.compactMap(\.cctopSessionId), [unrelatedCctopSessionID])
+        XCTAssertEqual(manager.recentResumeTargets.map(\.projectPath), [unrelatedProjectPath])
     }
 
     @MainActor
@@ -370,6 +405,39 @@ final class SessionManagerVisibilityTests: XCTestCase {
         finished.status = .working
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
         try finished.writeToFile(path: sessionPath)
+        let fastPeerID = "finished-peer-fast"
+        var fastPeer = finished
+        fastPeer.sessionId = fastPeerID
+        fastPeer.cctopSessionId = "00000000-0000-4000-8000-000000000001"
+        fastPeer.pid = 4_206
+        let fastPeerPath = (sessionsDir as NSString).appendingPathComponent("codex-\(fastPeerID).json")
+        try fastPeer.writeToFile(path: fastPeerPath)
+
+        let desktopPeerID = "finished-peer-desktop"
+        let desktopPeerProjectPath = (root as NSString).appendingPathComponent("desktop-peer-project")
+        try FileManager.default.createDirectory(atPath: desktopPeerProjectPath, withIntermediateDirectories: true)
+        var desktopPeer = codexDesktopSession(sessionId: desktopPeerID, projectPath: desktopPeerProjectPath)
+        desktopPeer.cctopSessionId = "00000000-0000-4000-8000-000000000002"
+        desktopPeer.harnessSessionId = threadID
+        desktopPeer.lastActivity = Date(timeIntervalSince1970: 2_100)
+        desktopPeer.disconnectedAt = Date(timeIntervalSince1970: 2_100)
+        desktopPeer.endedAt = Date(timeIntervalSince1970: 2_100)
+        let desktopPeerPath = (sessionsDir as NSString).appendingPathComponent("codex-\(desktopPeerID).json")
+        try desktopPeer.writeToFile(path: desktopPeerPath)
+
+        let legacyPeerID = "finished-peer-legacy"
+        var legacyPeer = codexDesktopSession(sessionId: legacyPeerID, projectPath: projectPath)
+        legacyPeer.cctopSessionId = "00000000-0000-4000-8000-000000000003"
+        legacyPeer.harnessSessionId = threadID
+        legacyPeer.lastActivity = Date(timeIntervalSince1970: 2_100)
+        legacyPeer.disconnectedAt = Date(timeIntervalSince1970: 2_100)
+        legacyPeer.endedAt = Date(timeIntervalSince1970: 2_100)
+        let legacyPeerPath = (sessionsDir as NSString).appendingPathComponent(
+            "33333333-3333-4333-8333-333333333333.json"
+        )
+        try legacyPeer.writeToFile(path: legacyPeerPath)
+        let finishedPeerIDs = [fastPeerID, desktopPeerID, legacyPeerID]
+        let finishedPeerPaths = [fastPeerPath, desktopPeerPath, legacyPeerPath]
 
         let suiteName = "cctop-unresolved-legacy-finished-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -379,7 +447,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         var sources = SessionDataSources.live()
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
-        sources.codexThreads = StubCodexThreadState(existing: [threadID], archived: [])
+        sources.codexThreads = StubCodexThreadState(existing: Set([threadID] + finishedPeerIDs), archived: [])
+        sources.desktopAppConnection = DesktopAppConnectionLookup { _ in false }
         sources.processAlive = { _ in false }
         sources.manualSessionVisibility = visibility
         let manager = SessionManager(
@@ -390,11 +459,13 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         XCTAssertTrue(manager.sessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertTrue(manager.cleanupSources.contains { $0.projectPath == projectPath })
         XCTAssertEqual(
-            manager.cleanupSources.filter { $0.sessionId == threadID }.map(\.projectPath),
-            [projectPath]
+            manager.cleanupSources.filter { $0.sessionId == desktopPeerID }.map(\.projectPath),
+            [desktopPeerProjectPath]
         )
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
+        XCTAssertTrue(finishedPeerPaths.allSatisfy(FileManager.default.fileExists(atPath:)))
         XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
         XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
         XCTAssertEqual(
@@ -402,32 +473,172 @@ final class SessionManagerVisibilityTests: XCTestCase {
             ["codex:\(threadID)"]
         )
 
+        manager.garbageCollectFinished()
+        XCTAssertTrue(finishedPeerPaths.allSatisfy(FileManager.default.fileExists(atPath:)))
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
+        try finishedPeerPaths.forEach { try FileManager.default.removeItem(atPath: $0) }
+
         manager.loadSessions()
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 1)
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
 
+        let readyPath = (root as NSString).appendingPathComponent("identity-lock-ready")
+        let lockHolder = try startSessionLockHolder(
+            lockPath: sessionPath + ".lock",
+            readyPath: readyPath,
+            holdSeconds: 10
+        )
+        defer { terminateProcess(lockHolder) }
+
         try FileManager.default.removeItem(atPath: identityBlockerPath)
         manager.loadSessions()
+        XCTAssertNil(manager.sessionFileCache[sessionPath]?.session.cctopSessionId)
+        waitForIdentityMigrationQueue(manager)
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
-        XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
         let migratedSessionIDs = visibility.hiddenSessionIDs
         XCTAssertEqual(migratedSessionIDs.count, 1)
+        XCTAssertNil(try Session.fromFile(path: sessionPath).cctopSessionId)
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:\(threadID)"]
+        )
         XCTAssertTrue(manager.sessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 1)
         XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
 
         manager.loadSessions()
+        waitForIdentityMigrationQueue(manager)
 
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
+        XCTAssertEqual(visibility.hiddenSessionIDs, migratedSessionIDs)
+        XCTAssertNil(try Session.fromFile(path: sessionPath).cctopSessionId)
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:\(threadID)"]
+        )
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 1)
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
+
+        terminateProcess(lockHolder)
+        manager.loadSessions()
+        waitForIdentityMigrationQueue(manager)
+        XCTAssertEqual(try Session.fromFile(path: sessionPath).cctopSessionId, migratedSessionIDs.first)
+
+        manager.loadSessions()
+
+        XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertEqual(visibility.hiddenSessionIDs, migratedSessionIDs)
         XCTAssertTrue(manager.sessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 1)
         XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
+
+        defaults.removeObject(forKey: ManualSessionVisibilityStore.defaultsKey)
+        defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        try FileManager.default.removeItem(atPath: sessionPath)
+        try fastPeer.writeToFile(path: fastPeerPath)
+        try desktopPeer.writeToFile(path: desktopPeerPath)
+        try legacyPeer.writeToFile(path: legacyPeerPath)
+
+        manager.loadSessions()
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:\(threadID)"]
+        )
+        XCTAssertTrue(finishedPeerPaths.allSatisfy(FileManager.default.fileExists(atPath:)))
+        XCTAssertEqual(
+            manager.cleanupSources.filter { $0.sessionId == desktopPeerID }.map(\.projectPath),
+            [desktopPeerProjectPath]
+        )
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
+
+        try FileManager.default.removeItem(atPath: desktopPeerPath)
+        try FileManager.default.removeItem(atPath: legacyPeerPath)
+        manager.loadSessions()
+
+        XCTAssertEqual(visibility.hiddenSessionIDs, [try XCTUnwrap(fastPeer.cctopSessionId)])
+        XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fastPeerPath))
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
+    }
+
+    @MainActor
+    func testUnresolvedLegacyHideKeepsNewlyArchivedCleanupSourceWhileRecentIsFrozen() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-unresolved-legacy-new-archive-\(UUID().uuidString)", isDirectory: true)
+        let sessionsURL = root.appendingPathComponent("sessions", isDirectory: true)
+        let historyURL = root.appendingPathComponent("history", isDirectory: true)
+        let finishedProjectURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: sessionsURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: historyURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let identityBlockerURL = root.appendingPathComponent("session-identities")
+        try Data("not a directory".utf8).write(to: identityBlockerURL)
+        let hiddenThreadID = "11111111-2222-4333-8444-555555555555"
+        var hidden = codexTerminalSession(sessionId: hiddenThreadID, projectPath: root.path)
+        hidden.cctopSessionId = nil
+        hidden.harnessSessionId = hiddenThreadID
+        let hiddenURL = sessionsURL.appendingPathComponent("codex-\(hiddenThreadID).json")
+        try hidden.writeToFile(path: hiddenURL.path)
+
+        var finished = Session(
+            sessionId: "unrelated-finished",
+            projectPath: finishedProjectURL.path,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        finished.cctopSessionId = "22222222-2222-4222-8222-222222222222"
+        finished.source = Session.opencodeSource
+        finished.pid = 4_208
+        finished.status = .working
+        let finishedURL = sessionsURL.appendingPathComponent("unrelated-finished.json")
+        try finished.writeToFile(path: finishedURL.path)
+
+        let suiteName = "cctop-unresolved-legacy-new-archive-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(["codex:\(hiddenThreadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = sessionsURL
+        sources.codexThreads = StubCodexThreadState(existing: [hiddenThreadID], archived: [])
+        sources.processAlive = { $0.sessionId == hiddenThreadID }
+        sources.manualSessionVisibility = ManualSessionVisibilityStore(defaults: defaults)
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: historyURL),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: finishedURL.path))
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(at: historyURL, includingPropertiesForKeys: nil).count, 1)
+        XCTAssertEqual(
+            manager.cleanupSources.filter { $0.sessionId == finished.sessionId }.map(\.projectPath),
+            [finishedProjectURL.path]
+        )
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:\(hiddenThreadID)"]
+        )
     }
 
     @MainActor
@@ -560,6 +771,204 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [sharedID])
+    }
+
+    @MainActor
+    func testManualHideRetainsFinishedMappedRecordsUntilBusyIdentityStampsRetry() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-manual-hide-busy-stamp-\(UUID().uuidString)", isDirectory: true)
+        let sessionsURL = root.appendingPathComponent("sessions", isDirectory: true)
+        let historyURL = root.appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: historyURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let suiteName = "cctop-manual-hide-busy-stamp-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+        let durableSessionID = "59253133-4a65-48fb-af2b-844463d3b5bb"
+        let terminalObservationID = "busy-terminal-observation"
+        let desktopObservationID = "busy-desktop-observation"
+        let projectPath = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .path
+        let initialNow = Date(timeIntervalSince1970: 2_000_000_000)
+
+        var terminal = Session(
+            sessionId: terminalObservationID,
+            projectPath: projectPath,
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        terminal.cctopSessionId = nil
+        terminal.harnessSessionId = durableSessionID
+        terminal.source = Session.codexSource
+        terminal.pid = 4_207
+        terminal.status = .waitingInput
+        terminal.lastActivity = initialNow
+        let terminalURL = sessionsURL.appendingPathComponent("codex-\(terminalObservationID).json")
+        try terminal.writeToFile(path: terminalURL.path)
+
+        var desktop = codexDesktopSession(sessionId: desktopObservationID, projectPath: projectPath)
+        desktop.cctopSessionId = nil
+        desktop.harnessSessionId = durableSessionID
+        desktop.lastActivity = initialNow
+        let desktopURL = sessionsURL.appendingPathComponent("\(durableSessionID).json")
+        try desktop.writeToFile(path: desktopURL.path)
+
+        let terminalLock = try startSessionLockHolder(
+            lockPath: terminalURL.path + ".lock",
+            readyPath: root.appendingPathComponent("terminal-lock-ready").path,
+            holdSeconds: 20
+        )
+        defer { terminateProcess(terminalLock) }
+        let desktopLock = try startSessionLockHolder(
+            lockPath: desktopURL.path + ".lock",
+            readyPath: root.appendingPathComponent("desktop-lock-ready").path,
+            holdSeconds: 20
+        )
+        defer { terminateProcess(desktopLock) }
+
+        var processAlive = true
+        var now = initialNow
+        var postedNotificationIDs: [String] = []
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = sessionsURL
+        sources.codexThreads = StubCodexThreadState(
+            existing: [terminalObservationID, desktopObservationID],
+            archived: []
+        )
+        sources.desktopAppConnection = DesktopAppConnectionLookup { _ in false }
+        sources.processAlive = { _ in processAlive }
+        sources.notificationsEnabled = { true }
+        sources.notificationClient = SessionNotificationClient(
+            add: { request, completion in
+                postedNotificationIDs.append(request.identifier)
+                completion(nil)
+            },
+            removePending: { _ in },
+            removeDelivered: { _ in }
+        )
+        sources.manualSessionVisibility = visibility
+        sources.now = { now }
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: historyURL),
+            dataSources: sources,
+            startMonitoring: false
+        )
+        waitForIdentityMigrationQueue(manager)
+
+        let hidden = try XCTUnwrap(manager.sessions.first)
+        let hiddenID = try XCTUnwrap(hidden.cctopSessionId)
+        XCTAssertEqual(manager.sessions.count, 1)
+        XCTAssertNil(try Session.fromFile(path: terminalURL.path).cctopSessionId)
+        XCTAssertNil(try Session.fromFile(path: desktopURL.path).cctopSessionId)
+
+        manager.hideSession(hidden)
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertEqual(visibility.hiddenSessionIDs, [hiddenID])
+
+        processAlive = false
+        now = initialNow.addingTimeInterval(SessionManager.lifecycleWindows.retention + 1)
+        manager.loadSessions()
+        waitForIdentityMigrationQueue(manager)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: terminalURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: desktopURL.path))
+        XCTAssertEqual(visibility.hiddenSessionIDs, [hiddenID])
+        XCTAssertEqual(
+            Set(manager.cleanupSources.map(\.sessionId)),
+            [terminalObservationID, desktopObservationID]
+        )
+        XCTAssertTrue(manager.historyManager.recentProjects.isEmpty)
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertTrue((try FileManager.default.contentsOfDirectory(at: historyURL, includingPropertiesForKeys: nil)).isEmpty)
+        XCTAssertTrue(postedNotificationIDs.isEmpty)
+
+        terminateProcess(terminalLock)
+        terminateProcess(desktopLock)
+        manager.garbageCollectFinished()
+        XCTAssertTrue(FileManager.default.fileExists(atPath: terminalURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: desktopURL.path))
+
+        manager.loadSessions()
+        waitForIdentityMigrationQueue(manager)
+        XCTAssertEqual(try Session.fromFile(path: terminalURL.path).cctopSessionId, hiddenID)
+        XCTAssertEqual(try Session.fromFile(path: desktopURL.path).cctopSessionId, hiddenID)
+
+        processAlive = true
+        now = initialNow
+        manager.loadSessions()
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertEqual(visibility.hiddenSessionIDs, [hiddenID])
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+        XCTAssertTrue(postedNotificationIDs.isEmpty)
+    }
+
+    @MainActor
+    func testMappedManualHideSurvivesMissingCodexDesktopMetadataBeforeIdentityStamp() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-mapped-hide-missing-codex-metadata-\(UUID().uuidString)", isDirectory: true)
+        let sessionsURL = root.appendingPathComponent("sessions", isDirectory: true)
+        let historyURL = root.appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: historyURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let durableSessionID = "69253133-4a65-48fb-af2b-844463d3b5bb"
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        var session = codexDesktopSession(sessionId: durableSessionID, projectPath: root.path)
+        session.cctopSessionId = nil
+        session.harnessSessionId = durableSessionID
+        session.lastActivity = now.addingTimeInterval(-60)
+        let sessionURL = sessionsURL.appendingPathComponent("codex-\(durableSessionID).json")
+        try session.writeToFile(path: sessionURL.path)
+
+        let mappedID = try CctopSessionIdentityStore(sessionsDir: sessionsURL).resolve(
+            source: session.source,
+            harnessSessionId: session.harnessSessionId,
+            legacySessionId: session.sessionId,
+            knownExistingIDs: []
+        )
+        let suiteName = "cctop-mapped-hide-missing-codex-metadata-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+        var hiddenSnapshot = session
+        hiddenSnapshot.cctopSessionId = mappedID
+        visibility.hide(hiddenSnapshot)
+
+        var missingSources = SessionDataSources.live()
+        missingSources.sessionsDir = sessionsURL
+        missingSources.codexThreads = StubCodexThreadState(existing: [], archived: [])
+        missingSources.desktopAppConnection = DesktopAppConnectionLookup { _ in true }
+        missingSources.processAlive = { _ in true }
+        missingSources.manualSessionVisibility = visibility
+        missingSources.now = { now }
+        let missingManager = SessionManager(
+            historyManager: HistoryManager(historyDir: historyURL),
+            dataSources: missingSources,
+            startMonitoring: false
+        )
+        waitForIdentityMigrationQueue(missingManager)
+
+        XCTAssertTrue(missingManager.sessions.isEmpty)
+        XCTAssertEqual(visibility.hiddenSessionIDs, [mappedID])
+        XCTAssertEqual(try Session.fromFile(path: sessionURL.path).cctopSessionId, mappedID)
+
+        var restoredSources = missingSources
+        restoredSources.codexThreads = StubCodexThreadState(existing: [durableSessionID], archived: [])
+        let restoredManager = SessionManager(
+            historyManager: HistoryManager(historyDir: historyURL),
+            dataSources: restoredSources,
+            startMonitoring: false
+        )
+
+        XCTAssertTrue(restoredManager.sessions.isEmpty)
+        XCTAssertEqual(visibility.hiddenSessionIDs, [mappedID])
     }
 
     @MainActor
@@ -1246,6 +1655,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try finishedDesktop.writeToFile(path: finishedDesktopPath)
 
         var sources = SessionDataSources.live()
+        sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-gc-hidden-cleanup")
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState(existing: ["finished-desktop"], archived: [])
         sources.claudeDesktopSessions = StubClaudeDesktopState(snapshot: ClaudeDesktopSessionMetadataSnapshot())
@@ -1300,6 +1710,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         defer { terminateProcess(lockHolder) }
 
         var sources = SessionDataSources.live()
+        sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-gc-busy-lock")
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState(existing: ["busy-finished-thread"], archived: [])
         sources.claudeDesktopSessions = StubClaudeDesktopState(snapshot: ClaudeDesktopSessionMetadataSnapshot())
@@ -2570,6 +2981,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         let claudeState = CountingClaudeDesktopState()
         var sources = SessionDataSources.live()
+        sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-claude-batched-gc")
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState()
         sources.claudeDesktopSessions = claudeState
@@ -2616,6 +3028,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         let claudeState = SequencedClaudeDesktopState(archivedResponses: [[], ["finished-claude-race"]])
         var sources = SessionDataSources.live()
+        sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-claude-gc-archive-race")
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState()
         sources.claudeDesktopSessions = claudeState

--- a/menubar/CctopMenubarTests/SessionTestSupport.swift
+++ b/menubar/CctopMenubarTests/SessionTestSupport.swift
@@ -2,20 +2,26 @@ import XCTest
 @testable import CctopMenubar
 
 extension XCTestCase {
+    func isolatedManualSessionVisibility(prefix: String) -> ManualSessionVisibilityStore {
+        let suiteName = "\(prefix)-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Could not create isolated user defaults")
+        }
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+        return ManualSessionVisibilityStore(defaults: defaults)
+    }
+
     func isolatedSessionDataSources(
         prefix: String
     ) throws -> (sources: SessionDataSources, visibility: ManualSessionVisibilityStore) {
         let sessionsDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
-        let suiteName = "\(prefix)-\(UUID().uuidString)"
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         addTeardownBlock {
             try? FileManager.default.removeItem(at: sessionsDir)
-            defaults.removePersistentDomain(forName: suiteName)
         }
 
-        let visibility = ManualSessionVisibilityStore(defaults: defaults)
+        let visibility = isolatedManualSessionVisibility(prefix: prefix)
         var sources = SessionDataSources.live()
         sources.sessionsDir = sessionsDir
         sources.manualSessionVisibility = visibility
@@ -236,14 +242,13 @@ extension XCTestCase {
     ) -> SessionManager {
         var sources = SessionDataSources.live()
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
+        sources.manualSessionVisibility = manualSessionVisibility
+            ?? isolatedManualSessionVisibility(prefix: "cctop-manager")
         if let desktopAppConnection {
             sources.desktopAppConnection = desktopAppConnection
         }
         if let processAlive {
             sources.processAlive = processAlive
-        }
-        if let manualSessionVisibility {
-            sources.manualSessionVisibility = manualSessionVisibility
         }
         if let now {
             sources.now = now

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -756,6 +756,36 @@ final class SessionTests: XCTestCase {
         XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
     }
 
+    func testManualSessionVisibilityRetainsLegacyKeyUntilEveryExactMatchHasPermanentIdentity() {
+        let suiteName = "cctop-manual-visibility-partly-identified-legacy-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(["codex:ambiguous"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        let store = ManualSessionVisibilityStore(defaults: defaults)
+        let firstID = "11111111-1111-4111-8111-111111111111"
+        let secondID = "22222222-2222-4222-8222-222222222222"
+        let first = Session.mock(id: "ambiguous", cctopSessionId: firstID, source: Session.codexSource)
+        var second = Session.mock(id: "ambiguous", cctopSessionId: secondID, source: Session.codexSource)
+        second.cctopSessionId = nil
+
+        let partlyIdentifiedIDs = store.migrateLegacyStableKeys(
+            using: [first, second],
+            inventoryComplete: true
+        )
+
+        XCTAssertEqual(partlyIdentifiedIDs, [firstID])
+        XCTAssertEqual(store.unresolvedDurableLegacyKeys, ["codex:ambiguous"])
+
+        second.cctopSessionId = secondID
+        let fullyIdentifiedIDs = store.migrateLegacyStableKeys(
+            using: [first, second],
+            inventoryComplete: true
+        )
+
+        XCTAssertEqual(fullyIdentifiedIDs, [firstID, secondID])
+        XCTAssertTrue(store.unresolvedDurableLegacyKeys.isEmpty)
+    }
+
     func testManualSessionVisibilityIgnoresRowsWithoutPermanentIdentity() {
         let suiteName = "cctop-manual-visibility-legacy-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -704,6 +704,10 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(partialIDs, [codexID, desktopID])
         XCTAssertEqual(store.hiddenSessionIDs, [codexID, desktopID])
         XCTAssertEqual(
+            store.unresolvedDurableLegacyKeys,
+            ["codex:durable-codex", "codex:missing", "desktop:durable-desktop"]
+        )
+        XCTAssertEqual(
             defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
             ["active:42", "codex:durable-codex", "codex:missing", "desktop:durable-desktop"]
         )
@@ -714,6 +718,7 @@ final class SessionTests: XCTestCase {
         )
 
         XCTAssertEqual(completeIDs, [codexID, desktopID])
+        XCTAssertTrue(store.unresolvedDurableLegacyKeys.isEmpty)
         XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
     }
 

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -695,9 +695,12 @@ final class SessionTests: XCTestCase {
             source: Session.ccSource
         )
         let active = Session.mock(id: "terminal", cctopSessionId: activeID, pid: 42, source: Session.ccSource)
+        var unstampedCodex = codex
+        unstampedCodex.cctopSessionId = nil
 
         let partialIDs = store.migrateLegacyStableKeys(
             using: [codex, desktop, active],
+            persistedSessions: [unstampedCodex, desktop, active],
             inventoryComplete: false
         )
 
@@ -714,44 +717,88 @@ final class SessionTests: XCTestCase {
 
         let completeIDs = store.migrateLegacyStableKeys(
             using: [codex, desktop, active],
+            persistedSessions: [unstampedCodex, desktop, active],
             inventoryComplete: true
         )
 
         XCTAssertEqual(completeIDs, [codexID, desktopID])
+        XCTAssertEqual(store.unresolvedDurableLegacyKeys, ["codex:durable-codex"])
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:durable-codex"]
+        )
+
+        let confirmedIDs = store.migrateLegacyStableKeys(
+            using: [codex, desktop, active],
+            persistedSessions: [codex, desktop, active],
+            inventoryComplete: true
+        )
+
+        XCTAssertEqual(confirmedIDs, [codexID, desktopID])
         XCTAssertTrue(store.unresolvedDurableLegacyKeys.isEmpty)
         XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
+    }
+
+    func testLegacyManualHideEvidenceAcceptsOnlyCanonicalSupportedUUIDKeys() {
+        let sessionID = "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE"
+        let lowercaseID = sessionID.lowercased()
+
+        XCTAssertEqual(
+            ManualSessionVisibilityStore.durableEvidence(forLegacyKey: "codex:\(sessionID)"),
+            "codex:\(lowercaseID)"
+        )
+        XCTAssertEqual(
+            ManualSessionVisibilityStore.durableEvidence(forLegacyKey: "desktop:\(sessionID)"),
+            "cc:\(lowercaseID)"
+        )
+        for key in ["active:\(sessionID)", "cc:\(sessionID)", "codex:not-a-uuid", "desktop:\(sessionID.replacingOccurrences(of: "-", with: ""))"] {
+            XCTAssertNil(ManualSessionVisibilityStore.durableEvidence(forLegacyKey: key))
+        }
     }
 
     func testManualSessionVisibilityRetainsAmbiguousLegacyKey() {
         let suiteName = "cctop-manual-visibility-ambiguous-legacy-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        defaults.set(["codex:ambiguous"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        let threadID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+        let legacyKey = "codex:\(threadID)"
+        defaults.set([legacyKey], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
         let store = ManualSessionVisibilityStore(defaults: defaults)
         let firstID = "11111111-1111-4111-8111-111111111111"
         let secondID = "22222222-2222-4222-8222-222222222222"
-        let first = Session.mock(id: "ambiguous", cctopSessionId: firstID, source: Session.codexSource)
-        var second = Session.mock(id: "ambiguous", cctopSessionId: secondID, source: Session.codexSource)
-        second.cctopSessionId = nil
-
-        let partialIDs = store.migrateLegacyStableKeys(using: [first], inventoryComplete: false)
-
-        XCTAssertEqual(partialIDs, [firstID])
-        XCTAssertEqual(
-            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
-            ["codex:ambiguous"]
+        var legacy = Session.mock(id: threadID, harnessSessionId: threadID, source: Session.codexSource)
+        legacy.cctopSessionId = nil
+        let unresolvedIDs = store.migrateLegacyStableKeys(
+            using: [legacy],
+            persistedSessions: [legacy],
+            inventoryComplete: true
         )
 
-        let unresolvedIDs = store.migrateLegacyStableKeys(using: [first, second], inventoryComplete: true)
+        XCTAssertTrue(unresolvedIDs.isEmpty)
+        XCTAssertTrue(store.hiddenSessionIDs.isEmpty)
+        XCTAssertEqual(store.unresolvedDurableLegacyKeys, [legacyKey])
 
-        XCTAssertEqual(unresolvedIDs, [firstID])
-        XCTAssertEqual(store.unresolvedDurableLegacyKeys, ["codex:ambiguous"])
+        let first = Session.mock(
+            id: "first-observation",
+            cctopSessionId: firstID,
+            harnessSessionId: threadID,
+            source: Session.codexSource
+        )
+        let second = Session.mock(
+            id: "second-observation",
+            cctopSessionId: secondID,
+            harnessSessionId: threadID,
+            source: Session.codexSource
+        )
+        let ambiguousIDs = store.migrateLegacyStableKeys(
+            using: [legacy, first, second],
+            persistedSessions: [legacy, first, second],
+            inventoryComplete: true
+        )
 
-        second.cctopSessionId = secondID
-        let ambiguousIDs = store.migrateLegacyStableKeys(using: [first, second], inventoryComplete: true)
-
-        XCTAssertEqual(ambiguousIDs, [firstID])
-        XCTAssertEqual(store.unresolvedDurableLegacyKeys, ["codex:ambiguous"])
+        XCTAssertTrue(ambiguousIDs.isEmpty)
+        XCTAssertTrue(store.hiddenSessionIDs.isEmpty)
+        XCTAssertEqual(store.unresolvedDurableLegacyKeys, [legacyKey])
     }
 
     func testManualSessionVisibilityIgnoresRowsWithoutPermanentIdentity() {
@@ -843,6 +890,7 @@ final class SessionTests: XCTestCase {
 
         let recorder = Recorder()
         var sources = SessionDataSources.live()
+        sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-replace-notification")
         let sessionsDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
@@ -949,6 +997,7 @@ final class SessionTests: XCTestCase {
 
         let recorder = Recorder()
         var sources = SessionDataSources.live()
+        sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-reused-pid-notification")
         let sessionsDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -675,6 +675,82 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(store.hiddenSessionIDs, [secondID])
     }
 
+    func testManualSessionVisibilityMigratesOnlyExactDurableLegacyKeys() {
+        let suiteName = "cctop-manual-visibility-legacy-migration-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let codexID = "11111111-1111-4111-8111-111111111111"
+        let desktopID = "22222222-2222-4222-8222-222222222222"
+        let activeID = "33333333-3333-4333-8333-333333333333"
+        defaults.set(
+            ["active:42", "codex:durable-codex", "codex:missing", "desktop:durable-desktop"],
+            forKey: ManualSessionVisibilityStore.legacyDefaultsKey
+        )
+        let store = ManualSessionVisibilityStore(defaults: defaults)
+        let codex = Session.mock(id: "durable-codex", cctopSessionId: codexID, source: Session.codexSource)
+        let desktop = Session.mock(
+            id: "durable-desktop",
+            cctopSessionId: desktopID,
+            terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop),
+            source: Session.ccSource
+        )
+        let active = Session.mock(id: "terminal", cctopSessionId: activeID, pid: 42, source: Session.ccSource)
+
+        let partialIDs = store.migrateLegacyStableKeys(
+            using: [codex, desktop, active],
+            inventoryComplete: false
+        )
+
+        XCTAssertEqual(partialIDs, [codexID, desktopID])
+        XCTAssertEqual(store.hiddenSessionIDs, [codexID, desktopID])
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["active:42", "codex:durable-codex", "codex:missing", "desktop:durable-desktop"]
+        )
+
+        let completeIDs = store.migrateLegacyStableKeys(
+            using: [codex, desktop, active],
+            inventoryComplete: true
+        )
+
+        XCTAssertEqual(completeIDs, [codexID, desktopID])
+        XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
+    }
+
+    func testManualSessionVisibilityCollectsLateExactMatchBeforeRetiringLegacyKey() {
+        let suiteName = "cctop-manual-visibility-ambiguous-legacy-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(["codex:ambiguous"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
+        let store = ManualSessionVisibilityStore(defaults: defaults)
+        let first = Session.mock(
+            id: "ambiguous",
+            cctopSessionId: "11111111-1111-4111-8111-111111111111",
+            source: Session.codexSource
+        )
+        let second = Session.mock(
+            id: "ambiguous",
+            cctopSessionId: "22222222-2222-4222-8222-222222222222",
+            source: Session.codexSource
+        )
+
+        let partialIDs = store.migrateLegacyStableKeys(using: [first], inventoryComplete: false)
+
+        XCTAssertEqual(partialIDs, ["11111111-1111-4111-8111-111111111111"])
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:ambiguous"]
+        )
+
+        let completeIDs = store.migrateLegacyStableKeys(using: [first, second], inventoryComplete: true)
+
+        XCTAssertEqual(completeIDs, [
+            "11111111-1111-4111-8111-111111111111",
+            "22222222-2222-4222-8222-222222222222",
+        ])
+        XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
+    }
+
     func testManualSessionVisibilityIgnoresRowsWithoutPermanentIdentity() {
         let suiteName = "cctop-manual-visibility-legacy-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -722,42 +722,8 @@ final class SessionTests: XCTestCase {
         XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
     }
 
-    func testManualSessionVisibilityCollectsLateExactMatchBeforeRetiringLegacyKey() {
+    func testManualSessionVisibilityRetainsAmbiguousLegacyKey() {
         let suiteName = "cctop-manual-visibility-ambiguous-legacy-\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        defaults.set(["codex:ambiguous"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
-        let store = ManualSessionVisibilityStore(defaults: defaults)
-        let first = Session.mock(
-            id: "ambiguous",
-            cctopSessionId: "11111111-1111-4111-8111-111111111111",
-            source: Session.codexSource
-        )
-        let second = Session.mock(
-            id: "ambiguous",
-            cctopSessionId: "22222222-2222-4222-8222-222222222222",
-            source: Session.codexSource
-        )
-
-        let partialIDs = store.migrateLegacyStableKeys(using: [first], inventoryComplete: false)
-
-        XCTAssertEqual(partialIDs, ["11111111-1111-4111-8111-111111111111"])
-        XCTAssertEqual(
-            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
-            ["codex:ambiguous"]
-        )
-
-        let completeIDs = store.migrateLegacyStableKeys(using: [first, second], inventoryComplete: true)
-
-        XCTAssertEqual(completeIDs, [
-            "11111111-1111-4111-8111-111111111111",
-            "22222222-2222-4222-8222-222222222222",
-        ])
-        XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
-    }
-
-    func testManualSessionVisibilityRetainsLegacyKeyUntilEveryExactMatchHasPermanentIdentity() {
-        let suiteName = "cctop-manual-visibility-partly-identified-legacy-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set(["codex:ambiguous"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
@@ -768,22 +734,24 @@ final class SessionTests: XCTestCase {
         var second = Session.mock(id: "ambiguous", cctopSessionId: secondID, source: Session.codexSource)
         second.cctopSessionId = nil
 
-        let partlyIdentifiedIDs = store.migrateLegacyStableKeys(
-            using: [first, second],
-            inventoryComplete: true
+        let partialIDs = store.migrateLegacyStableKeys(using: [first], inventoryComplete: false)
+
+        XCTAssertEqual(partialIDs, [firstID])
+        XCTAssertEqual(
+            defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
+            ["codex:ambiguous"]
         )
 
-        XCTAssertEqual(partlyIdentifiedIDs, [firstID])
+        let unresolvedIDs = store.migrateLegacyStableKeys(using: [first, second], inventoryComplete: true)
+
+        XCTAssertEqual(unresolvedIDs, [firstID])
         XCTAssertEqual(store.unresolvedDurableLegacyKeys, ["codex:ambiguous"])
 
         second.cctopSessionId = secondID
-        let fullyIdentifiedIDs = store.migrateLegacyStableKeys(
-            using: [first, second],
-            inventoryComplete: true
-        )
+        let ambiguousIDs = store.migrateLegacyStableKeys(using: [first, second], inventoryComplete: true)
 
-        XCTAssertEqual(fullyIdentifiedIDs, [firstID, secondID])
-        XCTAssertTrue(store.unresolvedDurableLegacyKeys.isEmpty)
+        XCTAssertEqual(ambiguousIDs, [firstID])
+        XCTAssertEqual(store.unresolvedDurableLegacyKeys, ["codex:ambiguous"])
     }
 
     func testManualSessionVisibilityIgnoresRowsWithoutPermanentIdentity() {


### PR DESCRIPTION
Manual-hide identity layer. Its panel/navigation prerequisite is now on `master` via #230 at `7cb2500b`.

Notification and Recent identity leaves follow this PR.

## Problem

Legacy manual hides persist source-specific stable keys, while the current visibility path uses permanent `cctop_session_id` values. Migrating from incomplete or ambiguous inventory could otherwise reveal a hidden session or discard its fallback before a later observation supplies the permanent identity.

## Solution

Migrate only an exact, unambiguous Codex or desktop legacy key to its single matching permanent cctop ID before the visible projection and logical deduplication. Retain unresolved keys and finished identity evidence across partial or unreadable inventories, and retire migrated or proven-missing keys only after a complete inventory. A migrated fallback remains until the permanent ID is confirmed on disk, including when a busy session-file lock delays the identity stamp.

If that busy record finishes before the retry succeeds, consult only an already-existing durable mapping whose permanent ID is already hidden. Keep the finished record through archive and desktop garbage collection, including the bare-UUID legacy sweep, then let the existing asynchronous stamp retry repair its JSON. This lookup never creates a mapping or guesses an identity.

Existing mapped hides also remain authoritative while Codex Desktop metadata is temporarily missing, so the permanent preference cannot be pruned before the JSON stamp is repaired. While an unresolved legacy key freezes Recent, successful unrelated archives are still added to Cleanup immediately without thawing the frozen Recent projection.

The retained hidden record remains available to lifecycle and Cleanup while the canonical visible projection keeps the logical session out of the panel, Navigate, notifications, Recent desktop targets, display state, and Stream Deck. This durable retention is the intentional consequence of the hide-only contract.

## Scope

This layer contains only the product-persistence compatibility change. The independent exact-restart verification defect was fixed separately; this PR does not change focus resolution, panel/navigation policy, client identity, restart tooling, tombstones, or add an unhide registry.

## Verification

- Focused migration, missing-metadata, busy-lock, retained-evidence, and frozen-Cleanup regressions pass (5/5); the two newest tests failed on the previous production behavior with five assertions and pass on this head.
- `make all`: lint, contract, plugin gates, build, and 1,194 Swift tests.
- Exact committed-tree smoke: the real `cctop chief watchdog` retained permanent ID `c55987ce-b573-41eb-b06a-928522c03a6a` in preferences and session JSON across `make all`, an exact app restart, and two app-routed canonical reloads; every reload reported zero display matches while the lifecycle record remained available.
- Exact runtime identity: sole PID 14863 from the 8953 Debug app with matching display owner/start and loaded binary/dylib inodes; installed `cctop-hook` 0.20.1 matched the Release hash; Launch Services' live claimant was the exact app; no Xcode, test host, or competing app remained.
