### PR TITLE
Reopen recent projects in the exact Warp channel that hosted them

### DIFF
--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -82,6 +82,20 @@ enum HostApp: CaseIterable {
         return hostApp
     }
 
+    /// Stricter variant for bundle IDs that will be handed to NSWorkspace as a
+    /// launch target: only a host's canonical bundle ID or one of Warp's exact
+    /// channel bundle IDs qualifies. A merely prefix-matched ID (e.g.
+    /// `dev.warp.not-warp` planted in user-writable history) classifies as Warp
+    /// for display but must never be launched.
+    static func projectOpener(fromStoredBundleIdentifier bundleIdentifier: String?) -> HostApp? {
+        guard let bundleIdentifier,
+              let hostApp = projectOpener(fromBundleIdentifier: bundleIdentifier),
+              bundleIdentifier == hostApp.bundleID
+                || WarpFocusLink.channelBundleIDs.contains(bundleIdentifier)
+        else { return nil }
+        return hostApp
+    }
+
     var canOpenRecentProject: Bool {
         switch self {
         case .vscode, .cursor, .windsurf, .zed,

--- a/menubar/CctopMenubar/Models/RecentProject+Mock.swift
+++ b/menubar/CctopMenubar/Models/RecentProject+Mock.swift
@@ -7,6 +7,7 @@ extension RecentProject {
         daysAgo: Int = 1,
         sessionCount: Int = 3,
         editor: String? = "Cursor",
+        editorBundleId: String? = nil,
         agent: String? = "Codex",
         workspaceFile: String? = nil
     ) -> RecentProject {
@@ -17,6 +18,7 @@ extension RecentProject {
             lastSessionAt: Date().addingTimeInterval(TimeInterval(-daysAgo * 86400)),
             sessionCount: sessionCount,
             lastEditor: editor,
+            lastEditorBundleId: editorBundleId,
             lastAgent: agent,
             workspaceFile: workspaceFile
         )

--- a/menubar/CctopMenubar/Models/RecentProject.swift
+++ b/menubar/CctopMenubar/Models/RecentProject.swift
@@ -68,12 +68,12 @@ struct RecentProject: Identifiable, Equatable {
         return hostApp.displayName
     }
 
-    /// The captured bundle ID, kept only when it identifies a known project
-    /// opener on its own. History files are user-writable, so the resolver
-    /// validates again before opening anything with it.
+    /// The captured bundle ID, kept only when it is an exact known project-opener
+    /// bundle ID (canonical host or Warp channel). History files are user-writable,
+    /// so the resolver validates again before opening anything with it.
     static func projectOpenerBundleId(from terminal: TerminalInfo?) -> String? {
         guard let bundleId = terminal?.bundleId,
-              HostApp.projectOpener(fromBundleIdentifier: bundleId) != nil else { return nil }
+              HostApp.projectOpener(fromStoredBundleIdentifier: bundleId) != nil else { return nil }
         return bundleId
     }
 

--- a/menubar/CctopMenubar/Models/RecentProject.swift
+++ b/menubar/CctopMenubar/Models/RecentProject.swift
@@ -7,6 +7,10 @@ struct RecentProject: Identifiable, Equatable {
     let lastSessionAt: Date
     let sessionCount: Int
     let lastEditor: String?
+    /// Captured host bundle ID, kept alongside the display name because one name
+    /// can cover several bundle IDs (Warp release channels). Defaults to nil so
+    /// legacy history projections keep name-based opening.
+    var lastEditorBundleId: String?
     let lastAgent: String?
     let workspaceFile: String?
 
@@ -62,6 +66,15 @@ struct RecentProject: Identifiable, Equatable {
     static func projectOpenerName(from terminal: TerminalInfo?) -> String? {
         guard let hostApp = projectOpener(from: terminal) else { return nil }
         return hostApp.displayName
+    }
+
+    /// The captured bundle ID, kept only when it identifies a known project
+    /// opener on its own. History files are user-writable, so the resolver
+    /// validates again before opening anything with it.
+    static func projectOpenerBundleId(from terminal: TerminalInfo?) -> String? {
+        guard let bundleId = terminal?.bundleId,
+              HostApp.projectOpener(fromBundleIdentifier: bundleId) != nil else { return nil }
+        return bundleId
     }
 
     static func agentName(from session: Session) -> String? {

--- a/menubar/CctopMenubar/Models/Session.swift
+++ b/menubar/CctopMenubar/Models/Session.swift
@@ -112,6 +112,11 @@ struct WarpFocusLink: Equatable {
         "warposs": "dev.warp.WarpOss"
     ]
 
+    /// The exact bundle IDs Warp ships, one per release channel. Stored opener
+    /// bundle IDs are checked against this set so a prefix-matched impostor in
+    /// user-writable data can never become a launch target.
+    static let channelBundleIDs: Set<String> = Set(bundleIDsByScheme.values)
+
     let url: URL
     let bundleID: String
 

--- a/menubar/CctopMenubar/Services/FocusTerminal+Recent.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal+Recent.swift
@@ -1,9 +1,14 @@
 import Foundation
 
 func resolveRecentProjectOpenStrategy(project: RecentProject) -> FocusStrategy {
-    guard let opener = project.lastEditor,
-          let hostApp = HostApp.projectOpener(fromProgramName: opener),
-          let bundleID = hostApp.bundleID else {
+    // Prefer the captured bundle ID over the display name when it identifies a
+    // known project opener on its own: one name can cover several bundle IDs
+    // (Warp release channels all display as "Warp"), and only the captured ID
+    // reopens the exact app that hosted the session. An unrecognized stored ID
+    // (tampered history, uninstalled fork) falls back to the name-derived app.
+    let storedOpener = HostApp.projectOpener(fromBundleIdentifier: project.lastEditorBundleId)
+    guard let hostApp = storedOpener ?? HostApp.projectOpener(fromProgramName: project.lastEditor),
+          let bundleID = storedOpener != nil ? project.lastEditorBundleId : hostApp.bundleID else {
         return .openInFinder(project.projectPath)
     }
 

--- a/menubar/CctopMenubar/Services/FocusTerminal+Recent.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal+Recent.swift
@@ -6,7 +6,7 @@ func resolveRecentProjectOpenStrategy(project: RecentProject) -> FocusStrategy {
     // (Warp release channels all display as "Warp"), and only the captured ID
     // reopens the exact app that hosted the session. An unrecognized stored ID
     // (tampered history, uninstalled fork) falls back to the name-derived app.
-    let storedOpener = HostApp.projectOpener(fromBundleIdentifier: project.lastEditorBundleId)
+    let storedOpener = HostApp.projectOpener(fromStoredBundleIdentifier: project.lastEditorBundleId)
     guard let hostApp = storedOpener ?? HostApp.projectOpener(fromProgramName: project.lastEditor),
           let bundleID = storedOpener != nil ? project.lastEditorBundleId : hostApp.bundleID else {
         return .openInFinder(project.projectPath)

--- a/menubar/CctopMenubar/Services/HistoryManager.swift
+++ b/menubar/CctopMenubar/Services/HistoryManager.swift
@@ -119,6 +119,7 @@ class HistoryManager: ObservableObject {
                     lastSessionAt: entry.latest.effectiveEndDate,
                     sessionCount: entry.count,
                     lastEditor: RecentProject.projectOpenerName(from: entry.latest.terminal),
+                    lastEditorBundleId: RecentProject.projectOpenerBundleId(from: entry.latest.terminal),
                     lastAgent: RecentProject.agentName(from: entry.latest),
                     workspaceFile: entry.latest.workspaceFile
                 )

--- a/menubar/CctopMenubarTests/FocusTerminalTests.swift
+++ b/menubar/CctopMenubarTests/FocusTerminalTests.swift
@@ -168,6 +168,16 @@ final class FocusTerminalTests: XCTestCase {
         )
     }
 
+    func testRecentProjectWarpPrefixImpostorBundleIdFallsBackToName() {
+        // dev.warp.* classifies as Warp for display, but only the four exact
+        // channel bundle IDs may be launched from stored history.
+        let project = RecentProject.mock(editor: "Warp", editorBundleId: "dev.warp.not-warp")
+        XCTAssertEqual(
+            resolveRecentProjectOpenStrategy(project: project),
+            .openWithApp(bundleID: "dev.warp.Warp-Stable", target: project.projectPath)
+        )
+    }
+
     func testRecentProjectKnownEditorOpensWorkspaceFileWithApp() {
         let workspaceFile = "/Users/dev/projects/my-project/my-project.code-workspace"
         let project = RecentProject.mock(editor: "Cursor", workspaceFile: workspaceFile)

--- a/menubar/CctopMenubarTests/FocusTerminalTests.swift
+++ b/menubar/CctopMenubarTests/FocusTerminalTests.swift
@@ -138,6 +138,36 @@ final class FocusTerminalTests: XCTestCase {
         )
     }
 
+    func testRecentProjectPrefersStoredWarpChannelBundleId() {
+        // All Warp channels display as "Warp"; the stored bundle ID reopens the
+        // exact channel that hosted the session instead of hard-coded stable.
+        let project = RecentProject.mock(editor: "Warp", editorBundleId: "dev.warp.Warp-Preview")
+        XCTAssertEqual(
+            resolveRecentProjectOpenStrategy(project: project),
+            .openWithApp(bundleID: "dev.warp.Warp-Preview", target: project.projectPath)
+        )
+    }
+
+    func testRecentProjectWithoutStoredBundleIdKeepsNameDerivedApp() {
+        // Legacy history projections have no bundle ID; names keep resolving to
+        // the canonical bundle as before.
+        let project = RecentProject.mock(editor: "Warp")
+        XCTAssertEqual(
+            resolveRecentProjectOpenStrategy(project: project),
+            .openWithApp(bundleID: "dev.warp.Warp-Stable", target: project.projectPath)
+        )
+    }
+
+    func testRecentProjectUnrecognizedStoredBundleIdFallsBackToName() {
+        // History files are user-writable; an unrecognized bundle ID must never
+        // launch an arbitrary app, only the name-derived one.
+        let project = RecentProject.mock(editor: "Warp", editorBundleId: "com.evil.app")
+        XCTAssertEqual(
+            resolveRecentProjectOpenStrategy(project: project),
+            .openWithApp(bundleID: "dev.warp.Warp-Stable", target: project.projectPath)
+        )
+    }
+
     func testRecentProjectKnownEditorOpensWorkspaceFileWithApp() {
         let workspaceFile = "/Users/dev/projects/my-project/my-project.code-workspace"
         let project = RecentProject.mock(editor: "Cursor", workspaceFile: workspaceFile)

--- a/menubar/CctopMenubarTests/HistoryManagerTests.swift
+++ b/menubar/CctopMenubarTests/HistoryManagerTests.swift
@@ -236,6 +236,34 @@ final class HistoryManagerTests: XCTestCase {
         XCTAssertEqual(result[0].projectName, "app")
     }
 
+    func testBuildRecentProjectsKeepsWarpChannelBundleId() {
+        // tmux inside Warp Preview: the display name collapses to "Warp", so only
+        // the captured bundle ID identifies which channel to reopen.
+        let sessions = [
+            mockSession(project: "app", endedAt: Date(), terminal: TerminalInfo(
+                program: "tmux", bundleId: "dev.warp.Warp-Preview"
+            )),
+        ]
+        let result = recentProjects(from: sessions)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].lastEditor, "Warp")
+        XCTAssertEqual(result[0].lastEditorBundleId, "dev.warp.Warp-Preview")
+    }
+
+    func testBuildRecentProjectsDropsBundleIdThatIsNotAProjectOpener() {
+        // cmux is a recognized host but cannot reopen projects, so its bundle ID
+        // must not be stored as an opener; the program name still resolves one.
+        let sessions = [
+            mockSession(project: "app", endedAt: Date(), terminal: TerminalInfo(
+                program: "Code", bundleId: "com.cmuxterm.app"
+            )),
+        ]
+        let result = recentProjects(from: sessions)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].lastEditor, "VS Code")
+        XCTAssertNil(result[0].lastEditorBundleId)
+    }
+
     func testBuildRecentProjectsExcludesActive() {
         let now = Date()
         let sessions = [

--- a/menubar/CctopMenubarTests/HistoryManagerTests.swift
+++ b/menubar/CctopMenubarTests/HistoryManagerTests.swift
@@ -250,6 +250,20 @@ final class HistoryManagerTests: XCTestCase {
         XCTAssertEqual(result[0].lastEditorBundleId, "dev.warp.Warp-Preview")
     }
 
+    func testBuildRecentProjectsDropsWarpPrefixImpostorBundleId() {
+        // A dev.warp.* value that is not one of Warp's four exact channel bundle
+        // IDs still displays as Warp but is never stored as a launch target.
+        let sessions = [
+            mockSession(project: "app", endedAt: Date(), terminal: TerminalInfo(
+                program: "WarpTerminal", bundleId: "dev.warp.not-warp"
+            )),
+        ]
+        let result = recentProjects(from: sessions)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].lastEditor, "Warp")
+        XCTAssertNil(result[0].lastEditorBundleId)
+    }
+
     func testBuildRecentProjectsDropsBundleIdThatIsNotAProjectOpener() {
         // cmux is a recognized host but cannot reopen projects, so its bundle ID
         // must not be stored as an opener; the program name still resolves one.


### PR DESCRIPTION
> [!NOTE]
> Stacked on #244 (it moved `resolveRecentProjectOpenStrategy` into `FocusTerminal+Recent.swift` and added the `dev.warp.*` bundle recognition this change relies on). GitHub retargets this PR to `master` automatically once #244 merges and its branch is deleted.

## Problem

Recent Projects stores only a display name for the terminal that hosted a session (`lastEditor`, e.g. `"Warp"`), and reopening maps that name back to a hard-coded canonical bundle ID. Warp is the one supported host where a single display name covers several bundle IDs — its release channels ship as `dev.warp.Warp-Stable`, `dev.warp.Warp-Preview`, `dev.warp.Warp-Dev`, and `dev.warp.WarpOss` ([warpdotdev/warp `script/macos/bundle`](https://github.com/warpdotdev/warp/blob/main/script/macos/bundle)). So a project whose sessions ran in Warp Preview reopens in stable Warp when both are installed, or falls back to Finder. Raised by [a Codex review comment on #244](https://github.com/st0012/cctop/pull/244#discussion_r3711536258); the conflation predates #244 for the common `TERM_PROGRAM=WarpTerminal` case.

No history-schema change is needed: history files are full archived `Session` JSONs and already persist `terminal.bundle_id`. The channel was lost only in the in-memory Recent Projects projection, which means the fix also applies retroactively to previously archived sessions.

## Solution

- `buildRecentProjects` carries the captured bundle ID into `RecentProject.lastEditorBundleId`, kept only when it independently resolves to a known project opener (`HostApp.projectOpener(fromBundleIdentifier:)`), so desktop apps, cmux, and unknown bundles are dropped at projection time.
- `resolveRecentProjectOpenStrategy` prefers the stored bundle ID when it validates as a project opener, and otherwise keeps today's name-derived resolution. History files are user-writable, so an unrecognized bundle ID can never launch an arbitrary app — it falls back to the name-derived one.
- Projections without a bundle ID (legacy or non-opener hosts) behave exactly as before.

## Verification

- `make all` (swiftlint strict, hook contract, both builds, full suite): 1191/1191 Swift tests pass.
- New tests cover the preview-channel round-trip through the projection (`tmux` inside Warp Preview archives as `lastEditor: "Warp"` + `lastEditorBundleId: "dev.warp.Warp-Preview"` and reopens with the preview bundle), the cmux bundle being dropped as a non-opener, legacy nil-field behavior staying name-based, and an unrecognized stored bundle ID falling back instead of launching.