### PR TITLE
Name session actions by their focus behavior

### DIFF
--- a/menubar/CctopMenubar/Views/PopupView+Sessions.swift
+++ b/menubar/CctopMenubar/Views/PopupView+Sessions.swift
@@ -1,5 +1,46 @@
 import SwiftUI
 
+extension FocusStrategy {
+    var actionTitle: String {
+        switch self {
+        case .openWithApp(let bundleID, _):
+            let name = HostApp.from(bundleIdentifier: bundleID)?.displayName ?? "App"
+            return "Open Project in \(name)"
+        case .iTerm2:
+            return "Focus iTerm2 Pane"
+        case .kitty:
+            return "Focus Kitty Window"
+        case .ghostty:
+            return "Focus Ghostty Terminal"
+        case .appleTerminal:
+            return "Focus Terminal Tab"
+        case .activateByName(let name):
+            let host = HostApp.from(editorName: name)
+            if host == .cmux { return "Focus cmux" }
+            let displayName = host == .unknown ? name : host.displayName
+            return "Bring \(displayName) Forward"
+        case .activateByBundleID(let bundleID):
+            let host = HostApp.from(bundleIdentifier: bundleID)
+            if host == .cmux { return "Focus cmux" }
+            let name = host?.displayName ?? "App"
+            return "Bring \(name) Forward"
+        case .openURL(let url, _):
+            if url.scheme?.lowercased() == "codex" {
+                return "Focus Codex Task"
+            }
+            if url.scheme?.lowercased() == "cmux" {
+                let target = url.pathComponents.contains("surface") ? "Surface" : "Pane"
+                return "Focus cmux \(target)"
+            }
+            return "Open Session"
+        case .openInFinder:
+            return "Open Project in Finder"
+        case .unavailable:
+            return "Why Focus Is Unavailable"
+        }
+    }
+}
+
 struct PanelSessionRow: Identifiable {
     let slot: Int
     let session: Session
@@ -76,7 +117,9 @@ extension PopupView {
     }
 
     private func sessionRow(_ row: PanelSessionRow, showNavigateNumbers: Bool) -> some View {
-        SessionCardView(
+        let focusStrategy = resolveFocusStrategy(session: row.session)
+        let focusActionTitle = focusStrategy.actionTitle
+        return SessionCardView(
             session: row.session,
             navigateIndex: showNavigateNumbers && isNavigateActive ? row.slot + 1 : nil,
             showSourceBadge: hasMultipleSources,
@@ -87,10 +130,15 @@ extension PopupView {
         .onTapGesture { focusSession(row.session) }
         .contextMenu {
             Button { focusSession(row.session) } label: {
-                Label("Jump to Terminal", systemImage: "terminal")
+                Label(focusActionTitle, systemImage: "scope")
             }
-            Button { openInFinder(path: row.session.projectPath) } label: {
-                Label("Open in Finder", systemImage: "folder")
+            switch focusStrategy {
+            case .openInFinder:
+                EmptyView()
+            default:
+                Button { openInFinder(path: row.session.projectPath) } label: {
+                    Label("Open in Finder", systemImage: "folder")
+                }
             }
             Button { copyPath(row.session.projectPath) } label: {
                 Label("Copy Project Path", systemImage: "doc.on.doc")
@@ -101,7 +149,7 @@ extension PopupView {
             }
             .disabled(!Session.isValidCctopSessionId(row.session.cctopSessionId))
         }
-        .help("Click to jump to session")
+        .help(focusActionTitle)
         .accessibilityActions {
             Button("Hide Session") { requestHideSession(row.session) }
                 .disabled(!Session.isValidCctopSessionId(row.session.cctopSessionId))

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -25,6 +25,31 @@ final class FocusStrategyTests: XCTestCase {
         )
     }
 
+    func testActionTitleDescribesResolvedFocusBehavior() throws {
+        let codexURL = try XCTUnwrap(URL(string: "codex://threads/019e1eff-3374-74b0-8d3d-6fba94e7d75f"))
+
+        XCTAssertEqual(FocusStrategy.openURL(codexURL).actionTitle, "Focus Codex Task")
+        XCTAssertEqual(FocusStrategy.iTerm2(guid: "ABC-123").actionTitle, "Focus iTerm2 Pane")
+        XCTAssertEqual(FocusStrategy.appleTerminal(tty: "/dev/ttys003").actionTitle, "Focus Terminal Tab")
+        XCTAssertEqual(
+            FocusStrategy.ghostty(GhosttyFocusTarget(tty: nil, matchDirectory: projectPath, restoreDirectory: nil)).actionTitle,
+            "Focus Ghostty Terminal"
+        )
+        XCTAssertEqual(FocusStrategy.activateByName("cmux").actionTitle, "Focus cmux")
+        let cmuxBundleID = try XCTUnwrap(HostApp.cmux.bundleID)
+        XCTAssertEqual(FocusStrategy.activateByBundleID(cmuxBundleID).actionTitle, "Focus cmux")
+        XCTAssertEqual(
+            FocusStrategy.openWithApp(bundleID: "com.microsoft.VSCode", target: projectPath).actionTitle,
+            "Open Project in VS Code"
+        )
+        XCTAssertEqual(
+            FocusStrategy.activateByBundleID(HostAppBundleID.claudeDesktop).actionTitle,
+            "Bring Claude Desktop Forward"
+        )
+        XCTAssertEqual(FocusStrategy.openInFinder(projectPath).actionTitle, "Open Project in Finder")
+        XCTAssertEqual(FocusStrategy.unavailable(.codexTaskIdentifierInvalid).actionTitle, "Why Focus Is Unavailable")
+    }
+
     // MARK: - Editors use openWithApp (not Process/env)
 
     func testVSCodeUsesOpenWithApp() {


### PR DESCRIPTION
Session context menus now name the action that will actually run, such as Focus Codex Task, Focus iTerm2 Pane, or Open Project in Finder. Finder remains a separate action when it is not already the primary route.