### PR TITLE
Use permanent identity for desktop Recent rows

### DIFF
--- a/menubar/CctopMenubar/Models/RecentResumeTarget.swift
+++ b/menubar/CctopMenubar/Models/RecentResumeTarget.swift
@@ -37,6 +37,10 @@ enum RecentResumeTarget: Identifiable, Equatable {
         case .project(let project):
             return "project:\(project.id)"
         case .desktopThread(let thread):
+            if let cctopSessionID = thread.cctopSessionId,
+               Session.isValidCctopSessionId(cctopSessionID) {
+                return "desktop:\(cctopSessionID)"
+            }
             return "desktop:\(thread.sourceApp.displayName):\(thread.sessionId)"
         }
     }
@@ -169,7 +173,7 @@ enum RecentResumeTarget: Identifiable, Equatable {
         from classification: SessionClassificationSnapshot,
         excludingSessionIDs: Set<String>
     ) -> [RecentResumeTarget] {
-        var targetsByID: [String: RecentResumeTarget] = [:]
+        var targetsByID: [String: (target: RecentResumeTarget, candidate: DedupCandidate)] = [:]
         for record in classification.records {
             if let cctopSessionID = record.candidate.session.cctopSessionId,
                excludingSessionIDs.contains(cctopSessionID) {
@@ -184,12 +188,12 @@ enum RecentResumeTarget: Identifiable, Equatable {
             }
             let target = RecentResumeTarget.desktopThread(thread)
             if let existing = targetsByID[target.id],
-               existing.lastSessionAt >= target.lastSessionAt {
+               !SessionLifecyclePolicy.prefers(record.candidate, over: existing.candidate) {
                 continue
             }
-            targetsByID[target.id] = target
+            targetsByID[target.id] = (target, record.candidate)
         }
-        return Array(targetsByID.values)
+        return targetsByID.values.map(\.target)
     }
 
     private static func desktopThreadSourceApp(for disposition: SessionDisposition) -> HostApp? {

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -159,6 +159,9 @@ class SessionManager: ObservableObject {
         )
         let activeProjectPaths = classification.protectedProjectPathsForCleanup
         let recentExcludedPaths = activeProjectPaths.union(classification.manualHiddenProjectPaths(hiddenSessionIDs))
+        let publishedSessionIDs = Set(newSessions.compactMap {
+            SessionIdentityPolicy.logicalIdentity(for: $0).cctopSessionID
+        })
         let shouldFreezeVisibilityProjections = !unresolvedLegacyKeys.isEmpty
             || (!inventoryComplete && !hiddenSessionIDs.isEmpty)
         if !shouldFreezeVisibilityProjections {
@@ -166,7 +169,7 @@ class SessionManager: ObservableObject {
             publishRecentResumeTargets(RecentResumeTarget.build(
                 projects: historyManager.recentProjects,
                 classification: classification,
-                excludingDesktopSessionIDs: hiddenSessionIDs
+                excludingDesktopSessionIDs: hiddenSessionIDs.union(publishedSessionIDs)
             ))
             refreshCleanupSources(from: observedCleanupSources, activeProjectPaths: activeProjectPaths)
         } else { // Freeze existing items, add unresolved finished evidence, and only grow path protection.

--- a/menubar/CctopMenubarTests/SessionLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/SessionLifecycleTests.swift
@@ -742,6 +742,157 @@ final class SessionLifecycleTests: XCTestCase {
         XCTAssertEqual(visibleAfterHidingCodex.map(\.title), ["Run plugin node:test suites in CI"])
     }
 
+    func testRecentResumeTargetsUsePermanentIdentityAndDeterministicArchivedObservation() throws {
+        let permanentID = "11111111-1111-4111-8111-111111111111"
+        let preferredSessionID = "preferred-archived-observation"
+        let otherSessionID = "other-archived-observation"
+        let preferred = candidate(
+            sessionId: preferredSessionID,
+            pid: 1,
+            bundleId: HostAppBundleID.claudeDesktop,
+            lifecycleRank: SessionLifecycle.dormant.rawValue,
+            source: Session.ccSource,
+            lastActivity: Date(timeIntervalSince1970: 3_000),
+            mtime: Date(timeIntervalSince1970: 4_000),
+            path: "/a-preferred.json"
+        ) { session in
+            session.cctopSessionId = permanentID
+            session.sessionName = "Preferred archived observation"
+            session.desktopProjectName = "Preferred project"
+        }
+        let other = candidate(
+            sessionId: otherSessionID,
+            pid: 2,
+            bundleId: HostAppBundleID.claudeDesktop,
+            lifecycleRank: SessionLifecycle.dormant.rawValue,
+            source: Session.ccSource,
+            lastActivity: Date(timeIntervalSince1970: 3_000),
+            mtime: Date(timeIntervalSince1970: 4_000),
+            path: "/z-other.json"
+        ) { session in
+            session.cctopSessionId = permanentID
+            session.sessionName = "Other archived observation"
+            session.desktopProjectName = "Other project"
+        }
+        let metadata = ClaudeDesktopSessionMetadataSnapshot(
+            matchedSessionIDs: [preferredSessionID, otherSessionID],
+            archivedSessionIDs: [preferredSessionID, otherSessionID],
+            isAuthoritative: true
+        )
+
+        let forward = RecentResumeTarget.build(
+            projects: [],
+            classification: SessionManager.sessionClassificationSnapshot(
+                in: [preferred, other],
+                claudeMetadata: metadata
+            )
+        )
+        let reversed = RecentResumeTarget.build(
+            projects: [],
+            classification: SessionManager.sessionClassificationSnapshot(
+                in: [other, preferred],
+                claudeMetadata: metadata
+            )
+        )
+
+        XCTAssertEqual(forward, reversed)
+        XCTAssertEqual(forward.count, 1)
+        let target = try XCTUnwrap(forward.first)
+        XCTAssertEqual(target.id, "desktop:\(permanentID)")
+        guard case .desktopThread(let thread) = target else {
+            return XCTFail("Expected one archived desktop target")
+        }
+        XCTAssertEqual(thread.sessionId, preferredSessionID)
+        XCTAssertEqual(thread.cctopSessionId, permanentID)
+        XCTAssertEqual(thread.title, "Preferred archived observation")
+        XCTAssertEqual(thread.projectName, "Preferred project")
+        XCTAssertEqual(thread.sourceApp, .claudeDesktop)
+        XCTAssertEqual(
+            resolveRecentResumeTargetOpenStrategy(target: target),
+            .activateByBundleID(HostApp.claudeDesktop.bundleID!)
+        )
+    }
+
+    func testRecentResumeTargetPermanentIdentityIsStableAcrossObservationMetadataChanges() throws {
+        let permanentID = "22222222-2222-4222-8222-222222222222"
+        let sessionID = "archived-observation"
+        func target(title: String, projectName: String) throws -> RecentResumeTarget {
+            let archived = candidate(
+                sessionId: sessionID,
+                pid: 1,
+                bundleId: HostAppBundleID.codexDesktop,
+                lifecycleRank: SessionLifecycle.dormant.rawValue,
+                source: Session.codexSource,
+                path: "/archived.json"
+            ) { session in
+                session.cctopSessionId = permanentID
+                session.sessionName = title
+                session.desktopProjectName = projectName
+            }
+            let classification = SessionManager.sessionClassificationSnapshot(
+                in: [archived],
+                codexThreads: StubCodexThreadState(archived: [sessionID])
+            )
+            let targets = RecentResumeTarget.build(projects: [], classification: classification)
+            XCTAssertEqual(targets.count, 1)
+            return try XCTUnwrap(targets.first)
+        }
+
+        let original = try target(title: "Original title", projectName: "Original project")
+        let updated = try target(title: "Updated title", projectName: "Updated project")
+
+        XCTAssertEqual(original.id, "desktop:\(permanentID)")
+        XCTAssertEqual(updated.id, original.id)
+        XCTAssertNotEqual(updated.title, original.title)
+        guard case .desktopThread(let originalThread) = original,
+              case .desktopThread(let updatedThread) = updated else {
+            return XCTFail("Expected archived desktop targets")
+        }
+        XCTAssertNotEqual(updatedThread.projectName, originalThread.projectName)
+    }
+
+    func testRecentResumeTargetsKeepLegacyIdentityFallbackWithoutValidPermanentID() {
+        let nilID = candidate(
+            sessionId: "legacy-without-id",
+            pid: 1,
+            bundleId: HostAppBundleID.claudeDesktop,
+            lifecycleRank: SessionLifecycle.dormant.rawValue,
+            source: Session.ccSource,
+            path: "/legacy-without-id.json"
+        ) { session in
+            session.cctopSessionId = nil
+            session.sessionName = "Legacy without ID"
+        }
+        let invalidID = candidate(
+            sessionId: "legacy-invalid-id",
+            pid: 2,
+            bundleId: HostAppBundleID.claudeDesktop,
+            lifecycleRank: SessionLifecycle.dormant.rawValue,
+            source: Session.ccSource,
+            path: "/legacy-invalid-id.json"
+        ) { session in
+            session.cctopSessionId = "not-a-permanent-id"
+            session.sessionName = "Legacy invalid ID"
+        }
+        let metadata = ClaudeDesktopSessionMetadataSnapshot(
+            matchedSessionIDs: [nilID.session.sessionId, invalidID.session.sessionId],
+            archivedSessionIDs: [nilID.session.sessionId, invalidID.session.sessionId],
+            isAuthoritative: true
+        )
+        let classification = SessionManager.sessionClassificationSnapshot(
+            in: [nilID, invalidID],
+            claudeMetadata: metadata
+        )
+
+        XCTAssertEqual(
+            Set(RecentResumeTarget.build(projects: [], classification: classification).map(\.id)),
+            [
+                "desktop:Claude Desktop:legacy-without-id",
+                "desktop:Claude Desktop:legacy-invalid-id",
+            ]
+        )
+    }
+
     func testRecentResumeTargetsExcludeNonArchivedDesktopHiddenReasons() {
         let missing = candidate(
             sessionId: "missing-thread",
@@ -871,6 +1022,7 @@ final class SessionLifecycleTests: XCTestCase {
             RecentResumeTarget.project(project).metadataText,
             "Codex \u{00B7} 2 sessions \u{00B7} /Users/dev/projects/a-very-long-parent-path/billing-api"
         )
+        XCTAssertEqual(RecentResumeTarget.project(project).id, "project:\(project.id)")
     }
 
     func testRecentResumeTargetDesktopThreadOpenHelpTextUsesCautiousArchiveLanguage() {

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -698,8 +698,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             startMonitoring: false
         )
         let hidden = try XCTUnwrap(manager.sessions.first { $0.sessionId == live.sessionId })
-        XCTAssertEqual(manager.recentResumeTargets.map(\.title), ["Archived desktop observation"])
-        XCTAssertEqual(manager.recentResumeTargets.compactMap(\.cctopSessionId), [sharedID])
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
 
         manager.hideSession(hidden)
 
@@ -715,6 +714,67 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertTrue(manager.sessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [sharedID])
+    }
+
+    @MainActor
+    func testPublishedSessionSuppressesArchivedRecentTargetUntilObservationEnds() throws {
+        let root = NSTemporaryDirectory() + "cctop-recent-live-suppression-\(UUID().uuidString)"
+        let sessionsURL = URL(fileURLWithPath: root).appendingPathComponent("sessions", isDirectory: true)
+        let historyURL = URL(fileURLWithPath: root).appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: historyURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let sharedID = "33333333-3333-4333-8333-333333333333"
+        let durableConversationID = "59253133-4a65-48fb-af2b-844463d3b5bb"
+        var live = Session(
+            sessionId: "live-terminal-observation",
+            projectPath: "/tmp/live-terminal",
+            branch: "main",
+            terminal: TerminalInfo(program: "zsh")
+        )
+        live.cctopSessionId = sharedID
+        live.harnessSessionId = durableConversationID
+        live.source = Session.ccSource
+        live.pid = 4_205
+        live.status = .working
+        let liveURL = sessionsURL.appendingPathComponent("live-terminal.json")
+        try live.writeToFile(path: liveURL.path)
+
+        var archived = claudeDesktopSession(
+            sessionId: durableConversationID,
+            projectPath: "/tmp/archived-desktop"
+        )
+        archived.cctopSessionId = sharedID
+        archived.harnessSessionId = durableConversationID
+        archived.sessionName = "Archived desktop observation"
+        archived.lastActivity = Date(timeIntervalSince1970: 2_000)
+        try archived.writeToFile(path: sessionsURL.appendingPathComponent("archived-desktop.json").path)
+
+        var sources = SessionDataSources.live()
+        sources.sessionsDir = sessionsURL
+        sources.claudeDesktopSessions = StubClaudeDesktopState(snapshot: ClaudeDesktopSessionMetadataSnapshot(
+            matchedSessionIDs: [durableConversationID],
+            archivedSessionIDs: [durableConversationID],
+            isAuthoritative: true
+        ))
+        sources.desktopAppConnection = DesktopAppConnectionLookup { _ in false }
+        sources.processAlive = { $0.sessionId == live.sessionId }
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: historyURL),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        XCTAssertEqual(manager.sessions.map(\.cctopSessionId), [sharedID])
+        XCTAssertTrue(manager.recentResumeTargets.isEmpty)
+
+        try FileManager.default.removeItem(at: liveURL)
+        manager.loadSessions()
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertEqual(manager.recentResumeTargets.map(\.id), ["desktop:\(sharedID)"])
+        XCTAssertEqual(manager.recentResumeTargets.map(\.title), ["Archived desktop observation"])
     }
 
     @MainActor


### PR DESCRIPTION
## Problem

Archived desktop observations used host-specific session references as Recent row identity. Multiple observations of one permanent cctop session could therefore appear as separate rows, and a matching live or manually hidden observation could leave the archived row visible.

## Solution

- Use a valid permanent cctop session ID for desktop Recent identity and deduplication, retaining the existing host/session fallback for legacy records.
- Select one archived observation with the existing lifecycle preference and deterministic tie-break while preserving that observation’s host data for reopening.
- Suppress archived desktop rows whose permanent ID is currently live or manually hidden. Project Recent identity and behavior are unchanged.

This is the Recent sibling leaf above PR #228. Its base is codex/manual-hide-persistence at exact head 6c2689c4d52dc1227658b9a212b3f4c840a0c114.

## Verification

- Focused permanent-identity, live-suppression, and manual-hide tests passed.
- make all passed, including 1,198 Swift tests.
- Exact-build smoke proved one deterministic archived row, stable identity across metadata changes, live suppression and return, hidden suppression across an exact restart with byte-identical preferences restoration, and unchanged project Recent.
- Native archived-row clicking remains the classified macOS interaction residual; focused production tests prove the selected archived-host bundle strategy and that no live permanent-ID retarget path is used.