### PR TITLE
Isolate tests from developer cctop state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Test Stream Deck version bump
         run: scripts/test-bump-streamdeck-version.sh
       - name: Test
-        run: xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -configuration Debug -derivedDataPath menubar/build/
+        run: make swift-test
       - name: Smoke test cctop-hook
         run: |
           SMOKE_DIR=$(mktemp -d)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,7 @@ xcodebuild build -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -c
 open menubar/build/Build/Products/Debug/CctopMenubar.app
 
 # Run tests
-xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar -configuration Debug -derivedDataPath menubar/build/
+make swift-test
 ```
 
 **Visual verification:** Open the Xcode project and use SwiftUI Previews (Canvas) for instant visual feedback. All views have `#Preview` blocks with mock data.
@@ -699,9 +699,7 @@ Most static panel screenshots under `docs/` are generated from `CctopMenubarTest
 
 ```bash
 # Regenerate all snapshot-backed PNGs under the macOS temp directory
-xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar \
-  -only-testing:CctopMenubarTests/SnapshotTests \
-  -derivedDataPath menubar/build/ CODE_SIGN_IDENTITY="-"
+make snapshots
 
 # Copy the public documentation screenshots into docs/
 snapshot_dir="$(getconf DARWIN_USER_TEMP_DIR)cctop-screenshots"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,7 @@ xcodebuild build \
 
 ```bash
 # Swift tests
-xcodebuild test \
-  -project menubar/CctopMenubar.xcodeproj \
-  -scheme CctopMenubar \
-  -configuration Debug \
-  -derivedDataPath menubar/build/
+make swift-test
 
 # Lint checks
 swiftlint lint --strict

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROJECT = menubar/CctopMenubar.xcodeproj
 DERIVED = menubar/build
 SIGN = CODE_SIGN_IDENTITY="-"
 
-.PHONY: all build test lint contract clean install run restart
+.PHONY: all build test swift-test snapshots lint contract clean install run restart
 
 all: lint contract build test
 
@@ -26,7 +26,23 @@ test:
 	else \
 		echo "WARNING: skipping pi extension tests: Node >= 23.6 required for TypeScript type stripping, found $$(node --version)"; \
 	fi
-	xcodebuild test -project $(PROJECT) -scheme CctopMenubar -configuration Debug -derivedDataPath $(DERIVED) $(SIGN)
+	$(MAKE) swift-test
+
+swift-test:
+	scripts/run-swift-tests-isolated.sh \
+		test -project $(PROJECT) -scheme CctopMenubar -configuration Debug \
+		-derivedDataPath $(DERIVED) $(SIGN) \
+		-skip-testing:CctopMenubarTests/SnapshotTests \
+		-skip-testing:CctopMenubarTests/QASnapshotTests
+
+# Artifact generators are opt-in and run behind the same isolated test boundary.
+snapshots:
+	scripts/run-swift-tests-isolated.sh \
+		test -project $(PROJECT) -scheme CctopMenubar -configuration Debug \
+		-derivedDataPath $(DERIVED) $(SIGN) \
+		-only-testing:CctopMenubarTests/SnapshotTests \
+		-only-testing:CctopMenubarTests/QASnapshotTests \
+		-only-testing:CctopMenubarTests/WorktreeCleanupScenarioSnapshotTests
 
 lint:
 	swiftlint lint --strict

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ swift-test:
 		-skip-testing:CctopMenubarTests/SnapshotTests \
 		-skip-testing:CctopMenubarTests/QASnapshotTests
 
-# Artifact generators are opt-in and run behind the same isolated test boundary.
+# Stateful screenshot suites are opt-in; isolated cleanup layout contracts stay in default coverage.
 snapshots:
 	scripts/run-swift-tests-isolated.sh \
 		test -project $(PROJECT) -scheme CctopMenubar -configuration Debug \

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -45,11 +45,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         static let legacyTopY = "panelCustomTopY"
     }
 
+    private static var isXcodeTestHost: Bool {
+        let environment = ProcessInfo.processInfo.environment
+        return environment["CCTOP_XCODE_TEST_HOST"] == "1"
+            || environment["XCTestConfigurationFilePath"] != nil
+    }
+
     func applicationWillFinishLaunching(_ notification: Notification) {
+        guard !Self.isXcodeTestHost else { return }
         registerURLHandler()
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        guard !Self.isXcodeTestHost else { return }
         UserDefaults.standard.register(defaults: ["notificationsEnabled": true])
         notificationPermissionReconciler.refresh()
         migrateLegacyPanelPosition()

--- a/menubar/CctopMenubarTests/ForkSessionTests.swift
+++ b/menubar/CctopMenubarTests/ForkSessionTests.swift
@@ -98,6 +98,8 @@ final class ForkSessionTests: XCTestCase {
         process.arguments = ["SessionStart"]
         process.environment = [
             "CCTOP_SESSIONS_DIR": sessionsDir,
+            "CFFIXED_USER_HOME": sessionsDir,
+            "HOME": sessionsDir,
             "TERM_PROGRAM": "Test",
         ]
 
@@ -115,6 +117,13 @@ final class ForkSessionTests: XCTestCase {
 
         try? process.run()
         process.waitUntilExit()
+
+        let isolatedLogPath = (sessionsDir as NSString)
+            .appendingPathComponent(".cctop/logs/\(sessionId).log")
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: isolatedLogPath),
+            "The hook subprocess must keep its log inside the test home"
+        )
 
         // Find the session file created by the hook (scan for live PID)
         let fm = FileManager.default
@@ -276,7 +285,10 @@ final class ForkSessionTests: XCTestCase {
         try term.writeToFile(path: termPath)
 
         HookHandler.cleanupSessionsForProject(
-            sessionsDir: sessionsDir, projectPath: project, currentPid: UInt32(getpid())
+            sessionsDir: sessionsDir,
+            projectPath: project,
+            currentPid: UInt32(getpid()),
+            logger: HookLogger(logsDir: sessionsDir + "logs")
         )
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: desktopPath),
@@ -297,7 +309,10 @@ final class ForkSessionTests: XCTestCase {
         FileManager.default.createFile(atPath: lockPath, contents: Data())
 
         HookHandler.cleanupSessionsForProject(
-            sessionsDir: sessionsDir, projectPath: project, currentPid: UInt32(getpid())
+            sessionsDir: sessionsDir,
+            projectPath: project,
+            currentPid: UInt32(getpid()),
+            logger: HookLogger(logsDir: sessionsDir + "logs")
         )
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: termPath))

--- a/menubar/CctopMenubarTests/HistoryManagerTests.swift
+++ b/menubar/CctopMenubarTests/HistoryManagerTests.swift
@@ -612,7 +612,10 @@ final class HistoryManagerTests: XCTestCase {
     }
 
     func testRebuildRecentProjectsRefreshesWhenProjectPathExistenceChanges() throws {
-        let projectDir = URL(fileURLWithPath: NSHomeDirectory())
+        let projectDir = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("build", isDirectory: true)
             .appendingPathComponent(".cctop-history-path-state-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: projectDir) }

--- a/menubar/CctopMenubarTests/PluginManagerCcDetectionTests.swift
+++ b/menubar/CctopMenubarTests/PluginManagerCcDetectionTests.swift
@@ -74,9 +74,7 @@ final class PluginManagerCcDetectionTests: XCTestCase {
 }
 
 /// Integration coverage for `refresh()` against a staged home directory.
-/// Only the oc/pi/cc flags are asserted: Codex detection reads `~/.codex`
-/// through `CodexPluginInstaller`, which is not derived from the injected
-/// home directory.
+/// The scoped HOME also keeps Codex detection inside the same fixture.
 @MainActor
 final class PluginManagerRefreshTests: XCTestCase {
 
@@ -90,7 +88,7 @@ final class PluginManagerRefreshTests: XCTestCase {
             contents: "{}"
         )
 
-        let manager = PluginManager(homeDirectory: home)
+        let manager = withTemporaryHomeDirectory(home) { PluginManager(homeDirectory: home) }
 
         XCTAssertTrue(manager.ccInstalled)
         XCTAssertTrue(manager.ocConfigExists)
@@ -100,7 +98,8 @@ final class PluginManagerRefreshTests: XCTestCase {
     }
 
     func testRefreshAgainstEmptyHomeReportsNothingInstalled() {
-        let manager = PluginManager(homeDirectory: makeTempHome())
+        let home = makeTempHome()
+        let manager = withTemporaryHomeDirectory(home) { PluginManager(homeDirectory: home) }
 
         XCTAssertFalse(manager.ccInstalled)
         XCTAssertFalse(manager.ocConfigExists)

--- a/menubar/CctopMenubarTests/PluginManagerStreamDeckTests.swift
+++ b/menubar/CctopMenubarTests/PluginManagerStreamDeckTests.swift
@@ -5,14 +5,14 @@ import XCTest
 final class PluginManagerStreamDeckTests: XCTestCase {
     func testDetectsStreamDeckAndItsInstalledPlugin() throws {
         let home = makeTempDirectory()
-        let manager = PluginManager(homeDirectory: home)
+        let manager = withTemporaryHomeDirectory(home) { PluginManager(homeDirectory: home) }
         XCTAssertFalse(manager.sdConfigExists)
 
         let support = home.appendingPathComponent(
             "Library/Application Support/com.elgato.StreamDeck"
         )
         try FileManager.default.createDirectory(at: support, withIntermediateDirectories: true)
-        manager.refresh()
+        withTemporaryHomeDirectory(home) { manager.refresh() }
         XCTAssertTrue(manager.sdConfigExists)
         XCTAssertFalse(manager.sdInstalled)
 
@@ -20,7 +20,7 @@ final class PluginManagerStreamDeckTests: XCTestCase {
         try FileManager.default.createDirectory(at: plugin, withIntermediateDirectories: true)
         try Data(#"{"Version":"0.19.5.0"}"#.utf8)
             .write(to: plugin.appendingPathComponent("manifest.json"))
-        manager.refresh()
+        withTemporaryHomeDirectory(home) { manager.refresh() }
 
         XCTAssertTrue(manager.sdInstalled)
     }

--- a/menubar/CctopMenubarTests/QASnapshotTests.swift
+++ b/menubar/CctopMenubarTests/QASnapshotTests.swift
@@ -6,9 +6,7 @@ import SwiftUI
 ///
 /// Each test saves a PNG to /tmp/cctop-qa/<scenario>.png for visual inspection.
 /// Run all QA snapshots:
-///   xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar \
-///     -only-testing:CctopMenubarTests/QASnapshotTests \
-///     -derivedDataPath menubar/build/ CODE_SIGN_IDENTITY="-"
+///   make snapshots
 @MainActor
 final class QASnapshotTests: XCTestCase {
 

--- a/menubar/CctopMenubarTests/SessionLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/SessionLifecycleTests.swift
@@ -68,7 +68,12 @@ final class SessionLifecycleTests: XCTestCase {
             now: Self.lifeNow,
             desktopAppConnectionLookup: DesktopAppConnectionLookup { bundleID in
                 bundleID == HostAppBundleID.codexDesktop
-            }
+            },
+            codexThreads: StubCodexThreadState(),
+            claudeDesktopSessions: StubClaudeDesktopState(
+                snapshot: ClaudeDesktopSessionMetadataSnapshot()
+            ),
+            processAlive: { _ in false }
         )
 
         XCTAssertEqual(candidates.map(\.session.lifecycle), [.active])
@@ -165,7 +170,7 @@ final class SessionLifecycleTests: XCTestCase {
                 cliID: "cli-project"
             ]
         )
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-batched-codex-state").sources
         sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-batched-codex-state")
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = codexThreads
@@ -211,6 +216,7 @@ final class SessionLifecycleTests: XCTestCase {
         let manager = makeManager(
             sessionsDir: sessionsDir,
             historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB),
             desktopAppConnection: DesktopAppConnectionLookup { bundleID in
                 bundleID == HostAppBundleID.codexDesktop
             }
@@ -251,6 +257,7 @@ final class SessionLifecycleTests: XCTestCase {
         let manager = makeManager(
             sessionsDir: sessionsDir,
             historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB),
             desktopAppConnection: DesktopAppConnectionLookup { bundleID in
                 bundleID == HostAppBundleID.codexDesktop
             }
@@ -332,7 +339,8 @@ final class SessionLifecycleTests: XCTestCase {
             historyDir: historyDir,
             desktopAppConnection: DesktopAppConnectionLookup { bundleID in
                 bundleID == HostAppBundleID.codexDesktop
-            }
+            },
+            processAlive: { $0.pid == pid && $0.isAlive }
         )
 
         XCTAssertEqual(manager.sessions.map(\.lifecycle), [.active])
@@ -977,7 +985,7 @@ final class SessionLifecycleTests: XCTestCase {
         claude.lastActivity = Date(timeIntervalSince1970: 2000)
         try claude.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("\(claudeID).json"))
 
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-recent-desktop-targets").sources
         sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-recent-desktop-targets")
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState(archived: [codexID])
@@ -1220,7 +1228,7 @@ final class SessionLifecycleTests: XCTestCase {
         let codexState = SequencedCodexClassificationState(
             snapshots: [.available(initial), .unreadable, .available(changed)]
         )
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-classification-retention").sources
         sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-classification-retention")
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = codexState

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -752,6 +752,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try archived.writeToFile(path: sessionsURL.appendingPathComponent("archived-desktop.json").path)
 
         var sources = SessionDataSources.live()
+        sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-recent-live-suppression")
         sources.sessionsDir = sessionsURL
         sources.claudeDesktopSessions = StubClaudeDesktopState(snapshot: ClaudeDesktopSessionMetadataSnapshot(
             matchedSessionIDs: [durableConversationID],

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -150,7 +150,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
 
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-legacy-manual-hide").sources
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState(
             existing: [threadID, currentObservationID, conflictingObservationID],
@@ -264,7 +264,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
 
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-unresolved-legacy-archived").sources
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState(
             existing: [threadID, unrelatedThreadID],
@@ -345,7 +345,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         defaults.set(["active:42"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
 
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-process-key-partial").sources
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState(existing: [threadID], archived: [threadID])
         sources.desktopAppConnection = DesktopAppConnectionLookup { _ in true }
@@ -445,7 +445,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
 
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-unresolved-legacy-finished").sources
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState(existing: Set([threadID] + finishedPeerIDs), archived: [])
         sources.desktopAppConnection = DesktopAppConnectionLookup { _ in false }
@@ -616,7 +616,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set(["codex:\(hiddenThreadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
 
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-unresolved-legacy-new-archive").sources
         sources.sessionsDir = sessionsURL
         sources.codexThreads = StubCodexThreadState(existing: [hiddenThreadID], archived: [])
         sources.processAlive = { $0.sessionId == hiddenThreadID }
@@ -682,7 +682,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             to: URL(fileURLWithPath: (sessionsDir as NSString).appendingPathComponent("unrelated-broken.json"))
         )
 
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-manual-hide-shared-id").sources
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.claudeDesktopSessions = StubClaudeDesktopState(snapshot: ClaudeDesktopSessionMetadataSnapshot(
             matchedSessionIDs: [durableConversationID],
@@ -751,8 +751,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         archived.lastActivity = Date(timeIntervalSince1970: 2_000)
         try archived.writeToFile(path: sessionsURL.appendingPathComponent("archived-desktop.json").path)
 
-        var sources = SessionDataSources.live()
-        sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-recent-live-suppression")
+        var sources = try isolatedSessionDataSources(prefix: "cctop-recent-live-suppression").sources
         sources.sessionsDir = sessionsURL
         sources.claudeDesktopSessions = StubClaudeDesktopState(snapshot: ClaudeDesktopSessionMetadataSnapshot(
             matchedSessionIDs: [durableConversationID],
@@ -808,7 +807,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         hidden.sessionName = "Archived-only observation"
         try hidden.writeToFile(path: sessionsURL.appendingPathComponent("archived-only.json").path)
 
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-manual-hide-archived-only").sources
         sources.sessionsDir = sessionsURL
         sources.claudeDesktopSessions = StubClaudeDesktopState(snapshot: ClaudeDesktopSessionMetadataSnapshot(
             matchedSessionIDs: [durableConversationID],
@@ -896,7 +895,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         var processAlive = true
         var now = initialNow
         var postedNotificationIDs: [String] = []
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-manual-hide-busy-stamp").sources
         sources.sessionsDir = sessionsURL
         sources.codexThreads = StubCodexThreadState(
             existing: [terminalObservationID, desktopObservationID],
@@ -1002,7 +1001,9 @@ final class SessionManagerVisibilityTests: XCTestCase {
         hiddenSnapshot.cctopSessionId = mappedID
         visibility.hide(hiddenSnapshot)
 
-        var missingSources = SessionDataSources.live()
+        var missingSources = try isolatedSessionDataSources(
+            prefix: "cctop-mapped-hide-missing-codex-metadata"
+        ).sources
         missingSources.sessionsDir = sessionsURL
         missingSources.codexThreads = StubCodexThreadState(existing: [], archived: [])
         missingSources.desktopAppConnection = DesktopAppConnectionLookup { _ in true }
@@ -1077,7 +1078,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         visibility.hide(finished)
         try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: historyURL.path)
 
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-manual-hide-archive-failure").sources
         sources.sessionsDir = sessionsURL
         sources.processAlive = { _ in false }
         sources.manualSessionVisibility = visibility
@@ -1715,7 +1716,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         finishedDesktop.disconnectedAt = old
         try finishedDesktop.writeToFile(path: finishedDesktopPath)
 
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-hidden-cleanup-gc").sources
         sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-gc-hidden-cleanup")
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState(existing: ["finished-desktop"], archived: [])
@@ -1770,7 +1771,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let lockHolder = try startSessionLockHolder(lockPath: sessionPath + ".lock", readyPath: readyPath, holdSeconds: 1.5)
         defer { terminateProcess(lockHolder) }
 
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-busy-gc").sources
         sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-gc-busy-lock")
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState(existing: ["busy-finished-thread"], archived: [])
@@ -1864,7 +1865,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
         FileManager.default.createFile(atPath: cliPath + ".lock", contents: nil)
         FileManager.default.createFile(atPath: desktopPath + ".lock", contents: nil)
 
-        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB)
+        )
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions, [])
@@ -1903,7 +1908,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
             projectPath: (root as NSString).appendingPathComponent("projects/cctop")
         ).writeToFile(path: sessionPath)
 
-        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB)
+        )
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), ["delegated-visible"])
@@ -1950,7 +1959,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
         memorySession.hidden = true
         try memorySession.writeToFile(path: memoryPath)
 
-        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB)
+        )
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), ["delegated-sticky"])
@@ -1995,7 +2008,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
         session.hidden = true
         try session.writeToFile(path: sessionPath)
 
-        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB)
+        )
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions, [])
@@ -2034,7 +2051,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
         session.hidden = true
         try session.writeToFile(path: sessionPath)
 
-        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB)
+        )
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions, [])
@@ -2073,6 +2094,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let manager = makeManager(
             sessionsDir: sessionsDir,
             historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB),
             desktopAppConnection: DesktopAppConnectionLookup { _ in true }
         )
         manager.loadSessions()
@@ -2121,6 +2143,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let manager = makeManager(
             sessionsDir: sessionsDir,
             historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB),
             desktopAppConnection: DesktopAppConnectionLookup { _ in true },
             now: { now }
         )
@@ -2163,6 +2186,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let manager = makeManager(
             sessionsDir: sessionsDir,
             historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB),
             desktopAppConnection: DesktopAppConnectionLookup { _ in true },
             now: { now }
         )
@@ -2401,6 +2425,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let manager = makeManager(
             sessionsDir: sessionsDir,
             historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB),
             desktopAppConnection: DesktopAppConnectionLookup { _ in true }
         )
         manager.loadSessions()
@@ -2438,6 +2463,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let manager = makeManager(
             sessionsDir: sessionsDir,
             historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB),
             desktopAppConnection: DesktopAppConnectionLookup { _ in true }
         )
         manager.loadSessions()
@@ -2475,6 +2501,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let manager = makeManager(
             sessionsDir: sessionsDir,
             historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB),
             desktopAppConnection: DesktopAppConnectionLookup { _ in true }
         )
         manager.loadSessions()
@@ -2517,7 +2544,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let desktopPath = (sessionsDir as NSString).appendingPathComponent("codex-conv-a.json")
         try desktopKeyed.writeToFile(path: desktopPath)
 
-        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB)
+        )
         manager.loadSessions()
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: oldPath))
@@ -2547,7 +2578,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
         session.lastActivity = Date()
         try session.writeToFile(path: sessionPath)
 
-        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB)
+        )
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), [])
@@ -2589,7 +2624,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
         session.lastActivity = Date()
         try session.writeToFile(path: sessionPath)
 
-        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB)
+        )
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), [])
@@ -2634,7 +2673,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
         session.lastActivity = Date()
         try session.writeToFile(path: sessionPath)
 
-        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            claudeDesktopSessions: ClaudeDesktopSessionArchiveLookup(sessionsDirectory: claudeDir)
+        )
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), [])
@@ -2685,7 +2728,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
         session.lastActivity = Date()
         try session.writeToFile(path: sessionPath)
 
-        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            claudeDesktopSessions: ClaudeDesktopSessionArchiveLookup(sessionsDirectory: claudeDir)
+        )
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), [])
@@ -2726,7 +2773,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
         session.disconnectedAt = ended
         try session.writeToFile(path: sessionPath)
 
-        let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
+        let manager = makeManager(
+            sessionsDir: sessionsDir,
+            historyDir: historyDir,
+            claudeDesktopSessions: ClaudeDesktopSessionArchiveLookup(sessionsDirectory: claudeDir)
+        )
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), [])
@@ -2751,10 +2802,16 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let session = codexDesktopSession(sessionId: "live-thread", projectPath: "/tmp/p")
 
         try writeCodexStateDatabase(path: stateDB, archivedThreads: ["live-thread"])
-        XCTAssertTrue(SessionManager.isCodexDesktopThreadArchived(session))
+        XCTAssertTrue(SessionManager.isCodexDesktopThreadArchived(
+            session,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB)
+        ))
 
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [])
-        XCTAssertFalse(SessionManager.isCodexDesktopThreadArchived(session))
+        XCTAssertFalse(SessionManager.isCodexDesktopThreadArchived(
+            session,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB)
+        ))
     }
 
     // The archive check is gated on the Codex Desktop bundle ID, so a non-Codex-Desktop session
@@ -2850,6 +2907,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let manager = makeManager(
             sessionsDir: sessionsDir,
             historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB),
             desktopAppConnection: DesktopAppConnectionLookup { _ in false }
         )
 
@@ -2890,7 +2948,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         defaults.set(["codex:\(threadID)"], forKey: ManualSessionVisibilityStore.legacyDefaultsKey)
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
 
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-unresolved-legacy-desktop-gc").sources
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState(existing: [threadID], archived: [])
         sources.desktopAppConnection = DesktopAppConnectionLookup { _ in false }
@@ -3001,6 +3059,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let manager = makeManager(
             sessionsDir: sessionsDir,
             historyDir: historyDir,
+            claudeDesktopSessions: ClaudeDesktopSessionArchiveLookup(sessionsDirectory: claudeDir),
             desktopAppConnection: DesktopAppConnectionLookup { _ in false }
         )
 
@@ -3041,7 +3100,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         }
 
         let claudeState = CountingClaudeDesktopState()
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-batched-claude-gc").sources
         sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-claude-batched-gc")
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState()
@@ -3088,7 +3147,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try session.writeToFile(path: sessionPath)
 
         let claudeState = SequencedClaudeDesktopState(archivedResponses: [[], ["finished-claude-race"]])
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-rechecked-claude-gc").sources
         sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-claude-gc-archive-race")
         sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
         sources.codexThreads = StubCodexThreadState()
@@ -3150,7 +3209,9 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let candidates = SessionManager.buildCandidates(
             [URL(fileURLWithPath: claudePath), URL(fileURLWithPath: codexPath)],
             now: Date(),
-            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true }
+            desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true },
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB),
+            claudeDesktopSessions: ClaudeDesktopSessionArchiveLookup(sessionsDirectory: claudeDir)
         )
         let namesByID = Dictionary(uniqueKeysWithValues: candidates.map { ($0.session.sessionId, $0.session.desktopProjectName) })
 
@@ -3188,6 +3249,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let manager = makeManager(
             sessionsDir: sessionsDir,
             historyDir: historyDir,
+            codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB),
             desktopAppConnection: DesktopAppConnectionLookup { _ in false }
         )
         manager.garbageCollectFinished()

--- a/menubar/CctopMenubarTests/SessionTestSupport.swift
+++ b/menubar/CctopMenubarTests/SessionTestSupport.swift
@@ -22,10 +22,51 @@ extension XCTestCase {
         }
 
         let visibility = isolatedManualSessionVisibility(prefix: prefix)
-        var sources = SessionDataSources.live()
-        sources.sessionsDir = sessionsDir
-        sources.manualSessionVisibility = visibility
+        let sources = isolatedSessionDataSources(
+            sessionsDir: sessionsDir,
+            manualSessionVisibility: visibility
+        )
         return (sources, visibility)
+    }
+
+    func isolatedSessionDataSources(
+        sessionsDir: URL,
+        manualSessionVisibility: ManualSessionVisibilityStore
+    ) -> SessionDataSources {
+        let testProcessID = UInt32(ProcessInfo.processInfo.processIdentifier)
+        return SessionDataSources(
+            sessionsDir: sessionsDir,
+            codexThreads: StubCodexThreadState(),
+            claudeDesktopSessions: StubClaudeDesktopState(
+                snapshot: ClaudeDesktopSessionMetadataSnapshot()
+            ),
+            desktopAppConnection: DesktopAppConnectionLookup { _ in false },
+            processAlive: { $0.pid == testProcessID },
+            notificationsEnabled: { false },
+            notificationClient: SessionNotificationClient(
+                add: { _, completion in completion(nil) },
+                removePending: { _ in },
+                removeDelivered: { _ in }
+            ),
+            manualSessionVisibility: manualSessionVisibility,
+            now: Date.init
+        )
+    }
+
+    func withTemporaryHomeDirectory<T>(
+        _ homeDirectory: URL,
+        body: () throws -> T
+    ) rethrows -> T {
+        let previousHome = ProcessInfo.processInfo.environment["HOME"]
+        setenv("HOME", homeDirectory.path, 1)
+        defer {
+            if let previousHome {
+                setenv("HOME", previousHome, 1)
+            } else {
+                unsetenv("HOME")
+            }
+        }
+        return try body()
     }
 
     func executeSQLite(_ sql: String, path: String) throws {
@@ -235,15 +276,25 @@ extension XCTestCase {
     func makeManager(
         sessionsDir: String,
         historyDir: String,
+        codexThreads: (any CodexThreadStateProviding)? = nil,
+        claudeDesktopSessions: (any ClaudeDesktopSessionStateProviding)? = nil,
         desktopAppConnection: DesktopAppConnectionLookup? = nil,
         processAlive: ((Session) -> Bool)? = nil,
         manualSessionVisibility: ManualSessionVisibilityStore? = nil,
         now: (() -> Date)? = nil
     ) -> SessionManager {
-        var sources = SessionDataSources.live()
-        sources.sessionsDir = URL(fileURLWithPath: sessionsDir)
-        sources.manualSessionVisibility = manualSessionVisibility
+        let visibility = manualSessionVisibility
             ?? isolatedManualSessionVisibility(prefix: "cctop-manager")
+        var sources = isolatedSessionDataSources(
+            sessionsDir: URL(fileURLWithPath: sessionsDir),
+            manualSessionVisibility: visibility
+        )
+        if let codexThreads {
+            sources.codexThreads = codexThreads
+        }
+        if let claudeDesktopSessions {
+            sources.claudeDesktopSessions = claudeDesktopSessions
+        }
         if let desktopAppConnection {
             sources.desktopAppConnection = desktopAppConnection
         }

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -967,7 +967,7 @@ final class SessionTests: XCTestCase {
         }
 
         let recorder = Recorder()
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-replace-notification").sources
         sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-replace-notification")
         let sessionsDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -1037,7 +1037,7 @@ final class SessionTests: XCTestCase {
         )
 
         let recorder = Recorder()
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-hidden-notification").sources
         sources.sessionsDir = sessionsDir
         sources.manualSessionVisibility = store
         sources.notificationClient = SessionNotificationClient(
@@ -1076,7 +1076,7 @@ final class SessionTests: XCTestCase {
         }
 
         let recorder = Recorder()
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-reused-pid-notification").sources
         sources.manualSessionVisibility = isolatedManualSessionVisibility(prefix: "cctop-reused-pid-notification")
         let sessionsDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -1264,7 +1264,7 @@ final class SessionTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let recorder = Recorder()
-        var sources = SessionDataSources.live()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-hide-notification").sources
         sources.sessionsDir = sessionsDir
         sources.manualSessionVisibility = ManualSessionVisibilityStore(defaults: defaults)
         sources.notificationsEnabled = { false }

--- a/menubar/CctopMenubarTests/SnapshotTests.swift
+++ b/menubar/CctopMenubarTests/SnapshotTests.swift
@@ -124,9 +124,7 @@ final class SnapshotTests: XCTestCase {
     /// Renders the PopupView with showcase sessions and saves light + dark screenshots.
     ///
     /// Run with:
-    ///   xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar \
-    ///     -only-testing:CctopMenubarTests/SnapshotTests/testGenerateMenubarScreenshot \
-    ///     -derivedDataPath menubar/build/ CODE_SIGN_IDENTITY="-"
+    ///   make snapshots
     func testGenerateMenubarScreenshot() throws {
         let view = PopupView(
             sessions: Session.qaShowcase, updater: DisabledUpdater(), pluginManager: inertPluginManager()
@@ -151,9 +149,7 @@ final class SnapshotTests: XCTestCase {
     /// and marketing site. Shows the full breadth of agent support in one shot.
     ///
     /// Run with:
-    ///   xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar \
-    ///     -only-testing:CctopMenubarTests/SnapshotTests/testGenerateEmptyStateScreenshot \
-    ///     -derivedDataPath menubar/build/ CODE_SIGN_IDENTITY="-"
+    ///   make snapshots
     func testGenerateEmptyStateScreenshot() throws {
         let pm = inertPluginManager()
         pm.ccInstalled = false
@@ -185,31 +181,6 @@ final class SnapshotTests: XCTestCase {
         let view = SettingsSection(updater: DisabledUpdater(), pluginManager: pm)
         try renderScreenshot(view: view, colorScheme: .light, filename: "onboarding-settings-light.png", width: 360)
         try renderScreenshot(view: view, colorScheme: .dark, filename: "onboarding-settings-dark.png", width: 360)
-    }
-
-    func testOnboardingCopyNamesDesktopHostsAndOmitsLegacyCodexFlag() throws {
-        let repo = try repoRoot()
-        let checkedFiles = [
-            "menubar/CctopMenubar/Views/EmptyStateView.swift",
-            "menubar/CctopMenubar/Views/SettingsSection.swift",
-            "menubar/CctopMenubar/Views/CodexPluginRowView.swift",
-            "README.md",
-            "site/index.html",
-            "plugins/codex/cctop-shim.sh",
-        ]
-
-        let combined = try checkedFiles.map { path in
-            try String(contentsOf: repo.appendingPathComponent(path), encoding: .utf8)
-        }.joined(separator: "\n")
-
-        XCTAssertFalse(combined.contains("codex_hooks feature flag"))
-        XCTAssertFalse(combined.contains("Enable experimental feature?"))
-        XCTAssertFalse(combined.contains("will show a startup warning"))
-        XCTAssertTrue(combined.contains("Claude Code / Desktop"))
-        XCTAssertTrue(combined.contains("Codex CLI / Desktop"))
-        XCTAssertTrue(combined.contains("Claude Desktop"))
-        XCTAssertTrue(combined.contains("Codex Desktop"))
-        XCTAssertTrue(combined.contains("Install Hooks"))
     }
 
     func testGenerateRecentProjectsScreenshot() throws {
@@ -567,9 +538,7 @@ final class SnapshotTests: XCTestCase {
     /// Generates theme showcase screenshots for all 4 themes in both dark and light modes.
     ///
     /// Run with:
-    ///   xcodebuild test -project menubar/CctopMenubar.xcodeproj -scheme CctopMenubar \
-    ///     -only-testing:CctopMenubarTests/SnapshotTests/testGenerateThemeScreenshots \
-    ///     -derivedDataPath menubar/build/ CODE_SIGN_IDENTITY="-"
+    ///   make snapshots
     func testGenerateThemeScreenshots() throws {
         for theme in AppTheme.allCases {
             ThemeManager.shared.setTheme(theme)
@@ -591,26 +560,6 @@ final class SnapshotTests: XCTestCase {
             view: view, colorScheme: colorScheme,
             directoryName: "cctop-screenshots", filename: filename, width: width
         )
-    }
-
-    func testSessionRowsAvoidPerRowTimelineAndInfiniteAnimations() throws {
-        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
-        let viewsDirectory = testsDirectory
-            .deletingLastPathComponent()
-            .appendingPathComponent("CctopMenubar/Views")
-        let viewSources = try FileManager.default.contentsOfDirectory(
-            at: viewsDirectory,
-            includingPropertiesForKeys: nil
-        )
-        .filter { $0.pathExtension == "swift" }
-        let source = try viewSources
-            .map { try String(contentsOf: $0) }
-            .joined(separator: "\n")
-
-        XCTAssertFalse(source.contains("TimelineView("))
-        XCTAssertFalse(source.contains("repeatForever"))
-        XCTAssertFalse(source.contains("BlinkingCaret("))
-        XCTAssertFalse(viewSources.contains { $0.lastPathComponent == "BlinkingCaret.swift" })
     }
 
     private func recentProofSession(
@@ -640,4 +589,51 @@ final class SnapshotTests: XCTestCase {
         )
     }
 
+}
+
+final class SnapshotContractTests: XCTestCase {
+    func testOnboardingCopyNamesDesktopHostsAndOmitsLegacyCodexFlag() throws {
+        let repo = try repoRoot()
+        let checkedFiles = [
+            "menubar/CctopMenubar/Views/EmptyStateView.swift",
+            "menubar/CctopMenubar/Views/SettingsSection.swift",
+            "menubar/CctopMenubar/Views/CodexPluginRowView.swift",
+            "README.md",
+            "site/index.html",
+            "plugins/codex/cctop-shim.sh",
+        ]
+
+        let combined = try checkedFiles.map { path in
+            try String(contentsOf: repo.appendingPathComponent(path), encoding: .utf8)
+        }.joined(separator: "\n")
+
+        XCTAssertFalse(combined.contains("codex_hooks feature flag"))
+        XCTAssertFalse(combined.contains("Enable experimental feature?"))
+        XCTAssertFalse(combined.contains("will show a startup warning"))
+        XCTAssertTrue(combined.contains("Claude Code / Desktop"))
+        XCTAssertTrue(combined.contains("Codex CLI / Desktop"))
+        XCTAssertTrue(combined.contains("Claude Desktop"))
+        XCTAssertTrue(combined.contains("Codex Desktop"))
+        XCTAssertTrue(combined.contains("Install Hooks"))
+    }
+
+    func testSessionRowsAvoidPerRowTimelineAndInfiniteAnimations() throws {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let viewsDirectory = testsDirectory
+            .deletingLastPathComponent()
+            .appendingPathComponent("CctopMenubar/Views")
+        let viewSources = try FileManager.default.contentsOfDirectory(
+            at: viewsDirectory,
+            includingPropertiesForKeys: nil
+        )
+        .filter { $0.pathExtension == "swift" }
+        let source = try viewSources
+            .map { try String(contentsOf: $0) }
+            .joined(separator: "\n")
+
+        XCTAssertFalse(source.contains("TimelineView("))
+        XCTAssertFalse(source.contains("repeatForever"))
+        XCTAssertFalse(source.contains("BlinkingCaret("))
+        XCTAssertFalse(viewSources.contains { $0.lastPathComponent == "BlinkingCaret.swift" })
+    }
 }

--- a/scripts/run-swift-tests-isolated.sh
+++ b/scripts/run-swift-tests-isolated.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKTREE_NAME="$(basename "$(dirname "$REPO_ROOT")")"
+TEMP_BASE="${TMPDIR:-/tmp}"
+TEST_HOME="$(mktemp -d "${TEMP_BASE%/}/cctop-tests-${WORKTREE_NAME}.XXXXXX")"
+TEST_RUN_ID="$TEST_HOME"
+TEST_HOST_APP="$REPO_ROOT/menubar/build/Build/Products/Debug/CctopMenubar.app"
+TEST_HOST_EXECUTABLE="$TEST_HOST_APP/Contents/MacOS/CctopMenubar"
+LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+test_started=0
+
+test_host_pids() {
+    /bin/ps eww -axo pid=,command= 2>/dev/null \
+        | /usr/bin/awk -v executable="$TEST_HOST_EXECUTABLE" -v run_id="CCTOP_XCODE_TEST_RUN_ID=$TEST_RUN_ID" '
+            $2 == executable && index($0, run_id) {
+                print $1
+            }
+        '
+}
+
+any_test_host_pids() {
+    /bin/ps eww -axo pid=,command= 2>/dev/null \
+        | /usr/bin/awk -v executable="$TEST_HOST_EXECUTABLE" '
+            $2 == executable &&
+                (index($0, "CCTOP_XCODE_TEST_HOST=1") || index($0, "XCTestConfigurationFilePath=")) {
+                print $1
+            }
+        '
+}
+
+wait_for_test_host_exit() {
+    local attempt
+    local pids
+    for attempt in {1..20}; do
+        pids="$(test_host_pids)"
+        [[ -z "$pids" ]] && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+cleanup() {
+    local command_status=$?
+    local cleanup_status=0
+    local pids
+    trap - EXIT
+    set +e
+
+    pids="$(test_host_pids)"
+    if [[ -n "$pids" ]]; then
+        kill $pids 2>/dev/null
+        if ! wait_for_test_host_exit; then
+            pids="$(test_host_pids)"
+            kill -KILL $pids 2>/dev/null
+            wait_for_test_host_exit || cleanup_status=1
+        fi
+    fi
+
+    if [[ $test_started -eq 1 && -x "$LSREGISTER" && -d "$TEST_HOST_APP" ]]; then
+        "$LSREGISTER" -u "$TEST_HOST_APP" >/dev/null 2>&1 || cleanup_status=1
+    fi
+
+    case "$TEST_HOME" in
+        "${TEMP_BASE%/}"/cctop-tests-*) rm -rf -- "$TEST_HOME" || cleanup_status=1 ;;
+        *) cleanup_status=1 ;;
+    esac
+
+    if [[ $command_status -ne 0 ]]; then
+        exit "$command_status"
+    fi
+    exit "$cleanup_status"
+}
+trap cleanup EXIT
+
+if [[ "$#" -lt 9 || "$1" != "test" ]]; then
+    echo "run-swift-tests-isolated.sh only supports the repository Debug test invocation" >&2
+    exit 2
+fi
+
+project=""
+scheme=""
+configuration=""
+derived_data=""
+arguments=("$@")
+for ((index = 0; index < ${#arguments[@]}; index++)); do
+    argument="${arguments[$index]}"
+    case "$argument" in
+        test|CODE_SIGN_IDENTITY=-|-only-testing:*|-skip-testing:*) ;;
+        -project|-scheme|-configuration|-derivedDataPath)
+            ((++index))
+            [[ $index -lt ${#arguments[@]} ]] || exit 2
+            value="${arguments[$index]}"
+            case "$argument" in
+                -project) project="$value" ;;
+                -scheme) scheme="$value" ;;
+                -configuration) configuration="$value" ;;
+                -derivedDataPath) derived_data="$value" ;;
+            esac
+            ;;
+        *)
+            echo "Unsupported isolated Swift test argument: $argument" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ "$project" != "menubar/CctopMenubar.xcodeproj" || "$scheme" != "CctopMenubar" ||
+      "$configuration" != "Debug" || "$derived_data" != "menubar/build" ]]; then
+    echo "run-swift-tests-isolated.sh requires the repository CctopMenubar Debug test product" >&2
+    exit 2
+fi
+
+existing_test_hosts="$(any_test_host_pids)"
+if [[ -n "$existing_test_hosts" ]]; then
+    echo "Refusing to start with an existing exact-path CctopMenubar test host: $existing_test_hosts" >&2
+    exit 1
+fi
+
+mkdir -p "$TEST_HOME/Library/Preferences"
+export HOME="$TEST_HOME"
+export CFFIXED_USER_HOME="$TEST_HOME"
+export CCTOP_XCODE_TEST_HOST=1
+export CCTOP_XCODE_TEST_RUN_ID="$TEST_RUN_ID"
+export LLVM_PROFILE_FILE="$TEST_HOME/default-%p.profraw"
+
+cd "$REPO_ROOT"
+test_started=1
+xcodebuild "$@"

--- a/scripts/run-swift-tests-isolated.sh
+++ b/scripts/run-swift-tests-isolated.sh
@@ -71,6 +71,8 @@ cleanup() {
         fi
     fi
 
+    # Xcode can register this exact shared test-host bundle while launching it. Remove that registration;
+    # callers preserving a developer runtime must restore and verify the lane-owned app afterward.
     if [[ $test_started -eq 1 && -x "$LSREGISTER" && -d "$TEST_HOST_APP" ]]; then
         "$LSREGISTER" -u "$TEST_HOST_APP" >/dev/null 2>&1 || cleanup_status=1
     fi

--- a/scripts/run-swift-tests-isolated.sh
+++ b/scripts/run-swift-tests-isolated.sh
@@ -15,8 +15,14 @@ test_started=0
 test_host_pids() {
     /bin/ps eww -axo pid=,command= 2>/dev/null \
         | /usr/bin/awk -v executable="$TEST_HOST_EXECUTABLE" -v run_id="CCTOP_XCODE_TEST_RUN_ID=$TEST_RUN_ID" '
-            $2 == executable && index($0, run_id) {
-                print $1
+            {
+                pid = $1
+                sub(/^[[:space:]]*[0-9]+[[:space:]]+/, "")
+                executable_matches = index($0, executable) == 1 &&
+                    (length($0) == length(executable) || substr($0, length(executable) + 1, 1) == " ")
+            }
+            executable_matches && index($0, run_id) {
+                print pid
             }
         '
 }
@@ -24,9 +30,15 @@ test_host_pids() {
 any_test_host_pids() {
     /bin/ps eww -axo pid=,command= 2>/dev/null \
         | /usr/bin/awk -v executable="$TEST_HOST_EXECUTABLE" '
-            $2 == executable &&
+            {
+                pid = $1
+                sub(/^[[:space:]]*[0-9]+[[:space:]]+/, "")
+                executable_matches = index($0, executable) == 1 &&
+                    (length($0) == length(executable) || substr($0, length(executable) + 1, 1) == " ")
+            }
+            executable_matches &&
                 (index($0, "CCTOP_XCODE_TEST_HOST=1") || index($0, "XCTestConfigurationFilePath=")) {
-                print $1
+                print pid
             }
         '
 }


### PR DESCRIPTION
## Problem

A visibility test mixed a temporary session inventory with the production manual-hide preference store, allowing its fixture inventory to prune a real hidden-session ID. The follow-up audit found the broader hosted Swift suite could still inherit developer preferences, cctop session/history/identity paths, installed integration state, and normal app startup side effects.

## Solution

- Run the normal Swift test entry point with disposable `HOME` and `CFFIXED_USER_HOME`, uniquely own and clean the exact test host, and keep stateful screenshot artifact generators opt-in.
- Stop AppDelegate startup side effects in an XCTest-hosted app while leaving production startup unchanged.
- Replace live test data providers and ambient paths with existing isolated stores, exact staged fixtures, and explicit synthetic process behavior.
- Keep non-artifact snapshot contracts and safe cleanup layout coverage in the default suite.

Production persistence, identity, pruning, and display projection behavior are unchanged.

## Verification

- `make all` passes, including 1,169 Swift tests.
- Focused and full runs left the complete cctop preference domain and privacy-safe hashes for sessions, history, identities, logs, hooks, and installed plugins unchanged.
- The rebuilt exact app retained the real watchdog hide across fresh projection: the permanent ID remains in preferences and its session JSON, is absent from display state, and an unrelated normal session remains visible.