### PR TITLE
Use permanent identity for panel navigation

### DIFF
--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -33,6 +33,12 @@ automatically pruned in this version.
 Deleting cctop's local session and identity data resets this continuity.
 Cross-machine sync is not supported.
 
+Panel and keyboard navigation use this permanent ID as their logical identity.
+For a legacy record whose ID is still absent or invalid, they temporarily fall
+back to cctop's existing source- and host-aware session key. That fallback is
+never persisted as a replacement ID; indirect focus is allowed only when its
+current match is unique, otherwise the action fails closed.
+
 ### `harness_session_id`
 
 Type: `string`
@@ -76,20 +82,27 @@ privacy-safe stale-state diagnostic, performs exactly one synchronous canonical
 reload and one re-resolution, then fails closed if the target is still missing.
 It never falls back to a client conversation reference, PID, or display slot.
 
-Panel, URL focus, DisplayStateWriter, and Stream Deck all consume that canonical
-order. The projection never independently sorts, deduplicates, or removes rows,
-so slots stay aligned with the panel even when two observations share one
-`cctop_session_id`. A direct panel or keyboard selection still focuses the exact
-observation represented by the selected row, without re-resolving its permanent ID.
+`SessionManager` collapses visible observations with the same logical identity
+into one panel row before applying its existing status-group ordering. The first
+logical row position is retained while the existing lifecycle preference chooses
+the current observation. Panel, URL focus, DisplayStateWriter, and Stream Deck
+then consume that canonical order. DisplayStateWriter never independently sorts,
+deduplicates, or removes manager rows, so its slots remain a one-to-one projection.
 
-This version does not reconcile multiple clients or multiple simultaneous focus
-targets. If the same conversation is open in more than one place, observations
-may remain separate or several rows may share one ID; permanent-ID commands use
-the first matching row in canonical panel order. This is the temporary
-single-target policy, not a user-selectable multi-target design. Future support
-extends the resolver with an explicit selection policy rather than changing
-logical identity, lifecycle/liveness classification, canonical order, or
-terminal/window execution.
+A direct pointer or context-menu action focuses the exact current observation
+rendered in that row. Keyboard selection instead retains logical identity and
+resolves it against current panel observations, so reloads, focus-target changes,
+and status-group movement cannot retarget selection by row index. Navigate-mode
+number slots freeze those identities at activation; a missing identity leaves its
+original number unusable rather than shifting a later conversation into that slot.
+
+This version does not offer user-selectable routing among multiple simultaneous
+focus targets. Observations sharing one ID form one logical panel row, and a
+permanent-ID resolver supplied with multiple current observations uses the first
+match in canonical panel order. This is the temporary single-target policy.
+Future support extends the resolver with an explicit selection policy rather than
+changing logical identity, lifecycle/liveness classification, canonical order,
+or terminal/window execution.
 Cross-client equivalence and cross-machine identity are out of scope. Manual hiding
 uses `cctop_session_id` as its preference key; notification grouping, cleanup,
 history, and other persisted preferences keep their separate contracts.

--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		D10000050000000000000001 /* SessionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000060000000000000001 /* SessionCardView.swift */; };
 		SBV000010000000000000001 /* SourceBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SBV000020000000000000001 /* SourceBadgeView.swift */; };
 		D10000070000000000000001 /* PopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000080000000000000001 /* PopupView.swift */; };
+		PVS000010000000000000001 /* PopupView+Sessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = PVS000020000000000000001 /* PopupView+Sessions.swift */; };
 		PVH000010000000000000001 /* PopupViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = PVH000020000000000000001 /* PopupViewHelpers.swift */; };
 		PVR000010000000000000001 /* PopupView+Recent.swift in Sources */ = {isa = PBXBuildFile; fileRef = PVR000020000000000000001 /* PopupView+Recent.swift */; };
 		D10000090000000000000001 /* QuitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000000A000000000000001 /* QuitButton.swift */; };
@@ -211,6 +212,7 @@
 		D10000060000000000000001 /* SessionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCardView.swift; sourceTree = "<group>"; };
 		SBV000020000000000000001 /* SourceBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceBadgeView.swift; sourceTree = "<group>"; };
 		D10000080000000000000001 /* PopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupView.swift; sourceTree = "<group>"; };
+		PVS000020000000000000001 /* PopupView+Sessions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PopupView+Sessions.swift"; sourceTree = "<group>"; };
 		PVH000020000000000000001 /* PopupViewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupViewHelpers.swift; sourceTree = "<group>"; };
 		FTR000020000000000000001 /* FocusTargetResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusTargetResolver.swift; sourceTree = "<group>"; };
 		E10000020000000000000001 /* FocusTerminal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusTerminal.swift; sourceTree = "<group>"; };
@@ -485,6 +487,7 @@
 				D10000060000000000000001 /* SessionCardView.swift */,
 				SBV000020000000000000001 /* SourceBadgeView.swift */,
 				D10000080000000000000001 /* PopupView.swift */,
+				PVS000020000000000000001 /* PopupView+Sessions.swift */,
 				PNV000020000000000000001 /* PopupNavigation.swift */,
 				PES000020000000000000001 /* PopupView+EmptyState.swift */,
 				PCU000020000000000000001 /* PopupView+Cleanup.swift */,
@@ -722,6 +725,7 @@
 				D10000050000000000000001 /* SessionCardView.swift in Sources */,
 				SBV000010000000000000001 /* SourceBadgeView.swift in Sources */,
 				D10000070000000000000001 /* PopupView.swift in Sources */,
+				PVS000010000000000000001 /* PopupView+Sessions.swift in Sources */,
 				PVH000010000000000000001 /* PopupViewHelpers.swift in Sources */,
 				D10000090000000000000001 /* QuitButton.swift in Sources */,
 				FTR000010000000000000001 /* FocusTargetResolver.swift in Sources */,

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -630,8 +630,10 @@ extension AppDelegate {
     }
 
     @MainActor private func jumpToSession(index: Int) {
-        guard let sessions = navigateController.activeSessionSnapshot, sessions.indices.contains(index) else { return }
-        focusTerminal(session: sessions[index])
+        guard let identity = navigateController.sessionIdentity(at: index) else { return }
+        let currentSessions = SessionDisplayPolicy.activeSessions(from: sessionManager.sessions)
+        guard let session = FocusTargetResolver.currentSession(for: identity, in: currentSessions) else { return }
+        focusTerminal(session: session)
         handleEvent(.navigateConfirmed)
     }
 

