### PR TITLE
Simplify permanent identity migration support

### DIFF
--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -26,7 +26,8 @@ reference; the raw reference is not copied into this directory. Existing
 publishable session JSON files without the field are assigned an ID once and
 stamped with the same per-file locking and atomic-write rules as hook updates.
 Hidden, finished, cleanup, and history records keep their existing identity
-contracts until a current hook or later visible observation needs this field.
+contracts until a current hook, manual-hide migration, or archived desktop
+Recent projection needs this field.
 Identity mappings intentionally outlive session and history cleanup and are not
 automatically pruned in this version.
 
@@ -103,9 +104,10 @@ match in canonical panel order. This is the temporary single-target policy.
 Future support extends the resolver with an explicit selection policy rather than
 changing logical identity, lifecycle/liveness classification, canonical order,
 or terminal/window execution.
-Cross-client equivalence and cross-machine identity are out of scope. Manual hiding
-uses `cctop_session_id` as its preference key; notification grouping, cleanup,
-history, and other persisted preferences keep their separate contracts.
+Cross-client equivalence and cross-machine identity are out of scope. Manual
+hiding and notification grouping use `cctop_session_id`. Archived desktop Recent
+rows also prefer it for logical row identity; path-based Recent Projects, Cleanup,
+and other persisted preferences keep their separate contracts.
 
 ## Terminal Focus Metadata
 

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -57,7 +57,8 @@ enum HookHandler {
             var session = loaded.session
             let isNewSessionFile = loaded.isNewSessionFile
 
-            stampFocusTarget(&session, pid: pid, startTime: startTime)
+            session.pid = pid
+            session.pidStartTime = startTime
             stampSessionIdentity(
                 &session, cctopSessionId: cctopSessionId,
                 input: input, source: source, safeId: safeId
@@ -507,13 +508,6 @@ extension HookHandler {
             logger.logError("SessionEnd: could not resolve cctop session identity: \(error)")
             return nil
         }
-    }
-
-    private static func stampFocusTarget(
-        _ session: inout Session, pid: UInt32, startTime: TimeInterval?
-    ) {
-        session.pid = pid
-        session.pidStartTime = startTime
     }
 
     private static func stampSessionIdentity(

--- a/menubar/CctopMenubar/Hook/HookInput.swift
+++ b/menubar/CctopMenubar/Hook/HookInput.swift
@@ -82,8 +82,9 @@ struct HookInput: Codable {
     /// which carries the SessionStart trigger kind ("startup"/"resume"/"clear"), not a
     /// tool name.
     ///
-    /// MIGRATION(harness_name): Remove the `source` fallback after opencode/pi plugins
-    /// shipping `harness_name` have been in the wild for at least one release cycle.
+    /// MIGRATION(harness_name): Remove the `source` fallback only after installer/status
+    /// logic enforces plugins that send `harness_name`, or older-plugin compatibility is
+    /// explicitly dropped. Installed opencode/pi plugins are not automatically overwritten.
     private static let knownHarnesses: Set<String> = ["cc", "codex", "opencode", "pi"]
 
     var resolvedHarnessName: String? {

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -15,7 +15,7 @@ enum SessionIdentityPolicy {
     static let notificationSessionPIDKey = "sessionPID"
     static let notificationCctopSessionIDKey = "cctopSessionID"
 
-    /// Stable grouping key shared by dedup and notification transition guards.
+    /// Legacy grouping key used by pre-ID dedup and conservative compatibility paths.
     static func stableKey(for session: Session) -> String {
         if session.isCodex {
             return "codex:\(session.sessionId)"

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -138,6 +138,9 @@ enum SessionIdentityPolicy {
 /// The stored payload is intentionally limited to opaque cctop-owned session IDs.
 struct ManualSessionVisibilityStore {
     static let defaultsKey = "manuallyHiddenCctopSessionIDs"
+    // MIGRATION(permanent_identity): Only pre-release manual-hide builds wrote this key.
+    // Reconsider after the first tagged release containing this migration, but remove it
+    // only with an explicit decision to stop preserving those pre-release preferences.
     static let legacyDefaultsKey = "manuallyHiddenSessionStableKeys"
     static let live = ManualSessionVisibilityStore(defaults: .standard)
 

--- a/menubar/CctopMenubar/Services/SessionManager+Loading.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Loading.swift
@@ -90,15 +90,15 @@ extension SessionManager {
         let identityStore = CctopSessionIdentityStore(sessionsDir: dataSources.sessionsDir)
         for index in records.indices where !Session.isValidCctopSessionId(records[index].session.cctopSessionId) {
             var session = records[index].session
-            let evidence = CctopSessionIdentityStore.durableEvidence(
+            guard let evidence = CctopSessionIdentityStore.durableEvidence(
                 source: session.source,
                 harnessSessionId: session.harnessSessionId,
                 legacySessionId: session.sessionId
-            )
-            guard let evidence else {
-                scheduleRecordLocalCctopSessionIdentityStamp(
+            ) else {
+                scheduleCctopSessionIdentityStamp(
                     url: records[index].url,
-                    snapshot: session
+                    snapshot: session,
+                    resolvedID: nil
                 )
                 continue
             }
@@ -115,7 +115,8 @@ extension SessionManager {
                 idsByEvidence[evidence, default: []].insert(cctopSessionId)
                 scheduleCctopSessionIdentityStamp(
                     url: records[index].url,
-                    snapshot: records[index].session
+                    snapshot: records[index].session,
+                    resolvedID: cctopSessionId
                 )
             } catch {
                 let fileName = records[index].url.lastPathComponent
@@ -192,37 +193,12 @@ extension SessionManager {
         return SessionClassificationSnapshot(records: records, evidence: classification.evidence)
     }
 
-    private func scheduleRecordLocalCctopSessionIdentityStamp(url: URL, snapshot: Session) {
+    private func scheduleCctopSessionIdentityStamp(
+        url: URL,
+        snapshot: Session,
+        resolvedID: String?
+    ) {
         guard pendingIdentityMigrationPaths.insert(url.path).inserted else { return }
-        cctopIdentityMigrationQueue.async { [weak self] in
-            do {
-                _ = try withSessionLockIfAvailable(sessionPath: url.path) {
-                    guard var current = try? Session.fromFile(path: url.path),
-                          !Session.isValidCctopSessionId(current.cctopSessionId),
-                          current.sessionId == snapshot.sessionId,
-                          current.source == snapshot.source,
-                          current.harnessSessionId == snapshot.harnessSessionId else { return }
-                    current.cctopSessionId = Session.makeCctopSessionId()
-                    try current.writeToFile(path: url.path)
-                }
-            } catch {
-                let fileName = url.lastPathComponent
-                let reason = error.localizedDescription
-                sessionManagerLogger.warning(
-                    "record-local identity stamp failed for \(fileName, privacy: .public): \(reason, privacy: .public)"
-                )
-            }
-            DispatchQueue.main.async {
-                guard let self else { return }
-                self.pendingIdentityMigrationPaths.remove(url.path)
-                self.sessionFileCache.removeValue(forKey: url.path)
-            }
-        }
-    }
-
-    private func scheduleCctopSessionIdentityStamp(url: URL, snapshot: Session) {
-        guard let cctopSessionId = snapshot.cctopSessionId,
-              pendingIdentityMigrationPaths.insert(url.path).inserted else { return }
         cctopIdentityMigrationQueue.async { [weak self] in
             do {
                 _ = try withSessionLockIfAvailable(sessionPath: url.path) {
@@ -233,14 +209,15 @@ extension SessionManager {
                     guard current.sessionId == snapshot.sessionId,
                           current.source == snapshot.source,
                           current.harnessSessionId == snapshot.harnessSessionId else { return }
-                    current.cctopSessionId = cctopSessionId
+                    current.cctopSessionId = resolvedID ?? Session.makeCctopSessionId()
                     try current.writeToFile(path: url.path)
                 }
             } catch {
                 let fileName = url.lastPathComponent
                 let reason = error.localizedDescription
+                let prefix = resolvedID == nil ? "record-local identity stamp" : "identity stamp"
                 sessionManagerLogger.warning(
-                    "identity stamp failed for \(fileName, privacy: .public): \(reason, privacy: .public)"
+                    "\(prefix, privacy: .public) failed for \(fileName, privacy: .public): \(reason, privacy: .public)"
                 )
             }
             DispatchQueue.main.async {


### PR DESCRIPTION
Stack: final cleanup layer on top of [#234](https://github.com/st0012/cctop/pull/234).

## Problem

The permanent-identity migration accumulated duplicate asynchronous stamp paths and a focus-target wrapper that no longer owned behavior. A few comments and docs also described the pre-migration consumer contracts.

## Solution

- Share one lock-held, revalidated identity-stamp pipeline while preserving mapped and record-local ID generation.
- Inline the two-field focus-target stamp and remove its single-use wrapper.
- Align identity documentation with manual hiding, notifications, and archived desktop Recent rows.

## Verification

- Focused permanent-identity suite: 38 passed
- Stream Deck suite: 34 passed
- `make all`: 1,205 Swift tests passed
- Exact-build integrated smoke: two observations shared one permanent ID and one display row; URL focus selected the current target; real Hide Session removed visible/Recent/display projections while lifecycle records remained; fixtures and preferences were fully cleaned