### PR TITLE
Hide internal Codex worker sessions

### DIFF
--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -219,8 +219,10 @@ When `is_subagent` is `true`, the session file represents a delegated subagent's
 Clients that can identify internal helper sessions should set `is_subagent: true` in their hook payloads. For Codex sessions, cctop decodes the structured `threads.source` value from Codex's local thread database: `SessionSource::SubAgent(...)` and `SessionSource::Internal(...)` are hidden, while `cli` and `vscode` remain user-visible even if the legacy diagnostic `thread_source` says `subagent`. `thread_spawn_edges` corroborates topology but is not the primary classifier, because review and guardian helpers may have no edge. Missing, malformed, unknown, or contradictory source evidence fails open and is counted in the session-load diagnostics.
 
 Codex hooks do not yet expose semantic visibility or openability for ephemeral
-root workers. cctop treats an explicitly null `transcript_path` only as a short
-deferral signal, not as proof that a session is internal. Hiding still requires
+root workers. cctop treats an explicitly null `transcript_path` on a positively
+identified `startup` only as a short deferral signal, not as proof that a session
+is internal. Resume, missing, unknown, or contradictory start-kind evidence fails
+open. Hiding still requires
 a narrow worker discriminator: the exact Codex-owned memories directory or the
 project-suggestion prompt fragment at its observed fixed template position. The
 memories directory is intentionally reserved for this classification. The

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -176,7 +176,7 @@ Default: `false` when omitted.
 
 When `hidden` is `true`, cctop reads the session file but does not show that session in the active list, does not archive it into Recent Projects, and does not remove it during dead-session cleanup.
 
-Use `hidden` for real session records that should remain on disk for liveness, debugging, or ownership tracking, but should not appear as user-facing work. Current examples include Codex Desktop memory-maintenance sessions and Codex Desktop title-generation helper sessions. Future cases can use the same attribute for background or delegated review sessions, such as Codex sessions summoned by Claude for review.
+Use `hidden` for real session records that should remain on disk for liveness, debugging, or ownership tracking, but should not appear as user-facing work. Current examples include Codex memory-maintenance, project-suggestion, and title-generation helper sessions. Future cases can use the same attribute for background or delegated review sessions, such as Codex sessions summoned by Claude for review.
 
 Do not use file deletion as the hiding signal. Delete a session file only when the session is genuinely obsolete and no longer useful as state.
 
@@ -217,5 +217,17 @@ Default: `false` when omitted.
 When `is_subagent` is `true`, the session file represents a delegated subagent's own workspace rather than the user's top-level conversation. cctop marks these records `hidden` and keeps the file on disk. This is distinct from `active_subagents`, which belongs on the parent user-facing session to show how many delegated agents it currently owns.
 
 Clients that can identify internal helper sessions should set `is_subagent: true` in their hook payloads. For Codex sessions, cctop decodes the structured `threads.source` value from Codex's local thread database: `SessionSource::SubAgent(...)` and `SessionSource::Internal(...)` are hidden, while `cli` and `vscode` remain user-visible even if the legacy diagnostic `thread_source` says `subagent`. `thread_spawn_edges` corroborates topology but is not the primary classifier, because review and guardian helpers may have no edge. Missing, malformed, unknown, or contradictory source evidence fails open and is counted in the session-load diagnostics.
+
+Codex hooks do not yet expose semantic visibility or openability for ephemeral
+root workers. cctop treats an explicitly null `transcript_path` only as a short
+deferral signal, not as proof that a session is internal. Hiding still requires
+a narrow worker discriminator: the exact Codex-owned memories directory or the
+project-suggestion prompt fragment at its observed fixed template position. The
+memories directory is intentionally reserved for this classification. The
+project-suggestion rule applies prospectively to hook events; existing records
+fail open because transcript-field presence is not persisted. The preferred
+upstream contract is an explicit `user_openable`/visibility field or structured
+session source on every hook; `ephemeral` alone would describe persistence, not
+whether a task belongs in the user-facing session list.
 
 Older cctop versions may have persisted both `is_subagent = true` and `hidden = true` from `thread_source` alone. cctop clears that sticky pair only when structured source proves `cli` or `vscode`, the edge schema is readable and has no spawn edge for the thread, and no independent memory/title auto-hide rule applies.

--- a/fixtures/codex-SessionStart-null-transcript.json
+++ b/fixtures/codex-SessionStart-null-transcript.json
@@ -1,0 +1,8 @@
+{
+  "session_id": "019090a0-6644-7c6a-b3c1-1e8d5c9c0002",
+  "transcript_path": null,
+  "cwd": "/tmp/test-project",
+  "hook_event_name": "SessionStart",
+  "harness_name": "codex",
+  "trigger": "startup"
+}