--- a/menubar/CctopMenubar/Models/Session+Mock.swift
+++ b/menubar/CctopMenubar/Models/Session+Mock.swift
@@ -22,7 +22,7 @@ extension Session {
     ) -> Session {
         var session = Session(
             sessionId: id,
-            cctopSessionId: cctopSessionId ?? "00000000-0000-4000-8000-000000000001",
+            cctopSessionId: cctopSessionId ?? makeCctopSessionId(),
             harnessSessionId: harnessSessionId,
             projectPath: "/Users/test/projects/\(project)",
             projectName: project,

--- a/menubar/CctopMenubar/Models/SessionDisplayPolicy.swift
+++ b/menubar/CctopMenubar/Models/SessionDisplayPolicy.swift
@@ -4,8 +4,8 @@ import Foundation
 /// This does not change lifecycle or cleanup semantics.
 enum SessionDisplayPolicy {
     struct Signature: Equatable {
-        let activeIDs: [String]
-        let idleIDs: [String]
+        let activeIDs: [SessionIdentityPolicy.LogicalIdentity]
+        let idleIDs: [SessionIdentityPolicy.LogicalIdentity]
 
         static let empty = Signature(activeIDs: [], idleIDs: [])
     }
@@ -34,35 +34,37 @@ enum SessionDisplayPolicy {
     ) -> [Session] {
         let active = activeSessions(from: sessions, now: now)
         let activeByKey = Dictionary(
-            active.map { (SessionIdentityPolicy.stableKey(for: $0), $0) },
+            active.map { (SessionIdentityPolicy.logicalIdentity(for: $0), $0) },
             uniquingKeysWith: { first, _ in first }
         )
         let activeKeys = Set(activeByKey.keys)
         var groups = Array(repeating: [Session](), count: SessionStatus.idle.sortOrder + 1)
-        var placedKeys: Set<String> = []
+        var placedKeys: Set<SessionIdentityPolicy.LogicalIdentity> = []
 
         for previous in activeSessions(from: previousSessions, now: now) {
-            let key = SessionIdentityPolicy.stableKey(for: previous)
-            guard let current = activeByKey[key], current.status.sortOrder == previous.status.sortOrder else { continue }
+            let key = SessionIdentityPolicy.logicalIdentity(for: previous)
+            guard !placedKeys.contains(key),
+                  let current = activeByKey[key],
+                  current.status.sortOrder == previous.status.sortOrder else { continue }
             groups[current.status.sortOrder].append(current)
             placedKeys.insert(key)
         }
 
         for current in active {
-            let key = SessionIdentityPolicy.stableKey(for: current)
+            let key = SessionIdentityPolicy.logicalIdentity(for: current)
             guard placedKeys.insert(key).inserted else { continue }
             groups[current.status.sortOrder].append(current)
         }
 
         let orderedActive = groups.flatMap { $0 }
-        let nonActive = sessions.filter { !activeKeys.contains(SessionIdentityPolicy.stableKey(for: $0)) }
+        let nonActive = sessions.filter { !activeKeys.contains(SessionIdentityPolicy.logicalIdentity(for: $0)) }
         return orderedActive + nonActive
     }
 
     static func signature(for sessions: [Session], now: Date = Date()) -> Signature {
         Signature(
-            activeIDs: activeSessions(from: sessions, now: now).map(\.id),
-            idleIDs: idleSessions(from: sessions, now: now).map(\.id)
+            activeIDs: activeSessions(from: sessions, now: now).map(SessionIdentityPolicy.logicalIdentity),
+            idleIDs: idleSessions(from: sessions, now: now).map(SessionIdentityPolicy.logicalIdentity)
         )
     }
 

--- a/menubar/CctopMenubar/Services/FocusTargetResolver.swift
+++ b/menubar/CctopMenubar/Services/FocusTargetResolver.swift
@@ -7,4 +7,20 @@ enum FocusTargetResolver {
         guard Session.isValidCctopSessionId(cctopSessionID) else { return nil }
         return observations.first { $0.cctopSessionId == cctopSessionID }
     }
+
+    /// Resolve panel/navigation identity against current observations. Permanent IDs use
+    /// the canonical first-match policy; legacy keys remain usable only when unambiguous.
+    static func currentSession(
+        for identity: SessionIdentityPolicy.LogicalIdentity,
+        in observations: [Session]
+    ) -> Session? {
+        if let cctopSessionID = identity.cctopSessionID {
+            return currentSession(forCctopSessionID: cctopSessionID, in: observations)
+        }
+
+        guard case .legacy(let stableKey) = identity else { return nil }
+        let matches = observations.filter { SessionIdentityPolicy.stableKey(for: $0) == stableKey }
+        guard matches.count == 1 else { return nil }
+        return matches[0]
+    }
 }

--- a/menubar/CctopMenubar/Services/NavigateController.swift
+++ b/menubar/CctopMenubar/Services/NavigateController.swift
@@ -6,29 +6,29 @@ class NavigateController: ObservableObject {
     let didActivateSubject = PassthroughSubject<Void, Never>()
     let didConfirmSubject = PassthroughSubject<Void, Never>()
     let navActionSubject = PassthroughSubject<PanelNavAction, Never>()
-    /// Canonically ordered session snapshot captured when navigate activates.
-    /// Prevents reordering while badges are visible.
-    private(set) var frozenSessions: [Session] = []
-    var activeSessionSnapshot: [Session]? {
-        isActive ? frozenSessions : nil
+    /// Canonically ordered logical identities captured when navigate activates.
+    /// Array positions remain the numbered slots even when an observation disappears.
+    private(set) var frozenSessionIdentities: [SessionIdentityPolicy.LogicalIdentity] = []
+    var activeSessionIdentitySnapshot: [SessionIdentityPolicy.LogicalIdentity]? {
+        isActive ? frozenSessionIdentities : nil
     }
     private var timeoutWork: DispatchWorkItem?
 
     func activate(sessions: [Session]) {
-        frozenSessions = sessions
+        frozenSessionIdentities = sessions.map(SessionIdentityPolicy.logicalIdentity)
         isActive = true
         didActivateSubject.send()
     }
 
-    /// Remove a hidden session without disturbing the frozen order of the remaining rows.
-    func removeSession(withCctopSessionID cctopSessionID: String) {
-        frozenSessions.removeAll { $0.cctopSessionId == cctopSessionID }
+    func sessionIdentity(at index: Int) -> SessionIdentityPolicy.LogicalIdentity? {
+        guard isActive, frozenSessionIdentities.indices.contains(index) else { return nil }
+        return frozenSessionIdentities[index]
     }
 
     /// Resets all navigate state.
     func deactivate() {
         isActive = false
-        frozenSessions = []
+        frozenSessionIdentities = []
         cancelTimeout()
     }
 

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -1,6 +1,16 @@
 import Foundation
 
 enum SessionIdentityPolicy {
+    enum LogicalIdentity: Hashable {
+        case permanent(UUID)
+        case legacy(String)
+
+        var cctopSessionID: String? {
+            guard case .permanent(let id) = self else { return nil }
+            return id.uuidString.lowercased()
+        }
+    }
+
     static let notificationSessionIDKey = "sessionID"
     static let notificationSessionPIDKey = "sessionPID"
     static let notificationCctopSessionIDKey = "cctopSessionID"
@@ -14,6 +24,17 @@ enum SessionIdentityPolicy {
             return "desktop:\(session.sessionId)"
         }
         return "active:\(session.id)"
+    }
+
+    /// Panel identity prefers cctop's permanent UUID. Legacy records retain the existing
+    /// source- and host-aware key until a permanent ID becomes available.
+    static func logicalIdentity(for session: Session) -> LogicalIdentity {
+        if let cctopSessionID = session.cctopSessionId,
+           Session.isValidCctopSessionId(cctopSessionID),
+           let id = UUID(uuidString: cctopSessionID) {
+            return .permanent(id)
+        }
+        return .legacy(stableKey(for: session))
     }
 
     static func notificationRequestIdentifier(for session: Session) -> String {
@@ -67,19 +88,6 @@ enum SessionIdentityPolicy {
         return string
     }
 
-    /// Collapse duplicate display ids during migration, keeping the most recently active copy.
-    static func dedupedByDisplayID(_ sessions: [Session]) -> [Session] {
-        var byID: [String: Session] = [:]
-        for session in sessions {
-            let id = session.id
-            if let existing = byID[id], existing.lastActivity >= session.lastActivity {
-                continue
-            }
-            byID[id] = session
-        }
-        return byID.values.sorted { $0.id < $1.id }
-    }
-
     /// Collapse multiple files for one conversation only for hosts with stable conversation identity.
     static func dedupedCandidatesByStableKey(_ candidates: [DedupCandidate]) -> [DedupCandidate] {
         var byKey: [String: DedupCandidate] = [:]
@@ -89,6 +97,26 @@ enum SessionIdentityPolicy {
             byKey[key] = candidate
         }
         return byKey.values.sorted { stableKey(for: $0.session) < stableKey(for: $1.session) }
+    }
+
+    /// Collapse visible observations that resolve to one logical panel row. The first
+    /// occurrence owns the row position while the lifecycle policy chooses its observation.
+    static func dedupedCandidatesByLogicalIdentity(_ candidates: [DedupCandidate]) -> [DedupCandidate] {
+        var result: [DedupCandidate] = []
+        var indexByIdentity: [LogicalIdentity: Int] = [:]
+
+        for candidate in candidates {
+            let identity = logicalIdentity(for: candidate.session)
+            if let index = indexByIdentity[identity] {
+                if SessionLifecyclePolicy.prefers(candidate, over: result[index]) {
+                    result[index] = candidate
+                }
+            } else {
+                indexByIdentity[identity] = result.count
+                result.append(candidate)
+            }
+        }
+        return result
     }
 }
 

--- a/menubar/CctopMenubar/Services/SessionManager+Loading.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Loading.swift
@@ -142,7 +142,16 @@ extension SessionManager {
         knownRecords: [(url: URL, session: Session)]
     ) -> [Session] {
         let publishableWinners = winners.filter { $0.session.lifecycle != .finished }
-        return assigningCctopSessionIdentities(to: publishableWinners, knownRecords: knownRecords)
+        let identified = assigningCctopSessionIdentities(to: publishableWinners, knownRecords: knownRecords)
+        let identifiedCandidates = zip(publishableWinners, identified).map { candidate, session in
+            DedupCandidate(
+                session: session,
+                lifecycleRank: candidate.lifecycleRank,
+                mtime: candidate.mtime,
+                path: candidate.path
+            )
+        }
+        return SessionIdentityPolicy.dedupedCandidatesByLogicalIdentity(identifiedCandidates).map(\.session)
     }
 
     func identifyingRecentDesktopRecords(
@@ -255,13 +264,6 @@ extension SessionManager {
             modifiedSeconds: Int(info.st_mtimespec.tv_sec),
             modifiedNanoseconds: Int(info.st_mtimespec.tv_nsec),
             fileSize: Int64(info.st_size)
-        )
-    }
-
-    func currentStatusesByStableKey() -> [String: SessionStatus] {
-        Dictionary(
-            sessions.map { (SessionIdentityPolicy.stableKey(for: $0), $0.status) },
-            uniquingKeysWith: { first, _ in first }
         )
     }
 

--- a/menubar/CctopMenubar/Views/PopupNavigation.swift
+++ b/menubar/CctopMenubar/Views/PopupNavigation.swift
@@ -68,34 +68,26 @@ enum PopupTab: CaseIterable, Hashable {
 }
 
 struct PopupSelectionContext {
-    let activeSessions: [Session]
-    let idleSessions: [Session]
     let recentTargets: [RecentResumeTarget]
     let cleanupCandidates: [WorktreeCleanupCandidate]
 
     init(
-        activeSessions: [Session],
-        idleSessions: [Session],
         recentProjects: [RecentProject] = [],
         recentResumeTargets: [RecentResumeTarget]? = nil,
         cleanupCandidates: [WorktreeCleanupCandidate]
     ) {
-        self.activeSessions = activeSessions
-        self.idleSessions = idleSessions
         self.recentTargets = recentResumeTargets ?? recentProjects.map(RecentResumeTarget.project)
         self.cleanupCandidates = cleanupCandidates
     }
 }
 
 enum PopupSelectionTarget: Equatable {
-    case activeSession(Session)
-    case idleSession(Session)
     case recentTarget(RecentResumeTarget)
     case cleanupCandidate(WorktreeCleanupCandidate)
 
     var confirmsNavigate: Bool {
         switch self {
-        case .activeSession, .idleSession, .recentTarget:
+        case .recentTarget:
             return true
         case .cleanupCandidate:
             return false
@@ -108,12 +100,8 @@ enum PopupSelectionTarget: Equatable {
         in context: PopupSelectionContext
     ) -> PopupSelectionTarget? {
         switch tab {
-        case .active:
-            guard index < context.activeSessions.count else { return nil }
-            return .activeSession(context.activeSessions[index])
-        case .idle:
-            guard index < context.idleSessions.count else { return nil }
-            return .idleSession(context.idleSessions[index])
+        case .active, .idle:
+            return nil
         case .recent:
             guard index < context.recentTargets.count else { return nil }
             return .recentTarget(context.recentTargets[index])

--- a/menubar/CctopMenubar/Views/PopupView+Cleanup.swift
+++ b/menubar/CctopMenubar/Views/PopupView+Cleanup.swift
@@ -78,6 +78,7 @@ extension PopupView {
 
     func handleSelectedTabChanged(_ newTab: PopupTab) {
         selectedIndex = nil
+        selectedSessionIdentity = nil
         if newTab == .cleanup {
             onCleanupTabVisible()
         } else {

--- a/menubar/CctopMenubar/Views/PopupView+Sessions.swift
+++ b/menubar/CctopMenubar/Views/PopupView+Sessions.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+struct PanelSessionRow: Identifiable {
+    let slot: Int
+    let session: Session
+    let id: SessionIdentityPolicy.LogicalIdentity
+}
+
+extension PopupView {
+    var isNavigateActive: Bool { navigate?.isActive ?? false }
+    var hasMultipleSources: Bool { Set(sessions.map(\.agentBadge)).count > 1 }
+
+    var currentActiveSessions: [Session] {
+        SessionDisplayPolicy.activeSessions(from: sessions)
+    }
+
+    var activeSessionRows: [PanelSessionRow] {
+        guard let identities = navigate?.activeSessionIdentitySnapshot else {
+            return currentActiveSessions.enumerated().map { index, session in
+                PanelSessionRow(
+                    slot: index,
+                    session: session,
+                    id: SessionIdentityPolicy.logicalIdentity(for: session)
+                )
+            }
+        }
+        return identities.enumerated().compactMap { index, identity in
+            guard let session = FocusTargetResolver.currentSession(
+                for: identity,
+                in: currentActiveSessions
+            ) else { return nil }
+            return PanelSessionRow(slot: index, session: session, id: identity)
+        }
+    }
+
+    var sortedActiveSessions: [Session] {
+        activeSessionRows.map(\.session)
+    }
+
+    var sortedIdleSessions: [Session] {
+        Session.sorted(SessionDisplayPolicy.idleSessions(from: sessions))
+    }
+
+    var idleSessionRows: [PanelSessionRow] {
+        sortedIdleSessions.enumerated().map { index, session in
+            PanelSessionRow(
+                slot: index,
+                session: session,
+                id: SessionIdentityPolicy.logicalIdentity(for: session)
+            )
+        }
+    }
+
+    func sessionList(
+        _ rows: [PanelSessionRow],
+        tab: PopupTab,
+        showNavigateNumbers: Bool = false
+    ) -> some View {
+        ScrollViewReader { proxy in
+            ScrollView(showsIndicators: false) {
+                LazyVStack(spacing: 2) {
+                    ForEach(rows) { row in
+                        sessionRow(row, showNavigateNumbers: showNavigateNumbers)
+                    }
+                }
+                .padding(.bottom, AppChrome.listVerticalPadding)
+            }
+            .frame(maxHeight: AppChrome.overlayMinimumContentHeight)
+            .onChange(of: selectedSessionIdentity) { identity in
+                guard selectedTab == tab, let identity else { return }
+                withAnimation(.easeOut(duration: 0.15)) {
+                    proxy.scrollTo(identity, anchor: .center)
+                }
+            }
+        }
+    }
+
+    private func sessionRow(_ row: PanelSessionRow, showNavigateNumbers: Bool) -> some View {
+        SessionCardView(
+            session: row.session,
+            navigateIndex: showNavigateNumbers && isNavigateActive ? row.slot + 1 : nil,
+            showSourceBadge: hasMultipleSources,
+            isSelected: selectedSessionIdentity == row.id,
+            relativeTimeNow: relativeTimeNow
+        )
+        .id(row.id)
+        .onTapGesture { focusSession(row.session) }
+        .contextMenu {
+            Button { focusSession(row.session) } label: {
+                Label("Jump to Terminal", systemImage: "terminal")
+            }
+            Button { openInFinder(path: row.session.projectPath) } label: {
+                Label("Open in Finder", systemImage: "folder")
+            }
+            Button { copyPath(row.session.projectPath) } label: {
+                Label("Copy Project Path", systemImage: "doc.on.doc")
+            }
+            Divider()
+            Button { requestHideSession(row.session) } label: {
+                Label("Hide Session", systemImage: "eye.slash")
+            }
+            .disabled(!Session.isValidCctopSessionId(row.session.cctopSessionId))
+        }
+        .help("Click to jump to session")
+        .accessibilityActions {
+            Button("Hide Session") { requestHideSession(row.session) }
+                .disabled(!Session.isValidCctopSessionId(row.session.cctopSessionId))
+        }
+    }
+
+    func moveSessionSelection(by delta: Int, in rows: [PanelSessionRow]) {
+        guard !rows.isEmpty else { return }
+        let currentIndex = selectedSessionIdentity.flatMap { identity in
+            rows.firstIndex { $0.id == identity }
+        }
+        let nextIndex = currentIndex.map {
+            ($0 + delta + rows.count) % rows.count
+        } ?? (delta > 0 ? 0 : rows.count - 1)
+        selectedSessionIdentity = rows[nextIndex].id
+    }
+
+    func confirmSessionSelection() {
+        guard let identity = selectedSessionIdentity else { return }
+        let observations = selectedTab == .active ? currentActiveSessions : sortedIdleSessions
+        guard let session = FocusTargetResolver.currentSession(for: identity, in: observations) else { return }
+        focusSession(session)
+        if isNavigateActive { navigate?.didConfirmSubject.send() }
+    }
+}

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -26,8 +26,9 @@ struct PopupView: View {
     var onCleanupTabHidden: () -> Void = {}
     /// Called (async on main) whenever content layout changes so the host can resize the panel.
     var onLayoutChanged: () -> Void = {}
-    @State private var selectedTab: PopupTab = .active
+    @State var selectedTab: PopupTab = .active
     @State var selectedIndex: Int?
+    @State var selectedSessionIdentity: SessionIdentityPolicy.LogicalIdentity?
     @State private var gearHovered = false
     @State private var versionHovered = false
     @State private var shortcutHovered = false
@@ -94,6 +95,7 @@ struct PopupView: View {
         }
         .onReceive(navigate?.didActivateSubject.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
             selectedIndex = nil
+            selectedSessionIdentity = nil
             if selectedTab != .active { selectedTab = .active }
             if overlayController.active != nil { closeOverlay(animated: false) }
         }
@@ -195,7 +197,7 @@ struct PopupView: View {
                             installAction: { pluginManager.installPiPlugin() },
                             installed: $piBannerInstalled, dismissed: $piBannerDismissed)
                     }
-                    sessionList(sortedActiveSessions, tab: .active, showNavigateNumbers: true)
+                    sessionList(activeSessionRows, tab: .active, showNavigateNumbers: true)
                 }
             }
         }
@@ -206,37 +208,7 @@ struct PopupView: View {
         if sortedIdleSessions.isEmpty {
             noIdleSessionsContent
         } else {
-            sessionList(sortedIdleSessions, tab: .idle)
-        }
-    }
-    private func sessionList(_ list: [Session], tab: PopupTab, showNavigateNumbers: Bool = false) -> some View {
-        panelList(list, tab: tab) { index, session, isSelected in
-            SessionCardView(
-                session: session,
-                navigateIndex: showNavigateNumbers && isNavigateActive ? index + 1 : nil,
-                showSourceBadge: hasMultipleSources,
-                isSelected: isSelected,
-                relativeTimeNow: relativeTimeNow
-            )
-            .onTapGesture { focusSession(session) }
-            .contextMenu {
-                Button { focusSession(session) } label: {
-                    Label("Jump to Terminal", systemImage: "terminal")
-                }
-                Button { openInFinder(path: session.projectPath) } label: {
-                    Label("Open in Finder", systemImage: "folder")
-                }
-                Button { copyPath(session.projectPath) } label: {
-                    Label("Copy Project Path", systemImage: "doc.on.doc")
-                }
-                Divider()
-                Button { requestHideSession(session) } label: { Label("Hide Session", systemImage: "eye.slash") }
-                    .disabled(!Session.isValidCctopSessionId(session.cctopSessionId))
-            }
-            .help("Click to jump to session")
-            .accessibilityActions {
-                Button("Hide Session") { requestHideSession(session) }.disabled(!Session.isValidCctopSessionId(session.cctopSessionId))
-            }
+            sessionList(idleSessionRows, tab: .idle)
         }
     }
     func panelList<Item: Identifiable, Row: View>(
@@ -366,15 +338,6 @@ extension PopupView {
             .layoutPriority(-1)
         } else { EmptyView() }
     }
-    private var isNavigateActive: Bool { navigate?.isActive ?? false }
-    private var hasMultipleSources: Bool { Set(sessions.map(\.agentBadge)).count > 1 }
-    private var sortedActiveSessions: [Session] {
-        let current = SessionDisplayPolicy.activeSessions(from: sessions)
-        return navigate?.activeSessionSnapshot ?? current
-    }
-    private var sortedIdleSessions: [Session] {
-        Session.sorted(SessionDisplayPolicy.idleSessions(from: sessions))
-    }
     var actionableCleanupCandidates: [WorktreeCleanupCandidate] {
         cleanupCandidates.filter(\.state.isActionable)
     }
@@ -388,7 +351,7 @@ extension PopupView {
         PopupTab.allCases
     }
 
-    private func focusSession(_ session: Session) {
+    func focusSession(_ session: Session) {
         guard Date().timeIntervalSince(lastFocusTime) > 0.5 else { return }
         lastFocusTime = Date()
         focusTerminal(session: session)
@@ -420,31 +383,43 @@ extension PopupView {
         case .up: moveSelection(by: -1)
         case .down: moveSelection(by: 1)
         case .confirm: confirmSelection()
-        case .escape, .reset: selectedIndex = nil
+        case .escape, .reset:
+            selectedIndex = nil
+            selectedSessionIdentity = nil
         case .toggleTab, .previousTab, .nextTab: switchTab(to: action)
         }
     }
 
     private func moveSelection(by delta: Int) {
-        let count: Int
         switch selectedTab {
-        case .active: count = sortedActiveSessions.count
-        case .idle: count = sortedIdleSessions.count
-        case .recent: count = recentTargets.count
-        case .cleanup: count = actionableCleanupCandidates.count
+        case .active:
+            moveSessionSelection(by: delta, in: activeSessionRows)
+            return
+        case .idle:
+            moveSessionSelection(by: delta, in: idleSessionRows)
+            return
+        case .recent:
+            moveIndexedSelection(by: delta, count: recentTargets.count)
+        case .cleanup:
+            moveIndexedSelection(by: delta, count: actionableCleanupCandidates.count)
         }
+    }
+
+    private func moveIndexedSelection(by delta: Int, count: Int) {
         guard count > 0 else { return }
         selectedIndex = selectedIndex.map { ($0 + delta + count) % count } ?? (delta > 0 ? 0 : count - 1)
     }
 
     private func confirmSelection() {
+        if selectedTab == .active || selectedTab == .idle {
+            confirmSessionSelection()
+            return
+        }
         guard let index = selectedIndex else { return }
         guard let target = PopupSelectionTarget.target(
             for: selectedTab,
             index: index,
             in: PopupSelectionContext(
-                activeSessions: sortedActiveSessions,
-                idleSessions: sortedIdleSessions,
                 recentProjects: recentProjects,
                 recentResumeTargets: recentTargets,
                 cleanupCandidates: actionableCleanupCandidates
@@ -453,8 +428,6 @@ extension PopupView {
             return
         }
         switch target {
-        case .activeSession(let session), .idleSession(let session):
-            focusSession(session)
         case .recentTarget(let target):
             openRecentResumeTarget(target)
             NSApp.deactivate()

--- a/menubar/CctopMenubar/Views/PopupViewHelpers.swift
+++ b/menubar/CctopMenubar/Views/PopupViewHelpers.swift
@@ -301,8 +301,8 @@ extension PopupView {
               Session.isValidCctopSessionId(cctopSessionID),
               sessions.contains(where: { $0.cctopSessionId == cctopSessionID }) else { return }
         onHideSession(session)
-        navigate?.removeSession(withCctopSessionID: cctopSessionID)
         selectedIndex = nil
+        selectedSessionIdentity = nil
     }
 }
 

--- a/menubar/CctopMenubarTests/NavigateControllerTests.swift
+++ b/menubar/CctopMenubarTests/NavigateControllerTests.swift
@@ -18,7 +18,7 @@ final class NavigateControllerTests: XCTestCase {
 
     func testInitialState() {
         XCTAssertFalse(sut.isActive)
-        XCTAssertTrue(sut.frozenSessions.isEmpty)
+        XCTAssertTrue(sut.frozenSessionIdentities.isEmpty)
     }
 
     // MARK: - Activate
@@ -34,7 +34,7 @@ final class NavigateControllerTests: XCTestCase {
             Session.mock(id: "2", project: "beta", status: .working),
         ]
         sut.activate(sessions: sessions)
-        XCTAssertEqual(sut.frozenSessions.count, 2)
+        XCTAssertEqual(sut.frozenSessionIdentities.count, 2)
     }
 
     func testActivatePreservesCanonicalSessionOrder() {
@@ -48,13 +48,16 @@ final class NavigateControllerTests: XCTestCase {
 
         sut.activate(sessions: [waiting, workingOld, workingNew, idle])
 
-        XCTAssertEqual(sut.frozenSessions.map(\.projectName), ["alpha", "beta", "gamma", "delta"])
+        XCTAssertEqual(
+            sut.frozenSessionIdentities,
+            [waiting, workingOld, workingNew, idle].map { SessionIdentityPolicy.logicalIdentity(for: $0) }
+        )
     }
 
     func testActivateWithEmptySessions() {
         sut.activate(sessions: [])
         XCTAssertTrue(sut.isActive)
-        XCTAssertTrue(sut.frozenSessions.isEmpty)
+        XCTAssertTrue(sut.frozenSessionIdentities.isEmpty)
     }
 
     // MARK: - Deactivate
@@ -68,7 +71,7 @@ final class NavigateControllerTests: XCTestCase {
     func testDeactivateClearsFrozenSessions() {
         sut.activate(sessions: [.mock(), .mock(id: "2")])
         sut.deactivate()
-        XCTAssertTrue(sut.frozenSessions.isEmpty)
+        XCTAssertTrue(sut.frozenSessionIdentities.isEmpty)
     }
 
     func testDeactivateCancelsTimeout() {
@@ -85,7 +88,7 @@ final class NavigateControllerTests: XCTestCase {
     func testDeactivateFromInactiveStateIsNoOp() {
         sut.deactivate()
         XCTAssertFalse(sut.isActive)
-        XCTAssertTrue(sut.frozenSessions.isEmpty)
+        XCTAssertTrue(sut.frozenSessionIdentities.isEmpty)
     }
 
     // MARK: - Frozen sessions are a snapshot
@@ -98,50 +101,95 @@ final class NavigateControllerTests: XCTestCase {
 
         // Mutating the original array shouldn't affect frozen sessions
         sessions.append(.mock(id: "2", project: "beta", status: .idle))
-        XCTAssertEqual(sut.frozenSessions.count, 1)
+        XCTAssertEqual(sut.frozenSessionIdentities.count, 1)
     }
 
-    func testRemovingHiddenSessionPreservesFrozenSurvivorOrder() {
-        let hiddenSessionID = "22222222-2222-4222-8222-222222222222"
+    func testFrozenSlotResolvesReplacementCurrentObservation() throws {
+        let sharedID = "22222222-2222-4222-8222-222222222222"
+        let first = Session.mock(
+            id: "first", cctopSessionId: sharedID,
+            status: .working, pid: 100, source: Session.opencodeSource
+        )
+        let replacement = Session.mock(
+            id: "replacement", cctopSessionId: sharedID,
+            status: .waitingInput, pid: 200, source: Session.opencodeSource
+        )
+        sut.activate(sessions: [first])
+
+        let identity = try XCTUnwrap(sut.sessionIdentity(at: 0))
+        let resolved = FocusTargetResolver.currentSession(for: identity, in: [replacement])
+
+        XCTAssertEqual(resolved?.pid, 200)
+    }
+
+    func testFrozenLegacySlotResolvesSameStableKeyAfterPermanentIDStamp() throws {
+        var legacy = Session.mock(
+            id: "legacy", status: .working, pid: 100, source: Session.opencodeSource
+        )
+        legacy.cctopSessionId = nil
+        sut.activate(sessions: [legacy])
+
+        var stamped = legacy
+        stamped.cctopSessionId = "22222222-2222-4222-8222-222222222222"
+        let identity = try XCTUnwrap(sut.sessionIdentity(at: 0))
+        let resolved = FocusTargetResolver.currentSession(for: identity, in: [stamped])
+
+        XCTAssertEqual(resolved?.cctopSessionId, stamped.cctopSessionId)
+        XCTAssertEqual(resolved?.pid, 100)
+        XCTAssertNil(FocusTargetResolver.currentSession(for: identity, in: [stamped, stamped]))
+    }
+
+    func testMissingFrozenSlotDoesNotRetargetLaterSlot() throws {
         let first = Session.mock(
             id: "first", cctopSessionId: "11111111-1111-4111-8111-111111111111",
-            status: .waitingInput, source: Session.codexSource
-        )
-        let hidden = Session.mock(
-            id: "hidden", cctopSessionId: hiddenSessionID,
             status: .working, source: Session.codexSource
         )
-        let secondHiddenObservation = Session.mock(
-            id: "hidden-again", cctopSessionId: hiddenSessionID,
-            status: .idle, source: Session.codexSource
+        let second = Session.mock(
+            id: "second", cctopSessionId: "22222222-2222-4222-8222-222222222222",
+            status: .working, source: Session.codexSource
         )
-        let last = Session.mock(
-            id: "last", cctopSessionId: "33333333-3333-4333-8333-333333333333",
-            status: .idle, source: Session.codexSource
-        )
-        sut.activate(sessions: [first, hidden, secondHiddenObservation, last])
+        sut.activate(sessions: [first, second])
 
-        sut.removeSession(withCctopSessionID: hiddenSessionID)
+        let firstIdentity = try XCTUnwrap(sut.sessionIdentity(at: 0))
+        let secondIdentity = try XCTUnwrap(sut.sessionIdentity(at: 1))
 
-        XCTAssertEqual(sut.frozenSessions.map(\.sessionId), ["first", "last"])
+        XCTAssertNil(FocusTargetResolver.currentSession(for: firstIdentity, in: [second]))
+        XCTAssertEqual(FocusTargetResolver.currentSession(for: secondIdentity, in: [second])?.sessionId, "second")
     }
 
-    func testRemovingLastHiddenSessionPreservesActiveEmptySnapshot() {
-        let hiddenSessionID = "22222222-2222-4222-8222-222222222222"
-        let hidden = Session.mock(
-            id: "hidden", cctopSessionId: hiddenSessionID,
+    @MainActor
+    func testPopupRowsPreserveFrozenSlotAndBindReplacementObservation() throws {
+        let missing = Session.mock(
+            id: "missing", cctopSessionId: "11111111-1111-4111-8111-111111111111",
             status: .working, source: Session.codexSource
         )
-        sut.activate(sessions: [hidden])
+        let original = Session.mock(
+            id: "original", cctopSessionId: "22222222-2222-4222-8222-222222222222",
+            status: .working, pid: 100, source: Session.codexSource
+        )
+        let replacement = Session.mock(
+            id: "replacement", cctopSessionId: original.cctopSessionId,
+            status: .waitingInput, pid: 200, source: Session.codexSource
+        )
+        sut.activate(sessions: [missing, original])
 
-        sut.removeSession(withCctopSessionID: hiddenSessionID)
+        let view = PopupView(
+            sessions: [replacement],
+            updater: DisabledUpdater(),
+            pluginManager: inertPluginManager(),
+            navigate: sut
+        )
+        let row = try XCTUnwrap(view.activeSessionRows.first)
 
-        XCTAssertEqual(sut.activeSessionSnapshot, [])
-        XCTAssertTrue(sut.isActive)
+        XCTAssertEqual(view.activeSessionRows.count, 1)
+        XCTAssertEqual(row.slot, 1)
+        XCTAssertEqual(row.id, SessionIdentityPolicy.logicalIdentity(for: original))
+        XCTAssertEqual(row.session, replacement)
     }
 
     func testInactiveControllerHasNoActiveSnapshot() {
-        XCTAssertNil(sut.activeSessionSnapshot)
+        XCTAssertNil(sut.activeSessionIdentitySnapshot)
+        XCTAssertNil(sut.sessionIdentity(at: 0))
     }
 
     // MARK: - Timeout
@@ -221,13 +269,13 @@ final class NavigateControllerTests: XCTestCase {
         sut.activate(sessions: sessions)
 
         XCTAssertTrue(sut.isActive)
-        XCTAssertEqual(sut.frozenSessions.count, 2)
+        XCTAssertEqual(sut.frozenSessionIdentities.count, 2)
 
         // Deactivate resets all state
         sut.deactivate()
 
         XCTAssertFalse(sut.isActive)
-        XCTAssertTrue(sut.frozenSessions.isEmpty)
+        XCTAssertTrue(sut.frozenSessionIdentities.isEmpty)
     }
 
     func testMultipleActivateDeactivateCycles() {
@@ -235,11 +283,11 @@ final class NavigateControllerTests: XCTestCase {
             let sessions = [Session.mock(id: "\(i)", status: .working)]
             sut.activate(sessions: sessions)
             XCTAssertTrue(sut.isActive)
-            XCTAssertEqual(sut.frozenSessions.count, 1)
+            XCTAssertEqual(sut.frozenSessionIdentities.count, 1)
 
             sut.deactivate()
             XCTAssertFalse(sut.isActive)
-            XCTAssertTrue(sut.frozenSessions.isEmpty)
+            XCTAssertTrue(sut.frozenSessionIdentities.isEmpty)
         }
     }
 
@@ -253,7 +301,9 @@ final class NavigateControllerTests: XCTestCase {
 
         sut.activate(sessions: [older, newer])
 
-        XCTAssertEqual(sut.frozenSessions[0].projectName, "older")
-        XCTAssertEqual(sut.frozenSessions[1].projectName, "newer")
+        XCTAssertEqual(
+            sut.frozenSessionIdentities,
+            [older, newer].map { SessionIdentityPolicy.logicalIdentity(for: $0) }
+        )
     }
 }

--- a/menubar/CctopMenubarTests/SessionDedupTests.swift
+++ b/menubar/CctopMenubarTests/SessionDedupTests.swift
@@ -23,28 +23,47 @@ final class SessionDedupTests: XCTestCase {
         XCTAssertEqual(cc.id, "31349")
     }
 
-    /// A transient migration window can leave two files for the same conversation (the old
-    /// PID-keyed file plus the new codex-<id> file), so the loaded list can contain two
-    /// sessions with the same id. dedupedByID must collapse them (keeping the freshest)
-    /// so nothing keyed by id — SwiftUI identity, the status map — ever sees a duplicate.
-    func testDedupedByIDCollapsesDuplicateIDsKeepingFreshest() {
-        var old = Session(sessionId: "conv-a", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
-        old.source = "codex"; old.pid = 31349
-        old.sessionName = "stale"
-        old.lastActivity = Date(timeIntervalSinceNow: -120)
+    func testLogicalIdentityPrefersPermanentIDAndFallsBackForLegacyRecords() {
+        let sharedID = "11111111-1111-4111-8111-111111111111"
+        let first = Session.mock(id: "first", cctopSessionId: sharedID, pid: 100, source: Session.opencodeSource)
+        let replacement = Session.mock(id: "replacement", cctopSessionId: sharedID, pid: 200, source: Session.opencodeSource)
+        var legacy = Session.mock(id: "legacy", pid: 300, source: Session.opencodeSource)
+        legacy.cctopSessionId = nil
+        var invalid = legacy
+        invalid.cctopSessionId = "not-a-uuid"
 
-        var fresh = Session(sessionId: "conv-a", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
-        fresh.source = "codex"; fresh.pid = 31349
-        fresh.sessionName = "current"
-        fresh.lastActivity = Date()
+        XCTAssertEqual(
+            SessionIdentityPolicy.logicalIdentity(for: first),
+            SessionIdentityPolicy.logicalIdentity(for: replacement)
+        )
+        XCTAssertEqual(
+            SessionIdentityPolicy.logicalIdentity(for: legacy),
+            SessionIdentityPolicy.logicalIdentity(for: invalid)
+        )
+        XCTAssertNotEqual(
+            SessionIdentityPolicy.logicalIdentity(for: first),
+            SessionIdentityPolicy.logicalIdentity(for: legacy)
+        )
+    }
 
-        var other = Session(sessionId: "conv-b", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
-        other.source = "codex"; other.pid = 31349
+    func testLogicalDedupKeepsFirstRowPositionAndPreferredObservation() {
+        let sharedID = "11111111-1111-4111-8111-111111111111"
+        let old = candidate(
+            sessionId: "old", pid: 100, bundleId: nil, lifecycleRank: 1,
+            lastActivity: Date(timeIntervalSince1970: 10), path: "/old.json"
+        ) { $0.cctopSessionId = sharedID }
+        let other = candidate(
+            sessionId: "other", pid: 200, bundleId: nil, lifecycleRank: 0,
+            path: "/other.json"
+        )
+        let current = candidate(
+            sessionId: "current", pid: 300, bundleId: nil, lifecycleRank: 0,
+            lastActivity: Date(timeIntervalSince1970: 20), path: "/current.json"
+        ) { $0.cctopSessionId = sharedID }
 
-        let result = SessionIdentityPolicy.dedupedByDisplayID([old, fresh, other])
-        // Two distinct ids survive; the duplicate id keeps the most recently active entry.
-        XCTAssertEqual(result.map(\.id).sorted(), ["conv-a", "conv-b"])
-        XCTAssertEqual(result.first { $0.id == "conv-a" }?.sessionName, "current")
+        let result = SessionIdentityPolicy.dedupedCandidatesByLogicalIdentity([old, other, current])
+
+        XCTAssertEqual(result.map(\.session.pid), [300, 200])
     }
 
     // MARK: - Desktop dedup by session_id (Phase 1, total order)

--- a/menubar/CctopMenubarTests/SessionDisplayPolicyTests.swift
+++ b/menubar/CctopMenubarTests/SessionDisplayPolicyTests.swift
@@ -36,7 +36,10 @@ final class SessionDisplayPolicyTests: XCTestCase {
 
         XCTAssertEqual(
             SessionDisplayPolicy.signature(for: sessions, now: now),
-            .init(activeIDs: ["fresh"], idleIDs: ["stale", "dormant"])
+            .init(
+                activeIDs: [SessionIdentityPolicy.logicalIdentity(for: sessions[0])],
+                idleIDs: sessions[1...].map { SessionIdentityPolicy.logicalIdentity(for: $0) }
+            )
         )
     }
 
@@ -231,6 +234,57 @@ final class SessionDisplayPolicyTests: XCTestCase {
             SessionIdentityPolicy.stableKey(for: previous[0]),
             SessionIdentityPolicy.stableKey(for: result[0])
         )
+    }
+
+    func testReconciledActiveOrderUsesPermanentIdentityAcrossObservationReplacementAndStatusMovement() {
+        let now = Date(timeIntervalSince1970: 95_000)
+        let sharedID = "11111111-1111-4111-8111-111111111111"
+        var logicalSession = Session.mock(
+            id: "old-observation", cctopSessionId: sharedID,
+            status: .working, pid: 100, source: Session.opencodeSource
+        )
+        let workingPeer = Session.mock(id: "peer", status: .working, pid: 200, source: Session.opencodeSource)
+        let previous = [logicalSession, workingPeer]
+
+        logicalSession = Session.mock(
+            id: "new-observation", cctopSessionId: sharedID,
+            status: .waitingInput, pid: 300, source: Session.opencodeSource
+        )
+        let result = SessionDisplayPolicy.reconcilingActiveOrder(
+            in: [workingPeer, logicalSession], preserving: previous, now: now
+        )
+
+        XCTAssertEqual(result.map(\.pid), [300, 200])
+        XCTAssertEqual(
+            result.map { SessionIdentityPolicy.logicalIdentity(for: $0) },
+            [
+                SessionIdentityPolicy.logicalIdentity(for: logicalSession),
+                SessionIdentityPolicy.logicalIdentity(for: workingPeer),
+            ]
+        )
+    }
+
+    func testReconciledActiveOrderDoesNotReplayDuplicatePreviousLogicalRows() {
+        let now = Date(timeIntervalSince1970: 96_000)
+        let sharedID = "11111111-1111-4111-8111-111111111111"
+        let previousFirst = Session.mock(
+            id: "old-first", cctopSessionId: sharedID,
+            status: .working, pid: 100, source: Session.opencodeSource
+        )
+        let previousSecond = Session.mock(
+            id: "old-second", cctopSessionId: sharedID,
+            status: .working, pid: 200, source: Session.opencodeSource
+        )
+        let current = Session.mock(
+            id: "current", cctopSessionId: sharedID,
+            status: .working, pid: 300, source: Session.opencodeSource
+        )
+
+        let result = SessionDisplayPolicy.reconcilingActiveOrder(
+            in: [current], preserving: [previousFirst, previousSecond], now: now
+        )
+
+        XCTAssertEqual(result.map(\.pid), [300])
     }
 
     private func activeIdle(id: String, lastActivity: Date) -> Session {

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -1500,7 +1500,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             processAlive: { _ in true }
         )
         let publishedIDs = Set(manager.sessions.compactMap(\.cctopSessionId))
-        XCTAssertEqual(manager.sessions.count, 2)
+        XCTAssertEqual(manager.sessions.count, 1)
         XCTAssertEqual(publishedIDs.count, 1)
         XCTAssertTrue(publishedIDs.allSatisfy(Session.isValidCctopSessionId))
 

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -2253,6 +2253,28 @@ final class SessionTests: XCTestCase {
         XCTAssertNil(FocusTargetResolver.currentSession(forCctopSessionID: currentID, in: []))
     }
 
+    func testLogicalFocusResolverUsesFirstCanonicalPermanentObservation() {
+        let cctopSessionID = "11111111-2222-4333-8444-555555555555"
+        let first = Session.mock(id: "first", cctopSessionId: cctopSessionID, pid: 111)
+        let second = Session.mock(id: "second", cctopSessionId: cctopSessionID, pid: 222)
+        let identity = SessionIdentityPolicy.logicalIdentity(for: first)
+
+        XCTAssertEqual(FocusTargetResolver.currentSession(for: identity, in: [first, second])?.pid, 111)
+        XCTAssertEqual(FocusTargetResolver.currentSession(for: identity, in: [second, first])?.pid, 222)
+    }
+
+    func testLogicalFocusResolverKeepsLegacyFallbackUniqueAndFailsClosedWhenAmbiguous() {
+        var first = Session.mock(id: "first", pid: 111, source: Session.opencodeSource)
+        first.cctopSessionId = nil
+        var duplicate = Session.mock(id: "duplicate", pid: 111, source: Session.opencodeSource)
+        duplicate.cctopSessionId = nil
+        let identity = SessionIdentityPolicy.logicalIdentity(for: first)
+
+        XCTAssertEqual(FocusTargetResolver.currentSession(for: identity, in: [first])?.sessionId, "first")
+        XCTAssertNil(FocusTargetResolver.currentSession(for: identity, in: [first, duplicate]))
+        XCTAssertNil(FocusTargetResolver.currentSession(for: identity, in: []))
+    }
+
     func testRepeatedCctopSessionIDKeepsRowsAndResolvesFirstCanonicalObservation() {
         let now = Date()
         let cctopSessionID = "11111111-2222-4333-8444-555555555555"

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1445,8 +1445,6 @@ final class WorktreeCleanupTests: XCTestCase {
             for: .cleanup,
             index: 0,
             in: PopupSelectionContext(
-                activeSessions: [],
-                idleSessions: [],
                 recentProjects: [],
                 cleanupCandidates: [candidate]
             )
@@ -1547,8 +1545,6 @@ final class WorktreeCleanupTests: XCTestCase {
             for: .cleanup,
             index: 0,
             in: PopupSelectionContext(
-                activeSessions: [],
-                idleSessions: [],
                 recentProjects: [],
                 cleanupCandidates: [candidate]
             )


### PR DESCRIPTION
Layer 2: panel and navigation identity

Parent: #227 at exact head `58e2a3f65317569e61e2ae1ab6f652d0740d0522`

Next dependent layer: #228. Notification and Recent leaves remain above it.

## Problem

Panel rows and frozen navigation could follow transient observations, allowing one logical conversation to duplicate or rebind when its observation or status group changed.

## Solution

Project visible sessions to one canonical row per permanent ID, freeze navigation by logical identity, and resolve the current observation only when an action fires. Direct row clicks still retain their exact visible observation, with conservative unique-only legacy fallback.

## Verification

- `make all`
- Exact d73a smoke collapsed duplicate observations, preserved canonical ordering through waiting-to-working regrouping, and routed permanent-ID focus through #227.