### PR TITLE
Use truthful integration status labels

### DIFF
--- a/menubar/CctopMenubar/Views/CodexPluginRowView.swift
+++ b/menubar/CctopMenubar/Views/CodexPluginRowView.swift
@@ -273,8 +273,8 @@ private struct CodexHookTrustInstructions: View {
     }
 }
 
-/// Trusted-hooks badge for the Codex row. "Ready" rather than "Connected":
-/// trusted hooks mean tracking will work, not that a session is live.
+/// Trusted-hooks badge for the Codex row. "Ready" rather than "Installed":
+/// trusted hooks mean tracking will work, not merely that hook files exist.
 struct HooksReadyBadge: View {
     var body: some View {
         StatusDotBadge(text: "Ready")

--- a/menubar/CctopMenubar/Views/EmptyStateView.swift
+++ b/menubar/CctopMenubar/Views/EmptyStateView.swift
@@ -16,7 +16,7 @@ struct EmptyStateView: View {
             heroMark
             heroCopy
             agentCard
-            if anyUninstalled {
+            if setupNeeded {
                 restartHint
             }
         }
@@ -60,7 +60,7 @@ struct EmptyStateView: View {
     }
 
     private var subtitle: String {
-        if allConnected {
+        if setupComplete {
             return "Start a session \u{2014} it will appear here automatically."
         }
         if codexHooksDisabled {
@@ -174,7 +174,7 @@ struct EmptyStateView: View {
         if agent == .codex {
             HooksReadyBadge()
         } else {
-            ConnectedBadge()
+            InstalledBadge()
         }
     }
 
@@ -274,14 +274,14 @@ struct EmptyStateView: View {
 
     // MARK: - Derived state
 
-    private var anyUninstalled: Bool {
+    private var setupNeeded: Bool {
         AgentKind.allCases.contains {
             isDetected($0) && (!isInstalled($0) || needsUpdate($0) || needsHookTrust($0))
         }
     }
 
-    private var allConnected: Bool {
-        !anyUninstalled
+    private var setupComplete: Bool {
+        !setupNeeded
     }
 
     private var codexHooksUntrusted: Bool {
@@ -398,7 +398,7 @@ private func previewPluginManager(
     .background(Color.panelBackground)
 }
 
-#Preview("All connected") {
+#Preview("All installed") {
     EmptyStateView(
         pluginManager: previewPluginManager(
             cc: true,

--- a/menubar/CctopMenubar/Views/SettingsControls.swift
+++ b/menubar/CctopMenubar/Views/SettingsControls.swift
@@ -38,7 +38,7 @@ struct StatusDotBadge: View {
     }
 }
 
-struct ConnectedBadge: View { var body: some View { StatusDotBadge(text: "Connected") } }
+struct InstalledBadge: View { var body: some View { StatusDotBadge(text: "Installed") } }
 
 struct AmberSegmentedPicker<Value: Hashable>: View {
     let options: [(value: Value, label: String)]

--- a/menubar/CctopMenubar/Views/SettingsSection+Preview.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection+Preview.swift
@@ -34,7 +34,7 @@ private func previewPendingCodexTrustPM() -> PluginManager {
     SettingsSection(updater: DisabledUpdater(), pluginManager: previewBasePM()).frame(width: 320).padding()
 }
 
-#Preview("All connected") {
+#Preview("All installed") {
     SettingsSection(updater: DisabledUpdater(), pluginManager: previewPM()).frame(width: 320).padding()
 }
 

--- a/menubar/CctopMenubar/Views/SettingsSection.swift
+++ b/menubar/CctopMenubar/Views/SettingsSection.swift
@@ -386,7 +386,7 @@ private struct PluginRowView: View {
             } else if needsUpdate {
                 updateButton
             } else if installed {
-                ConnectedBadge()
+                InstalledBadge()
                 Button { if !remove() { flashFailed() } } label: {
                     Text("Remove").font(.system(size: 10))
                         .foregroundStyle(removeHovered ? Color.textPrimary : Color.textMuted)
@@ -423,7 +423,7 @@ private struct ClaudeCodePluginRowView: View {
                 .foregroundStyle(Color.textPrimary)
             Spacer()
             if pluginManager.ccInstalled {
-                ConnectedBadge()
+                InstalledBadge()
             } else {
                 ClaudeCodeInstallButton()
             }

--- a/menubar/CctopMenubar/Views/StreamDeckPluginRowView.swift
+++ b/menubar/CctopMenubar/Views/StreamDeckPluginRowView.swift
@@ -27,7 +27,7 @@ struct StreamDeckPluginRowView: View {
             if pluginManager.sdNeedsUpdate {
                 installButton("Update Plugin")
             } else if pluginManager.sdInstalled {
-                ConnectedBadge()
+                InstalledBadge()
                 removeButton
             } else {
                 installButton("Install Plugin")


### PR DESCRIPTION
Settings now distinguish installation from readiness. Claude Code, opencode, pi, and Stream Deck use Installed when present, while Codex retains Ready for its stronger hook-trust state. Existing update controls remain unchanged.