--- a/hook-input.schema.json
+++ b/hook-input.schema.json
@@ -28,7 +28,10 @@
       ],
       "description": "The hook event that triggered this payload"
     },
-    "transcript_path":  { "type": "string" },
+    "transcript_path":  {
+      "type": ["string", "null"],
+      "description": "Transcript path when available. Explicit null is distinct from omission."
+    },
     "permission_mode":  { "type": "string" },
     "prompt":           { "type": "string" },
     "tool_name":        { "type": "string" },
@@ -45,7 +48,10 @@
       "type": "boolean",
       "description": "Whether this payload belongs to a subagent-owned session rather than a user-facing session"
     },
-    "source":           { "type": "string", "description": "Tool that created this session (e.g. \"opencode\")" },
+    "source":           {
+      "type": "string",
+      "description": "Legacy harness name, or the SessionStart kind in older Codex payloads"
+    },
     "harness_name":     {
       "type": "string",
       "enum": ["cc", "codex", "opencode", "pi"],

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -25,10 +25,8 @@ enum HookHandler {
         let label = HookLogger.sessionLabel(cwd: input.cwd, sessionId: safeId)
         let sessionPath = (sessionsDir as NSString).appendingPathComponent(sessionFileName(input: input, pid: pid, safeSessionId: safeId))
 
-        if event == .sessionStart
-            && source == Session.codexSource
-            && input.hasExplicitlyNullTranscriptPath
-            && !FileManager.default.fileExists(atPath: sessionPath) {
+        if event == .sessionStart, input.hasCodexStartupDeferralEvidence,
+           !FileManager.default.fileExists(atPath: sessionPath) {
             runProjectCleanupIfNeeded(event: event, sessionsDir: sessionsDir, input: input, pid: pid, deps: deps)
             return
         }
@@ -74,9 +72,12 @@ enum HookHandler {
 
             let (oldStatus, newStatus) = applyTransition(&session, event: event, input: input, branch: branch, terminal: terminal)
             applySessionName(&session, event: event, input: input, names: deps.names)
+            if event != .sessionStart, isNewSessionFile, source == Session.codexSource {
+                session.workspaceFile = Session.findWorkspaceFile(in: input.cwd)
+            }
             applySideEffects(event: event, session: &session, input: input, sessionsDir: sessionsDir, safeId: safeId)
             if input.isSubagentSession == true { session.isSubagentSession = true }
-            if session.shouldAutoHide || input.isCodexProjectSuggestionWorker { session.hidden = true }
+            if session.shouldAutoHide || (event == .userPromptSubmit && input.hasCodexProjectSuggestionEvidence) { session.hidden = true }
             session.markWrittenByHook(version: Config.hookVersion, isNewSessionFile: isNewSessionFile)
 
             let suffix = newStatus == nil ? " (preserved)" : ""

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -25,6 +25,14 @@ enum HookHandler {
         let label = HookLogger.sessionLabel(cwd: input.cwd, sessionId: safeId)
         let sessionPath = (sessionsDir as NSString).appendingPathComponent(sessionFileName(input: input, pid: pid, safeSessionId: safeId))
 
+        if event == .sessionStart
+            && source == Session.codexSource
+            && input.hasExplicitlyNullTranscriptPath
+            && !FileManager.default.fileExists(atPath: sessionPath) {
+            runProjectCleanupIfNeeded(event: event, sessionsDir: sessionsDir, input: input, pid: pid, deps: deps)
+            return
+        }
+
         let branch = deps.currentBranch(input.cwd)
         let terminal = captureTerminalInfo(env: deps.environment(), process: deps.process)
         let startTime = deps.process.startTime(pid: pid)
@@ -68,7 +76,7 @@ enum HookHandler {
             applySessionName(&session, event: event, input: input, names: deps.names)
             applySideEffects(event: event, session: &session, input: input, sessionsDir: sessionsDir, safeId: safeId)
             if input.isSubagentSession == true { session.isSubagentSession = true }
-            if session.shouldAutoHide { session.hidden = true }
+            if session.shouldAutoHide || input.isCodexProjectSuggestionWorker { session.hidden = true }
             session.markWrittenByHook(version: Config.hookVersion, isNewSessionFile: isNewSessionFile)
 
             let suffix = newStatus == nil ? " (preserved)" : ""

--- a/menubar/CctopMenubar/Hook/HookInput.swift
+++ b/menubar/CctopMenubar/Hook/HookInput.swift
@@ -1,9 +1,14 @@
 import Foundation
 
 struct HookInput: Codable {
+    private static let codexProjectSuggestionPromptFragment =
+        "Generate 0 to 3 hyperpersonalized suggestions"
+    private static let codexSuggestionPromptFragmentOffset = 12
+
     let sessionId: String
     let cwd: String
     var transcriptPath: String?
+    private var transcriptPathFieldPresent = false
     var permissionMode: String?
     let hookEventName: String
     var prompt: String?
@@ -48,6 +53,7 @@ struct HookInput: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         sessionId = try container.decode(String.self, forKey: .sessionId)
         cwd = try container.decode(String.self, forKey: .cwd)
+        transcriptPathFieldPresent = container.contains(.transcriptPath)
         transcriptPath = try container.decodeIfPresent(String.self, forKey: .transcriptPath)
         permissionMode = try container.decodeIfPresent(String.self, forKey: .permissionMode)
         hookEventName = try container.decode(String.self, forKey: .hookEventName)
@@ -92,6 +98,19 @@ struct HookInput: Codable {
         // MIGRATION(harness_name): Legacy fallback for old plugins that send `source`.
         if let source, Self.knownHarnesses.contains(source) { return source }
         return nil
+    }
+
+    var hasExplicitlyNullTranscriptPath: Bool {
+        transcriptPathFieldPresent && transcriptPath == nil
+    }
+
+    var isCodexProjectSuggestionWorker: Bool {
+        guard resolvedHarnessName == Session.codexSource,
+              hasExplicitlyNullTranscriptPath,
+              let prompt,
+              let range = prompt.range(of: Self.codexProjectSuggestionPromptFragment) else { return false }
+        return prompt.distance(from: prompt.startIndex, to: range.lowerBound)
+            == Self.codexSuggestionPromptFragmentOffset
     }
 }
 

--- a/menubar/CctopMenubar/Hook/HookInput.swift
+++ b/menubar/CctopMenubar/Hook/HookInput.swift
@@ -7,8 +7,8 @@ struct HookInput: Codable {
 
     let sessionId: String
     let cwd: String
-    var transcriptPath: String?
-    private var transcriptPathFieldPresent = false
+    let transcriptPath: String?
+    private let transcriptPathFieldPresent: Bool
     var permissionMode: String?
     let hookEventName: String
     var prompt: String?
@@ -100,13 +100,33 @@ struct HookInput: Codable {
         return nil
     }
 
-    var hasExplicitlyNullTranscriptPath: Bool {
+    var transcriptPathWasExplicitlyNull: Bool {
         transcriptPathFieldPresent && transcriptPath == nil
     }
 
-    var isCodexProjectSuggestionWorker: Bool {
+    /// Reads Codex's SessionStart kind from `trigger` or the legacy non-harness
+    /// `source` field. Contradictory aliases intentionally fail open.
+    var codexSessionStartKind: String? {
+        let legacyKind: String?
+        if let source, Self.knownHarnesses.contains(source) {
+            guard harnessName == nil || harnessName == source else { return nil }
+            legacyKind = nil
+        } else {
+            legacyKind = source
+        }
+        guard trigger == nil || legacyKind == nil || trigger == legacyKind else { return nil }
+        return trigger ?? legacyKind
+    }
+
+    var hasCodexStartupDeferralEvidence: Bool {
+        resolvedHarnessName == Session.codexSource
+            && codexSessionStartKind == "startup"
+            && transcriptPathWasExplicitlyNull
+    }
+
+    var hasCodexProjectSuggestionEvidence: Bool {
         guard resolvedHarnessName == Session.codexSource,
-              hasExplicitlyNullTranscriptPath,
+              transcriptPathWasExplicitlyNull,
               let prompt,
               let range = prompt.range(of: Self.codexProjectSuggestionPromptFragment) else { return false }
         return prompt.distance(from: prompt.startIndex, to: range.lowerBound)

--- a/menubar/CctopMenubar/Models/Config.swift
+++ b/menubar/CctopMenubar/Models/Config.swift
@@ -169,11 +169,10 @@ extension Session {
     private static let codexTitleGenerationPromptPrefix =
         "You are a helpful assistant. You will be presented with a user prompt, and your job is to provide a short title"
 
-    /// True for Codex Desktop's local memory-consolidation runs. These are maintenance
-    /// artifacts, not user workspace sessions, so cctop marks their live files hidden.
+    /// True for Codex's local memory-consolidation runs. Codex owns this exact directory,
+    /// and app-server hooks do not consistently preserve their Desktop bundle identity.
     var isCodexMemoryMaintenanceSession: Bool {
         source == Session.codexSource
-            && terminal?.bundleId == HostAppBundleID.codexDesktop
             && Config.standardizedPath(projectPath) == Config.standardizedPath(Config.codexMemoriesDir())
     }
 

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -1255,13 +1255,14 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertTrue(try loadSession("codex-title-helper.json").hidden)
     }
 
-    func testCodexExplicitlyNullSessionStartDefersUntilUnrelatedPrompt() throws {
+    func testCodexExplicitlyNullStartupDefersUntilOrdinaryPrompt() throws {
         try handleHook("""
         {
           "session_id":"ephemeral-user-task",
           "cwd":"/tmp/ordinary-project",
           "hook_event_name":"SessionStart",
           "harness_name":"codex",
+          "trigger":"startup",
           "transcript_path":null
         }
         """, hookName: "SessionStart")
@@ -1281,7 +1282,80 @@ final class HookHandlerTests: XCTestCase {
 
         let session = try loadSession("codex-ephemeral-user-task.json")
         XCTAssertFalse(session.hidden)
-        XCTAssertNil(session.sessionName)
+    }
+
+    func testCodexNullTranscriptStartDefersOnlyWithPositiveStartupEvidence() throws {
+        let cases: [(id: String, fields: String, shouldDefer: Bool)] = [
+            ("native-startup", #", "trigger":"startup""#, true),
+            ("legacy-startup", #", "source":"startup""#, true),
+            ("matching-startup", #", "trigger":"startup", "source":"startup""#, true),
+            ("resume", #", "trigger":"resume""#, false),
+            ("missing", "", false),
+            ("unknown", #", "trigger":"background""#, false),
+            ("kind-conflict", #", "trigger":"startup", "source":"resume""#, false),
+            ("harness-conflict", #", "trigger":"startup", "source":"opencode""#, false)
+        ]
+
+        for testCase in cases {
+            try handleHook("""
+            {
+              "session_id":"\(testCase.id)",
+              "cwd":"/tmp/ordinary-project",
+              "hook_event_name":"SessionStart",
+              "harness_name":"codex",
+              "transcript_path":null\(testCase.fields)
+            }
+            """, hookName: "SessionStart")
+
+            XCTAssertEqual(
+                sessionFileExists("codex-\(testCase.id).json"),
+                !testCase.shouldDefer,
+                testCase.id
+            )
+        }
+    }
+
+    func testCodexRecordMaterializedAfterDeferredStartupCapturesWorkspaceForAnyTranscriptShape() throws {
+        let project = NSTemporaryDirectory() + "cctop-deferred-workspace-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: project, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: project) }
+        let workspaceFile = (project as NSString).appendingPathComponent("ordinary.code-workspace")
+        try "{}".write(toFile: workspaceFile, atomically: true, encoding: .utf8)
+        let transcriptCases = [
+            (id: "null", field: #", "transcript_path":null"#),
+            (id: "missing", field: ""),
+            (id: "durable", field: #", "transcript_path":"/tmp/transcript.jsonl""#)
+        ]
+
+        for testCase in transcriptCases {
+            try handleHook("""
+            {
+              "session_id":"workspace-\(testCase.id)",
+              "cwd":"\(project)",
+              "hook_event_name":"SessionStart",
+              "harness_name":"codex",
+              "trigger":"startup",
+              "transcript_path":null
+            }
+            """, hookName: "SessionStart")
+            XCTAssertFalse(sessionFileExists("codex-workspace-\(testCase.id).json"))
+
+            try handleHook("""
+            {
+              "session_id":"workspace-\(testCase.id)",
+              "cwd":"\(project)",
+              "hook_event_name":"UserPromptSubmit",
+              "harness_name":"codex",
+              "prompt":"Ordinary user task"\(testCase.field)
+            }
+            """, hookName: "UserPromptSubmit")
+
+            XCTAssertEqual(
+                try loadSession("codex-workspace-\(testCase.id).json").workspaceFile,
+                workspaceFile,
+                testCase.id
+            )
+        }
     }
 
     func testCodexExplicitlyNullSessionStartStillRunsProjectCleanup() throws {
@@ -1310,6 +1384,7 @@ final class HookHandlerTests: XCTestCase {
           "cwd":"/tmp/ordinary-project",
           "hook_event_name":"SessionStart",
           "harness_name":"codex",
+          "trigger":"startup",
           "transcript_path":null
         }
         """, hookName: "SessionStart", deps: makeDeps(alive: false))
@@ -1324,7 +1399,8 @@ final class HookHandlerTests: XCTestCase {
           "session_id":"legacy-codex-task",
           "cwd":"/tmp/ordinary-project",
           "hook_event_name":"SessionStart",
-          "harness_name":"codex"
+          "harness_name":"codex",
+          "trigger":"startup"
         }
         """, hookName: "SessionStart")
 
@@ -1338,6 +1414,7 @@ final class HookHandlerTests: XCTestCase {
           "cwd":"/tmp/ordinary-project",
           "hook_event_name":"SessionStart",
           "harness_name":"opencode",
+          "trigger":"startup",
           "transcript_path":null
         }
         """, hookName: "SessionStart")
@@ -1353,6 +1430,7 @@ final class HookHandlerTests: XCTestCase {
           "cwd":"/tmp/ordinary-project",
           "hook_event_name":"SessionStart",
           "harness_name":"codex",
+          "trigger":"startup",
           "transcript_path":null
         }
         """, hookName: "SessionStart")
@@ -1385,7 +1463,7 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertEqual(stopped.status, .waitingInput)
     }
 
-    func testCodexSuggestionSignatureWithDurableOrLegacyTranscriptStaysVisible() throws {
+    func testCodexSuggestionEvidenceRequiresPromptEventAndExplicitlyNullTranscript() throws {
         let suggestionPrompt = "Task input: Generate 0 to 3 hyperpersonalized suggestions for the user."
         try handleHook("""
         {
@@ -1409,6 +1487,19 @@ final class HookHandlerTests: XCTestCase {
         }
         """, hookName: "UserPromptSubmit")
         XCTAssertFalse(try loadSession("codex-legacy-suggestion-text.json").hidden)
+
+        try handleHook("""
+        {
+          "session_id":"incidental-prompt-field",
+          "cwd":"/tmp/ordinary-project",
+          "hook_event_name":"PreToolUse",
+          "harness_name":"codex",
+          "transcript_path":null,
+          "prompt":\(try jsonString(suggestionPrompt)),
+          "tool_name":"Bash"
+        }
+        """, hookName: "PreToolUse")
+        XCTAssertFalse(try loadSession("codex-incidental-prompt-field.json").hidden)
     }
 
     func testCodexMemoryWorkerIsHiddenWhenPromptArrivesAfterDeferredStart() throws {
@@ -1422,6 +1513,7 @@ final class HookHandlerTests: XCTestCase {
           "cwd":"\(memoriesDir)",
           "hook_event_name":"SessionStart",
           "harness_name":"codex",
+          "trigger":"startup",
           "transcript_path":null
         }
         """, hookName: "SessionStart")

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -180,13 +180,16 @@ final class HookHandlerTests: XCTestCase {
 
     func testCodexResumeUpdatesFocusTargetAndPreservesCctopSessionID() throws {
         let reference = "11111111-2222-4333-8444-555555555555"
-        let input = """
+        let firstStart = """
         {"session_id": "\(reference)", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart", "harness_name": "codex"}
         """
+        let resumedStart = """
+        {"session_id": "\(reference)", "cwd": "/tmp/test-project", "hook_event_name": "SessionStart", "harness_name": "codex", "transcript_path": null}
+        """
         let fileName = "codex-\(reference).json"
-        try handleHook(input, hookName: "SessionStart", deps: makeDeps(pid: 4242, startTime: 1_000))
+        try handleHook(firstStart, hookName: "SessionStart", deps: makeDeps(pid: 4242, startTime: 1_000))
         let first = try loadSession(fileName)
-        try handleHook(input, hookName: "SessionStart", deps: makeDeps(pid: 5002, startTime: 2_000))
+        try handleHook(resumedStart, hookName: "SessionStart", deps: makeDeps(pid: 5002, startTime: 2_000))
         let resumed = try loadSession(fileName)
 
         XCTAssertEqual(resumed.cctopSessionId, first.cctopSessionId)
@@ -1250,6 +1253,192 @@ final class HookHandlerTests: XCTestCase {
         """
         try handleHook(promptJSON, hookName: "UserPromptSubmit", deps: deps)
         XCTAssertTrue(try loadSession("codex-title-helper.json").hidden)
+    }
+
+    func testCodexExplicitlyNullSessionStartDefersUntilUnrelatedPrompt() throws {
+        try handleHook("""
+        {
+          "session_id":"ephemeral-user-task",
+          "cwd":"/tmp/ordinary-project",
+          "hook_event_name":"SessionStart",
+          "harness_name":"codex",
+          "transcript_path":null
+        }
+        """, hookName: "SessionStart")
+
+        XCTAssertFalse(sessionFileExists("codex-ephemeral-user-task.json"))
+
+        try handleHook("""
+        {
+          "session_id":"ephemeral-user-task",
+          "cwd":"/tmp/ordinary-project",
+          "hook_event_name":"UserPromptSubmit",
+          "harness_name":"codex",
+          "transcript_path":null,
+          "prompt":"Quoted: Generate 0 to 3 hyperpersonalized suggestions for a test fixture"
+        }
+        """, hookName: "UserPromptSubmit")
+
+        let session = try loadSession("codex-ephemeral-user-task.json")
+        XCTAssertFalse(session.hidden)
+        XCTAssertNil(session.sessionName)
+    }
+
+    func testCodexExplicitlyNullSessionStartStillRunsProjectCleanup() throws {
+        let stalePath = sessionFilePath("7777.json")
+        let stale = Session(
+            sessionId: "stale-same-project",
+            projectPath: "/tmp/ordinary-project",
+            projectName: "ordinary-project",
+            branch: "main",
+            status: .idle,
+            lastPrompt: nil,
+            lastActivity: Date(timeIntervalSince1970: 900),
+            startedAt: Date(timeIntervalSince1970: 800),
+            terminal: TerminalInfo(program: "Code"),
+            pid: 7777,
+            pidStartTime: 900,
+            lastTool: nil,
+            lastToolDetail: nil,
+            notificationMessage: nil
+        )
+        try stale.writeToFile(path: stalePath)
+
+        try handleHook("""
+        {
+          "session_id":"deferred-cleanup-trigger",
+          "cwd":"/tmp/ordinary-project",
+          "hook_event_name":"SessionStart",
+          "harness_name":"codex",
+          "transcript_path":null
+        }
+        """, hookName: "SessionStart", deps: makeDeps(alive: false))
+
+        XCTAssertFalse(sessionFileExists("codex-deferred-cleanup-trigger.json"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stalePath))
+    }
+
+    func testCodexSessionStartWithoutTranscriptFieldKeepsLegacyBehavior() throws {
+        try handleHook("""
+        {
+          "session_id":"legacy-codex-task",
+          "cwd":"/tmp/ordinary-project",
+          "hook_event_name":"SessionStart",
+          "harness_name":"codex"
+        }
+        """, hookName: "SessionStart")
+
+        XCTAssertTrue(sessionFileExists("codex-legacy-codex-task.json"))
+    }
+
+    func testNonCodexExplicitlyNullSessionStartIsNotDeferred() throws {
+        try handleHook("""
+        {
+          "session_id":"opencode-null-path",
+          "cwd":"/tmp/ordinary-project",
+          "hook_event_name":"SessionStart",
+          "harness_name":"opencode",
+          "transcript_path":null
+        }
+        """, hookName: "SessionStart")
+
+        XCTAssertTrue(sessionFileExists())
+    }
+
+    func testCodexProjectSuggestionWorkerStaysHiddenThroughStop() throws {
+        let sessionId = "project-suggestion-worker"
+        try handleHook("""
+        {
+          "session_id":"\(sessionId)",
+          "cwd":"/tmp/ordinary-project",
+          "hook_event_name":"SessionStart",
+          "harness_name":"codex",
+          "transcript_path":null
+        }
+        """, hookName: "SessionStart")
+        XCTAssertFalse(sessionFileExists("codex-\(sessionId).json"))
+
+        let suggestionPrompt = "Task input: Generate 0 to 3 hyperpersonalized suggestions for the user."
+        try handleHook("""
+        {
+          "session_id":"\(sessionId)",
+          "cwd":"/tmp/ordinary-project",
+          "hook_event_name":"UserPromptSubmit",
+          "harness_name":"codex",
+          "transcript_path":null,
+          "prompt":\(try jsonString(suggestionPrompt))
+        }
+        """, hookName: "UserPromptSubmit")
+        XCTAssertTrue(try loadSession("codex-\(sessionId).json").hidden)
+
+        try handleHook("""
+        {
+          "session_id":"\(sessionId)",
+          "cwd":"/tmp/ordinary-project",
+          "hook_event_name":"Stop",
+          "harness_name":"codex",
+          "transcript_path":null
+        }
+        """, hookName: "Stop")
+        let stopped = try loadSession("codex-\(sessionId).json")
+        XCTAssertTrue(stopped.hidden)
+        XCTAssertEqual(stopped.status, .waitingInput)
+    }
+
+    func testCodexSuggestionSignatureWithDurableOrLegacyTranscriptStaysVisible() throws {
+        let suggestionPrompt = "Task input: Generate 0 to 3 hyperpersonalized suggestions for the user."
+        try handleHook("""
+        {
+          "session_id":"durable-suggestion-text",
+          "cwd":"/tmp/ordinary-project",
+          "hook_event_name":"UserPromptSubmit",
+          "harness_name":"codex",
+          "transcript_path":"/tmp/transcript.jsonl",
+          "prompt":\(try jsonString(suggestionPrompt))
+        }
+        """, hookName: "UserPromptSubmit")
+        XCTAssertFalse(try loadSession("codex-durable-suggestion-text.json").hidden)
+
+        try handleHook("""
+        {
+          "session_id":"legacy-suggestion-text",
+          "cwd":"/tmp/ordinary-project",
+          "hook_event_name":"UserPromptSubmit",
+          "harness_name":"codex",
+          "prompt":\(try jsonString(suggestionPrompt))
+        }
+        """, hookName: "UserPromptSubmit")
+        XCTAssertFalse(try loadSession("codex-legacy-suggestion-text.json").hidden)
+    }
+
+    func testCodexMemoryWorkerIsHiddenWhenPromptArrivesAfterDeferredStart() throws {
+        let memoriesDir = NSTemporaryDirectory() + "cctop-internal-memories-\(UUID().uuidString)"
+        setenv("CCTOP_CODEX_MEMORIES_DIR", memoriesDir, 1)
+        defer { unsetenv("CCTOP_CODEX_MEMORIES_DIR") }
+
+        try handleHook("""
+        {
+          "session_id":"memory-worker",
+          "cwd":"\(memoriesDir)",
+          "hook_event_name":"SessionStart",
+          "harness_name":"codex",
+          "transcript_path":null
+        }
+        """, hookName: "SessionStart")
+        XCTAssertFalse(sessionFileExists("codex-memory-worker.json"))
+
+        try handleHook("""
+        {
+          "session_id":"memory-worker",
+          "cwd":"\(memoriesDir)",
+          "hook_event_name":"UserPromptSubmit",
+          "harness_name":"codex",
+          "transcript_path":null,
+          "prompt":"Maintain internal memory state"
+        }
+        """, hookName: "UserPromptSubmit")
+
+        XCTAssertTrue(try loadSession("codex-memory-worker.json").hidden)
     }
 
     func testHookInputMarkedSubagentWritesHiddenSession() throws {

--- a/menubar/CctopMenubarTests/HookInputTests.swift
+++ b/menubar/CctopMenubarTests/HookInputTests.swift
@@ -25,19 +25,19 @@ final class HookInputTests: XCTestCase {
         XCTAssertEqual(input.cwd, "/tmp/test-project")
         XCTAssertEqual(input.hookEventName, "SessionStart")
         XCTAssertEqual(input.transcriptPath, "/tmp/transcript.jsonl")
-        XCTAssertFalse(input.hasExplicitlyNullTranscriptPath)
+        XCTAssertFalse(input.transcriptPathWasExplicitlyNull)
     }
 
     func testTranscriptPathFieldPresenceDistinguishesNullFromMissing() throws {
         let explicitNull = try JSONDecoder().decode(HookInput.self, from: Data("""
         {"session_id":"null-path","cwd":"/tmp","hook_event_name":"SessionStart","transcript_path":null}
         """.utf8))
-        XCTAssertTrue(explicitNull.hasExplicitlyNullTranscriptPath)
+        XCTAssertTrue(explicitNull.transcriptPathWasExplicitlyNull)
 
         let missing = try JSONDecoder().decode(HookInput.self, from: Data("""
         {"session_id":"missing-path","cwd":"/tmp","hook_event_name":"SessionStart"}
         """.utf8))
-        XCTAssertFalse(missing.hasExplicitlyNullTranscriptPath)
+        XCTAssertFalse(missing.transcriptPathWasExplicitlyNull)
     }
 
     // MARK: - UserPromptSubmit
@@ -240,6 +240,7 @@ final class HookInputTests: XCTestCase {
         )
         XCTAssertEqual(input.source, "startup")
         XCTAssertNil(input.resolvedHarnessName, "'startup' is not a harness name")
+        XCTAssertEqual(input.codexSessionStartKind, "startup")
     }
 
     func testHarnessNameSetViaCLIArg() throws {

--- a/menubar/CctopMenubarTests/HookInputTests.swift
+++ b/menubar/CctopMenubarTests/HookInputTests.swift
@@ -25,6 +25,19 @@ final class HookInputTests: XCTestCase {
         XCTAssertEqual(input.cwd, "/tmp/test-project")
         XCTAssertEqual(input.hookEventName, "SessionStart")
         XCTAssertEqual(input.transcriptPath, "/tmp/transcript.jsonl")
+        XCTAssertFalse(input.hasExplicitlyNullTranscriptPath)
+    }
+
+    func testTranscriptPathFieldPresenceDistinguishesNullFromMissing() throws {
+        let explicitNull = try JSONDecoder().decode(HookInput.self, from: Data("""
+        {"session_id":"null-path","cwd":"/tmp","hook_event_name":"SessionStart","transcript_path":null}
+        """.utf8))
+        XCTAssertTrue(explicitNull.hasExplicitlyNullTranscriptPath)
+
+        let missing = try JSONDecoder().decode(HookInput.self, from: Data("""
+        {"session_id":"missing-path","cwd":"/tmp","hook_event_name":"SessionStart"}
+        """.utf8))
+        XCTAssertFalse(missing.hasExplicitlyNullTranscriptPath)
     }
 
     // MARK: - UserPromptSubmit

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -1371,7 +1371,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertTrue(session.isCodexMemoryMaintenanceSession)
     }
 
-    func testCodexMemoryMaintenanceClassificationIsNarrow() {
+    func testCodexReservedMemoryDirectoryClassificationIsNarrow() {
         let root = NSTemporaryDirectory() + "cctop-memory-\(UUID().uuidString)"
         let memoriesDir = (root as NSString).appendingPathComponent("bob/.codex/memories")
         setenv("CCTOP_CODEX_MEMORIES_DIR", memoriesDir, 1)
@@ -1386,18 +1386,24 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         XCTAssertFalse(normalProject.isCodexMemoryMaintenanceSession)
 
-        var nonDesktopMemory = Session(
-            sessionId: "codex-cli-memory",
+        var userLaunchedMemoryTask = Session(
+            sessionId: "user-launched-memory-task",
             projectPath: memoriesDir,
             branch: "main",
             terminal: TerminalInfo(program: "zsh")
         )
-        nonDesktopMemory.source = Session.codexSource
-        XCTAssertFalse(nonDesktopMemory.isCodexMemoryMaintenanceSession)
+        userLaunchedMemoryTask.source = Session.codexSource
+        XCTAssertTrue(userLaunchedMemoryTask.isCodexMemoryMaintenanceSession)
 
         var nonCodexMemory = codexDesktopSession(sessionId: "other-memory", projectPath: memoriesDir)
         nonCodexMemory.source = "cc"
         XCTAssertFalse(nonCodexMemory.isCodexMemoryMaintenanceSession)
+
+        let neighboringMemoriesProject = codexDesktopSession(
+            sessionId: "neighboring-memories",
+            projectPath: (root as NSString).appendingPathComponent("bob/projects/memories")
+        )
+        XCTAssertFalse(neighboringMemoriesProject.isCodexMemoryMaintenanceSession)
 
         XCTAssertEqual(normalProject.projectName, "cctop")
     }


### PR DESCRIPTION
## Problem

Codex emits ordinary hook lifecycles for project-suggestion and periodic memories workers even though those workers do not have user-openable tasks. cctop therefore persisted them as visible sessions, so each new worker ID could reappear in the panel and downstream projections.

## Solution

- Defer only brand-new Codex starts with an exact, non-contradictory `startup` kind and an explicitly null `transcript_path`. Resume, missing, unknown, and contradictory start-kind evidence fails open and remains visible.
- Materialize ordinary deferred tasks on their first later hook and restore workspace metadata regardless of that event's transcript shape.
- Hide project-suggestion workers only on `UserPromptSubmit` when the known fragment occurs at the fixed observed template position, and hide Codex workers rooted at the exact configured memories directory.
- Fail open for omitted or durable transcript evidence, shifted or quoted prompt text, neighboring paths, non-Codex clients, and existing suggestion records that lack persisted evidence.

The configured memories directory is intentionally reserved: a user-launched Codex task in that exact directory is also hidden. Project-suggestion template drift fails open, so a changed Codex template may make a worker visible again instead of risking broader user-task hiding. The preferred long-term contract is structured upstream visibility or `user_openable` metadata on every hook.