### PR TITLE
Consolidate identity and manual-hide evidence logic

### DIFF
--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -727,11 +727,7 @@ private func loadOrCreateSession(
             )
         }
         var replacement = fresh
-        if CctopSessionIdentityStore.durableEvidence(
-            source: fresh.source,
-            harnessSessionId: fresh.harnessSessionId,
-            legacySessionId: fresh.sessionId
-        ) == nil {
+        if CctopSessionIdentityStore.durableEvidence(for: fresh) == nil {
             replacement.cctopSessionId = Session.makeCctopSessionId()
         }
         return (replacement, true)

--- a/menubar/CctopMenubar/Services/CctopSessionIdentityStore.swift
+++ b/menubar/CctopMenubar/Services/CctopSessionIdentityStore.swift
@@ -72,11 +72,7 @@ struct CctopSessionIdentityStore {
             if knownExistingIDs == nil {
                 for url in sessionFiles() {
                     guard let session = try? Session.fromFile(path: url.path),
-                          Self.durableEvidence(
-                            source: session.source,
-                            harnessSessionId: session.harnessSessionId,
-                            legacySessionId: session.sessionId
-                          ) == evidence,
+                          Self.durableEvidence(for: session) == evidence,
                           Session.isValidCctopSessionId(session.cctopSessionId),
                           let cctopSessionId = session.cctopSessionId else { continue }
                     existing.insert(cctopSessionId)
@@ -94,6 +90,15 @@ struct CctopSessionIdentityStore {
             throw StoreError.corruptMapping(mappingURL.lastPathComponent)
         }
         return resolved
+    }
+
+    /// Session-shaped convenience over `durableEvidence(source:harnessSessionId:legacySessionId:)`.
+    static func durableEvidence(for session: Session) -> String? {
+        durableEvidence(
+            source: session.source,
+            harnessSessionId: session.harnessSessionId,
+            legacySessionId: session.sessionId
+        )
     }
 
     /// Current reliable same-machine resume evidence. OpenCode deliberately remains

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -37,6 +37,11 @@ enum SessionIdentityPolicy {
         return .legacy(stableKey(for: session))
     }
 
+    /// The validated permanent cctop session ID, if the session carries one.
+    static func permanentSessionID(for session: Session) -> String? {
+        logicalIdentity(for: session).cctopSessionID
+    }
+
     static func notificationRequestIdentifier(forCctopSessionID cctopSessionID: String) -> String? {
         guard Session.isValidCctopSessionId(cctopSessionID) else { return nil }
         return "session-\(cctopSessionID)"
@@ -83,7 +88,7 @@ enum SessionIdentityPolicy {
         guard !candidates.isEmpty else { return nil }
         var permanentIDs: Set<String> = []
         for candidate in candidates {
-            guard let cctopSessionID = logicalIdentity(for: candidate).cctopSessionID else { return nil }
+            guard let cctopSessionID = permanentSessionID(for: candidate) else { return nil }
             permanentIDs.insert(cctopSessionID)
         }
         guard permanentIDs.count == 1 else { return nil }
@@ -134,6 +139,28 @@ enum SessionIdentityPolicy {
     }
 }
 
+/// One pass's snapshot of every way a session can match a manual hide: migrated
+/// permanent IDs, unresolved pre-release legacy keys, and the durable evidence those
+/// keys imply. Built once per load/GC pass so the visibility filter, cleanup
+/// retention, and file sweeps agree on the same answer.
+struct ManualHideEvidence {
+    let hiddenSessionIDs: Set<String>
+    let legacyKeys: Set<String>
+    let legacyEvidence: Set<String>
+
+    var hasUnresolvedLegacyKeys: Bool { !legacyKeys.isEmpty }
+
+    func matches(_ session: Session) -> Bool {
+        if let cctopSessionID = session.cctopSessionId, hiddenSessionIDs.contains(cctopSessionID) {
+            return true
+        }
+        if legacyKeys.contains(SessionIdentityPolicy.stableKey(for: session)) {
+            return true
+        }
+        return CctopSessionIdentityStore.durableEvidence(for: session).map(legacyEvidence.contains) ?? false
+    }
+}
+
 /// Persists manual visibility preferences independently from hook-owned session files.
 /// The stored payload is intentionally limited to opaque cctop-owned session IDs.
 struct ManualSessionVisibilityStore {
@@ -162,6 +189,22 @@ struct ManualSessionVisibilityStore {
     /// A partial inventory may already have contributed a permanent ID. Process keys never participate.
     var unresolvedDurableLegacyKeys: Set<String> {
         legacyStableKeys.filter(Self.isDurableLegacyKey)
+    }
+
+    /// Snapshot manual-hide match state for one pass over the given session inventory.
+    /// The inventory only contributes durable evidence for sessions still matching an
+    /// unresolved legacy key; permanent IDs and legacy keys come from the store itself.
+    func manualHideEvidence(in sessions: [Session]) -> ManualHideEvidence {
+        let legacyKeys = unresolvedDurableLegacyKeys
+        var evidence = Set(legacyKeys.compactMap(Self.durableEvidence(forLegacyKey:)))
+        evidence.formUnion(sessions
+            .filter { legacyKeys.contains(SessionIdentityPolicy.stableKey(for: $0)) }
+            .compactMap(CctopSessionIdentityStore.durableEvidence(for:)))
+        return ManualHideEvidence(
+            hiddenSessionIDs: hiddenSessionIDs,
+            legacyKeys: legacyKeys,
+            legacyEvidence: evidence
+        )
     }
 
     func isHidden(_ session: Session) -> Bool {
@@ -244,42 +287,40 @@ struct ManualSessionVisibilityStore {
         return migratedSessionIDs
     }
 
-    private static func persistedLegacyMigrationMatches(
-        in sessions: [Session],
-        legacyKeys: Set<String>
-    ) -> (
-        sessionIDsByEvidence: [String: Set<String>],
-        unresolvedEvidence: Set<String>,
-        unresolvedMatchedKeys: Set<String>,
-        sessionIDsByKey: [String: Set<String>]
-    ) {
+    /// What the persisted (disk-stamped) inventory says about legacy hide keys:
+    /// which permanent IDs each durable evidence or legacy key maps to, and which
+    /// evidence/keys matched a record that has no permanent ID yet.
+    private struct PersistedLegacyMatches {
         var sessionIDsByEvidence: [String: Set<String>] = [:]
         var unresolvedEvidence: Set<String> = []
         var unresolvedMatchedKeys: Set<String> = []
         var sessionIDsByKey: [String: Set<String>] = [:]
+    }
+
+    private static func persistedLegacyMigrationMatches(
+        in sessions: [Session],
+        legacyKeys: Set<String>
+    ) -> PersistedLegacyMatches {
+        var matches = PersistedLegacyMatches()
         for session in sessions {
-            let cctopSessionID = SessionIdentityPolicy.logicalIdentity(for: session).cctopSessionID
-            if let evidence = CctopSessionIdentityStore.durableEvidence(
-                source: session.source,
-                harnessSessionId: session.harnessSessionId,
-                legacySessionId: session.sessionId
-            ) {
+            let cctopSessionID = SessionIdentityPolicy.permanentSessionID(for: session)
+            if let evidence = CctopSessionIdentityStore.durableEvidence(for: session) {
                 if let cctopSessionID {
-                    sessionIDsByEvidence[evidence, default: []].insert(cctopSessionID)
+                    matches.sessionIDsByEvidence[evidence, default: []].insert(cctopSessionID)
                 } else {
-                    unresolvedEvidence.insert(evidence)
+                    matches.unresolvedEvidence.insert(evidence)
                 }
             }
 
             let key = SessionIdentityPolicy.stableKey(for: session)
             guard legacyKeys.contains(key) else { continue }
             if let cctopSessionID {
-                sessionIDsByKey[key, default: []].insert(cctopSessionID)
+                matches.sessionIDsByKey[key, default: []].insert(cctopSessionID)
             } else {
-                unresolvedMatchedKeys.insert(key)
+                matches.unresolvedMatchedKeys.insert(key)
             }
         }
-        return (sessionIDsByEvidence, unresolvedEvidence, unresolvedMatchedKeys, sessionIDsByKey)
+        return matches
     }
 
     private static func legacyMigrationCandidateIDs(
@@ -287,14 +328,10 @@ struct ManualSessionVisibilityStore {
         persistedSessionIDsByEvidence: [String: Set<String>]
     ) -> Set<String> {
         var matches: Set<String> = []
-        if let cctopSessionID = SessionIdentityPolicy.logicalIdentity(for: session).cctopSessionID {
+        if let cctopSessionID = SessionIdentityPolicy.permanentSessionID(for: session) {
             matches.insert(cctopSessionID)
         }
-        if let evidence = CctopSessionIdentityStore.durableEvidence(
-            source: session.source,
-            harnessSessionId: session.harnessSessionId,
-            legacySessionId: session.sessionId
-        ) {
+        if let evidence = CctopSessionIdentityStore.durableEvidence(for: session) {
             matches.formUnion(persistedSessionIDsByEvidence[evidence] ?? [])
         }
         return matches

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -216,17 +216,12 @@ private extension Session {
 extension SessionManager {
     func retainedFinishedCleanupSources(
         winners: [DedupCandidate],
-        unresolvedLegacyKeys: Set<String>,
-        unresolvedLegacyEvidence: Set<String>
+        manualHides: ManualHideEvidence
     ) -> [SessionCleanupSource] {
         winners.compactMap { candidate in
             let session = candidate.session
             guard candidate.lifecycleRank == SessionLifecycle.finished.rawValue,
-                  shouldRetainFinishedManualHideEvidence(
-                      session,
-                      legacyKeys: unresolvedLegacyKeys,
-                      legacyEvidence: unresolvedLegacyEvidence
-                  ),
+                  shouldRetainFinishedManualHideEvidence(session, matching: manualHides),
                   session.hasCleanupSourcePath else {
                 return nil
             }
@@ -237,17 +232,12 @@ extension SessionManager {
     func archiveAndRemoveFinishedNonDesktop(
         _ candidates: [DedupCandidate],
         winners: [DedupCandidate],
-        unresolvedLegacyKeys: Set<String>,
-        unresolvedLegacyEvidence: Set<String>
+        manualHides: ManualHideEvidence
     ) -> [SessionCleanupSource] {
         let winnerPaths = Set(winners.map(\.path))
         var newlyArchivedCleanupSources: [SessionCleanupSource] = []
         for candidate in candidates {
-            guard !shouldRetainFinishedManualHideEvidence(
-                candidate.session,
-                legacyKeys: unresolvedLegacyKeys,
-                legacyEvidence: unresolvedLegacyEvidence
-            ) else { continue }
+            guard !shouldRetainFinishedManualHideEvidence(candidate.session, matching: manualHides) else { continue }
             // A finished dedup winner is a real completed non-desktop session, so keep today's
             // Recent Projects behavior. A finished duplicate loser is stale migration debris;
             // remove it without archiving so it cannot later surface as a separate session.
@@ -264,11 +254,9 @@ extension SessionManager {
 
     func shouldRetainFinishedManualHideEvidence(
         _ session: Session,
-        legacyKeys: Set<String>,
-        legacyEvidence: Set<String>
+        matching manualHides: ManualHideEvidence
     ) -> Bool {
-        shouldRetainManualHideEvidence(session, legacyKeys: legacyKeys, legacyEvidence: legacyEvidence)
-            || hasExistingMappedManualHide(session)
+        manualHides.matches(session) || hasExistingMappedManualHide(session)
     }
 
     func hasExistingMappedManualHide(_ session: Session) -> Bool {
@@ -285,63 +273,19 @@ extension SessionManager {
         return hiddenSessionIDs.contains(existingID)
     }
 
-    func shouldRetainManualHideEvidence(
-        _ session: Session,
-        legacyKeys: Set<String>,
-        legacyEvidence: Set<String>
-    ) -> Bool {
-        dataSources.manualSessionVisibility.isHidden(session)
-            || legacyKeys.contains(SessionIdentityPolicy.stableKey(for: session))
-            || CctopSessionIdentityStore.durableEvidence(
-                source: session.source,
-                harnessSessionId: session.harnessSessionId,
-                legacySessionId: session.sessionId
-            ).map(legacyEvidence.contains) == true
-    }
-
     func sweepLegacyUUIDFileIfNeeded(
         _ url: URL,
-        unresolvedLegacyKeys: Set<String>,
-        unresolvedLegacyEvidence: Set<String>
+        manualHides: ManualHideEvidence
     ) -> Bool {
         guard Self.isLegacyUUIDFilename(url.deletingPathExtension().lastPathComponent) else { return false }
         if !dataSources.manualSessionVisibility.hasStoredHideEvidence {
             try? FileManager.default.removeItem(at: url) // Pre-PID legacy file; no live writer to race.
         } else if let data = try? Data(contentsOf: url),
                   let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data),
-                  !shouldRetainFinishedManualHideEvidence(
-                      session,
-                      legacyKeys: unresolvedLegacyKeys,
-                      legacyEvidence: unresolvedLegacyEvidence
-                  ) {
+                  !shouldRetainFinishedManualHideEvidence(session, matching: manualHides) {
             try? FileManager.default.removeItem(at: url)
         }
         return true
-    }
-
-    func unresolvedManualHideEvidence(in sessions: [Session], legacyKeys: Set<String>) -> Set<String> {
-        var evidence = Set(legacyKeys.compactMap {
-            ManualSessionVisibilityStore.durableEvidence(forLegacyKey: $0)
-        })
-        evidence.formUnion(sessions
-            .filter { legacyKeys.contains(SessionIdentityPolicy.stableKey(for: $0)) }
-            .compactMap {
-                CctopSessionIdentityStore.durableEvidence(
-                    source: $0.source,
-                    harnessSessionId: $0.harnessSessionId,
-                    legacySessionId: $0.sessionId
-                )
-            })
-        return evidence
-    }
-
-    func unresolvedManualHideEvidence(in files: [URL], legacyKeys: Set<String>) -> Set<String> {
-        unresolvedManualHideEvidence(
-            in: files.compactMap { url in
-                (try? Data(contentsOf: url)).flatMap { try? JSONDecoder.sessionDecoder.decode(Session.self, from: $0) }
-            },
-            legacyKeys: legacyKeys
-        )
     }
 
     func mergingCleanupSources(

--- a/menubar/CctopMenubar/Services/SessionManager+Loading.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Loading.swift
@@ -79,22 +79,15 @@ extension SessionManager {
         var records = candidates.map { (url: URL(fileURLWithPath: $0.path), session: $0.session) }
         var idsByEvidence: [String: Set<String>] = [:]
         for record in knownRecords where Session.isValidCctopSessionId(record.session.cctopSessionId) {
-            guard let evidence = CctopSessionIdentityStore.durableEvidence(
-                source: record.session.source,
-                harnessSessionId: record.session.harnessSessionId,
-                legacySessionId: record.session.sessionId
-            ), let cctopSessionId = record.session.cctopSessionId else { continue }
+            guard let evidence = CctopSessionIdentityStore.durableEvidence(for: record.session),
+                  let cctopSessionId = record.session.cctopSessionId else { continue }
             idsByEvidence[evidence, default: []].insert(cctopSessionId)
         }
 
         let identityStore = CctopSessionIdentityStore(sessionsDir: dataSources.sessionsDir)
         for index in records.indices where !Session.isValidCctopSessionId(records[index].session.cctopSessionId) {
             var session = records[index].session
-            guard let evidence = CctopSessionIdentityStore.durableEvidence(
-                source: session.source,
-                harnessSessionId: session.harnessSessionId,
-                legacySessionId: session.sessionId
-            ) else {
+            guard let evidence = CctopSessionIdentityStore.durableEvidence(for: session) else {
                 scheduleCctopSessionIdentityStamp(
                     url: records[index].url,
                     snapshot: session,
@@ -159,11 +152,7 @@ extension SessionManager {
             guard case .hidden(let reason) = record.disposition else { return false }
             switch reason {
             case .archivedCodexDesktop, .archivedClaudeDesktop:
-                return CctopSessionIdentityStore.durableEvidence(
-                    source: session.source,
-                    harnessSessionId: session.harnessSessionId,
-                    legacySessionId: session.sessionId
-                ) != nil
+                return CctopSessionIdentityStore.durableEvidence(for: session) != nil
             case .persistedHidden, .autoHidden, .missingCodexDesktopThread, .codexInternalHelper, .codexExecHelper,
                  .orphanedEndedClaudeDesktop, .claudeDesktopStartupPlaceholder:
                 return false

--- a/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
@@ -116,13 +116,13 @@ extension SessionManager {
     ) -> [SessionNotificationAction] {
         let newByCctopSessionID: [String: Session] = Dictionary(
             newSessions.compactMap { session in
-                SessionIdentityPolicy.logicalIdentity(for: session).cctopSessionID.map { ($0, session) }
+                SessionIdentityPolicy.permanentSessionID(for: session).map { ($0, session) }
             },
             uniquingKeysWith: { first, _ in first }
         )
         let oldByCctopSessionID: [String: Session] = Dictionary(
             oldSessions.compactMap { session in
-                SessionIdentityPolicy.logicalIdentity(for: session).cctopSessionID.map { ($0, session) }
+                SessionIdentityPolicy.permanentSessionID(for: session).map { ($0, session) }
             },
             uniquingKeysWith: { first, _ in first }
         )
@@ -148,7 +148,7 @@ extension SessionManager {
     }
 
     nonisolated static func notificationRequest(for session: Session) -> UNNotificationRequest? {
-        guard let cctopSessionID = SessionIdentityPolicy.logicalIdentity(for: session).cctopSessionID,
+        guard let cctopSessionID = SessionIdentityPolicy.permanentSessionID(for: session),
               let identifier = SessionIdentityPolicy.notificationRequestIdentifier(
                   forCctopSessionID: cctopSessionID
               ),
@@ -172,7 +172,7 @@ extension SessionManager {
     }
 
     func postNotification(for session: Session) {
-        guard let cctopSessionID = SessionIdentityPolicy.logicalIdentity(for: session).cctopSessionID,
+        guard let cctopSessionID = SessionIdentityPolicy.permanentSessionID(for: session),
               let currentSession = FocusTargetResolver.currentSession(
                   forCctopSessionID: cctopSessionID,
                   in: SessionDisplayPolicy.activeSessions(from: sessions)

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -106,28 +106,14 @@ class SessionManager: ObservableObject {
         let now = dataSources.now()
         let identifiedCandidates = identifiedPublishableCandidates(winners: winners, knownRecords: allDecoded)
         let identifiedInventory = classification.records.map(\.candidate.session) + identifiedCandidates.map(\.session)
-        let hiddenSessionIDs = dataSources.manualSessionVisibility.migrateLegacyStableKeys(
+        dataSources.manualSessionVisibility.migrateLegacyStableKeys(
             using: identifiedInventory, persistedSessions: allDecoded.map(\.session), inventoryComplete: inventoryComplete
         )
-        let unresolvedLegacyKeys = dataSources.manualSessionVisibility.unresolvedDurableLegacyKeys
-        let unresolvedLegacyEvidence = unresolvedManualHideEvidence(in: identifiedInventory, legacyKeys: unresolvedLegacyKeys)
-        let retainedFinishedCleanupSources = retainedFinishedCleanupSources(
-            winners: winners,
-            unresolvedLegacyKeys: unresolvedLegacyKeys,
-            unresolvedLegacyEvidence: unresolvedLegacyEvidence
-        )
+        let manualHides = dataSources.manualSessionVisibility.manualHideEvidence(in: identifiedInventory)
+        let hiddenSessionIDs = manualHides.hiddenSessionIDs
+        let retainedFinishedCleanupSources = retainedFinishedCleanupSources(winners: winners, manualHides: manualHides)
         let observedCleanupSources = classification.cleanupSources + retainedFinishedCleanupSources
-        let visibleCandidates = identifiedCandidates.filter { candidate in
-            let session = candidate.session
-            let hiddenByPermanentID = session.cctopSessionId.map(hiddenSessionIDs.contains) ?? false
-            let hiddenByLegacyKey = unresolvedLegacyKeys.contains(SessionIdentityPolicy.stableKey(for: session))
-            let hiddenByLegacyEvidence = CctopSessionIdentityStore.durableEvidence(
-                source: session.source,
-                harnessSessionId: session.harnessSessionId,
-                legacySessionId: session.sessionId
-            ).map(unresolvedLegacyEvidence.contains) ?? false
-            return !hiddenByPermanentID && !hiddenByLegacyKey && !hiddenByLegacyEvidence
-        }
+        let visibleCandidates = identifiedCandidates.filter { !manualHides.matches($0.session) }
         let identifiedSessions = SessionIdentityPolicy.dedupedCandidatesByLogicalIdentity(visibleCandidates).map(\.session)
         let loadedSessions = identifiedSessions.map { adjustDisplayStatus($0) }
         let orderedSessions = SessionDisplayPolicy.reconcilingActiveOrder(in: loadedSessions, preserving: oldSessions, now: now)
@@ -154,15 +140,14 @@ class SessionManager: ObservableObject {
         let newlyArchivedCleanupSources = archiveAndRemoveFinishedNonDesktop(
             classification.finishedNonDesktopCandidates,
             winners: winners,
-            unresolvedLegacyKeys: unresolvedLegacyKeys,
-            unresolvedLegacyEvidence: unresolvedLegacyEvidence
+            manualHides: manualHides
         )
         let activeProjectPaths = classification.protectedProjectPathsForCleanup
         let recentExcludedPaths = activeProjectPaths.union(classification.manualHiddenProjectPaths(hiddenSessionIDs))
         let publishedSessionIDs = Set(newSessions.compactMap {
-            SessionIdentityPolicy.logicalIdentity(for: $0).cctopSessionID
+            SessionIdentityPolicy.permanentSessionID(for: $0)
         })
-        let shouldFreezeVisibilityProjections = !unresolvedLegacyKeys.isEmpty
+        let shouldFreezeVisibilityProjections = manualHides.hasUnresolvedLegacyKeys
             || (!inventoryComplete && !hiddenSessionIDs.isEmpty)
         if !shouldFreezeVisibilityProjections {
             _ = historyManager.rebuildRecentProjects(excludingActive: recentExcludedPaths)
@@ -313,13 +298,16 @@ class SessionManager: ObservableObject {
         let fm = FileManager.default
         guard let files = try? fm.contentsOfDirectory(at: sessionsDir, includingPropertiesForKeys: nil) else { return }
         let now = dataSources.now()
-        let legacyKeys = dataSources.manualSessionVisibility.unresolvedDurableLegacyKeys
         let jsonFiles = files.filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasSuffix(".tmp") }
-        let legacyEvidence = unresolvedManualHideEvidence(in: jsonFiles, legacyKeys: legacyKeys)
+        let manualHides = dataSources.manualSessionVisibility.manualHideEvidence(
+            in: jsonFiles.compactMap { url in
+                (try? Data(contentsOf: url)).flatMap { try? JSONDecoder.sessionDecoder.decode(Session.self, from: $0) }
+            }
+        )
         preloadDesktopArchiveStateForFinishedSessions(in: jsonFiles, now: now)
         var removedAny = false
         for url in jsonFiles {
-            if sweepLegacyUUIDFileIfNeeded(url, unresolvedLegacyKeys: legacyKeys, unresolvedLegacyEvidence: legacyEvidence) { continue }
+            if sweepLegacyUUIDFileIfNeeded(url, manualHides: manualHides) { continue }
             withSessionLockForMaintenance(sessionPath: url.path, sessionId: url.deletingPathExtension().lastPathComponent, action: "desktop GC") {
                 guard let data = try? Data(contentsOf: url),
                       let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data) else {
@@ -337,11 +325,7 @@ class SessionManager: ObservableObject {
                     desktopAppRunning: Self.desktopAppRunning(for: session, lookup: dataSources.desktopAppConnection)
                 )
                 guard life == .finished else { return }
-                guard !shouldRetainFinishedManualHideEvidence(
-                    session,
-                    legacyKeys: legacyKeys,
-                    legacyEvidence: legacyEvidence
-                ) else { return }
+                guard !shouldRetainFinishedManualHideEvidence(session, matching: manualHides) else { return }
                 // Re-check external archive state under the lock so a concurrent archive retains its file.
                 guard !Self.isArchivedDesktopSession(
                     session,


### PR DESCRIPTION
## Problem

The permanent-identity migration series (#221, #227, #228, #230, #231, #234, #235) accreted duplication in the identity-related logic:

- The "does this session match a manual hide" question was answered three different ways in three places — the `loadSessions` visible filter, finished-session cleanup retention, and the GC/legacy-file sweep — with `legacyKeys`/`legacyEvidence` `Set<String>` pairs threaded through six function signatures.
- The session-shaped `CctopSessionIdentityStore.durableEvidence(source:harnessSessionId:legacySessionId:)` call was spelled out five lines at a time at ~10 sites across the app and the hook.
- `persistedLegacyMigrationMatches` returned an unlabeled 4-tuple.
- The `logicalIdentity(for:).cctopSessionID` chain appeared at 8 sites without a name for the concept.

## Solution

- Add `ManualHideEvidence`, a per-pass snapshot (permanent IDs + unresolved legacy keys + their durable evidence) built once by `ManualSessionVisibilityStore.manualHideEvidence(in:)`, with a single `matches(_:)` predicate. The visible filter, cleanup retention, and sweep now agree by construction; `shouldRetainManualHideEvidence` and both `unresolvedManualHideEvidence` overloads are deleted.
- Add `CctopSessionIdentityStore.durableEvidence(for: Session)` and adopt it at all session-shaped call sites (app + hook).
- Replace the 4-tuple with a documented `PersistedLegacyMatches` struct.
- Add `SessionIdentityPolicy.permanentSessionID(for:)` naming the validated-permanent-ID lookup.

Behavior-preserving throughout: `matches(_:)` is the exact disjunction of the three original checks, and the snapshot is built after `migrateLegacyStableKeys` persists, matching the old locals. Net −45 lines.

## Verification

- `make all` green locally: swiftlint strict (0 violations), hook contract validation, both targets build, 1169 Swift tests plus the opencode/Stream Deck/pi suites (run through the isolated-state harness from #237).