### PR TITLE
Separate session data from user sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Keep canonical repository guidance in this file. Pointer files, such as `CLAUDE.
 - Keep app liveness, client liveness, visibility, archive state, hidden state, subagent state, and hook provenance separate.
 - If a shared source changes, update all owners in the same change. Shared sources include schemas, hook versions, install paths, and release tooling.
 - For every version change, run `scripts/bump-version.sh <version>`. Do not edit version values separately.
-- Preserve the canonical order from `SessionManager.sessions`. A direct row action must use the exact current observation that the row shows.
+- Preserve the canonical order from `SessionManager.sessions`. A direct row action must use the exact `SessionData` value that the row shows.
 - Keep Stream Deck downstream of the app. It reads `~/.cctop/display-state.json` and must not recreate session policy.
 
 ## Driver Workflow

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -13,12 +13,12 @@ Type: `string` (lowercase UUID)
 Default: absent only on legacy records awaiting migration.
 
 `cctop_session_id` is an opaque identifier generated and owned by cctop for a
-logical session. It is random: it is never derived from the client, title,
+user session. It is random: it is never derived from the client, title,
 project path, prompt or transcript content, PID, process generation, terminal,
 window, or focus target. When a client supplies a supported durable resume
 reference, the value remains stable across cctop and client restarts on the
 same machine while cctop's local identity data remains. Otherwise it is
-permanent only for that observed record.
+permanent only for that session record.
 
 For supported resume contracts, cctop keeps a private UUID-only mapping under
 `~/.cctop/session-identities/`. Mapping filenames hash the source-scoped client
@@ -63,47 +63,109 @@ may replace a PID-keyed record only through `SessionStart`-driven rotation.
 |---|---|---|
 | Codex CLI/Desktop | Yes | The client supplies the same UUID conversation reference across process generations. |
 | Claude Code/Desktop | Yes when a UUID session reference is available | Claude session/transcript state preserves that UUID across resume. |
-| pi | Yes only when `getSessionId()` supplies a real UUID | Synthetic `pi-<pid>` fallback observations remain record-local. |
+| pi | Yes only when `getSessionId()` supplies a real UUID | Synthetic `pi-<pid>` fallback records remain separate. |
 | OpenCode | Not yet | The plugin intentionally uses a process-scoped synthetic reference until per-event session routing is reliable. |
 
-Every newly observed record still receives a `cctop_session_id`; “not yet” means
-cctop cannot promise that a later reopened observation will recover the same
-one. References are always source-scoped. cctop never infers that conversations
+Every new session record still receives a `cctop_session_id`. “Not yet” means
+that cctop cannot promise the same ID for a later reopened record.
+References are always source-scoped. cctop never infers that conversations
 from different clients contain the same content.
+
+### Internal session model
+
+The names separate decoded data from the work session that the user sees.
+
+- `SessionData` is the Codable payload model for one hook-owned JSON file.
+- `SessionRecord` contains one `SessionData` value plus file and runtime evidence.
+- One or more related `SessionRecord` values form a `UserSession`.
+- `displayRecord.data` supplies the visible row and the current target for indirect actions.
+
+`SessionDataCleanupSource` is a cleanup-only projection derived from
+`SessionData`. It is not a persisted `SessionRecord` or a `UserSession`.
+
+The selected winner's valid `cctop_session_id` becomes the permanent identity
+of at most one current `UserSession`. More than one `SessionRecord` can carry
+that ID because one work session can have more than one file or host record.
+Older retained records can contain a stale or conflicting ID, but they do not
+redefine the current group. Hidden and finished records do not form a current
+`UserSession`, even when they carry an ID.
+
+The hook and identity store assign the ID to `SessionData` before the app forms
+`UserSession`. `CctopSessionID` owns ID creation and validation. `SessionData`
+only carries the serialized value.
+
+`SessionData.lifecycle` is an existing display overlay. cctop derives it after
+decode and never writes it to JSON. `SessionRecord` also stores the lifecycle
+comparison rank, file path, and modification time. The record is not a
+persisted schema.
+
+`SessionData` replaces the old `Session` type name. The value describes one
+file payload, not the full work session that the user sees. `SessionRecord`
+replaces the old “observation” name because “record” describes its role more
+clearly.
+
+`SessionDataSources` is a separate dependency container for `SessionManager`.
+It is not part of this three-layer model.
+
+`UserSession` means one current, user-visible work session. It is not a user
+account, a stored schema, or a client connection.
+
+A work session can move between CLI and desktop surfaces of the same supported
+client when both records have matching identity evidence. cctop never groups
+different clients by project, title, prompt, or transcript content.
+
+`LogicalIdentity` remains the name of the grouping rule. It uses the winner's
+permanent cctop ID when that ID is valid. An unstamped legacy record uses a safe
+fallback until it receives a permanent ID. It is not a separate session type.
+
+Stable-key selection first chooses one authoritative record for each host
+conversation. That record sets the group identity. Older related records remain
+attached as evidence, even when their identity data is stale.
+
+`SessionManager.sessions` remains the canonical visible row order. It contains
+the selected `SessionData` from each visible `UserSession`.
+
+Direct row actions keep the exact rendered `SessionData`. Indirect URL,
+notification, hide, and keyboard actions resolve the current `UserSession` and
+fail closed when the identity evidence is missing, invalid, or ambiguous.
+
+Hidden, archived, finished, and cleanup-only records do not automatically enter
+the `UserSession` projection.
 
 ### Stream Deck routing
 
 Display-state schema v2 publishes `cctop_session_id` for every session row.
 Stream Deck caches the ID that a key rendered, so a press cannot accidentally
 target an unrelated session that moved into the same slot. cctop then resolves
-that permanent session ID against current observations from canonical
-`SessionManager.sessions`. It focuses the first matching current observation in
-canonical panel order. If no current observation matches, cctop records a
-privacy-safe stale-state diagnostic, performs exactly one synchronous canonical
-reload and one re-resolution, then fails closed if the target is still missing.
-It never falls back to a client conversation reference, PID, or display slot.
+that permanent session ID to the canonical `UserSession`. It focuses the
+session's `focusTarget`, which is the `displayRecord.data` selected by the
+existing lifecycle preference. If no current user session matches, cctop records
+a privacy-safe stale-state diagnostic. It performs one canonical reload and one
+re-resolution, then fails closed if the target is still missing. It never falls
+back to a client conversation reference, PID, or display slot.
 
-`SessionManager` collapses visible observations with the same logical identity
+`SessionManager` collapses visible records with the same logical identity
 into one panel row before applying its existing status-group ordering. The first
-logical row position is retained while the existing lifecycle preference chooses
-the current observation. Panel, URL focus, DisplayStateWriter, and Stream Deck
+user-session row position is retained while the existing lifecycle preference
+chooses the display record. Panel, URL focus, DisplayStateWriter, and Stream Deck
 then consume that canonical order. DisplayStateWriter never independently sorts,
 deduplicates, or removes manager rows, so its slots remain a one-to-one projection.
 
-A direct pointer or context-menu action focuses the exact current observation
+A direct pointer or context-menu action focuses the exact current record
 rendered in that row. Keyboard selection instead retains logical identity and
-resolves it against current panel observations, so reloads, focus-target changes,
+resolves it against current user sessions, so reloads, focus-target changes,
 and status-group movement cannot retarget selection by row index. Navigate-mode
 number slots freeze those identities at activation; a missing identity leaves its
 original number unusable rather than shifting a later conversation into that slot.
 
 This version does not offer user-selectable routing among multiple simultaneous
-focus targets. Observations sharing one ID form one logical panel row, and a
-permanent-ID resolver supplied with multiple current observations uses the first
-match in canonical panel order. This is the temporary single-target policy.
-Future support extends the resolver with an explicit selection policy rather than
-changing logical identity, lifecycle/liveness classification, canonical order,
-or terminal/window execution.
+focus targets. Records sharing one ID form one user-session row. The
+permanent-ID resolver finds that canonical `UserSession` and uses its
+`displayRecord` as the focus target. The existing lifecycle preference selects
+that record. This is the temporary single-target policy. Future support extends
+the resolver with an explicit selection policy rather than changing logical
+identity, lifecycle/liveness classification, canonical order, or terminal/window
+execution.
 Cross-client equivalence and cross-machine identity are out of scope. Manual
 hiding and notification grouping use `cctop_session_id`. Archived desktop Recent
 rows also prefer it for logical row identity; path-based Recent Projects, Cleanup,
@@ -199,7 +261,7 @@ available until the record is removed externally.
 Upgrades migrate an unambiguous legacy Codex or desktop key to its permanent
 `cctop_session_id` before building the visible projection. The canonical source
 and session UUID in the key can adopt the sole permanent ID already stamped on
-a peer even after the exact legacy observation disappears. Partial inventories
+a peer even after the exact legacy record disappears. Partial inventories
 retain the fallback; zero or multiple matching permanent IDs keep every current
 candidate hidden and the visibility projections frozen. Complete inventories
 retire disk-confirmed migrations and proven-missing keys. Process/PID keys are

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -17,23 +17,32 @@ The key split is intentional:
 
 ## Display Pipeline
 
+This pipeline uses the internal model from
+[`session-files.md`](session-files.md#internal-session-model). The grouping step
+does not change lifecycle, persistence, or canonical row order.
+
 ```mermaid
 flowchart TD
-    A["Session .json files"] --> B["Decode records"]
-    B --> C["Build SessionClassificationSnapshot<br/>lifecycle + host metadata"]
-    C --> D{"Disposition"}
+    A["Session JSON files"] --> B["Decode as SessionData"]
+    B --> C["Create SessionRecord<br/>SessionData + file and runtime evidence"]
+    C --> D["Build SessionClassificationSnapshot<br/>lifecycle + host metadata"]
+    D --> E{"Disposition"}
 
-    D -->|"archived Codex thread"| E["Hide active/dormant record<br/>preserve .json"]
-    D -->|"archived Claude Desktop session"| E
-    D -->|"archived Codex or Claude Desktop + known project path"| L["Emit cleanup source<br/>preserve .json"]
-    D -->|"subagent-owned session"| K["Mark hidden<br/>preserve .json"]
-    D -->|"Claude orphan startup record"| E
-    D -->|"display record"| F["Deduplicate by stable key"]
+    E -->|"archived Codex thread"| F["Hide active/dormant record<br/>preserve .json"]
+    E -->|"archived Claude Desktop session"| F
+    E -->|"archived Codex or Claude Desktop + known project path"| M["Emit cleanup source<br/>preserve .json"]
+    E -->|"subagent-owned session"| L["Mark hidden<br/>preserve .json"]
+    E -->|"Claude orphan startup record"| F
+    E -->|"display record"| G["Select stable-key winners"]
 
-    F --> G{"Winner lifecycle"}
-    G -->|active| H["Publish active session"]
-    G -->|dormant| I["Publish dormant session<br/>neutral status, no notifications"]
-    G -->|finished| J["Do not publish"]
+    G --> H{"Winner lifecycle"}
+    H -->|finished| O["Do not publish"]
+    H -->|active| I["Group current records into UserSession<br/>using the winner's cctop ID or legacy fallback"]
+    H -->|dormant| I
+    I --> J["Choose displayRecord<br/>and preserve canonical row order"]
+    J --> K{"Display lifecycle"}
+    K -->|active| N["Publish through SessionManager.sessions<br/>as active"]
+    K -->|dormant| P["Publish through SessionManager.sessions<br/>as dormant, with neutral status"]
 ```
 
 ## Lifecycle Derivation

--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -13,8 +13,8 @@
 		TOMLDEC0100000000000002 /* TOMLDecoder in Frameworks */ = {isa = PBXBuildFile; productRef = TOMLDEC0300000000000002 /* TOMLDecoder */; };
 		A10000010000000000000001 /* CctopApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000001 /* CctopApp.swift */; };
 		AC0000010000000000000001 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AC0000020000000000000001 /* Assets.xcassets */; };
-		B10000010000000000000001 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000020000000000000001 /* Session.swift */; };
-		SNC000010000000000000001 /* Session+NotificationContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = SNC000020000000000000001 /* Session+NotificationContent.swift */; };
+		B10000010000000000000001 /* SessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000020000000000000001 /* SessionData.swift */; };
+		SNC000010000000000000001 /* SessionData+NotificationContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = SNC000020000000000000001 /* SessionData+NotificationContent.swift */; };
 		B10000030000000000000001 /* SessionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000040000000000000001 /* SessionStatus.swift */; };
 		C10000010000000000000001 /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000020000000000000001 /* SessionManager.swift */; };
 		D10000010000000000000001 /* StatusChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000020000000000000001 /* StatusChip.swift */; };
@@ -33,7 +33,7 @@
 		EMUX0010000000000000001 /* FocusTerminal+Multiplexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EMUX0020000000000000001 /* FocusTerminal+Multiplexer.swift */; };
 		ERCT00010000000000000001 /* FocusTerminal+Recent.swift in Sources */ = {isa = PBXBuildFile; fileRef = ERCT00020000000000000001 /* FocusTerminal+Recent.swift */; };
 		EK0000010000000000000001 /* HostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EK0000020000000000000001 /* HostApp.swift */; };
-		F10000010000000000000001 /* Session+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000020000000000000001 /* Session+Mock.swift */; };
+		F10000010000000000000001 /* SessionData+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000020000000000000001 /* SessionData+Mock.swift */; };
 		FK0000010000000000000001 /* ForkSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FK0000020000000000000001 /* ForkSessionTests.swift */; };
 		FT0000010000000000000001 /* WorkspaceFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT0000020000000000000001 /* WorkspaceFileTests.swift */; };
 		FT0000010000000000000002 /* FocusTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT0000020000000000000002 /* FocusTerminalTests.swift */; };
@@ -79,7 +79,7 @@
 		P10000030000000000000001 /* HookInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = P10000040000000000000001 /* HookInput.swift */; };
 		P10000050000000000000001 /* HookHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = P10000060000000000000001 /* HookHandler.swift */; };
 		P10000070000000000000001 /* HookLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = P10000080000000000000001 /* HookLogger.swift */; };
-		P10000090000000000000001 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000020000000000000001 /* Session.swift */; };
+		P10000090000000000000001 /* SessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000020000000000000001 /* SessionData.swift */; };
 		HM0000010000000000000001 /* HistoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = HM0000020000000000000001 /* HistoryManager.swift */; };
 		JM0000010000000000000001 /* NavigateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = JM0000020000000000000001 /* NavigateController.swift */; };
 		PC0000010000000000000001 /* PanelCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = PC0000020000000000000001 /* PanelCoordinator.swift */; };
@@ -150,6 +150,7 @@
 		WCT000010000000000000001 /* WorktreeCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = WCT000020000000000000001 /* WorktreeCleanupTests.swift */; };
 		SLP000010000000000000001 /* SessionLifecyclePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = SLP000020000000000000001 /* SessionLifecyclePolicy.swift */; };
 		SIP000010000000000000001 /* SessionIdentityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = SIP000020000000000000001 /* SessionIdentityPolicy.swift */; };
+		LGS000010000000000000001 /* UserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = LGS000020000000000000001 /* UserSession.swift */; };
 		CSI000010000000000000001 /* CctopSessionIdentityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CSI000030000000000000001 /* CctopSessionIdentityStore.swift */; };
 		CSI000020000000000000001 /* CctopSessionIdentityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CSI000030000000000000001 /* CctopSessionIdentityStore.swift */; };
 		DCL000010000000000000001 /* DesktopAppConnectionLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCL000020000000000000001 /* DesktopAppConnectionLookup.swift */; };
@@ -188,12 +189,13 @@
 		A10000020000000000000001 /* CctopApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CctopApp.swift; sourceTree = "<group>"; };
 		A10000030000000000000001 /* CctopMenubar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CctopMenubar.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC0000020000000000000001 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		B10000020000000000000001 /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
-		SNC000020000000000000001 /* Session+NotificationContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Session+NotificationContent.swift"; sourceTree = "<group>"; };
+		B10000020000000000000001 /* SessionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionData.swift; sourceTree = "<group>"; };
+		SNC000020000000000000001 /* SessionData+NotificationContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionData+NotificationContent.swift"; sourceTree = "<group>"; };
 		B10000040000000000000001 /* SessionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStatus.swift; sourceTree = "<group>"; };
 		C10000020000000000000001 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		SLP000020000000000000001 /* SessionLifecyclePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLifecyclePolicy.swift; sourceTree = "<group>"; };
 		SIP000020000000000000001 /* SessionIdentityPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIdentityPolicy.swift; sourceTree = "<group>"; };
+		LGS000020000000000000001 /* UserSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSession.swift; sourceTree = "<group>"; };
 		CSI000030000000000000001 /* CctopSessionIdentityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CctopSessionIdentityStore.swift; sourceTree = "<group>"; };
 		DCL000020000000000000001 /* DesktopAppConnectionLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopAppConnectionLookup.swift; sourceTree = "<group>"; };
 		CTA000020000000000000001 /* CodexThreadArchiveLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexThreadArchiveLookup.swift; sourceTree = "<group>"; };
@@ -221,7 +223,7 @@
 		EMUX0020000000000000001 /* FocusTerminal+Multiplexer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FocusTerminal+Multiplexer.swift"; sourceTree = "<group>"; };
 		ERCT00020000000000000001 /* FocusTerminal+Recent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FocusTerminal+Recent.swift"; sourceTree = "<group>"; };
 		EK0000020000000000000001 /* HostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostApp.swift; sourceTree = "<group>"; };
-		F10000020000000000000001 /* Session+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Session+Mock.swift"; sourceTree = "<group>"; };
+		F10000020000000000000001 /* SessionData+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionData+Mock.swift"; sourceTree = "<group>"; };
 		FK0000020000000000000001 /* ForkSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForkSessionTests.swift; sourceTree = "<group>"; };
 		FT0000020000000000000001 /* WorkspaceFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFileTests.swift; sourceTree = "<group>"; };
 		FT0000020000000000000002 /* FocusTerminalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusTerminalTests.swift; sourceTree = "<group>"; };
@@ -376,6 +378,7 @@
 				C10000020000000000000001 /* SessionManager.swift */,
 				SLP000020000000000000001 /* SessionLifecyclePolicy.swift */,
 				SIP000020000000000000001 /* SessionIdentityPolicy.swift */,
+				LGS000020000000000000001 /* UserSession.swift */,
 				CSI000030000000000000001 /* CctopSessionIdentityStore.swift */,
 				DCL000020000000000000001 /* DesktopAppConnectionLookup.swift */,
 				CTA000020000000000000001 /* CodexThreadArchiveLookup.swift */,
@@ -454,12 +457,12 @@
 		A10000080000000000000001 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				B10000020000000000000001 /* Session.swift */,
-				SNC000020000000000000001 /* Session+NotificationContent.swift */,
+				B10000020000000000000001 /* SessionData.swift */,
+				SNC000020000000000000001 /* SessionData+NotificationContent.swift */,
 				B10000040000000000000001 /* SessionStatus.swift */,
 				N10000040000000000000001 /* HookEvent.swift */,
 				N10000060000000000000001 /* Config.swift */,
-				F10000020000000000000001 /* Session+Mock.swift */,
+				F10000020000000000000001 /* SessionData+Mock.swift */,
 				H10000020000000000000001 /* AppSettings.swift */,
 				ATH000020000000000000001 /* AppTheme.swift */,
 				AGB000020000000000000001 /* AgentBadge.swift */,
@@ -702,12 +705,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				A10000010000000000000001 /* CctopApp.swift in Sources */,
-				B10000010000000000000001 /* Session.swift in Sources */,
-				SNC000010000000000000001 /* Session+NotificationContent.swift in Sources */,
+				B10000010000000000000001 /* SessionData.swift in Sources */,
+				SNC000010000000000000001 /* SessionData+NotificationContent.swift in Sources */,
 				B10000030000000000000001 /* SessionStatus.swift in Sources */,
 				C10000010000000000000001 /* SessionManager.swift in Sources */,
 				SLP000010000000000000001 /* SessionLifecyclePolicy.swift in Sources */,
 				SIP000010000000000000001 /* SessionIdentityPolicy.swift in Sources */,
+				LGS000010000000000000001 /* UserSession.swift in Sources */,
 				CSI000010000000000000001 /* CctopSessionIdentityStore.swift in Sources */,
 				DCL000010000000000000001 /* DesktopAppConnectionLookup.swift in Sources */,
 				CTA000010000000000000001 /* CodexThreadArchiveLookup.swift in Sources */,
@@ -734,7 +738,7 @@
 				ECMUX001000000000000001 /* FocusTerminal+Cmux.swift in Sources */,
 				EMUX0010000000000000001 /* FocusTerminal+Multiplexer.swift in Sources */,
 				ERCT00010000000000000001 /* FocusTerminal+Recent.swift in Sources */,
-				F10000010000000000000001 /* Session+Mock.swift in Sources */,
+				F10000010000000000000001 /* SessionData+Mock.swift in Sources */,
 				G10000010000000000000001 /* FloatingPanel.swift in Sources */,
 				G10000030000000000000001 /* AppDelegate.swift in Sources */,
 				H10000010000000000000001 /* AppSettings.swift in Sources */,
@@ -812,7 +816,7 @@
 				HD0000020000000000000001 /* HookDependencies.swift in Sources */,
 				P10000070000000000000001 /* HookLogger.swift in Sources */,
 				SN0000010000000000000001 /* SessionNameLookup.swift in Sources */,
-				P10000090000000000000001 /* Session.swift in Sources */,
+				P10000090000000000000001 /* SessionData.swift in Sources */,
 				P1000000A000000000000001 /* SessionStatus.swift in Sources */,
 				P1000000B000000000000001 /* HookEvent.swift in Sources */,
 				P1000000C000000000000001 /* Config.swift in Sources */,

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -417,7 +417,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             sessionManager.loadSessions()
             if let session = Self.notificationFocusSession(
                 matchingUserInfo: userInfo,
-                in: sessionManager.sessions
+                in: sessionManager.userSessions
             ) {
                 focusTerminal(session: session)
             }
@@ -435,15 +435,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     nonisolated static func notificationFocusSession(
         matchingUserInfo userInfo: [AnyHashable: Any],
-        in sessions: [Session]
-    ) -> Session? {
+        in userSessions: [UserSession]
+    ) -> SessionData? {
         guard let cctopSessionID = SessionIdentityPolicy.notificationCctopSessionID(
             matchingNotificationUserInfo: userInfo,
-            in: sessions
+            in: userSessions
         ) else { return nil }
         return FocusTargetResolver.currentSession(
             forCctopSessionID: cctopSessionID,
-            in: SessionDisplayPolicy.activeSessions(from: sessions)
+            in: SessionDisplayPolicy.activeSessions(from: userSessions)
         )
     }
 
@@ -654,7 +654,7 @@ extension AppDelegate {
 
     @MainActor private func jumpToSession(index: Int) {
         guard let identity = navigateController.sessionIdentity(at: index) else { return }
-        let currentSessions = SessionDisplayPolicy.activeSessions(from: sessionManager.sessions)
+        let currentSessions = SessionDisplayPolicy.activeSessions(from: sessionManager.userSessions)
         guard let session = FocusTargetResolver.currentSession(for: identity, in: currentSessions) else { return }
         focusTerminal(session: session)
         handleEvent(.navigateConfirmed)
@@ -780,7 +780,7 @@ extension AppDelegate {
             togglePanel()
         case "focus":
             guard let cctopSessionID = Self.focusSessionID(from: url),
-                  Session.isValidCctopSessionId(cctopSessionID) else {
+                  CctopSessionID.isValid(cctopSessionID) else {
                 Self.urlLogger.notice("Ignored malformed cctop focus command")
                 return
             }
@@ -788,7 +788,7 @@ extension AppDelegate {
             let initialActiveSessions = SessionDisplayPolicy.activeSessions(from: initialSessions)
             if let session = FocusTargetResolver.currentSession(
                 forCctopSessionID: cctopSessionID,
-                in: initialActiveSessions
+                in: SessionDisplayPolicy.activeSessions(from: sessionManager.userSessions)
             ) {
                 focusTerminal(session: session)
                 return
@@ -808,7 +808,7 @@ extension AppDelegate {
             let refreshedActiveSessions = SessionDisplayPolicy.activeSessions(from: refreshedSessions)
             let resolvedSession = FocusTargetResolver.currentSession(
                 forCctopSessionID: cctopSessionID,
-                in: refreshedActiveSessions
+                in: SessionDisplayPolicy.activeSessions(from: sessionManager.userSessions)
             )
             logFocusTargetRefreshOutcome(
                 outcome: resolvedSession == nil ? "final_missing" : "recovered_after_refresh",
@@ -840,12 +840,12 @@ extension AppDelegate {
 
     private func logFocusTargetMissBeforeRefresh(
         requestedID: String,
-        canonicalSessions: [Session],
-        activeSessions: [Session],
+        canonicalSessions: [SessionData],
+        activeSessions: [SessionData],
         displayState: DisplayState?
     ) {
         let processPID = ProcessInfo.processInfo.processIdentifier
-        let processStartTime = Session.processStartTime(pid: UInt32(processPID))
+        let processStartTime = SessionData.processStartTime(pid: UInt32(processPID))
         let appVersion = Bundle.main.appVersion.isEmpty ? "unavailable" : Bundle.main.appVersion
         let canonicalMatches = canonicalSessions.filter { $0.cctopSessionId == requestedID }
         let processStartValue = processStartTime.map { String($0) } ?? "unavailable"
@@ -863,8 +863,8 @@ extension AppDelegate {
             requested_cctop_session_id=\(requestedID, privacy: .private(mask: .hash)) \
             app_version=\(appVersion, privacy: .public) app_pid=\(processPID, privacy: .public) \
             app_start_time=\(processStartValue, privacy: .public) \
-            canonical_observation_count=\(canonicalSessions.count, privacy: .public) \
-            focus_eligible_observation_count=\(activeSessions.count, privacy: .public) \
+            canonical_record_count=\(canonicalSessions.count, privacy: .public) \
+            focus_eligible_record_count=\(activeSessions.count, privacy: .public) \
             requested_id_canonical_matches=\(canonicalMatches.count, privacy: .public) \
             display_state_generated_at=\(displayGeneratedAt, privacy: .public) \
             display_state_owner_pid=\(displayOwnerPID, privacy: .public) \
@@ -878,8 +878,8 @@ extension AppDelegate {
     private func logFocusTargetRefreshOutcome(
         outcome: String,
         requestedID: String,
-        canonicalSessions: [Session],
-        activeSessions: [Session],
+        canonicalSessions: [SessionData],
+        activeSessions: [SessionData],
         refreshElapsedMilliseconds: Double
     ) {
         let canonicalMatchCount = canonicalSessions.count { $0.cctopSessionId == requestedID }
@@ -892,8 +892,8 @@ extension AppDelegate {
             outcome=\(outcome, privacy: .public) \
             requested_cctop_session_id=\(requestedID, privacy: .private(mask: .hash)) \
             refresh_elapsed_ms=\(elapsed, privacy: .public) \
-            canonical_observation_count=\(canonicalSessions.count, privacy: .public) \
-            focus_eligible_observation_count=\(activeSessions.count, privacy: .public) \
+            canonical_record_count=\(canonicalSessions.count, privacy: .public) \
+            focus_eligible_record_count=\(activeSessions.count, privacy: .public) \
             requested_id_canonical_matches=\(canonicalMatchCount, privacy: .public) \
             requested_id_active_matches=\(activeMatchCount, privacy: .public)
             """

--- a/menubar/CctopMenubar/Hook/HookDependencies.swift
+++ b/menubar/CctopMenubar/Hook/HookDependencies.swift
@@ -16,9 +16,9 @@ protocol ProcessProbing {
 /// Production prober backed by getppid/sysctl/kill via the existing helpers.
 struct LiveProcessProber: ProcessProbing {
     func parentPID() -> UInt32 { HookHandler.getParentPID() }
-    func startTime(pid: UInt32) -> TimeInterval? { Session.processStartTime(pid: pid) }
+    func startTime(pid: UInt32) -> TimeInterval? { SessionData.processStartTime(pid: pid) }
     func isAlive(pid: UInt32) -> Bool { HookHandler.isPIDAlive(pid) }
-    func commandName(pid: UInt32) -> String? { Session.processCommandName(pid: pid) }
+    func commandName(pid: UInt32) -> String? { SessionData.processCommandName(pid: pid) }
     func controllingTTY() -> String? { HookHandler.findTTY() }
 }
 

--- a/menubar/CctopMenubar/Hook/HookHandler.swift
+++ b/menubar/CctopMenubar/Hook/HookHandler.swift
@@ -19,9 +19,9 @@ enum HookHandler {
         }
 
         let sessionsDir = deps.sessionsDir()
-        let safeId = Session.sanitizeSessionId(raw: input.sessionId)
+        let safeId = SessionData.sanitizeSessionId(raw: input.sessionId)
         let pid = deps.process.parentPID()
-        let source = input.resolvedHarnessName ?? Session.ccSource
+        let source = input.resolvedHarnessName ?? SessionData.ccSource
         let label = HookLogger.sessionLabel(cwd: input.cwd, sessionId: safeId)
         let sessionPath = (sessionsDir as NSString).appendingPathComponent(sessionFileName(input: input, pid: pid, safeSessionId: safeId))
 
@@ -47,45 +47,45 @@ enum HookHandler {
         // independently, and the last writer wins — clobbering the first writer's changes.
         var didApplyHook = false
         try withSessionLock(sessionPath: sessionPath, onError: deps.logger.logError) {
-            var freshSession = Session(sessionId: safeId, projectPath: input.cwd, branch: branch, terminal: terminal)
-            freshSession.source = source
-            freshSession.cctopSessionId = cctopSessionId
-            freshSession.harnessSessionId = input.sessionId
-            let loaded: (session: Session, isNewSessionFile: Bool)
+            var freshData = SessionData(sessionId: safeId, projectPath: input.cwd, branch: branch, terminal: terminal)
+            freshData.source = source
+            freshData.cctopSessionId = cctopSessionId
+            freshData.harnessSessionId = input.sessionId
+            let loaded: (data: SessionData, isNewSessionFile: Bool)
             do {
                 loaded = try loadOrCreateSession(
-                    path: sessionPath, event: event, startTime: startTime, fresh: freshSession
+                    path: sessionPath, event: event, startTime: startTime, fresh: freshData
                 )
             } catch {
                 logSessionLoadFailureOnce(hookName: hookName, sessionPath: sessionPath, error: error, logger: deps.logger)
                 return
             }
-            var session = loaded.session
+            var data = loaded.data
             let isNewSessionFile = loaded.isNewSessionFile
 
-            session.pid = pid
-            session.pidStartTime = startTime
+            data.pid = pid
+            data.pidStartTime = startTime
             stampSessionIdentity(
-                &session, cctopSessionId: cctopSessionId,
+                &data, cctopSessionId: cctopSessionId,
                 input: input, source: source, safeId: safeId
             )
 
-            let (oldStatus, newStatus) = applyTransition(&session, event: event, input: input, branch: branch, terminal: terminal)
-            applySessionName(&session, event: event, input: input, names: deps.names)
-            if event != .sessionStart, isNewSessionFile, source == Session.codexSource {
-                session.workspaceFile = Session.findWorkspaceFile(in: input.cwd)
+            let (oldStatus, newStatus) = applyTransition(&data, event: event, input: input, branch: branch, terminal: terminal)
+            applySessionName(&data, event: event, input: input, names: deps.names)
+            if event != .sessionStart, isNewSessionFile, source == SessionData.codexSource {
+                data.workspaceFile = SessionData.findWorkspaceFile(in: input.cwd)
             }
-            applySideEffects(event: event, session: &session, input: input, sessionsDir: sessionsDir, safeId: safeId)
-            if input.isSubagentSession == true { session.isSubagentSession = true }
-            if session.shouldAutoHide || (event == .userPromptSubmit && input.hasCodexProjectSuggestionEvidence) { session.hidden = true }
-            session.markWrittenByHook(version: Config.hookVersion, isNewSessionFile: isNewSessionFile)
+            applySideEffects(event: event, data: &data, input: input, sessionsDir: sessionsDir, safeId: safeId)
+            if input.isSubagentSession == true { data.isSubagentSession = true }
+            if data.shouldAutoHide || (event == .userPromptSubmit && input.hasCodexProjectSuggestionEvidence) { data.hidden = true }
+            data.markWrittenByHook(version: Config.hookVersion, isNewSessionFile: isNewSessionFile)
 
             let suffix = newStatus == nil ? " (preserved)" : ""
             deps.logger.appendHookLog(
                 sessionId: safeId, event: hookName, label: label,
-                transition: "\(oldStatus) -> \(session.status.rawValue)\(suffix)"
+                transition: "\(oldStatus) -> \(data.status.rawValue)\(suffix)"
             )
-            try session.writeToFile(path: sessionPath)
+            try data.writeToFile(path: sessionPath)
             didApplyHook = true
         }
 
@@ -94,29 +94,29 @@ enum HookHandler {
         }
     }
 
-    private static func clearToolState(_ session: inout Session) {
-        clearRunningToolState(&session)
-        session.notificationMessage = nil
+    private static func clearToolState(_ data: inout SessionData) {
+        clearRunningToolState(&data)
+        data.notificationMessage = nil
     }
 
-    private static func clearRunningToolState(_ session: inout Session) {
-        session.lastTool = nil
-        session.lastToolDetail = nil
+    private static func clearRunningToolState(_ data: inout SessionData) {
+        data.lastTool = nil
+        data.lastToolDetail = nil
     }
 
-    private static func applySubagentEvent(event: HookEvent, session: inout Session, input: HookInput) {
+    private static func applySubagentEvent(event: HookEvent, data: inout SessionData, input: HookInput) {
         switch event {
         case .subagentStart:
             guard let agentId = input.agentId, let agentType = input.agentType else { return }
-            if session.activeSubagents == nil { session.activeSubagents = [] }
-            if !session.activeSubagents!.contains(where: { $0.agentId == agentId }) {
-                session.activeSubagents!.append(
+            if data.activeSubagents == nil { data.activeSubagents = [] }
+            if !data.activeSubagents!.contains(where: { $0.agentId == agentId }) {
+                data.activeSubagents!.append(
                     SubagentInfo(agentId: agentId, agentType: agentType, startedAt: Date())
                 )
             }
         case .subagentStop:
             if let agentId = input.agentId {
-                session.activeSubagents?.removeAll { $0.agentId == agentId }
+                data.activeSubagents?.removeAll { $0.agentId == agentId }
             }
         default:
             break
@@ -125,36 +125,36 @@ enum HookHandler {
 
     /// Apply status transition and update session metadata. Returns (oldStatus, newStatus).
     private static func applyTransition(
-        _ session: inout Session, event: HookEvent, input: HookInput,
+        _ data: inout SessionData, event: HookEvent, input: HookInput,
         branch: String, terminal: TerminalInfo
     ) -> (String, SessionStatus?) {
-        let oldStatus = session.status.rawValue
-        let newStatus = Transition.forEvent(session.status, event: event)
-        if let newStatus { session.status = newStatus }
+        let oldStatus = data.status.rawValue
+        let newStatus = Transition.forEvent(data.status, event: event)
+        if let newStatus { data.status = newStatus }
         // Skip lastActivity for notificationPermission — PermissionRequest already set it,
         // and the menubar app needs the original timestamp for child-process-start-time comparison.
-        if event != .notificationPermission { session.lastActivity = Date() }
+        if event != .notificationPermission { data.lastActivity = Date() }
         if Transition.clearsInactiveMarkers(event: event) {
-            session.endedAt = nil
-            session.disconnectedAt = nil
+            data.endedAt = nil
+            data.disconnectedAt = nil
         }
-        session.branch = branch; session.terminal = terminal
+        data.branch = branch; data.terminal = terminal
         // MIGRATION(harness_name): The session JSON file still uses the `source` key.
         // Renaming the JSON key would require a reader-side migration in SessionManager.
         // Do that in a future PR once `harness_name` is settled.
-        if let harness = input.resolvedHarnessName { session.source = harness }
+        if let harness = input.resolvedHarnessName { data.source = harness }
         return (oldStatus, newStatus)
     }
 
     /// Update the user-visible session name. Runs right after applyTransition, once
     /// source/terminal are current, since the lookup strategy depends on both.
     private static func applySessionName(
-        _ session: inout Session, event: HookEvent, input: HookInput, names: any SessionNameResolving
+        _ data: inout SessionData, event: HookEvent, input: HookInput, names: any SessionNameResolving
     ) {
         if let name = input.sessionName {
-            session.sessionName = name
+            data.sessionName = name
         } else if event == .sessionStart || event == .userPromptSubmit || event == .stop
-                    || (session.source == "codex" && session.sessionName == nil) {
+                    || (data.source == "codex" && data.sessionName == nil) {
             // Only overwrite when the lookup succeeds (preserve-on-fail). Re-run on prompt
             // boundaries (and .stop, for Claude Code) to catch renames. Codex additionally
             // re-runs on ANY event while the name is still missing: it never fires .stop and
@@ -167,9 +167,9 @@ enum HookHandler {
             //                     Desktop never writes a `custom-title` to the CC transcript
             //   - terminal CC:    the transcript JSONL `custom-title` entry
             let lookedUp: String?
-            if session.source == "codex" {
+            if data.source == "codex" {
                 lookedUp = names.codexThreadName(sessionId: input.sessionId)
-            } else if session.terminal?.bundleId == HostAppBundleID.claudeDesktop {
+            } else if data.terminal?.bundleId == HostAppBundleID.claudeDesktop {
                 lookedUp = names.claudeDesktopTitle(cliSessionId: input.sessionId)
             } else {
                 lookedUp = names.transcriptSessionName(
@@ -177,27 +177,27 @@ enum HookHandler {
                 )
             }
             if let name = lookedUp {
-                session.sessionName = name
+                data.sessionName = name
             }
         }
     }
 
     private static func applySideEffects(
-        event: HookEvent, session: inout Session, input: HookInput,
+        event: HookEvent, data: inout SessionData, input: HookInput,
         sessionsDir: String, safeId: String
     ) {
         switch event {
         case .sessionStart:
-            clearToolState(&session)
-            session.activeSubagents = []
-            session.workspaceFile = Session.findWorkspaceFile(in: input.cwd)
+            clearToolState(&data)
+            data.activeSubagents = []
+            data.workspaceFile = SessionData.findWorkspaceFile(in: input.cwd)
         case .userPromptSubmit:
-            clearToolState(&session)
-            if let prompt = input.prompt { session.lastPrompt = prompt }
+            clearToolState(&data)
+            if let prompt = input.prompt { data.lastPrompt = prompt }
         case .preToolUse:
             if let toolName = input.toolName {
-                session.lastTool = toolName
-                session.lastToolDetail = extractToolDetail(toolName: toolName, toolInput: input.toolInput)
+                data.lastTool = toolName
+                data.lastToolDetail = extractToolDetail(toolName: toolName, toolInput: input.toolInput)
             }
 
         case .permissionRequest:
@@ -206,21 +206,21 @@ enum HookHandler {
                 if let detail { return "\(tool): \(detail)" }
                 return tool
             }
-            session.notificationMessage = msg
+            data.notificationMessage = msg
             // Keep lastTool/lastToolDetail from the preceding PreToolUse — when the
             // delayed Notification transitions to .working, the card can show what tool is running.
 
         case .notificationIdle, .notificationOther:
-            applyNotificationEvent(event: event, session: &session, input: input)
+            applyNotificationEvent(event: event, data: &data, input: input)
         case .stop:
-            clearToolState(&session)
+            clearToolState(&data)
         case .postToolUseFailure:
-            if let error = input.error { session.notificationMessage = error }
+            if let error = input.error { data.notificationMessage = error }
         case .subagentStart, .subagentStop:
-            applySubagentEvent(event: event, session: &session, input: input)
+            applySubagentEvent(event: event, data: &data, input: input)
 
         case .sessionError:
-            session.notificationMessage = input.error ?? input.message
+            data.notificationMessage = input.error ?? input.message
 
         // notificationPermission: PermissionRequest already handles side effects; Notification fires ~6s later.
         case .notificationPermission, .postCompact, .preCompact, .postToolUse, .sessionEnd, .unknown:
@@ -228,12 +228,12 @@ enum HookHandler {
         }
     }
 
-    private static func applyNotificationEvent(event: HookEvent, session: inout Session, input: HookInput) {
-        clearRunningToolState(&session)
+    private static func applyNotificationEvent(event: HookEvent, data: inout SessionData, input: HookInput) {
+        clearRunningToolState(&data)
         if event == .notificationIdle && input.notificationType == "idle_prompt" {
-            session.notificationMessage = nil
+            data.notificationMessage = nil
         } else if let message = input.message {
-            session.notificationMessage = message
+            data.notificationMessage = message
         }
     }
 
@@ -404,11 +404,11 @@ extension HookHandler {
     // swiftlint:disable:next function_body_length
     private static func handleSessionEnd(hookName: String, input: HookInput, deps: HookDependencies) {
         let pid = deps.process.parentPID()
-        let safeId = Session.sanitizeSessionId(raw: input.sessionId)
+        let safeId = SessionData.sanitizeSessionId(raw: input.sessionId)
         let sessionsDir = deps.sessionsDir()
         let primaryPath = (sessionsDir as NSString).appendingPathComponent(sessionFileName(input: input, pid: pid, safeSessionId: safeId))
         let label = HookLogger.sessionLabel(cwd: input.cwd, sessionId: safeId)
-        let source = input.resolvedHarnessName ?? Session.ccSource
+        let source = input.resolvedHarnessName ?? SessionData.ccSource
 
         // The end-time parent walk can resolve a different PID than at start (ancestors
         // exit during teardown), so the PID-derived path may miss the session's file or
@@ -420,19 +420,19 @@ extension HookHandler {
             // No file holds this session. Keep the legacy corrupt-file cleanup on the
             // primary path, but never touch another conversation's healthy file.
             try? withSessionLock(sessionPath: primaryPath, onError: deps.logger.logError) {
-                guard (try? Session.fromFile(path: primaryPath)) == nil else { return }
+                guard (try? SessionData.fromFile(path: primaryPath)) == nil else { return }
                 deps.logger.appendHookLog(sessionId: safeId, event: hookName, label: label, transition: "-> removed")
                 removeSession(at: primaryPath, sessionId: safeId, logger: deps.logger)
             }
             return
         }
 
-        let existingTarget = try? Session.fromFile(path: target.path)
-        let existingCctopSessionId = existingTarget.flatMap { session -> String? in
+        let existingTarget = try? SessionData.fromFile(path: target.path)
+        let existingCctopSessionId = existingTarget.flatMap { data -> String? in
             guard sessionEndIdentityMatch(
-                session, safeId: safeId, rawId: input.sessionId, source: source
-            ) == target.match, Session.isValidCctopSessionId(session.cctopSessionId) else { return nil }
-            return session.cctopSessionId
+                data, safeId: safeId, rawId: input.sessionId, source: source
+            ) == target.match, CctopSessionID.isValid(data.cctopSessionId) else { return nil }
+            return data.cctopSessionId
         }
         guard let cctopSessionId = existingCctopSessionId ?? resolvedCctopSessionIDForEnd(
             input: input, sessionsDir: sessionsDir, source: source,
@@ -442,9 +442,9 @@ extension HookHandler {
         // Stamp endedAt instead of deleting — the menubar app archives to history on next poll.
         try? withSessionLock(sessionPath: target.path, onError: deps.logger.logError) {
             // Re-validate under the lock: the file can change between the scan and the stamp.
-            guard var session = try? Session.fromFile(path: target.path),
+            guard var data = try? SessionData.fromFile(path: target.path),
                   sessionEndIdentityMatch(
-                    session, safeId: safeId, rawId: input.sessionId, source: source
+                    data, safeId: safeId, rawId: input.sessionId, source: source
                   ) == target.match else { return }
             // A legacy match is allowed only while it remains the sole fallback. If an
             // exact record appeared or another legacy candidate became visible after the
@@ -456,16 +456,16 @@ extension HookHandler {
                 ) == target else { return }
             }
             let endedAt = Date()
-            if shouldAdoptResolvedCctopSessionID(session, input: input, source: source, safeId: safeId) {
-                session.cctopSessionId = cctopSessionId
+            if shouldAdoptResolvedCctopSessionID(data, input: input, source: source, safeId: safeId) {
+                data.cctopSessionId = cctopSessionId
             }
-            session.endedAt = endedAt
-            if hasTrustedClaudeDesktopBundle(session, sourceOverride: input.resolvedHarnessName) {
-                session.disconnectedAt = session.disconnectedAt ?? endedAt
+            data.endedAt = endedAt
+            if hasTrustedClaudeDesktopBundle(data, sourceOverride: input.resolvedHarnessName) {
+                data.disconnectedAt = data.disconnectedAt ?? endedAt
             }
-            session.markWrittenByHook(version: Config.hookVersion, isNewSessionFile: false)
+            data.markWrittenByHook(version: Config.hookVersion, isNewSessionFile: false)
             do {
-                try session.writeToFile(path: target.path)
+                try data.writeToFile(path: target.path)
             } catch {
                 deps.logger.logError("\(hookName): \(error)")
                 return
@@ -493,11 +493,11 @@ extension HookHandler {
         input: HookInput, sessionPath: String, sessionsDir: String,
         source: String, safeId: String
     ) throws -> String {
-        if let session = try? Session.fromFile(path: sessionPath),
-           (session.source ?? Session.ccSource) == source,
-           session.harnessSessionId == input.sessionId,
-           Session.isValidCctopSessionId(session.cctopSessionId),
-           let cctopSessionId = session.cctopSessionId {
+        if let data = try? SessionData.fromFile(path: sessionPath),
+           (data.source ?? SessionData.ccSource) == source,
+           data.harnessSessionId == input.sessionId,
+           CctopSessionID.isValid(data.cctopSessionId),
+           let cctopSessionId = data.cctopSessionId {
             return cctopSessionId
         }
         return try resolveCctopSessionID(
@@ -520,21 +520,21 @@ extension HookHandler {
     }
 
     private static func stampSessionIdentity(
-        _ session: inout Session, cctopSessionId: String,
+        _ data: inout SessionData, cctopSessionId: String,
         input: HookInput, source: String, safeId: String
     ) {
-        if shouldAdoptResolvedCctopSessionID(session, input: input, source: source, safeId: safeId) {
-            session.cctopSessionId = cctopSessionId
+        if shouldAdoptResolvedCctopSessionID(data, input: input, source: source, safeId: safeId) {
+            data.cctopSessionId = cctopSessionId
         }
         // Stamped after a matching event loads the record so pre-field files gain the
         // exact reference mid-life; only SessionStart may rotate conversations.
-        session.harnessSessionId = input.sessionId
+        data.harnessSessionId = input.sessionId
     }
 
     private static func shouldAdoptResolvedCctopSessionID(
-        _ session: Session, input: HookInput, source: String, safeId: String
+        _ data: SessionData, input: HookInput, source: String, safeId: String
     ) -> Bool {
-        !Session.isValidCctopSessionId(session.cctopSessionId)
+        !CctopSessionID.isValid(data.cctopSessionId)
             || CctopSessionIdentityStore.durableEvidence(
                 source: source,
                 harnessSessionId: input.sessionId,
@@ -548,11 +548,11 @@ extension HookHandler {
     }
 
     private static func sessionEndIdentityMatch(
-        _ session: Session, safeId: String, rawId: String, source: String
+        _ data: SessionData, safeId: String, rawId: String, source: String
     ) -> SessionEndIdentityMatch? {
-        guard session.sessionId == safeId,
-              (session.source ?? Session.ccSource) == source else { return nil }
-        guard let harnessSessionId = session.harnessSessionId else { return .legacy }
+        guard data.sessionId == safeId,
+              (data.source ?? SessionData.ccSource) == source else { return nil }
+        guard let harnessSessionId = data.harnessSessionId else { return .legacy }
         return harnessSessionId == rawId ? .exact : nil
     }
 
@@ -562,12 +562,12 @@ extension HookHandler {
     private static func sessionEndTarget(
         primaryPath: String, sessionsDir: String, safeId: String, rawId: String, source: String
     ) -> SessionEndTarget? {
-        var exact: [(path: String, session: Session)] = []
+        var exact: [(path: String, data: SessionData)] = []
         var legacyPaths: [String] = []
-        forEachSession(in: sessionsDir) { path, session in
-            switch sessionEndIdentityMatch(session, safeId: safeId, rawId: rawId, source: source) {
+        forEachSession(in: sessionsDir) { path, data in
+            switch sessionEndIdentityMatch(data, safeId: safeId, rawId: rawId, source: source) {
             case .exact:
-                exact.append((path, session))
+                exact.append((path, data))
             case .legacy:
                 legacyPaths.append(path)
             case nil:
@@ -581,11 +581,11 @@ extension HookHandler {
             }
             var best = exact[0]
             for candidate in exact.dropFirst() {
-                let candidateUnended = candidate.session.endedAt == nil
-                let currentUnended = best.session.endedAt == nil
+                let candidateUnended = candidate.data.endedAt == nil
+                let currentUnended = best.data.endedAt == nil
                 if candidateUnended != currentUnended {
                     if candidateUnended { best = candidate }
-                } else if candidate.session.lastActivity > best.session.lastActivity {
+                } else if candidate.data.lastActivity > best.data.lastActivity {
                     best = candidate
                 }
             }
@@ -600,53 +600,53 @@ extension HookHandler {
         sessionsDir: String, projectPath: String, currentPid: UInt32?,
         process: any ProcessProbing = LiveProcessProber(), logger: HookLogger = HookLogger()
     ) {
-        forEachSession(in: sessionsDir) { path, session in
-            guard session.projectPath == projectPath, session.pid != currentPid else { return }
+        forEachSession(in: sessionsDir) { path, data in
+            guard data.projectPath == projectPath, data.pid != currentPid else { return }
 
             // Retained conversations are reaped by the menubar's lock-held lifecycle GC. The hook
             // must not delete a recent Codex thread or Claude Desktop sibling on a new process start.
-            guard !session.isCodex, !hasTrustedClaudeDesktopBundle(session) else { return }
+            guard !data.isCodex, !hasTrustedClaudeDesktopBundle(data) else { return }
 
-            guard !session.hidden, !session.shouldAutoHide else { return }
+            guard !data.hidden, !data.shouldAutoHide else { return }
 
             let isStale: Bool
-            if let pid = session.pid {
+            if let pid = data.pid {
                 if !process.isAlive(pid: pid) {
                     isStale = true
-                } else if let storedStart = session.pidStartTime,
+                } else if let storedStart = data.pidStartTime,
                           let currentStart = process.startTime(pid: pid),
                           abs(storedStart - currentStart) > 1.0 {
                     isStale = true  // PID reused by a different process
                 } else if let comm = process.commandName(pid: pid),
-                          Session.isForeignHarnessComm(comm, source: session.source) {
+                          SessionData.isForeignHarnessComm(comm, source: data.source) {
                     isStale = true  // PID adopted from/reused by another harness (issue #155)
                 } else {
                     isStale = false
                 }
             } else {
                 // MIGRATION(v0.6.0): Remove no-PID branch after all users have migrated.
-                isStale = -session.lastActivity.timeIntervalSinceNow > noPIDMaxAge
+                isStale = -data.lastActivity.timeIntervalSinceNow > noPIDMaxAge
             }
 
             if isStale {
-                removeSession(at: path, sessionId: session.sessionId, logger: logger)
+                removeSession(at: path, sessionId: data.sessionId, logger: logger)
             }
         }
     }
 
-    fileprivate static func hasTrustedClaudeDesktopBundle(_ session: Session, sourceOverride: String? = nil) -> Bool {
-        let bundleID = session.terminal?.bundleId
+    fileprivate static func hasTrustedClaudeDesktopBundle(_ data: SessionData, sourceOverride: String? = nil) -> Bool {
+        let bundleID = data.terminal?.bundleId
         return bundleID == HostAppBundleID.claudeDesktop
-            && Session.trustsDesktopBundle(source: session.source ?? sourceOverride, bundleId: bundleID)
+            && SessionData.trustsDesktopBundle(source: data.source ?? sourceOverride, bundleId: bundleID)
     }
 
-    private static func forEachSession(in dir: String, body: (String, Session) -> Void) {
+    private static func forEachSession(in dir: String, body: (String, SessionData) -> Void) {
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(atPath: dir) else { return }
         for entry in entries where entry.hasSuffix(".json") {
             let path = (dir as NSString).appendingPathComponent(entry)
-            guard let session = try? Session.fromFile(path: path) else { continue }
-            body(path, session)
+            guard let data = try? SessionData.fromFile(path: path) else { continue }
+            body(path, data)
         }
     }
 
@@ -657,8 +657,8 @@ extension HookHandler {
         // (one conversation dual-written as <pid>.json and codex-<sid>.json) — only
         // remove the log when no surviving session file still owns it.
         var sharedByOtherFile = false
-        forEachSession(in: (path as NSString).deletingLastPathComponent) { otherPath, session in
-            if otherPath != path, session.sessionId == sessionId { sharedByOtherFile = true }
+        forEachSession(in: (path as NSString).deletingLastPathComponent) { otherPath, data in
+            if otherPath != path, data.sessionId == sessionId { sharedByOtherFile = true }
         }
         if !sharedByOtherFile {
             logger.cleanupSessionLog(sessionId: sessionId)
@@ -681,11 +681,11 @@ private func logForeignHarnessWarning(
     // harness's own process. A foreign-harness PID means liveness for this file will
     // track the wrong process — log it so the adoption path can be confirmed in the field.
     guard let parentComm = deps.process.commandName(pid: pid),
-          Session.isForeignHarnessComm(parentComm, source: input.resolvedHarnessName) else {
+          SessionData.isForeignHarnessComm(parentComm, source: input.resolvedHarnessName) else {
         return
     }
     deps.logger.appendHookLog(
-        sessionId: Session.sanitizeSessionId(raw: input.sessionId), event: hookName, label: label,
+        sessionId: SessionData.sanitizeSessionId(raw: input.sessionId), event: hookName, label: label,
         transition: "warning: parent pid \(pid) is '\(parentComm)', a foreign harness"
     )
 }
@@ -706,12 +706,12 @@ private func runProjectCleanupIfNeeded(
 }
 
 private func loadOrCreateSession(
-    path: String, event: HookEvent, startTime: TimeInterval?, fresh: Session
-) throws -> (session: Session, isNewSessionFile: Bool) {
+    path: String, event: HookEvent, startTime: TimeInterval?, fresh: SessionData
+) throws -> (data: SessionData, isNewSessionFile: Bool) {
     guard FileManager.default.fileExists(atPath: path) else {
         return (fresh, true)
     }
-    let existing: Session
+    let existing: SessionData
     do {
         existing = try decodeExistingSessionFile(path: path)
     } catch SessionLoadError.undecodableExistingFile(_) where event == .sessionStart {
@@ -735,7 +735,7 @@ private func loadOrCreateSession(
         }
         var replacement = fresh
         if CctopSessionIdentityStore.durableEvidence(for: fresh) == nil {
-            replacement.cctopSessionId = Session.makeCctopSessionId()
+            replacement.cctopSessionId = CctopSessionID.make()
         }
         return (replacement, true)
     }
@@ -776,7 +776,7 @@ private enum SessionLoadError: Error, CustomStringConvertible {
     }
 }
 
-private func decodeExistingSessionFile(path: String) throws -> Session {
+private func decodeExistingSessionFile(path: String) throws -> SessionData {
     let data: Data
     do {
         data = try Data(contentsOf: URL(fileURLWithPath: path))
@@ -785,7 +785,7 @@ private func decodeExistingSessionFile(path: String) throws -> Session {
     }
 
     do {
-        return try JSONDecoder.sessionDecoder.decode(Session.self, from: data)
+        return try JSONDecoder.sessionDecoder.decode(SessionData.self, from: data)
     } catch {
         throw SessionLoadError.undecodableExistingFile(error)
     }
@@ -803,9 +803,9 @@ private func logSessionLoadFailureOnce(hookName: String, sessionPath: String, er
     )
 }
 
-private func canReplaceDecodedSessionFile(existing: Session, fresh: Session, event: HookEvent) -> Bool {
+private func canReplaceDecodedSessionFile(existing: SessionData, fresh: SessionData, event: HookEvent) -> Bool {
     guard event == .sessionStart else { return false }
-    guard existing.source != Session.codexSource, fresh.source != Session.codexSource else { return false }
+    guard existing.source != SessionData.codexSource, fresh.source != SessionData.codexSource else { return false }
     guard !HookHandler.hasTrustedClaudeDesktopBundle(existing),
           !HookHandler.hasTrustedClaudeDesktopBundle(fresh) else {
         return false
@@ -820,7 +820,7 @@ private func canReplaceDecodedSessionFile(existing: Session, fresh: Session, eve
 /// The `codex-` prefix also keeps Codex files out of the reader-side legacy UUID-file
 /// sweep (`SessionManager.isLegacyUUIDFilename`) — keep both sides in sync.
 func sessionFileName(input: HookInput, pid: UInt32, safeSessionId: String) -> String {
-    if input.resolvedHarnessName == Session.codexSource {
+    if input.resolvedHarnessName == SessionData.codexSource {
         return "codex-\(safeSessionId).json"
     }
     return "\(pid).json"

--- a/menubar/CctopMenubar/Hook/HookInput.swift
+++ b/menubar/CctopMenubar/Hook/HookInput.swift
@@ -119,13 +119,13 @@ struct HookInput: Codable {
     }
 
     var hasCodexStartupDeferralEvidence: Bool {
-        resolvedHarnessName == Session.codexSource
+        resolvedHarnessName == SessionData.codexSource
             && codexSessionStartKind == "startup"
             && transcriptPathWasExplicitlyNull
     }
 
     var hasCodexProjectSuggestionEvidence: Bool {
-        guard resolvedHarnessName == Session.codexSource,
+        guard resolvedHarnessName == SessionData.codexSource,
               transcriptPathWasExplicitlyNull,
               let prompt,
               let range = prompt.range(of: Self.codexProjectSuggestionPromptFragment) else { return false }

--- a/menubar/CctopMenubar/Models/AgentBadge.swift
+++ b/menubar/CctopMenubar/Models/AgentBadge.swift
@@ -29,7 +29,7 @@ enum AgentBadge: Equatable {
     }
 }
 
-extension Session {
+extension SessionData {
     /// Classify the session source. Codex is one source across every surface.
     ///
     var agentBadge: AgentBadge {

--- a/menubar/CctopMenubar/Models/Config.swift
+++ b/menubar/CctopMenubar/Models/Config.swift
@@ -165,21 +165,21 @@ enum Config {
     }
 }
 
-extension Session {
+extension SessionData {
     private static let codexTitleGenerationPromptPrefix =
         "You are a helpful assistant. You will be presented with a user prompt, and your job is to provide a short title"
 
     /// True for Codex's local memory-consolidation runs. Codex owns this exact directory,
     /// and app-server hooks do not consistently preserve their Desktop bundle identity.
     var isCodexMemoryMaintenanceSession: Bool {
-        source == Session.codexSource
+        source == SessionData.codexSource
             && Config.standardizedPath(projectPath) == Config.standardizedPath(Config.codexMemoriesDir())
     }
 
     /// True for Codex's internal title-generation helper runs. They briefly create
     /// hook-visible conversations in the current project, but are not user workspace sessions.
     var isCodexTitleGenerationSession: Bool {
-        source == Session.codexSource
+        source == SessionData.codexSource
             && (sessionName?.isEmpty ?? true)
             && (lastPrompt?.hasPrefix(Self.codexTitleGenerationPromptPrefix) == true)
             && (lastPrompt?.contains("Generate a concise UI title") == true)

--- a/menubar/CctopMenubar/Models/HostApp.swift
+++ b/menubar/CctopMenubar/Models/HostApp.swift
@@ -190,13 +190,13 @@ enum HostApp: CaseIterable {
     }
 }
 
-extension Session {
+extension SessionData {
     /// Trusts desktop bundles for Claude Desktop and nil-source legacy records.
     /// Codex focus ignores persisted `com.openai.codex` metadata.
     var trustedHostApp: HostApp? {
         guard let app = HostApp.from(bundleIdentifier: terminal?.bundleId) else { return nil }
         if app.isDesktopApp,
-           !Session.trustsDesktopBundle(source: source, bundleId: terminal?.bundleId) {
+           !SessionData.trustsDesktopBundle(source: source, bundleId: terminal?.bundleId) {
             return nil
         }
         return app
@@ -217,7 +217,7 @@ enum SessionHostClass: Equatable {
     case ambiguous  // unknown — preserve existing terminal-style cleanup semantics
 }
 
-extension Session {
+extension SessionData {
     /// Phase-1 non-Codex host classification from file-local signals only.
     /// Precedence: a recognized bundle id (`__CFBundleIdentifier`, the same trusted signal
     /// `trustedHostApp` uses) classifies desktop vs terminal. Failing that, a terminal

--- a/menubar/CctopMenubar/Models/RecentProject.swift
+++ b/menubar/CctopMenubar/Models/RecentProject.swift
@@ -64,13 +64,13 @@ struct RecentProject: Identifiable, Equatable {
         return hostApp.displayName
     }
 
-    static func agentName(from session: Session) -> String? {
+    static func agentName(from session: SessionData) -> String? {
         if session.isClaudeDesktopHost { return "Claude Desktop" }
         switch session.source {
-        case Session.codexSource?: return "Codex"
-        case Session.ccSource?: return "Claude Code"
-        case Session.opencodeSource?: return "opencode"
-        case Session.piSource?: return "pi"
+        case SessionData.codexSource?: return "Codex"
+        case SessionData.ccSource?: return "Claude Code"
+        case SessionData.opencodeSource?: return "opencode"
+        case SessionData.piSource?: return "pi"
         case .some(let source) where !source.isEmpty: return source
         default: return nil
         }

--- a/menubar/CctopMenubar/Models/RecentResumeTarget.swift
+++ b/menubar/CctopMenubar/Models/RecentResumeTarget.swift
@@ -35,7 +35,7 @@ enum RecentResumeTarget: Identifiable, Equatable {
             return "project:\(project.id)"
         case .desktopThread(let thread):
             if let cctopSessionID = thread.cctopSessionId,
-               Session.isValidCctopSessionId(cctopSessionID) {
+               CctopSessionID.isValid(cctopSessionID) {
                 return "desktop:\(cctopSessionID)"
             }
             return "desktop:Claude Desktop:\(thread.sessionId)"
@@ -166,14 +166,14 @@ enum RecentResumeTarget: Identifiable, Equatable {
         from classification: SessionClassificationSnapshot,
         excludingSessionIDs: Set<String>
     ) -> [RecentResumeTarget] {
-        var targetsByID: [String: (target: RecentResumeTarget, candidate: DedupCandidate)] = [:]
+        var targetsByID: [String: (target: RecentResumeTarget, candidate: SessionRecord)] = [:]
         for record in classification.records {
-            if let cctopSessionID = record.candidate.session.cctopSessionId,
+            if let cctopSessionID = record.candidate.data.cctopSessionId,
                excludingSessionIDs.contains(cctopSessionID) {
                 continue
             }
             guard isArchivedClaudeDesktop(record.disposition),
-                  let thread = DesktopThread(session: record.candidate.session) else {
+                  let thread = DesktopThread(session: record.candidate.data) else {
                 continue
             }
             let target = RecentResumeTarget.desktopThread(thread)
@@ -209,7 +209,7 @@ enum RecentResumeTarget: Identifiable, Equatable {
 }
 
 extension RecentResumeTarget.DesktopThread {
-    init?(session: Session) {
+    init?(session: SessionData) {
         let title = Self.displayTitle(for: session)
         guard !title.isEmpty else { return nil }
         self.init(
@@ -222,7 +222,7 @@ extension RecentResumeTarget.DesktopThread {
         )
     }
 
-    private static func displayTitle(for session: Session) -> String {
+    private static func displayTitle(for session: SessionData) -> String {
         [
             session.sessionName,
             session.lastPrompt,

--- a/menubar/CctopMenubar/Models/SessionData+Mock.swift
+++ b/menubar/CctopMenubar/Models/SessionData+Mock.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension Session {
+extension SessionData {
     static func mock(
         id: String = "test-123",
         cctopSessionId: String? = nil,
@@ -19,10 +19,10 @@ extension Session {
         source: String? = nil,
         activeSubagents: [SubagentInfo]? = nil,
         desktopProjectName: String? = nil
-    ) -> Session {
-        var session = Session(
+    ) -> SessionData {
+        var session = SessionData(
             sessionId: id,
-            cctopSessionId: cctopSessionId ?? makeCctopSessionId(),
+            cctopSessionId: cctopSessionId ?? CctopSessionID.make(),
             harnessSessionId: harnessSessionId,
             projectPath: "/Users/test/projects/\(project)",
             projectName: project,
@@ -45,7 +45,7 @@ extension Session {
         return session
     }
 
-    static let mockSessions: [Session] = {
+    static let mockSessions: [SessionData] = {
         var s1 = mock(
             id: "1", project: "cctop", branch: "pid-keyed-sessions",
             sessionName: "migrate-off-session-id",
@@ -76,32 +76,32 @@ extension Session {
 
     /// 5 sessions: adds a working session to the baseline 4.
     /// Badges should show: 0 attention, 2 working, 3 idle
-    static let qaFiveSessions: [Session] = mockSessions + [
+    static let qaFiveSessions: [SessionData] = mockSessions + [
         .mock(id: "5", project: "billing", branch: "feature/invoices", status: .working, lastTool: "Bash", lastToolDetail: "cargo test"),
     ]
 
     /// 6 sessions: adds two more to baseline 4.
     /// Badges should show: 0 attention, 2 working, 4 idle
-    static let qaSixSessions: [Session] = qaFiveSessions + [
+    static let qaSixSessions: [SessionData] = qaFiveSessions + [
         .mock(id: "6", project: "infra", branch: "main", status: .idle),
     ]
 
     /// 8 sessions: tests scrolling behavior.
-    static let qaEightSessions: [Session] = qaSixSessions + [
+    static let qaEightSessions: [SessionData] = qaSixSessions + [
         .mock(id: "7", project: "mobile-app", branch: "release/2.0",
               status: .waitingPermission, notificationMessage: "Allow Write: /config/prod.json"),
         .mock(id: "8", project: "analytics", branch: "fix/dashboard", status: .working, lastTool: "Grep", lastToolDetail: "*.ts"),
     ]
 
     /// All sessions needing attention (only amber badge visible).
-    static let qaAllAttention: [Session] = [
+    static let qaAllAttention: [SessionData] = [
         .mock(id: "1", project: "web-app", branch: "main", status: .waitingPermission, notificationMessage: "Allow Bash: rm -rf node_modules"),
         .mock(id: "2", project: "api", branch: "develop", status: .waitingInput, lastPrompt: "Which database migration strategy?"),
         .mock(id: "3", project: "worker", branch: "main", status: .needsAttention),
     ]
 
     /// All sessions idle (only gray badge visible).
-    static let qaAllIdle: [Session] = [
+    static let qaAllIdle: [SessionData] = [
         .mock(id: "1", project: "project-a", branch: "main", status: .idle),
         .mock(id: "2", project: "project-b", branch: "develop", status: .idle),
         .mock(id: "3", project: "project-c", branch: "main", status: .idle),
@@ -109,7 +109,7 @@ extension Session {
     ]
 
     /// Long project and branch names to test truncation.
-    static let qaLongNames: [Session] = [
+    static let qaLongNames: [SessionData] = [
         .mock(id: "1", project: "my-very-long-project-name-here",
               branch: "feature/JIRA-12345-implement-oauth2-refresh-token-rotation",
               status: .working, lastTool: "Edit",
@@ -122,7 +122,7 @@ extension Session {
     ]
 
     /// Long session names to test wrapping (e.g. forked sessions using first message as name).
-    static let qaLongSessionNames: [Session] = [
+    static let qaLongSessionNames: [SessionData] = [
         .mock(id: "1", project: "cctop",
               branch: "redesign",
               sessionName: "Can you use test data to show me what happens if the session name is super long like over 50 characters",
@@ -138,7 +138,7 @@ extension Session {
     ]
 
     /// Single session.
-    static let qaSingle: [Session] = [
+    static let qaSingle: [SessionData] = [
         .mock(id: "1", project: "solo-project", branch: "main", status: .working, lastTool: "Task", lastToolDetail: "Running tests"),
     ]
 
@@ -147,7 +147,7 @@ extension Session {
     /// and both attention pills (Permission + Waiting). Permission sorts above
     /// waitingInput, so the top card always shows the dedicated red-orange "Permission"
     /// pill alongside its italic notification note.
-    static let qaShowcase: [Session] = {
+    static let qaShowcase: [SessionData] = {
         // Top of list — waitingPermission sorts above everything else.
         // Demos the dedicated "Permission" pill + italic permission note.
         var s1 = mock(

--- a/menubar/CctopMenubar/Models/SessionData+NotificationContent.swift
+++ b/menubar/CctopMenubar/Models/SessionData+NotificationContent.swift
@@ -6,7 +6,7 @@ struct SessionNotificationContent: Equatable {
     let body: String
 }
 
-extension Session {
+extension SessionData {
     private static let notificationBodyLimit = 72
 
     var shouldPostAttentionNotification: Bool {

--- a/menubar/CctopMenubar/Models/SessionData.swift
+++ b/menubar/CctopMenubar/Models/SessionData.swift
@@ -210,11 +210,26 @@ enum SessionLifecycle: Int, Equatable {
     case finished = 2  // ended or aged out → eligible for GC
 }
 
-struct Session: Codable, Identifiable, Equatable {
+/// A cctop-owned user-session ID. The selected winner's value forms the current identity.
+/// Multiple `SessionRecord` values can carry the same ID before the app forms that group.
+enum CctopSessionID {
+    static func make() -> String {
+        UUID().uuidString.lowercased()
+    }
+
+    static func isValid(_ value: String?) -> Bool {
+        guard let value, let uuid = UUID(uuidString: value) else { return false }
+        return uuid.uuidString.lowercased() == value
+    }
+}
+
+/// The Codable model for session data decoded from one hook-owned JSON file.
+/// `lifecycle` is a derived display overlay and is never written to that JSON file.
+struct SessionData: Codable, Identifiable, Equatable {
     var sessionId: String
-    /// Cctop-owned identity for this logical session. It is deliberately independent of
-    /// harness references and live focus-target metadata. Nil only on legacy records that
-    /// have not yet been migrated by the app or touched by a current hook.
+    /// Serialized cctop-owned ID used to form one `UserSession`. It is deliberately
+    /// independent of harness references and live focus-target metadata. Nil only on legacy
+    /// records that have not yet been migrated by the app or touched by a current hook.
     var cctopSessionId: String?
     /// The exact unsanitized session reference supplied to the hook, byte-for-byte.
     /// This is lookup evidence for supported resume mappings, never cctop identity.
@@ -410,12 +425,12 @@ struct Session: Codable, Identifiable, Equatable {
     }
 
     /// Convenience init for creating new sessions (used by cctop-hook).
-    /// Delegates to the memberwise init so fields added to `Session` later pick up
+    /// Delegates to the memberwise init so fields added to `SessionData` later pick up
     /// their memberwise defaults here instead of needing a second hand-synced list.
     init(sessionId: String, projectPath: String, branch: String, terminal: TerminalInfo) {
         self.init(
             sessionId: sessionId,
-            cctopSessionId: Self.makeCctopSessionId(),
+            cctopSessionId: CctopSessionID.make(),
             projectPath: projectPath,
             projectName: Self.extractProjectName(projectPath),
             branch: branch,
@@ -431,15 +446,6 @@ struct Session: Codable, Identifiable, Equatable {
         )
     }
 
-    static func makeCctopSessionId() -> String {
-        UUID().uuidString.lowercased()
-    }
-
-    static func isValidCctopSessionId(_ value: String?) -> Bool {
-        guard let value, let uuid = UUID(uuidString: value) else { return false }
-        return uuid.uuidString.lowercased() == value
-    }
-
     mutating func markWrittenByHook(version: String, isNewSessionFile: Bool) {
         if isNewSessionFile { createdByHookVersion = version }
         lastWrittenByHookVersion = version
@@ -447,9 +453,9 @@ struct Session: Codable, Identifiable, Equatable {
 
     // MARK: - File I/O
 
-    static func fromFile(path: String) throws -> Session {
+    static func fromFile(path: String) throws -> SessionData {
         let data = try Data(contentsOf: URL(fileURLWithPath: path))
-        return try JSONDecoder.sessionDecoder.decode(Session.self, from: data)
+        return try JSONDecoder.sessionDecoder.decode(SessionData.self, from: data)
     }
 
     func writeToFile(path: String) throws {
@@ -487,8 +493,8 @@ struct Session: Codable, Identifiable, Equatable {
     /// Returns a copy with a new session_id (and optionally updated branch/terminal).
     /// Used when the same OS process gets a new CC session_id on resume.
     /// Copy-mutation preserves every other field by construction, so fields added
-    /// to `Session` later can never be silently dropped on session-id rotation.
-    func withSessionId(_ newId: String, branch: String? = nil, terminal: TerminalInfo? = nil) -> Session {
+    /// to `SessionData` later can never be silently dropped on session-id rotation.
+    func withSessionId(_ newId: String, branch: String? = nil, terminal: TerminalInfo? = nil) -> SessionData {
         var copy = self
         copy.sessionId = newId
         if let branch { copy.branch = branch }
@@ -522,7 +528,7 @@ struct Session: Codable, Identifiable, Equatable {
         return nil
     }
 
-    static func sorted(_ sessions: [Session]) -> [Session] {
+    static func sorted(_ sessions: [SessionData]) -> [SessionData] {
         // Live (active) sessions first, then dormant; within each tier by status, then recency.
         sessions.sorted {
             ($0.lifecycle.rawValue, $0.status.sortOrder, $1.lastActivity)
@@ -535,7 +541,7 @@ struct Session: Codable, Identifiable, Equatable {
     }
 }
 
-extension Session {
+extension SessionData {
     /// The best available inactive timestamp for ordering retained files.
     var effectiveEndDate: Date {
         disconnectedAt ?? endedAt ?? lastActivity
@@ -591,7 +597,7 @@ extension Session {
 
 // MARK: - Process Liveness
 
-extension Session {
+extension SessionData {
     static func processInfo(pid: UInt32) -> kinfo_proc? {
         var info = kinfo_proc()
         var size = MemoryLayout<kinfo_proc>.size

--- a/menubar/CctopMenubar/Models/SessionDisplayPolicy.swift
+++ b/menubar/CctopMenubar/Models/SessionDisplayPolicy.swift
@@ -12,33 +12,37 @@ enum SessionDisplayPolicy {
 
     static let staleIdleInterval: TimeInterval = 172_800 // 48 hours
 
-    static func activeSessions(from sessions: [Session], now: Date = Date()) -> [Session] {
-        sessions.filter { session in
-            session.lifecycle == .active && !isStaleActiveIdle(session, now: now)
-        }
+    static func activeSessions(from sessions: [SessionData], now: Date = Date()) -> [SessionData] {
+        sessions.filter { isActive($0, now: now) }
     }
 
-    static func idleSessions(from sessions: [Session], now: Date = Date()) -> [Session] {
-        sessions.filter { session in
-            session.lifecycle == .dormant || isStaleActiveIdle(session, now: now)
-        }
+    static func activeSessions(from userSessions: [UserSession], now: Date = Date()) -> [UserSession] {
+        userSessions.filter { isActive($0.displayRecord.data, now: now) }
+    }
+
+    static func idleSessions(from sessions: [SessionData], now: Date = Date()) -> [SessionData] {
+        sessions.filter { isIdle($0, now: now) }
+    }
+
+    static func idleSessions(from userSessions: [UserSession], now: Date = Date()) -> [UserSession] {
+        userSessions.filter { isIdle($0.displayRecord.data, now: now) }
     }
 
     /// Keeps Active status groups in priority order while preserving the relative order of peers
     /// that remain in a group. Sessions entering a group append after its surviving members, and
     /// the full-array return value leaves the current non-Active remainder unchanged.
     static func reconcilingActiveOrder(
-        in sessions: [Session],
-        preserving previousSessions: [Session],
+        in sessions: [SessionData],
+        preserving previousSessions: [SessionData],
         now: Date = Date()
-    ) -> [Session] {
+    ) -> [SessionData] {
         let active = activeSessions(from: sessions, now: now)
         let activeByKey = Dictionary(
             active.map { (SessionIdentityPolicy.logicalIdentity(for: $0), $0) },
             uniquingKeysWith: { first, _ in first }
         )
         let activeKeys = Set(activeByKey.keys)
-        var groups = Array(repeating: [Session](), count: SessionStatus.idle.sortOrder + 1)
+        var groups = Array(repeating: [SessionData](), count: SessionStatus.idle.sortOrder + 1)
         var placedKeys: Set<SessionIdentityPolicy.LogicalIdentity> = []
 
         for previous in activeSessions(from: previousSessions, now: now) {
@@ -61,16 +65,24 @@ enum SessionDisplayPolicy {
         return orderedActive + nonActive
     }
 
-    static func signature(for sessions: [Session], now: Date = Date()) -> Signature {
+    static func signature(for sessions: [SessionData], now: Date = Date()) -> Signature {
         Signature(
             activeIDs: activeSessions(from: sessions, now: now).map(SessionIdentityPolicy.logicalIdentity),
             idleIDs: idleSessions(from: sessions, now: now).map(SessionIdentityPolicy.logicalIdentity)
         )
     }
 
-    private static func isStaleActiveIdle(_ session: Session, now: Date) -> Bool {
+    private static func isStaleActiveIdle(_ session: SessionData, now: Date) -> Bool {
         guard session.lifecycle == .active, session.status == .idle else { return false }
         return now.timeIntervalSince(session.lastActivity) > staleIdleInterval
+    }
+
+    private static func isIdle(_ session: SessionData, now: Date) -> Bool {
+        session.lifecycle == .dormant || isStaleActiveIdle(session, now: now)
+    }
+
+    private static func isActive(_ session: SessionData, now: Date) -> Bool {
+        session.lifecycle == .active && !isStaleActiveIdle(session, now: now)
     }
 
 }

--- a/menubar/CctopMenubar/Models/StatusCounts.swift
+++ b/menubar/CctopMenubar/Models/StatusCounts.swift
@@ -26,7 +26,7 @@ struct StatusCounts: Equatable {
     }
 
     /// Create counts by aggregating session statuses.
-    init(sessions: [Session], now: Date = Date()) {
+    init(sessions: [SessionData], now: Date = Date()) {
         var perm = 0, attn = 0, work = 0, idleCount = 0
         // Only presentation-active sessions drive the menubar badge. Dormant and stale-idle
         // cards are retained for reachability, not live work, so they never inflate counts.

--- a/menubar/CctopMenubar/Services/CctopSessionIdentityStore.swift
+++ b/menubar/CctopMenubar/Services/CctopSessionIdentityStore.swift
@@ -1,9 +1,9 @@
 import CryptoKit
 import Foundation
 
-/// Persists cctop-owned session identities separately from live session records.
-/// Client references are used only as lookup evidence for clients whose local
-/// resume contracts expose a stable UUID.
+/// Persists the cctop-owned IDs used to form `UserSession` values. The hook and app
+/// assign IDs to `SessionData` before the app builds that projection. Client references
+/// are lookup evidence only for clients whose local resume contracts expose a stable UUID.
 struct CctopSessionIdentityStore {
     enum StoreError: Error {
         case corruptMapping(String)
@@ -50,7 +50,7 @@ struct CctopSessionIdentityStore {
             harnessSessionId: harnessSessionId,
             legacySessionId: legacySessionId
         ) else {
-            return Session.makeCctopSessionId()
+            return CctopSessionID.make()
         }
 
         let directory = identityDirectory
@@ -71,10 +71,10 @@ struct CctopSessionIdentityStore {
             var existing = knownExistingIDs ?? []
             if knownExistingIDs == nil {
                 for url in sessionFiles() {
-                    guard let session = try? Session.fromFile(path: url.path),
-                          Self.durableEvidence(for: session) == evidence,
-                          Session.isValidCctopSessionId(session.cctopSessionId),
-                          let cctopSessionId = session.cctopSessionId else { continue }
+                    guard let data = try? SessionData.fromFile(path: url.path),
+                          Self.durableEvidence(for: data) == evidence,
+                          CctopSessionID.isValid(data.cctopSessionId),
+                          let cctopSessionId = data.cctopSessionId else { continue }
                     existing.insert(cctopSessionId)
                 }
             }
@@ -82,7 +82,7 @@ struct CctopSessionIdentityStore {
                 throw StoreError.conflictingExistingIdentities(mappingURL.lastPathComponent)
             }
 
-            let cctopSessionId = existing.first ?? Session.makeCctopSessionId()
+            let cctopSessionId = existing.first ?? CctopSessionID.make()
             try writeMapping(Mapping(cctopSessionId: cctopSessionId), to: mappingURL)
             resolved = cctopSessionId
         }
@@ -92,12 +92,12 @@ struct CctopSessionIdentityStore {
         return resolved
     }
 
-    /// Session-shaped convenience over `durableEvidence(source:harnessSessionId:legacySessionId:)`.
-    static func durableEvidence(for session: Session) -> String? {
+    /// SessionData-shaped convenience over `durableEvidence(source:harnessSessionId:legacySessionId:)`.
+    static func durableEvidence(for data: SessionData) -> String? {
         durableEvidence(
-            source: session.source,
-            harnessSessionId: session.harnessSessionId,
-            legacySessionId: session.sessionId
+            source: data.source,
+            harnessSessionId: data.harnessSessionId,
+            legacySessionId: data.sessionId
         )
     }
 
@@ -111,8 +111,8 @@ struct CctopSessionIdentityStore {
     ) -> String? {
         // The established session-file migration contract treats a missing source as
         // Claude Code; retain that narrow legacy rule without inferring across clients.
-        let normalizedSource = source ?? Session.ccSource
-        guard [Session.codexSource, Session.ccSource, Session.piSource].contains(normalizedSource) else {
+        let normalizedSource = source ?? SessionData.ccSource
+        guard [SessionData.codexSource, SessionData.ccSource, SessionData.piSource].contains(normalizedSource) else {
             return nil
         }
         let reference = harnessSessionId.flatMap { $0.isEmpty ? nil : $0 } ?? legacySessionId
@@ -148,7 +148,7 @@ struct CctopSessionIdentityStore {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         let mapping = try decoder.decode(Mapping.self, from: Data(contentsOf: url))
-        guard Session.isValidCctopSessionId(mapping.cctopSessionId) else {
+        guard CctopSessionID.isValid(mapping.cctopSessionId) else {
             throw StoreError.corruptMapping(url.lastPathComponent)
         }
         return mapping.cctopSessionId

--- a/menubar/CctopMenubar/Services/DisplayStateWriter.swift
+++ b/menubar/CctopMenubar/Services/DisplayStateWriter.swift
@@ -73,13 +73,13 @@ final class DisplayStateWriter {
 
     private var lastSnapshot: Data?
 
-    func write(sessions: [Session], theme: AppTheme, appRunning: Bool, now: Date = Date()) {
+    func write(sessions: [SessionData], theme: AppTheme, appRunning: Bool, now: Date = Date()) {
         // An Xcode test host launches the app executable but is not a user-facing
         // cctop instance. It must not claim liveness or overwrite the user's surface.
         guard !Self.isXcodeTestHost else { return }
         let appPID = appRunning ? ProcessInfo.processInfo.processIdentifier : nil
         let appIdentity = appPID.flatMap { pid -> DisplayState.ProcessIdentity? in
-            guard let startTime = Session.processStartTime(pid: UInt32(pid)) else { return nil }
+            guard let startTime = SessionData.processStartTime(pid: UInt32(pid)) else { return nil }
             return DisplayState.ProcessIdentity(pid: pid, startTime: startTime)
         }
         let snapshot = Self.snapshot(
@@ -109,7 +109,7 @@ final class DisplayStateWriter {
     }
 
     static func snapshot(
-        sessions: [Session],
+        sessions: [SessionData],
         theme: AppTheme,
         appRunning: Bool,
         appIdentity: DisplayState.ProcessIdentity?,

--- a/menubar/CctopMenubar/Services/FocusTargetResolver.swift
+++ b/menubar/CctopMenubar/Services/FocusTargetResolver.swift
@@ -1,26 +1,32 @@
 import Foundation
 
 enum FocusTargetResolver {
-    /// Resolve a permanent logical id to the first matching current observation.
-    /// The caller supplies focus-eligible observations in canonical panel order.
-    static func currentSession(forCctopSessionID cctopSessionID: String, in observations: [Session]) -> Session? {
-        guard Session.isValidCctopSessionId(cctopSessionID) else { return nil }
-        return observations.first { $0.cctopSessionId == cctopSessionID }
+    /// Resolve permanent identity through the canonical user-session projection.
+    static func currentSession(
+        forCctopSessionID cctopSessionID: String,
+        in userSessions: [UserSession]
+    ) -> SessionData? {
+        guard CctopSessionID.isValid(cctopSessionID) else { return nil }
+        return userSessions.first { $0.identity.cctopSessionID == cctopSessionID }?.focusTarget
     }
 
-    /// Resolve panel/navigation identity against current observations. Permanent IDs use
-    /// the canonical first-match policy; legacy keys remain usable only when unambiguous.
+    /// Resolve panel/navigation identity through the canonical user-session projection.
+    /// Permanent IDs use the canonical group; legacy identities remain unique or fail closed.
     static func currentSession(
         for identity: SessionIdentityPolicy.LogicalIdentity,
-        in observations: [Session]
-    ) -> Session? {
+        in userSessions: [UserSession]
+    ) -> SessionData? {
         if let cctopSessionID = identity.cctopSessionID {
-            return currentSession(forCctopSessionID: cctopSessionID, in: observations)
+            return currentSession(forCctopSessionID: cctopSessionID, in: userSessions)
         }
 
         guard case .legacy(let stableKey) = identity else { return nil }
-        let matches = observations.filter { SessionIdentityPolicy.stableKey(for: $0) == stableKey }
+        let matches = userSessions.filter { userSession in
+            userSession.records.contains { record in
+                SessionIdentityPolicy.stableKey(for: record.data) == stableKey
+            }
+        }
         guard matches.count == 1 else { return nil }
-        return matches[0]
+        return matches[0].focusTarget
     }
 }

--- a/menubar/CctopMenubar/Services/FocusTerminal+Cmux.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal+Cmux.swift
@@ -39,12 +39,12 @@ func cmuxFocusArguments(socket: String, workspaceId: String, surfaceId: String?,
     return ["--socket", socket, "focus-surface", "--workspace", workspaceId, "--surface", surfaceId]
 }
 
-func resolveCmuxLiveMultiplexer(session: Session) -> MultiplexerInfo? {
+func resolveCmuxLiveMultiplexer(session: SessionData) -> MultiplexerInfo? {
     resolveCmuxLiveMultiplexer(session: session, environmentLookup: cmuxEnvironmentForProcess(pid:))
 }
 
 func resolveCmuxLiveMultiplexer(
-    session: Session,
+    session: SessionData,
     environmentLookup: (UInt32) -> [String: String]?
 ) -> MultiplexerInfo? {
     guard session.terminal?.multiplexer == nil,

--- a/menubar/CctopMenubar/Services/FocusTerminal+Multiplexer.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal+Multiplexer.swift
@@ -16,7 +16,7 @@ enum MultiplexerFocusStrategy: Equatable {
 /// Returns nil when the primary strategy uses the Codex app route so
 /// inherited terminal metadata cannot steal focus after the thread deep link.
 func resolveMultiplexerFocus(
-    session: Session,
+    session: SessionData,
     multiplexerOverride: MultiplexerInfo? = nil,
     primaryStrategy: FocusStrategy? = nil
 ) -> MultiplexerFocusStrategy? {

--- a/menubar/CctopMenubar/Services/FocusTerminal+Recent.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal+Recent.swift
@@ -10,7 +10,7 @@ func resolveRecentProjectOpenStrategy(project: RecentProject) -> FocusStrategy {
     let target: String
     if hostApp.usesWorkspaceFile {
         target = project.workspaceFile
-            ?? Session.findWorkspaceFile(in: project.projectPath)
+            ?? SessionData.findWorkspaceFile(in: project.projectPath)
             ?? project.projectPath
     } else {
         target = project.projectPath

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -34,7 +34,7 @@ struct GhosttyFocusTarget: Equatable {
 
 /// Resolve which strategy to use for jumping to a session.
 /// Pure function — no AppKit side effects, fully testable.
-func resolveFocusStrategy(session: Session) -> FocusStrategy {
+func resolveFocusStrategy(session: SessionData) -> FocusStrategy {
     resolveFocusStrategy(session: session, multiplexerOverride: nil)
 }
 
@@ -42,7 +42,7 @@ func resolveFocusStrategy(session: Session) -> FocusStrategy {
 /// freshly resolved multiplexer metadata for legacy live sessions.
 /// Pure function — no AppKit side effects, fully testable.
 func resolveFocusStrategy(
-    session: Session,
+    session: SessionData,
     multiplexerOverride: MultiplexerInfo?
 ) -> FocusStrategy {
     let terminal = session.terminal
@@ -125,7 +125,7 @@ func resolveFocusStrategy(
 private let focusQueue = DispatchQueue(label: "cctop.focus-terminal", qos: .userInitiated)
 /// Cmux `ps` probing, focus scripts, and kitty/multiplexer CLIs all block — so the whole jump runs on `focusQueue`, serial so a
 /// slow jump can't finish after (and steal focus from) a later one. AppKit calls hop back to the main thread.
-func focusTerminal(session: Session) {
+func focusTerminal(session: SessionData) {
     focusQueue.async {
         let multiplexerOverride = resolveCmuxLiveMultiplexer(session: session)
         let strategy = resolveFocusStrategy(session: session, multiplexerOverride: multiplexerOverride)
@@ -330,7 +330,7 @@ func buildOSC7CWD(host: String, workingDirectory: String) -> String {
     return "\u{1B}]7;file://\(host)\(encoded)\u{07}"
 }
 
-func ghosttyFocusTarget(for session: Session, temporaryDirectory: String = NSTemporaryDirectory()) -> GhosttyFocusTarget {
+func ghosttyFocusTarget(for session: SessionData, temporaryDirectory: String = NSTemporaryDirectory()) -> GhosttyFocusTarget {
     guard let tty = session.terminal?.tty,
           tty.range(of: #"^/dev/ttys\d+$"#, options: .regularExpression) != nil else {
         return GhosttyFocusTarget(tty: nil, matchDirectory: session.projectPath, restoreDirectory: nil)
@@ -345,7 +345,7 @@ func ghosttyFocusTarget(for session: Session, temporaryDirectory: String = NSTem
 }
 
 private func sanitizedGhosttyFocusComponent(_ value: String) -> String {
-    let sanitized = Session.sanitizeSessionId(raw: value)
+    let sanitized = SessionData.sanitizeSessionId(raw: value)
     return sanitized.isEmpty ? "session" : sanitized
 }
 

--- a/menubar/CctopMenubar/Services/HistoryManager.swift
+++ b/menubar/CctopMenubar/Services/HistoryManager.swift
@@ -13,7 +13,7 @@ class HistoryManager: ObservableObject {
     let historyDir: URL
     static let maxFiles = 50
     static let maxAgeDays = 30
-    private(set) var lastDecodedHistorySessions: [Session] = []
+    private(set) var lastDecodedHistorySessions: [SessionData] = []
     private var lastRebuildFingerprint: HistoryRebuildFingerprint?
 
     init(historyDir: URL = URL(fileURLWithPath: Config.historyDir())) {
@@ -27,7 +27,7 @@ class HistoryManager: ObservableObject {
     /// Sets `endedAt`, writes to history, prunes old files, and returns success.
     /// Codex conversations and Claude Desktop sessions are not archived as project-history rows.
     @discardableResult
-    func archiveSession(_ session: Session) -> Bool {
+    func archiveSession(_ session: SessionData) -> Bool {
         if session.isCodex || session.isClaudeDesktopHost {
             logger.info("skipping archive for retained session \(session.sessionId, privacy: .public)")
             return false
@@ -83,12 +83,12 @@ class HistoryManager: ObservableObject {
     /// Pure function: group sessions by project, take most recent per project,
     /// filter active, sort by date, cap at 10.
     static func buildRecentProjects(
-        from sessions: [Session],
+        from sessions: [SessionData],
         excludingActive activePaths: Set<String> = [],
         projectPathExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
     ) -> [RecentProject] {
         let activeProjectPaths = Set(activePaths.map(canonicalRecentProjectPath))
-        var grouped: [String: (latest: Session, count: Int, projectPath: String)] = [:]
+        var grouped: [String: (latest: SessionData, count: Int, projectPath: String)] = [:]
         for session in sessions {
             if session.isCodex || session.isClaudeDesktopHost { continue }
             let canonicalProjectPath = canonicalRecentProjectPath(session.projectPath)
@@ -174,7 +174,7 @@ class HistoryManager: ObservableObject {
 
     // MARK: - Internal (testable)
 
-    func loadDecodedHistoryFiles() -> [(url: URL, session: Session)] {
+    func loadDecodedHistoryFiles() -> [(url: URL, session: SessionData)] {
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(
             at: historyDir, includingPropertiesForKeys: nil
@@ -186,7 +186,7 @@ class HistoryManager: ObservableObject {
             $0.pathExtension == "json"
             && !$0.lastPathComponent.hasSuffix(".tmp")
         }
-        var decoded: [(url: URL, session: Session)] = jsonFiles
+        var decoded: [(url: URL, session: SessionData)] = jsonFiles
             .compactMap { url in
                 guard let data = try? Data(contentsOf: url) else {
                     logger.warning(
@@ -195,7 +195,7 @@ class HistoryManager: ObservableObject {
                     return nil
                 }
                 guard let session = try? JSONDecoder.sessionDecoder
-                    .decode(Session.self, from: data)
+                    .decode(SessionData.self, from: data)
                 else {
                     logger.error(
                         "loadDecodedHistoryFiles: decode failed \(url.lastPathComponent, privacy: .public)"
@@ -209,11 +209,11 @@ class HistoryManager: ObservableObject {
     }
 
     func filesToPrune(
-        from decoded: [(url: URL, session: Session)],
+        from decoded: [(url: URL, session: SessionData)],
         projectPathExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
     ) -> [URL] {
         var seenProjects: Set<String> = []
-        var capEligibleKeep: [(url: URL, session: Session)] = []
+        var capEligibleKeep: [(url: URL, session: SessionData)] = []
         var toRemove: [URL] = []
         let cutoff = Date().addingTimeInterval(
             TimeInterval(-Self.maxAgeDays * 86400)
@@ -258,7 +258,7 @@ class HistoryManager: ObservableObject {
     }
 
     private func historyFingerprint(
-        from decoded: [(url: URL, session: Session)],
+        from decoded: [(url: URL, session: SessionData)],
         excludingActive activePaths: Set<String>
     ) -> HistoryRebuildFingerprint? {
         let fm = FileManager.default
@@ -288,7 +288,7 @@ class HistoryManager: ObservableObject {
         )
     }
 
-    private func recentProjectPathFingerprints(from sessions: [Session]) -> [HistoryProjectPathFingerprint] {
+    private func recentProjectPathFingerprints(from sessions: [SessionData]) -> [HistoryProjectPathFingerprint] {
         var states: [String: Bool] = [:]
         for session in sessions where !session.isCodex && !session.isClaudeDesktopHost {
             let canonicalPath = Self.canonicalRecentProjectPath(session.projectPath)

--- a/menubar/CctopMenubar/Services/NavigateController.swift
+++ b/menubar/CctopMenubar/Services/NavigateController.swift
@@ -7,14 +7,14 @@ class NavigateController: ObservableObject {
     let didConfirmSubject = PassthroughSubject<Void, Never>()
     let navActionSubject = PassthroughSubject<PanelNavAction, Never>()
     /// Canonically ordered logical identities captured when navigate activates.
-    /// Array positions remain the numbered slots even when an observation disappears.
+    /// Array positions remain the numbered slots even when a session record disappears.
     private(set) var frozenSessionIdentities: [SessionIdentityPolicy.LogicalIdentity] = []
     var activeSessionIdentitySnapshot: [SessionIdentityPolicy.LogicalIdentity]? {
         isActive ? frozenSessionIdentities : nil
     }
     private var timeoutWork: DispatchWorkItem?
 
-    func activate(sessions: [Session]) {
+    func activate(sessions: [SessionData]) {
         frozenSessionIdentities = sessions.map(SessionIdentityPolicy.logicalIdentity)
         isActive = true
         didActivateSubject.send()

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -90,10 +90,7 @@ enum SessionIdentityPolicy {
         guard !matches.isEmpty else { return nil }
         var permanentIDs: Set<String> = []
         for match in matches {
-            let matchingIDs = Set(match.records.compactMap {
-                permanentSessionID(for: $0.data)
-            })
-            guard matchingIDs.count == 1, let cctopSessionID = matchingIDs.first else { return nil }
+            guard let cctopSessionID = match.identity.cctopSessionID else { return nil }
             permanentIDs.insert(cctopSessionID)
         }
         guard permanentIDs.count == 1 else { return nil }

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -16,7 +16,7 @@ enum SessionIdentityPolicy {
     static let notificationCctopSessionIDKey = "cctopSessionID"
 
     /// Legacy grouping key used by pre-ID dedup and conservative compatibility paths.
-    static func stableKey(for session: Session) -> String {
+    static func stableKey(for session: SessionData) -> String {
         if session.isCodex {
             return "codex:\(session.sessionId)"
         }
@@ -28,9 +28,9 @@ enum SessionIdentityPolicy {
 
     /// Panel identity prefers cctop's permanent UUID. Legacy records retain the existing
     /// source- and host-aware key until a permanent ID becomes available.
-    static func logicalIdentity(for session: Session) -> LogicalIdentity {
+    static func logicalIdentity(for session: SessionData) -> LogicalIdentity {
         if let cctopSessionID = session.cctopSessionId,
-           Session.isValidCctopSessionId(cctopSessionID),
+           CctopSessionID.isValid(cctopSessionID),
            let id = UUID(uuidString: cctopSessionID) {
             return .permanent(id)
         }
@@ -38,23 +38,23 @@ enum SessionIdentityPolicy {
     }
 
     /// The validated permanent cctop session ID, if the session carries one.
-    static func permanentSessionID(for session: Session) -> String? {
+    static func permanentSessionID(for session: SessionData) -> String? {
         logicalIdentity(for: session).cctopSessionID
     }
 
     static func notificationRequestIdentifier(forCctopSessionID cctopSessionID: String) -> String? {
-        guard Session.isValidCctopSessionId(cctopSessionID) else { return nil }
+        guard CctopSessionID.isValid(cctopSessionID) else { return nil }
         return "session-\(cctopSessionID)"
     }
 
     static func notificationUserInfo(forCctopSessionID cctopSessionID: String) -> [AnyHashable: Any]? {
-        guard Session.isValidCctopSessionId(cctopSessionID) else { return nil }
+        guard CctopSessionID.isValid(cctopSessionID) else { return nil }
         return [notificationCctopSessionIDKey: cctopSessionID]
     }
 
     /// Identifier used by already-delivered pre-migration notifications with durable
-    /// Codex or desktop conversation identity. Process-scoped observations are excluded.
-    static func legacyNotificationRequestIdentifier(for session: Session) -> String? {
+    /// Codex or desktop conversation identity. Process-scoped records are excluded.
+    static func legacyNotificationRequestIdentifier(for session: SessionData) -> String? {
         guard session.isCodex || session.hostClass == .desktop,
               !notificationSessionID(for: session).isEmpty else { return nil }
         return "session-\(stableKey(for: session))"
@@ -62,40 +62,45 @@ enum SessionIdentityPolicy {
 
     static func cctopSessionID(matchingNotificationUserInfo userInfo: [AnyHashable: Any]) -> String? {
         guard let cctopSessionID = nonEmptyString(userInfo[notificationCctopSessionIDKey]),
-              Session.isValidCctopSessionId(cctopSessionID) else { return nil }
+              CctopSessionID.isValid(cctopSessionID) else { return nil }
         return cctopSessionID
     }
 
-    /// Recover permanent identity from an already-delivered pre-migration payload.
-    /// A present permanent-ID field is authoritative; invalid or missing targets fail closed.
+    /// Recover a user session from a pre-migration notification even when the named
+    /// session record has not been stamped yet. The user-session group remains authoritative.
     static func notificationCctopSessionID(
         matchingNotificationUserInfo userInfo: [AnyHashable: Any],
-        in sessions: [Session]
+        in userSessions: [UserSession]
     ) -> String? {
         if let permanentValue = userInfo[notificationCctopSessionIDKey] {
             guard let cctopSessionID = nonEmptyString(permanentValue),
-                  Session.isValidCctopSessionId(cctopSessionID) else { return nil }
+                  CctopSessionID.isValid(cctopSessionID) else { return nil }
             return cctopSessionID
         }
 
         guard let sessionIDValue = userInfo[notificationSessionIDKey],
               let sessionID = nonEmptyString(sessionIDValue) else { return nil }
-        let candidates = sessions.filter {
-            ($0.isCodex || $0.hostClass == .desktop)
-                && notificationSessionID(for: $0) == sessionID
+        let matches = userSessions.filter { userSession in
+            userSession.records.contains { record in
+                let data = record.data
+                return (data.isCodex || data.hostClass == .desktop)
+                    && notificationSessionID(for: data) == sessionID
+            }
         }
-
-        guard !candidates.isEmpty else { return nil }
+        guard !matches.isEmpty else { return nil }
         var permanentIDs: Set<String> = []
-        for candidate in candidates {
-            guard let cctopSessionID = permanentSessionID(for: candidate) else { return nil }
+        for match in matches {
+            let matchingIDs = Set(match.records.compactMap {
+                permanentSessionID(for: $0.data)
+            })
+            guard matchingIDs.count == 1, let cctopSessionID = matchingIDs.first else { return nil }
             permanentIDs.insert(cctopSessionID)
         }
         guard permanentIDs.count == 1 else { return nil }
         return permanentIDs.first
     }
 
-    private static func notificationSessionID(for session: Session) -> String {
+    private static func notificationSessionID(for session: SessionData) -> String {
         if session.isCodex || session.hostClass == .desktop {
             return session.sessionId
         }
@@ -108,35 +113,16 @@ enum SessionIdentityPolicy {
     }
 
     /// Collapse multiple files for one conversation only for hosts with stable conversation identity.
-    static func dedupedCandidatesByStableKey(_ candidates: [DedupCandidate]) -> [DedupCandidate] {
-        var byKey: [String: DedupCandidate] = [:]
+    static func dedupedCandidatesByStableKey(_ candidates: [SessionRecord]) -> [SessionRecord] {
+        var byKey: [String: SessionRecord] = [:]
         for candidate in candidates {
-            let key = stableKey(for: candidate.session)
+            let key = stableKey(for: candidate.data)
             if let existing = byKey[key], SessionLifecyclePolicy.prefers(existing, over: candidate) { continue }
             byKey[key] = candidate
         }
-        return byKey.values.sorted { stableKey(for: $0.session) < stableKey(for: $1.session) }
+        return byKey.values.sorted { stableKey(for: $0.data) < stableKey(for: $1.data) }
     }
 
-    /// Collapse visible observations that resolve to one logical panel row. The first
-    /// occurrence owns the row position while the lifecycle policy chooses its observation.
-    static func dedupedCandidatesByLogicalIdentity(_ candidates: [DedupCandidate]) -> [DedupCandidate] {
-        var result: [DedupCandidate] = []
-        var indexByIdentity: [LogicalIdentity: Int] = [:]
-
-        for candidate in candidates {
-            let identity = logicalIdentity(for: candidate.session)
-            if let index = indexByIdentity[identity] {
-                if SessionLifecyclePolicy.prefers(candidate, over: result[index]) {
-                    result[index] = candidate
-                }
-            } else {
-                indexByIdentity[identity] = result.count
-                result.append(candidate)
-            }
-        }
-        return result
-    }
 }
 
 /// One pass's snapshot of every way a session can match a manual hide: migrated
@@ -150,7 +136,7 @@ struct ManualHideEvidence {
 
     var hasUnresolvedLegacyKeys: Bool { !legacyKeys.isEmpty }
 
-    func matches(_ session: Session) -> Bool {
+    func matches(_ session: SessionData) -> Bool {
         if let cctopSessionID = session.cctopSessionId, hiddenSessionIDs.contains(cctopSessionID) {
             return true
         }
@@ -178,7 +164,7 @@ struct ManualSessionVisibilityStore {
     }
 
     var hiddenSessionIDs: Set<String> {
-        Set((defaults.stringArray(forKey: Self.defaultsKey) ?? []).filter(Session.isValidCctopSessionId))
+        Set((defaults.stringArray(forKey: Self.defaultsKey) ?? []).filter(CctopSessionID.isValid))
     }
 
     var hasStoredHideEvidence: Bool {
@@ -194,7 +180,7 @@ struct ManualSessionVisibilityStore {
     /// Snapshot manual-hide match state for one pass over the given session inventory.
     /// The inventory only contributes durable evidence for sessions still matching an
     /// unresolved legacy key; permanent IDs and legacy keys come from the store itself.
-    func manualHideEvidence(in sessions: [Session]) -> ManualHideEvidence {
+    func manualHideEvidence(in sessions: [SessionData]) -> ManualHideEvidence {
         let legacyKeys = unresolvedDurableLegacyKeys
         var evidence = Set(legacyKeys.compactMap(Self.durableEvidence(forLegacyKey:)))
         evidence.formUnion(sessions
@@ -207,15 +193,15 @@ struct ManualSessionVisibilityStore {
         )
     }
 
-    func isHidden(_ session: Session) -> Bool {
+    func isHidden(_ session: SessionData) -> Bool {
         guard let cctopSessionID = session.cctopSessionId,
-              Session.isValidCctopSessionId(cctopSessionID) else { return false }
+              CctopSessionID.isValid(cctopSessionID) else { return false }
         return hiddenSessionIDs.contains(cctopSessionID)
     }
 
-    func hide(_ session: Session) {
+    func hide(_ session: SessionData) {
         guard let cctopSessionID = session.cctopSessionId,
-              Session.isValidCctopSessionId(cctopSessionID) else { return }
+              CctopSessionID.isValid(cctopSessionID) else { return }
         var sessionIDs = hiddenSessionIDs
         sessionIDs.insert(cctopSessionID)
         save(sessionIDs)
@@ -226,8 +212,8 @@ struct ManualSessionVisibilityStore {
     /// Process-scoped `active:<pid>` keys are retired rather than rebound to a new process generation.
     @discardableResult
     func migrateLegacyStableKeys(
-        using sessions: [Session],
-        persistedSessions: [Session],
+        using sessions: [SessionData],
+        persistedSessions: [SessionData],
         inventoryComplete: Bool
     ) -> Set<String> {
         let legacyKeys = legacyStableKeys
@@ -298,7 +284,7 @@ struct ManualSessionVisibilityStore {
     }
 
     private static func persistedLegacyMigrationMatches(
-        in sessions: [Session],
+        in sessions: [SessionData],
         legacyKeys: Set<String>
     ) -> PersistedLegacyMatches {
         var matches = PersistedLegacyMatches()
@@ -324,7 +310,7 @@ struct ManualSessionVisibilityStore {
     }
 
     private static func legacyMigrationCandidateIDs(
-        for session: Session,
+        for session: SessionData,
         persistedSessionIDsByEvidence: [String: Set<String>]
     ) -> Set<String> {
         var matches: Set<String> = []
@@ -342,8 +328,8 @@ struct ManualSessionVisibilityStore {
         guard components.count == 2 else { return nil }
         let source: String
         switch components[0] {
-        case "codex": source = Session.codexSource
-        case "desktop": source = Session.ccSource
+        case "codex": source = SessionData.codexSource
+        case "desktop": source = SessionData.ccSource
         default: return nil
         }
         let sessionID = String(components[1])

--- a/menubar/CctopMenubar/Services/SessionLifecyclePolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionLifecyclePolicy.swift
@@ -1,13 +1,17 @@
 import Foundation
 
-/// Ordering inputs for lifecycle deduplication, kept separate from `Session`'s stored fields
-/// so the total order is unit-testable without disk or process probing. `mtime` is
-/// `.distantPast` when unknown so the comparison stays total.
-struct DedupCandidate {
-    let session: Session
+/// One `SessionData` value plus the file and runtime evidence for that value.
+/// This in-memory record is not part of the persisted JSON schema.
+/// `mtime` is `.distantPast` when unknown so lifecycle preference remains a total order.
+struct SessionRecord {
+    let data: SessionData
     let lifecycleRank: Int   // 0 = active, 1 = dormant, 2 = finished (lower = preferred)
     let mtime: Date
     let path: String         // absolute file path; final, total tiebreak
+
+    func replacingData(_ data: SessionData) -> SessionRecord {
+        SessionRecord(data: data, lifecycleRank: lifecycleRank, mtime: mtime, path: path)
+    }
 }
 
 /// Tunable windows for lifecycle derivation.
@@ -25,7 +29,7 @@ enum SessionLifecyclePolicy {
     /// Pure connection derivation. Codex uses one source-level policy across every surface;
     /// other sessions retain their existing host-specific connection evidence.
     static func connectionState(
-        for session: Session, hostClass: SessionHostClass, processAlive: Bool,
+        for session: SessionData, hostClass: SessionHostClass, processAlive: Bool,
         now: Date, windows: LifecycleWindows, desktopAppRunning: Bool? = nil
     ) -> SessionConnectionState {
         if session.endedAt != nil { return .disconnected }
@@ -42,7 +46,7 @@ enum SessionLifecyclePolicy {
     /// Pure lifecycle derivation. Connection is detected uniformly first; host policy then
     /// decides what disconnected means for desktop versus non-desktop sessions.
     static func lifecycle(
-        for session: Session, hostClass: SessionHostClass, processAlive: Bool,
+        for session: SessionData, hostClass: SessionHostClass, processAlive: Bool,
         now: Date, windows: LifecycleWindows, desktopAppRunning: Bool? = nil
     ) -> SessionLifecycle {
         // Codex has one absolute inactivity cap across every surface. Bundle, PID,
@@ -72,13 +76,13 @@ enum SessionLifecyclePolicy {
         return now.timeIntervalSince(disconnectedAt) <= windows.retention ? .dormant : .finished
     }
 
-    static func prefers(_ lhs: DedupCandidate, over rhs: DedupCandidate) -> Bool {
+    static func prefers(_ lhs: SessionRecord, over rhs: SessionRecord) -> Bool {
         if lhs.lifecycleRank != rhs.lifecycleRank { return lhs.lifecycleRank < rhs.lifecycleRank }
-        if lhs.session.lastActivity != rhs.session.lastActivity {
-            return lhs.session.lastActivity > rhs.session.lastActivity
+        if lhs.data.lastActivity != rhs.data.lastActivity {
+            return lhs.data.lastActivity > rhs.data.lastActivity
         }
-        if lhs.session.effectiveEndDate != rhs.session.effectiveEndDate {
-            return lhs.session.effectiveEndDate > rhs.session.effectiveEndDate
+        if lhs.data.effectiveEndDate != rhs.data.effectiveEndDate {
+            return lhs.data.effectiveEndDate > rhs.data.effectiveEndDate
         }
         if lhs.mtime != rhs.mtime { return lhs.mtime > rhs.mtime }
         return lhs.path < rhs.path

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -12,7 +12,7 @@ struct SessionDataSources {
     var codexThreads: any CodexThreadStateProviding
     var claudeDesktopSessions: any ClaudeDesktopSessionStateProviding
     var desktopAppConnection: DesktopAppConnectionLookup
-    var processAlive: (Session) -> Bool
+    var processAlive: (SessionData) -> Bool
     var notificationsEnabled: () -> Bool
     var notificationClient: SessionNotificationClient = .live
     var manualSessionVisibility: ManualSessionVisibilityStore = .live
@@ -108,7 +108,7 @@ enum SessionDisposition: Equatable {
 
 struct ClassifiedSessionRecord {
     let url: URL
-    let candidate: DedupCandidate
+    let candidate: SessionRecord
     let disposition: SessionDisposition
 }
 
@@ -116,21 +116,21 @@ struct SessionClassificationSnapshot {
     let records: [ClassifiedSessionRecord]
     let evidence: SessionClassificationEvidence
 
-    var displayCandidates: [DedupCandidate] {
+    var displayCandidates: [SessionRecord] {
         records.compactMap { record in
             guard record.disposition == .display else { return nil }
             return record.candidate
         }
     }
 
-    var autoHiddenSessions: [(URL, Session)] {
+    var autoHiddenSessions: [(URL, SessionData)] {
         records.compactMap { record in
             guard case .hidden(.autoHidden) = record.disposition else { return nil }
-            return (record.url, record.candidate.session)
+            return (record.url, record.candidate.data)
         }
     }
 
-    var codexInternalHelperCandidates: [DedupCandidate] {
+    var codexInternalHelperCandidates: [SessionRecord] {
         records.compactMap { record in
             guard case .hidden(.codexInternalHelper) = record.disposition else { return nil }
             return record.candidate
@@ -141,44 +141,44 @@ struct SessionClassificationSnapshot {
         let displayProtected = SessionIdentityPolicy
             .dedupedCandidatesByStableKey(displayCandidates)
             .filter { $0.lifecycleRank != SessionLifecycle.finished.rawValue }
-            .map(\.session.projectPath)
+            .map(\.data.projectPath)
         let hiddenProtected = records.compactMap { record -> String? in
             guard case .hidden(let reason) = record.disposition,
                   reason.protectsCleanupPath,
                   record.candidate.lifecycleRank != SessionLifecycle.finished.rawValue else {
                 return nil
             }
-            return record.candidate.session.projectPath
+            return record.candidate.data.projectPath
         }
         return Set(displayProtected).union(hiddenProtected)
     }
 
-    var finishedNonDesktopCandidates: [DedupCandidate] {
+    var finishedNonDesktopCandidates: [SessionRecord] {
         displayCandidates.filter {
             $0.lifecycleRank == SessionLifecycle.finished.rawValue
-                && !$0.session.isCodex
-                && $0.session.hostClass != .desktop
+                && !$0.data.isCodex
+                && $0.data.hostClass != .desktop
         }
     }
 
     func manualHiddenProjectPaths(_ hiddenSessionIDs: Set<String>) -> Set<String> {
         Set(records.compactMap { record in
-            guard let cctopSessionID = record.candidate.session.cctopSessionId,
+            guard let cctopSessionID = record.candidate.data.cctopSessionId,
                   hiddenSessionIDs.contains(cctopSessionID) else { return nil }
-            return record.candidate.session.projectPath
+            return record.candidate.data.projectPath
         })
     }
 
     /// Archived conversations can seed worktree cleanup while preserving the session file.
     /// Finished non-retained sessions continue to contribute through history.
-    var cleanupSources: [SessionCleanupSource] {
+    var cleanupSources: [SessionDataCleanupSource] {
         records.compactMap { record in
             guard case .hidden(let reason) = record.disposition,
                   reason.emitsCleanupSource,
-                  record.candidate.session.hasCleanupSourcePath else {
+                  record.candidate.data.hasCleanupSourcePath else {
                 return nil
             }
-            return SessionCleanupSource(session: record.candidate.session)
+            return SessionDataCleanupSource(data: record.candidate.data)
         }
     }
 
@@ -203,7 +203,7 @@ private extension SessionHiddenReason {
     }
 }
 
-private extension Session {
+private extension SessionData {
     var hasCleanupSourcePath: Bool {
         let path = WorktreeCleanupScanner.standardizedPath(projectPath)
         return !path.isEmpty && path != "/"
@@ -212,29 +212,29 @@ private extension Session {
 
 extension SessionManager {
     func retainedFinishedCleanupSources(
-        winners: [DedupCandidate],
+        winners: [SessionRecord],
         manualHides: ManualHideEvidence
-    ) -> [SessionCleanupSource] {
+    ) -> [SessionDataCleanupSource] {
         winners.compactMap { candidate in
-            let session = candidate.session
+            let data = candidate.data
             guard candidate.lifecycleRank == SessionLifecycle.finished.rawValue,
-                  shouldRetainFinishedManualHideEvidence(session, matching: manualHides),
-                  session.hasCleanupSourcePath else {
+                  shouldRetainFinishedManualHideEvidence(data, matching: manualHides),
+                  data.hasCleanupSourcePath else {
                 return nil
             }
-            return SessionCleanupSource(session: session)
+            return SessionDataCleanupSource(data: data)
         }
     }
 
     func archiveAndRemoveFinishedNonDesktop(
-        _ candidates: [DedupCandidate],
-        winners: [DedupCandidate],
+        _ candidates: [SessionRecord],
+        winners: [SessionRecord],
         manualHides: ManualHideEvidence
-    ) -> [SessionCleanupSource] {
+    ) -> [SessionDataCleanupSource] {
         let winnerPaths = Set(winners.map(\.path))
-        var newlyArchivedCleanupSources: [SessionCleanupSource] = []
+        var newlyArchivedCleanupSources: [SessionDataCleanupSource] = []
         for candidate in candidates {
-            guard !shouldRetainFinishedManualHideEvidence(candidate.session, matching: manualHides) else { continue }
+            guard !shouldRetainFinishedManualHideEvidence(candidate.data, matching: manualHides) else { continue }
             // A finished dedup winner is a real completed non-desktop session, so keep today's
             // Recent Projects behavior. A finished duplicate loser is stale migration debris;
             // remove it without archiving so it cannot later surface as a separate session.
@@ -250,20 +250,20 @@ extension SessionManager {
     }
 
     func shouldRetainFinishedManualHideEvidence(
-        _ session: Session,
+        _ data: SessionData,
         matching manualHides: ManualHideEvidence
     ) -> Bool {
-        manualHides.matches(session) || hasExistingMappedManualHide(session)
+        manualHides.matches(data) || hasExistingMappedManualHide(data)
     }
 
-    func hasExistingMappedManualHide(_ session: Session) -> Bool {
-        guard !Session.isValidCctopSessionId(session.cctopSessionId) else { return false }
+    func hasExistingMappedManualHide(_ data: SessionData) -> Bool {
+        guard !CctopSessionID.isValid(data.cctopSessionId) else { return false }
         let hiddenSessionIDs = dataSources.manualSessionVisibility.hiddenSessionIDs
         guard !hiddenSessionIDs.isEmpty,
               let existingID = try? CctopSessionIdentityStore(sessionsDir: dataSources.sessionsDir).existingIdentity(
-                  source: session.source,
-                  harnessSessionId: session.harnessSessionId,
-                  legacySessionId: session.sessionId
+                  source: data.source,
+                  harnessSessionId: data.harnessSessionId,
+                  legacySessionId: data.sessionId
               ) else {
             return false
         }
@@ -277,18 +277,18 @@ extension SessionManager {
         guard Self.isLegacyUUIDFilename(url.deletingPathExtension().lastPathComponent) else { return false }
         if !dataSources.manualSessionVisibility.hasStoredHideEvidence {
             try? FileManager.default.removeItem(at: url) // Pre-PID legacy file; no live writer to race.
-        } else if let data = try? Data(contentsOf: url),
-                  let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data),
-                  !shouldRetainFinishedManualHideEvidence(session, matching: manualHides) {
+        } else if let fileData = try? Data(contentsOf: url),
+                  let data = try? JSONDecoder.sessionDecoder.decode(SessionData.self, from: fileData),
+                  !shouldRetainFinishedManualHideEvidence(data, matching: manualHides) {
             try? FileManager.default.removeItem(at: url)
         }
         return true
     }
 
     func mergingCleanupSources(
-        _ retained: [SessionCleanupSource],
-        with replacements: [SessionCleanupSource]
-    ) -> [SessionCleanupSource] {
+        _ retained: [SessionDataCleanupSource],
+        with replacements: [SessionDataCleanupSource]
+    ) -> [SessionDataCleanupSource] {
         retained.filter { source in
             !replacements.contains {
                 $0.sessionId == source.sessionId && $0.projectPath == source.projectPath
@@ -296,26 +296,26 @@ extension SessionManager {
         } + replacements
     }
 
-    private func archiveAndRemove(_ candidate: DedupCandidate) -> SessionCleanupSource? {
-        let session = candidate.session
+    private func archiveAndRemove(_ candidate: SessionRecord) -> SessionDataCleanupSource? {
+        let data = candidate.data
         // A dead non-desktop process holds no lock, so removing its .json needs no flock. Remove
         // the .json ONLY — never the .lock (unlinking a lock a hook still holds splits the inode).
-        if historyManager.archiveSession(session) {
+        if historyManager.archiveSession(data) {
             try? FileManager.default.removeItem(atPath: candidate.path)
-            return session.hasCleanupSourcePath ? SessionCleanupSource(session: session) : nil
+            return data.hasCleanupSourcePath ? SessionDataCleanupSource(data: data) : nil
         } else {
-            sessionManagerLogger.warning("skipping removal of \(session.sessionId, privacy: .public) — archive failed")
+            sessionManagerLogger.warning("skipping removal of \(data.sessionId, privacy: .public) — archive failed")
             return nil
         }
     }
 
-    private func removeStaleDuplicate(_ candidate: DedupCandidate) {
+    private func removeStaleDuplicate(_ candidate: SessionRecord) {
         sessionManagerLogger.info("removing stale duplicate session file \(candidate.path, privacy: .public)")
         try? FileManager.default.removeItem(atPath: candidate.path)
     }
 
     nonisolated static func desktopAppRunningByBundleID(
-        in sessions: [Session],
+        in sessions: [SessionData],
         lookup: DesktopAppConnectionLookup
     ) -> [String: Bool] {
         let bundleIDs = Set(sessions.compactMap { session -> String? in
@@ -326,7 +326,7 @@ extension SessionManager {
     }
 
     nonisolated static func desktopAppRunning(
-        for session: Session,
+        for session: SessionData,
         runningByBundleID: [String: Bool]
     ) -> Bool? {
         guard session.hostClass == .desktop,
@@ -337,7 +337,7 @@ extension SessionManager {
     }
 
     nonisolated static func desktopAppRunning(
-        for session: Session,
+        for session: SessionData,
         lookup: DesktopAppConnectionLookup
     ) -> Bool? {
         guard session.hostClass == .desktop,
@@ -351,26 +351,26 @@ extension SessionManager {
         in jsonFiles: [URL],
         now: Date
     ) {
-        var finished: [Session] = []
+        var finished: [SessionData] = []
         for url in jsonFiles {
             guard !Self.isLegacyUUIDFilename(url.deletingPathExtension().lastPathComponent),
-                  let data = try? Data(contentsOf: url),
-                  let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data),
-                  !session.hidden,
-                  !session.shouldAutoHide,
-                  session.isCodex || session.hostClass == .desktop else {
+                  let fileData = try? Data(contentsOf: url),
+                  let data = try? JSONDecoder.sessionDecoder.decode(SessionData.self, from: fileData),
+                  !data.hidden,
+                  !data.shouldAutoHide,
+                  data.isCodex || data.hostClass == .desktop else {
                 continue
             }
             let life = SessionLifecyclePolicy.lifecycle(
-                for: session,
-                hostClass: session.hostClass,
-                processAlive: dataSources.processAlive(session),
+                for: data,
+                hostClass: data.hostClass,
+                processAlive: dataSources.processAlive(data),
                 now: now,
                 windows: Self.lifecycleWindows,
-                desktopAppRunning: Self.desktopAppRunning(for: session, lookup: dataSources.desktopAppConnection)
+                desktopAppRunning: Self.desktopAppRunning(for: data, lookup: dataSources.desktopAppConnection)
             )
             if life == .finished {
-                finished.append(session)
+                finished.append(data)
             }
         }
 
@@ -385,12 +385,12 @@ extension SessionManager {
     }
 
     nonisolated static func sessionClassificationSnapshot(
-        in candidates: [DedupCandidate],
+        in candidates: [SessionRecord],
         codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup(),
         claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup(),
         now: Date = Date()
     ) -> SessionClassificationSnapshot {
-        let sessions = candidates.map(\.session)
+        let sessions = candidates.map(\.data)
         let claudeMetadata = claudeDesktopMetadataSnapshot(in: sessions, claudeDesktopSessions: claudeDesktopSessions)
         return sessionClassificationSnapshot(
             in: candidates,
@@ -402,14 +402,14 @@ extension SessionManager {
     }
 
     nonisolated static func sessionClassificationSnapshot(
-        in candidates: [DedupCandidate],
+        in candidates: [SessionRecord],
         claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?,
         codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup(),
         now: Date = Date()
     ) -> SessionClassificationSnapshot {
         sessionClassificationSnapshot(
             in: candidates,
-            sessions: candidates.map(\.session),
+            sessions: candidates.map(\.data),
             claudeMetadata: claudeMetadata,
             codexThreads: codexThreads,
             now: now
@@ -417,8 +417,8 @@ extension SessionManager {
     }
 
     private nonisolated static func sessionClassificationSnapshot(
-        in candidates: [DedupCandidate],
-        sessions: [Session],
+        in candidates: [SessionRecord],
+        sessions: [SessionData],
         claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?,
         codexThreads: any CodexThreadStateProviding,
         now: Date
@@ -458,7 +458,7 @@ extension SessionManager {
                 url: URL(fileURLWithPath: candidate.path),
                 candidate: candidate,
                 disposition: disposition(
-                    for: candidate.session,
+                    for: candidate.data,
                     evidence: evidence,
                     claudeMetadata: claudeMetadata
                 )
@@ -468,46 +468,46 @@ extension SessionManager {
     }
 
     private nonisolated static func disposition(
-        for session: Session,
+        for data: SessionData,
         evidence: SessionClassificationEvidence,
         claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?
     ) -> SessionDisposition {
         // Priority is behavior-bearing: Codex archive wins so no other hidden reason can protect
         // an archived path from Cleanup. Durable local hides then precede external missing/helper state.
-        let isArchivedCodexSession = session.isCodex
-            && evidence.archivedCodexThreadIDs.contains(session.sessionId)
+        let isArchivedCodexSession = data.isCodex
+            && evidence.archivedCodexThreadIDs.contains(data.sessionId)
         if isArchivedCodexSession {
             return .hidden(.archivedCodexThread)
         }
-        if session.hidden {
+        if data.hidden {
             return .hidden(.persistedHidden)
         }
-        if session.shouldAutoHide {
+        if data.shouldAutoHide {
             return .hidden(.autoHidden)
         }
-        if isMissingCodexSession(session, missingThreadIDs: evidence.missingCodexThreadIDs) {
+        if isMissingCodexSession(data, missingThreadIDs: evidence.missingCodexThreadIDs) {
             return .hidden(.missingCodexThread)
         }
-        if isCodexInternalHelperSession(session, internalHelperThreadIDs: evidence.codexInternalHelperThreadIDs) {
+        if isCodexInternalHelperSession(data, internalHelperThreadIDs: evidence.codexInternalHelperThreadIDs) {
             return .hidden(.codexInternalHelper)
         }
-        if isCodexExecHelperSession(session, execHelperThreadIDs: evidence.codexExecHelperThreadIDs) {
+        if isCodexExecHelperSession(data, execHelperThreadIDs: evidence.codexExecHelperThreadIDs) {
             return .hidden(.codexExecHelper)
         }
-        if isArchivedClaudeDesktopSession(session, archivedSessionIDs: evidence.archivedClaudeSessionIDs) {
+        if isArchivedClaudeDesktopSession(data, archivedSessionIDs: evidence.archivedClaudeSessionIDs) {
             return .hidden(.archivedClaudeDesktop)
         }
         // Claude Desktop `SessionEnd` is worker/session termination, not archive; matched metadata stays resumable.
-        if isOrphanedEndedClaudeDesktopSession(session, metadataSnapshot: claudeMetadata) {
+        if isOrphanedEndedClaudeDesktopSession(data, metadataSnapshot: claudeMetadata) {
             return .hidden(.orphanedEndedClaudeDesktop)
         }
-        if isClaudeDesktopStartupPlaceholder(session, metadataSnapshot: claudeMetadata) {
+        if isClaudeDesktopStartupPlaceholder(data, metadataSnapshot: claudeMetadata) {
             return .hidden(.claudeDesktopStartupPlaceholder)
         }
         return .display
     }
 
-    func deriveSessionClassification(from decoded: [(url: URL, session: Session)]) -> SessionClassificationSnapshot {
+    func deriveSessionClassification(from decoded: [(url: URL, session: SessionData)]) -> SessionClassificationSnapshot {
         let now = dataSources.now()
         let codexThreads = batchedCodexThreadState(
             in: decoded.map(\.session),
@@ -538,21 +538,21 @@ extension SessionManager {
     }
 
     private func repairStickyCodexDelegationState(
-        in decoded: [(url: URL, session: Session)],
+        in decoded: [(url: URL, session: SessionData)],
         codexThreads: FrozenCodexThreadState
-    ) -> [(url: URL, session: Session)] {
+    ) -> [(url: URL, session: SessionData)] {
         guard let index = codexThreads.index else { return decoded }
         let repairableThreadIDs = index.interactiveRootThreadIDs
             .intersection(index.knownNoSpawnEdgeThreadIDs)
         guard !repairableThreadIDs.isEmpty else { return decoded }
 
-        var repairedByPath: [String: Session] = [:]
-        for (url, session) in decoded where session.hidden
-            && session.isSubagentSession
-            && repairableThreadIDs.contains(session.sessionId) {
+        var repairedByPath: [String: SessionData] = [:]
+        for (url, data) in decoded where data.hidden
+            && data.isSubagentSession
+            && repairableThreadIDs.contains(data.sessionId) {
             withSessionLockForMaintenance(
                 sessionPath: url.path,
-                sessionId: session.sessionId,
+                sessionId: data.sessionId,
                 action: "Codex delegated-task classification repair"
             ) {
                 guard let repaired = try Self.repairedCodexInteractiveRootSessionSnapshot(
@@ -564,7 +564,7 @@ extension SessionManager {
                 try repaired.writeToFile(path: url.path)
                 repairedByPath[url.path] = repaired
                 sessionManagerLogger.info(
-                    "restoring interactive Codex session \(session.sessionId, privacy: .public)"
+                    "restoring interactive Codex session \(data.sessionId, privacy: .public)"
                 )
             }
         }
@@ -575,7 +575,7 @@ extension SessionManager {
     }
 
     private func batchedCodexThreadState(
-        in sessions: [Session],
+        in sessions: [SessionData],
         codexThreads: any CodexThreadStateProviding
     ) -> FrozenCodexThreadState {
         let threadIDs = Self.codexThreadIDs(in: sessions)
@@ -587,7 +587,7 @@ extension SessionManager {
         return FrozenCodexThreadState(index: effectiveIndex)
     }
 
-    private nonisolated static func codexThreadIDs(in sessions: [Session]) -> Set<String> {
+    private nonisolated static func codexThreadIDs(in sessions: [SessionData]) -> Set<String> {
         Set(
             sessions
                 .filter(\.isCodex)
@@ -598,7 +598,7 @@ extension SessionManager {
     /// Codex sessions should correspond to a Codex thread row. If the thread store is
     /// readable and the row is gone, the app should not publish the stale hook session.
     private nonisolated static func missingCodexThreadIDs(
-        in sessions: [Session],
+        in sessions: [SessionData],
         index: CodexThreadStateIndex?,
         now: Date
     ) -> Set<String> {
@@ -618,14 +618,14 @@ extension SessionManager {
     }
 
     nonisolated static func isMissingCodexSession(
-        _ session: Session,
+        _ session: SessionData,
         missingThreadIDs: Set<String>
     ) -> Bool {
         session.isCodex && missingThreadIDs.contains(session.sessionId)
     }
 
     nonisolated static func isCodexInternalHelperSession(
-        _ session: Session,
+        _ session: SessionData,
         internalHelperThreadIDs: Set<String>
     ) -> Bool {
         session.isCodex && internalHelperThreadIDs.contains(session.sessionId)
@@ -634,7 +634,7 @@ extension SessionManager {
     /// Codex can launch short-lived `codex exec` helper threads. They are useful as
     /// rollout artifacts but should not appear as user-visible cctop sessions.
     private nonisolated static func codexExecHelperThreadIDs(
-        in sessions: [Session],
+        in sessions: [SessionData],
         index: CodexThreadStateIndex?
     ) -> Set<String> {
         let threadIDs = codexThreadIDs(in: sessions)
@@ -642,7 +642,7 @@ extension SessionManager {
     }
 
     nonisolated static func isCodexExecHelperSession(
-        _ session: Session,
+        _ session: SessionData,
         execHelperThreadIDs: Set<String>
     ) -> Bool {
         session.isCodex && execHelperThreadIDs.contains(session.sessionId)
@@ -654,9 +654,9 @@ extension SessionManager {
     nonisolated static func codexInternalHelperHiddenSessionSnapshot(
         path: String,
         internalHelperThreadIDs: Set<String>
-    ) throws -> Session? {
+    ) throws -> SessionData? {
         guard FileManager.default.fileExists(atPath: path) else { return nil }
-        var latest = try Session.fromFile(path: path)
+        var latest = try SessionData.fromFile(path: path)
         guard !latest.hidden, latest.isCodex else { return nil }
         guard internalHelperThreadIDs.contains(latest.sessionId) else { return nil }
         latest.isSubagentSession = true
@@ -670,9 +670,9 @@ extension SessionManager {
     nonisolated static func repairedCodexInteractiveRootSessionSnapshot(
         path: String,
         repairableThreadIDs: Set<String>
-    ) throws -> Session? {
+    ) throws -> SessionData? {
         guard FileManager.default.fileExists(atPath: path) else { return nil }
-        var latest = try Session.fromFile(path: path)
+        var latest = try SessionData.fromFile(path: path)
         guard latest.hidden,
               latest.isSubagentSession,
               latest.isCodex,
@@ -686,20 +686,20 @@ extension SessionManager {
         return latest
     }
 
-    nonisolated static func autoHiddenSessionSnapshot(path: String) throws -> Session? {
+    nonisolated static func autoHiddenSessionSnapshot(path: String) throws -> SessionData? {
         guard FileManager.default.fileExists(atPath: path) else { return nil }
-        var latest = try Session.fromFile(path: path)
+        var latest = try SessionData.fromFile(path: path)
         guard !latest.hidden, latest.shouldAutoHide else { return nil }
         latest.hidden = true
         return latest
     }
 
-    func hideCodexInternalHelperSessions(_ candidates: [DedupCandidate]) {
-        let internalHelperThreadIDs = Set(candidates.map(\.session.sessionId))
+    func hideCodexInternalHelperSessions(_ candidates: [SessionRecord]) {
+        let internalHelperThreadIDs = Set(candidates.map(\.data.sessionId))
         for candidate in candidates {
             withSessionLockForMaintenance(
                 sessionPath: candidate.path,
-                sessionId: candidate.session.sessionId,
+                sessionId: candidate.data.sessionId,
                 action: "Codex internal helper hide"
             ) {
                 guard let hiddenSession = try Self.codexInternalHelperHiddenSessionSnapshot(
@@ -709,7 +709,7 @@ extension SessionManager {
                     return
                 }
                 sessionManagerLogger.info(
-                    "hiding Codex internal helper session \(candidate.session.sessionId, privacy: .public)"
+                    "hiding Codex internal helper session \(candidate.data.sessionId, privacy: .public)"
                 )
                 try hiddenSession.writeToFile(path: candidate.path)
             }
@@ -717,7 +717,7 @@ extension SessionManager {
     }
 
     nonisolated static func claudeDesktopMetadataSnapshot(
-        in sessions: [Session],
+        in sessions: [SessionData],
         claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup()
     ) -> ClaudeDesktopSessionMetadataSnapshot? {
         let sessionIDs = Set(
@@ -729,14 +729,14 @@ extension SessionManager {
     }
 
     nonisolated static func isArchivedClaudeDesktopSession(
-        _ session: Session,
+        _ session: SessionData,
         archivedSessionIDs: Set<String>
     ) -> Bool {
         session.isClaudeDesktopHost && archivedSessionIDs.contains(session.sessionId)
     }
 
     nonisolated static func isOrphanedEndedClaudeDesktopSession(
-        _ session: Session,
+        _ session: SessionData,
         metadataSnapshot: ClaudeDesktopSessionMetadataSnapshot?
     ) -> Bool {
         guard session.isClaudeDesktopHost,
@@ -747,7 +747,10 @@ extension SessionManager {
         return metadataSnapshot?.matchedSessionIDs.contains(session.sessionId) == false
     }
 
-    nonisolated static func isClaudeDesktopStartupPlaceholder(_ session: Session, metadataSnapshot: ClaudeDesktopSessionMetadataSnapshot?) -> Bool {
+    nonisolated static func isClaudeDesktopStartupPlaceholder(
+        _ session: SessionData,
+        metadataSnapshot: ClaudeDesktopSessionMetadataSnapshot?
+    ) -> Bool {
         guard session.isClaudeDesktopHost,
               session.endedAt == nil, session.disconnectedAt == nil,
               metadataSnapshot?.isAuthoritative == true, metadataSnapshot?.matchedSessionIDs.contains(session.sessionId) == false,
@@ -772,7 +775,7 @@ extension SessionManager {
     /// out from under a pending unarchive. When the store exists but cannot be read, the lookup
     /// returns nil and we fail SAFE.
     nonisolated static func isCodexThreadArchived(
-        _ session: Session,
+        _ session: SessionData,
         codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup()
     ) -> Bool {
         guard session.isCodex else { return false }
@@ -786,7 +789,7 @@ extension SessionManager {
     /// metadata means "not archived"; unreadable matching metadata means "unknown" and keeps the
     /// file.
     nonisolated static func isClaudeDesktopSessionArchived(
-        _ session: Session,
+        _ session: SessionData,
         claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup()
     ) -> Bool {
         guard session.isClaudeDesktopHost else { return false }
@@ -797,7 +800,7 @@ extension SessionManager {
     }
 
     nonisolated static func isArchivedRetainedSession(
-        _ session: Session,
+        _ session: SessionData,
         codexThreads: any CodexThreadStateProviding = CodexThreadArchiveLookup(),
         claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup()
     ) -> Bool {
@@ -808,30 +811,30 @@ extension SessionManager {
     /// Decode each session file, derive its lifecycle, and capture mtime — the inputs the dedup
     /// comparator needs. Pure (no published state), kept off the main class body.
     nonisolated static func buildCandidates(
-        _ sessionFiles: [(url: URL, session: Session)],
+        _ sessionFiles: [(url: URL, session: SessionData)],
         now: Date,
         desktopAppConnectionLookup: DesktopAppConnectionLookup = .live,
         claudeMetadata: ClaudeDesktopSessionMetadataSnapshot?,
-        processAlive: (Session) -> Bool = { $0.isAlive }
-    ) -> [DedupCandidate] {
+        processAlive: (SessionData) -> Bool = { $0.isAlive }
+    ) -> [SessionRecord] {
         let projectNames = claudeMetadata?.projectNamesBySessionID ?? [:]
         let desktopAppRunningByBundleID = desktopAppRunningByBundleID(
             in: sessionFiles.map(\.session),
             lookup: desktopAppConnectionLookup
         )
-        var candidates: [DedupCandidate] = []
-        for (url, var session) in sessionFiles {
-            if let projectName = projectNames[session.sessionId] {
-                session.desktopProjectName = projectName
+        var candidates: [SessionRecord] = []
+        for (url, var data) in sessionFiles {
+            if let projectName = projectNames[data.sessionId] {
+                data.desktopProjectName = projectName
             }
-            session.lifecycle = SessionLifecyclePolicy.lifecycle(
-                for: session, hostClass: session.hostClass, processAlive: processAlive(session),
+            data.lifecycle = SessionLifecyclePolicy.lifecycle(
+                for: data, hostClass: data.hostClass, processAlive: processAlive(data),
                 now: now, windows: lifecycleWindows,
-                desktopAppRunning: desktopAppRunning(for: session, runningByBundleID: desktopAppRunningByBundleID)
+                desktopAppRunning: desktopAppRunning(for: data, runningByBundleID: desktopAppRunningByBundleID)
             )
             let mtime = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
                 .contentModificationDate ?? .distantPast
-            candidates.append(DedupCandidate(session: session, lifecycleRank: session.lifecycle.rawValue,
+            candidates.append(SessionRecord(data: data, lifecycleRank: data.lifecycle.rawValue,
                                              mtime: mtime, path: url.path))
         }
         return candidates
@@ -842,18 +845,18 @@ extension SessionManager {
         now: Date,
         desktopAppConnectionLookup: DesktopAppConnectionLookup = .live,
         claudeDesktopSessions: any ClaudeDesktopSessionStateProviding = ClaudeDesktopSessionArchiveLookup(),
-        processAlive: (Session) -> Bool = { $0.isAlive }
-    ) -> [DedupCandidate] {
-        let sessionFiles: [(url: URL, session: Session)] = jsonFiles.compactMap { url in
-            guard let data = try? Data(contentsOf: url) else {
+        processAlive: (SessionData) -> Bool = { $0.isAlive }
+    ) -> [SessionRecord] {
+        let sessionFiles: [(url: URL, session: SessionData)] = jsonFiles.compactMap { url in
+            guard let fileData = try? Data(contentsOf: url) else {
                 sessionManagerLogger.warning("loadSessions: could not read \(url.lastPathComponent, privacy: .public)")
                 return nil
             }
-            guard let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data) else {
+            guard let data = try? JSONDecoder.sessionDecoder.decode(SessionData.self, from: fileData) else {
                 sessionManagerLogger.error("loadSessions: decode failed \(url.lastPathComponent, privacy: .public)")
                 return nil
             }
-            return (url, session)
+            return (url, data)
         }
 
         let claudeMetadata = claudeDesktopMetadataSnapshot(
@@ -867,6 +870,30 @@ extension SessionManager {
             claudeMetadata: claudeMetadata,
             processAlive: processAlive
         )
+    }
+
+    func withSessionLockForMaintenance(
+        sessionPath: String,
+        sessionId: String,
+        action: String,
+        body: () throws -> Void
+    ) {
+        do {
+            let didAcquire = try withSessionLockIfAvailable(
+                sessionPath: sessionPath,
+                onError: { sessionManagerLogger.warning("\($0, privacy: .public)") },
+                body: body
+            )
+            if !didAcquire {
+                sessionManagerLogger.info(
+                    "skipping \(action, privacy: .public) for \(sessionId, privacy: .public): session lock is busy"
+                )
+            }
+        } catch {
+            sessionManagerLogger.warning(
+                "skipping \(action, privacy: .public) for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+        }
     }
 
 }

--- a/menubar/CctopMenubar/Services/SessionManager+Loading.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Loading.swift
@@ -27,7 +27,7 @@ struct SessionLoadLogSignature: Equatable {
 
 struct SessionFileCacheEntry {
     let fingerprint: SessionFileFingerprint
-    let session: Session
+    let session: SessionData
 }
 
 struct SessionFileFingerprint: Equatable {
@@ -37,11 +37,11 @@ struct SessionFileFingerprint: Equatable {
 }
 
 extension SessionManager {
-    func decodedSessions(from jsonFiles: [URL]) -> [(url: URL, session: Session)] {
+    func decodedSessions(from jsonFiles: [URL]) -> [(url: URL, session: SessionData)] {
         let currentPaths = Set(jsonFiles.map(\.path))
         sessionFileCache = sessionFileCache.filter { currentPaths.contains($0.key) }
 
-        let decoded = jsonFiles.compactMap { url -> (url: URL, session: Session)? in
+        let decoded = jsonFiles.compactMap { url -> (url: URL, session: SessionData)? in
             guard let fingerprint = sessionFileFingerprint(for: url) else {
                 sessionFileCache.removeValue(forKey: url.path)
                 sessionManagerLogger.warning("loadSessions: could not stat \(url.lastPathComponent, privacy: .public)")
@@ -56,7 +56,7 @@ extension SessionManager {
                 return nil
             }
             do {
-                let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: data)
+                let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: data)
                 sessionFileCache[url.path] = SessionFileCacheEntry(
                     fingerprint: fingerprint,
                     session: session
@@ -73,24 +73,24 @@ extension SessionManager {
 
     // Build one evidence index and resolve the bounded publishable set in a single pass.
     func assigningCctopSessionIdentities(
-        to candidates: [DedupCandidate],
-        knownRecords: [(url: URL, session: Session)]
-    ) -> [Session] {
-        var records = candidates.map { (url: URL(fileURLWithPath: $0.path), session: $0.session) }
+        to candidates: [SessionRecord],
+        knownRecords: [(url: URL, session: SessionData)]
+    ) -> [SessionData] {
+        var records = candidates.map { (url: URL(fileURLWithPath: $0.path), session: $0.data) }
         var idsByEvidence: [String: Set<String>] = [:]
-        for record in knownRecords where Session.isValidCctopSessionId(record.session.cctopSessionId) {
+        for record in knownRecords where CctopSessionID.isValid(record.session.cctopSessionId) {
             guard let evidence = CctopSessionIdentityStore.durableEvidence(for: record.session),
                   let cctopSessionId = record.session.cctopSessionId else { continue }
             idsByEvidence[evidence, default: []].insert(cctopSessionId)
         }
 
         let identityStore = CctopSessionIdentityStore(sessionsDir: dataSources.sessionsDir)
-        for index in records.indices where !Session.isValidCctopSessionId(records[index].session.cctopSessionId) {
-            var session = records[index].session
-            guard let evidence = CctopSessionIdentityStore.durableEvidence(for: session) else {
+        for index in records.indices where !CctopSessionID.isValid(records[index].session.cctopSessionId) {
+            var data = records[index].session
+            guard let evidence = CctopSessionIdentityStore.durableEvidence(for: data) else {
                 scheduleCctopSessionIdentityStamp(
                     url: records[index].url,
-                    snapshot: session,
+                    snapshot: data,
                     resolvedID: nil
                 )
                 continue
@@ -98,13 +98,13 @@ extension SessionManager {
             let knownIDs = idsByEvidence[evidence] ?? []
             do {
                 let cctopSessionId = try identityStore.resolve(
-                    source: session.source,
-                    harnessSessionId: session.harnessSessionId,
-                    legacySessionId: session.sessionId,
+                    source: data.source,
+                    harnessSessionId: data.harnessSessionId,
+                    legacySessionId: data.sessionId,
                     knownExistingIDs: knownIDs
                 )
-                session.cctopSessionId = cctopSessionId
-                records[index].session = session
+                data.cctopSessionId = cctopSessionId
+                records[index].session = data
                 idsByEvidence[evidence, default: []].insert(cctopSessionId)
                 scheduleCctopSessionIdentityStamp(
                     url: records[index].url,
@@ -123,14 +123,14 @@ extension SessionManager {
     }
 
     func identifiedPublishableCandidates(
-        winners: [DedupCandidate],
-        knownRecords: [(url: URL, session: Session)]
-    ) -> [DedupCandidate] {
-        let publishableWinners = winners.filter { $0.session.lifecycle != .finished }
+        winners: [SessionRecord],
+        knownRecords: [(url: URL, session: SessionData)]
+    ) -> [SessionRecord] {
+        let publishableWinners = winners.filter { $0.data.lifecycle != .finished }
         let identified = assigningCctopSessionIdentities(to: publishableWinners, knownRecords: knownRecords)
-        return zip(publishableWinners, identified).map { candidate, session in
-            DedupCandidate(
-                session: session,
+        return zip(publishableWinners, identified).map { candidate, data in
+            SessionRecord(
+                data: data,
                 lifecycleRank: candidate.lifecycleRank,
                 mtime: candidate.mtime,
                 path: candidate.path
@@ -140,19 +140,19 @@ extension SessionManager {
 
     func identifyingPersistedRecords(
         in classification: SessionClassificationSnapshot,
-        knownRecords: [(url: URL, session: Session)]
+        knownRecords: [(url: URL, session: SessionData)]
     ) -> SessionClassificationSnapshot {
         let legacyKeys = dataSources.manualSessionVisibility.unresolvedDurableLegacyKeys
         let indices = classification.records.indices.filter { index in
             let record = classification.records[index]
-            let session = record.candidate.session
-            guard case .legacy(let stableKey) = SessionIdentityPolicy.logicalIdentity(for: session) else { return false }
-            if hasExistingMappedManualHide(session) { return true }
+            let data = record.candidate.data
+            guard case .legacy(let stableKey) = SessionIdentityPolicy.logicalIdentity(for: data) else { return false }
+            if hasExistingMappedManualHide(data) { return true }
             if legacyKeys.contains(stableKey) { return true }
             guard case .hidden(let reason) = record.disposition else { return false }
             switch reason {
             case .archivedClaudeDesktop:
-                return CctopSessionIdentityStore.durableEvidence(for: session) != nil
+                return CctopSessionIdentityStore.durableEvidence(for: data) != nil
             case .persistedHidden, .autoHidden, .archivedCodexThread, .missingCodexThread,
                  .codexInternalHelper, .codexExecHelper,
                  .orphanedEndedClaudeDesktop, .claudeDesktopStartupPlaceholder:
@@ -166,13 +166,13 @@ extension SessionManager {
             knownRecords: knownRecords
         )
         var records = classification.records
-        for (index, session) in zip(indices, identified) {
+        for (index, data) in zip(indices, identified) {
             let record = records[index]
             let candidate = record.candidate
             records[index] = ClassifiedSessionRecord(
                 url: record.url,
-                candidate: DedupCandidate(
-                    session: session,
+                candidate: SessionRecord(
+                    data: data,
                     lifecycleRank: candidate.lifecycleRank,
                     mtime: candidate.mtime,
                     path: candidate.path
@@ -185,21 +185,21 @@ extension SessionManager {
 
     private func scheduleCctopSessionIdentityStamp(
         url: URL,
-        snapshot: Session,
+        snapshot: SessionData,
         resolvedID: String?
     ) {
         guard pendingIdentityMigrationPaths.insert(url.path).inserted else { return }
         cctopIdentityMigrationQueue.async { [weak self] in
             do {
                 _ = try withSessionLockIfAvailable(sessionPath: url.path) {
-                    guard var current = try? Session.fromFile(path: url.path) else { return }
-                    if Session.isValidCctopSessionId(current.cctopSessionId) {
+                    guard var current = try? SessionData.fromFile(path: url.path) else { return }
+                    if CctopSessionID.isValid(current.cctopSessionId) {
                         return
                     }
                     guard current.sessionId == snapshot.sessionId,
                           current.source == snapshot.source,
                           current.harnessSessionId == snapshot.harnessSessionId else { return }
-                    current.cctopSessionId = resolvedID ?? Session.makeCctopSessionId()
+                    current.cctopSessionId = resolvedID ?? CctopSessionID.make()
                     try current.writeToFile(path: url.path)
                 }
             } catch {

--- a/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
@@ -67,34 +67,36 @@ struct SessionNotificationClient {
 
 enum SessionNotificationAction: Equatable {
     case remove(cctopSessionID: String)
-    case post(session: Session)
+    case post(session: SessionData)
 }
 
 @MainActor
 extension SessionManager {
-    func hideSession(_ session: Session) {
+    func hideSession(_ session: SessionData) {
         guard let cctopSessionID = session.cctopSessionId,
-              Session.isValidCctopSessionId(cctopSessionID),
-              sessions.contains(where: { $0.cctopSessionId == cctopSessionID }) else { return }
+              CctopSessionID.isValid(cctopSessionID),
+              sessions.contains(where: { $0.cctopSessionId == cctopSessionID }),
+              let hiddenUserSession = userSessions.first(where: {
+                  $0.identity.cctopSessionID == cctopSessionID
+              }) else { return }
 
-        let hiddenSessions = sessions.filter { $0.cctopSessionId == cctopSessionID }
+        let hiddenSessions = hiddenUserSession.records.map(\.data)
         let hiddenProjectPaths = Set(hiddenSessions.map { HistoryManager.canonicalRecentProjectPath($0.projectPath) })
         dataSources.manualSessionVisibility.hide(session)
-        let visibleSessions = sessions.filter { $0.cctopSessionId != cctopSessionID }
         recentResumeTargets.removeAll { target in
             if target.cctopSessionId == cctopSessionID { return true }
             guard case .project = target else { return false }
             return hiddenProjectPaths.contains(HistoryManager.canonicalRecentProjectPath(target.projectPath))
         }
         removeNotification(cctopSessionID: cctopSessionID, matching: hiddenSessions)
-        sessions = visibleSessions
+        updateSessionProjection(userSessions.filter { $0.identity.cctopSessionID != cctopSessionID })
     }
 
-    func isManuallyHidden(_ session: Session) -> Bool {
+    func isManuallyHidden(_ session: SessionData) -> Bool {
         dataSources.manualSessionVisibility.isHidden(session)
     }
 
-    func syncTransitionNotifications(for newSessions: [Session], oldSessions: [Session]) {
+    func syncTransitionNotifications(for newSessions: [SessionData], oldSessions: [SessionData]) {
         for action in Self.notificationActions(
             newSessions: newSessions,
             oldSessions: oldSessions,
@@ -102,7 +104,12 @@ extension SessionManager {
         ) {
             switch action {
             case .remove(let cctopSessionID):
-                removeNotification(cctopSessionID: cctopSessionID, matching: oldSessions)
+                removeNotification(
+                    cctopSessionID: cctopSessionID,
+                    matching: oldSessions.filter {
+                        SessionIdentityPolicy.permanentSessionID(for: $0) == cctopSessionID
+                    }
+                )
             case .post(let session):
                 sendNotification(for: session)
             }
@@ -110,17 +117,17 @@ extension SessionManager {
     }
 
     nonisolated static func notificationActions(
-        newSessions: [Session],
-        oldSessions: [Session],
+        newSessions: [SessionData],
+        oldSessions: [SessionData],
         notificationsEnabled: Bool
     ) -> [SessionNotificationAction] {
-        let newByCctopSessionID: [String: Session] = Dictionary(
+        let newByCctopSessionID: [String: SessionData] = Dictionary(
             newSessions.compactMap { session in
                 SessionIdentityPolicy.permanentSessionID(for: session).map { ($0, session) }
             },
             uniquingKeysWith: { first, _ in first }
         )
-        let oldByCctopSessionID: [String: Session] = Dictionary(
+        let oldByCctopSessionID: [String: SessionData] = Dictionary(
             oldSessions.compactMap { session in
                 SessionIdentityPolicy.permanentSessionID(for: session).map { ($0, session) }
             },
@@ -147,7 +154,7 @@ extension SessionManager {
         return actions
     }
 
-    nonisolated static func notificationRequest(for session: Session) -> UNNotificationRequest? {
+    nonisolated static func notificationRequest(for session: SessionData) -> UNNotificationRequest? {
         guard let cctopSessionID = SessionIdentityPolicy.permanentSessionID(for: session),
               let identifier = SessionIdentityPolicy.notificationRequestIdentifier(
                   forCctopSessionID: cctopSessionID
@@ -171,11 +178,11 @@ extension SessionManager {
         )
     }
 
-    func postNotification(for session: Session) {
+    func postNotification(for session: SessionData) {
         guard let cctopSessionID = SessionIdentityPolicy.permanentSessionID(for: session),
               let currentSession = FocusTargetResolver.currentSession(
                   forCctopSessionID: cctopSessionID,
-                  in: SessionDisplayPolicy.activeSessions(from: sessions)
+                  in: SessionDisplayPolicy.activeSessions(from: userSessions)
               ),
               currentSession.shouldPostAttentionNotification,
               !isManuallyHidden(currentSession),
@@ -191,7 +198,7 @@ extension SessionManager {
         }
     }
 
-    private func sendNotification(for session: Session) {
+    private func sendNotification(for session: SessionData) {
         let center = UNUserNotificationCenter.current()
         center.getNotificationSettings { settings in
             switch settings.authorizationStatus {
@@ -212,14 +219,18 @@ extension SessionManager {
         }
     }
 
-    private func removeNotification(cctopSessionID: String, matching observations: [Session]) {
+    private func removeNotification(cctopSessionID: String, matching sessions: [SessionData]) {
         guard let identifier = SessionIdentityPolicy.notificationRequestIdentifier(
             forCctopSessionID: cctopSessionID
         ) else { return }
         var identifiers = Set([identifier])
         identifiers.formUnion(
-            observations
-                .filter { $0.cctopSessionId == cctopSessionID }
+            sessions
+                .filter { session in
+                    SessionIdentityPolicy.permanentSessionID(for: session).map {
+                        $0 == cctopSessionID
+                    } ?? true
+                }
                 .compactMap(SessionIdentityPolicy.legacyNotificationRequestIdentifier)
         )
         let sortedIdentifiers = identifiers.sorted()

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -7,22 +7,23 @@ import os.log
 let sessionManagerLogger = Logger(subsystem: "com.st0012.CctopMenubar", category: "SessionManager")
 
 struct WorktreeCleanupSessionSnapshot {
-    let cleanupSources: [SessionCleanupSource]
+    let cleanupSources: [SessionDataCleanupSource]
     let activeProjectPaths: Set<String>
 }
 
 @MainActor
 // swiftlint:disable:next type_body_length
 class SessionManager: ObservableObject {
-    @Published var sessions: [Session] = []
+    @Published private(set) var sessions: [SessionData] = []
     @Published var recentResumeTargets: [RecentResumeTarget] = []
+    private(set) var userSessions: [UserSession] = []
 
     let historyManager: HistoryManager
     let dataSources: SessionDataSources
-    var cleanupRefreshHandler: (([SessionCleanupSource], Set<String>) -> Void)?
-    private(set) var cleanupSources: [SessionCleanupSource] = []
+    var cleanupRefreshHandler: (([SessionDataCleanupSource], Set<String>) -> Void)?
+    private(set) var cleanupSources: [SessionDataCleanupSource] = []
     private(set) var cleanupActiveProjectPaths: Set<String> = []
-    private var currentClassificationCleanupSources: [SessionCleanupSource] = []
+    private var currentClassificationCleanupSources: [SessionDataCleanupSource] = []
     var codexThreadClassificationMemory = CodexThreadClassificationMemory()
 
     private let sessionsDir: URL
@@ -73,7 +74,7 @@ class SessionManager: ObservableObject {
             lastDisplaySignature = .empty
             lastLoadLogSignature = nil
             sessionFileCache.removeAll()
-            sessions = []
+            updateSessionProjection([])
             if !hasStoredHideEvidence {
                 publishRecentResumeTargets(historyManager.recentProjects.map(RecentResumeTarget.project))
             }
@@ -105,7 +106,7 @@ class SessionManager: ObservableObject {
         let winners = SessionIdentityPolicy.dedupedCandidatesByStableKey(displayCandidates)
         let now = dataSources.now()
         let identifiedCandidates = identifiedPublishableCandidates(winners: winners, knownRecords: allDecoded)
-        let identifiedInventory = classification.records.map(\.candidate.session) + identifiedCandidates.map(\.session)
+        let identifiedInventory = classification.records.map(\.candidate.data) + identifiedCandidates.map(\.data)
         dataSources.manualSessionVisibility.migrateLegacyStableKeys(
             using: identifiedInventory, persistedSessions: allDecoded.map(\.session), inventoryComplete: inventoryComplete
         )
@@ -113,22 +114,31 @@ class SessionManager: ObservableObject {
         let hiddenSessionIDs = manualHides.hiddenSessionIDs
         let retainedFinishedCleanupSources = retainedFinishedCleanupSources(winners: winners, manualHides: manualHides)
         let observedCleanupSources = classification.cleanupSources + retainedFinishedCleanupSources
-        let visibleCandidates = identifiedCandidates.filter { !manualHides.matches($0.session) }
-        let identifiedSessions = SessionIdentityPolicy.dedupedCandidatesByLogicalIdentity(visibleCandidates).map(\.session)
-        let loadedSessions = identifiedSessions.map { adjustDisplayStatus($0) }
-        let orderedSessions = SessionDisplayPolicy.reconcilingActiveOrder(in: loadedSessions, preserving: oldSessions, now: now)
-        let newSessions = orderedSessions
-        let displaySignature = SessionDisplayPolicy.signature(for: newSessions, now: now)
-        syncTransitionNotifications(for: newSessions, oldSessions: oldSessions)
-        // Only publish when data actually changed, or when the presentation bucket changed
-        // because an active idle session crossed the stale-idle threshold.
-        if newSessions != sessions || displaySignature != lastDisplaySignature {
-            if newSessions.count != sessions.count {
-                sessionManagerLogger.info("loadSessions: session count \(self.sessions.count) -> \(newSessions.count)")
-            }
-            lastDisplaySignature = displaySignature
-            sessions = newSessions
+        let visibleCandidates = identifiedCandidates.filter { !manualHides.matches($0.data) }
+        let visibleRecords = displayCandidates.filter { !manualHides.matches($0.data) }
+        let groupedUserSessions = UserSession.grouping(
+            winners: visibleCandidates,
+            records: visibleRecords
+        )
+        let loadedUserSessions = groupedUserSessions.map {
+            $0.replacingDisplayData(adjustDisplayStatus($0.displayRecord.data))
         }
+        let loadedSessions = loadedUserSessions.map(\.displayRecord.data)
+        let orderedSessions = SessionDisplayPolicy.reconcilingActiveOrder(in: loadedSessions, preserving: oldSessions, now: now)
+        let userSessionsByID = Dictionary(
+            uniqueKeysWithValues: loadedUserSessions.map { ($0.identity, $0) }
+        )
+        let newUserSessions = orderedSessions.compactMap { data in
+            let identity = SessionIdentityPolicy.logicalIdentity(for: data)
+            return userSessionsByID[identity]?.replacingDisplayData(data)
+        }
+        let newSessions = newUserSessions.map(\.displayRecord.data)
+        let displaySignature = SessionDisplayPolicy.signature(for: newSessions, now: now)
+        updateSessionProjection(
+            newUserSessions,
+            displaySignature: displaySignature,
+            syncNotificationsFrom: oldSessions
+        )
 
         hideAutoHiddenSessions(autoHidden)
         hideCodexInternalHelperSessions(classification.codexInternalHelperCandidates)
@@ -171,7 +181,7 @@ class SessionManager: ObservableObject {
 
         // Prune permanent IDs only after a complete inventory; partial reads retain them to avoid revealing sessions.
         if inventoryComplete {
-            let validSessionIDs = Set(identifiedInventory.compactMap(\.cctopSessionId).filter(Session.isValidCctopSessionId))
+            let validSessionIDs = Set(identifiedInventory.compactMap(\.cctopSessionId).filter(CctopSessionID.isValid))
             dataSources.manualSessionVisibility.prune(retaining: validSessionIDs)
         }
     }
@@ -182,28 +192,26 @@ class SessionManager: ObservableObject {
         }
     }
 
-    func withSessionLockForMaintenance(
-        sessionPath: String,
-        sessionId: String,
-        action: String,
-        body: () throws -> Void
+    func updateSessionProjection(
+        _ newUserSessions: [UserSession],
+        displaySignature: SessionDisplayPolicy.Signature? = nil,
+        syncNotificationsFrom oldSessions: [SessionData]? = nil
     ) {
-        do {
-            let didAcquire = try withSessionLockIfAvailable(
-                sessionPath: sessionPath,
-                onError: { sessionManagerLogger.warning("\($0, privacy: .public)") },
-                body: body
-            )
-            if !didAcquire {
-                sessionManagerLogger.info(
-                    "skipping \(action, privacy: .public) for \(sessionId, privacy: .public): session lock is busy"
-                )
-            }
-        } catch {
-            sessionManagerLogger.warning(
-                "skipping \(action, privacy: .public) for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)"
-            )
+        let newSessions = newUserSessions.map(\.displayRecord.data)
+        userSessions = newUserSessions
+        if let oldSessions {
+            syncTransitionNotifications(for: newSessions, oldSessions: oldSessions)
         }
+
+        let displayChanged = displaySignature.map { $0 != lastDisplaySignature } ?? false
+        guard newSessions != sessions || displayChanged else { return }
+        if newSessions.count != sessions.count {
+            sessionManagerLogger.info("loadSessions: session count \(self.sessions.count) -> \(newSessions.count)")
+        }
+        if let displaySignature {
+            lastDisplaySignature = displaySignature
+        }
+        sessions = newSessions
     }
 
     func cleanupSnapshotForRemoval() -> WorktreeCleanupSessionSnapshot {
@@ -214,7 +222,7 @@ class SessionManager: ObservableObject {
         )
     }
 
-    private func hideAutoHiddenSessions(_ sessions: [(URL, Session)]) {
+    private func hideAutoHiddenSessions(_ sessions: [(URL, SessionData)]) {
         for (url, session) in sessions {
             withSessionLockForMaintenance(sessionPath: url.path, sessionId: session.sessionId, action: "auto-hide update") {
                 guard let hiddenSession = try Self.autoHiddenSessionSnapshot(path: url.path) else { return }
@@ -226,24 +234,24 @@ class SessionManager: ObservableObject {
         }
     }
 
-    private func autoHideReason(for session: Session) -> String {
+    private func autoHideReason(for session: SessionData) -> String {
         if session.isSubagentSession { return "subagent-owned" }
         if session.isCodexMemoryMaintenanceSession { return "Codex memory maintenance" }
         if session.isCodexTitleGenerationSession { return "Codex title generation" }
         return "maintenance"
     }
 
-    private func clearReconnectedDesktopSessions(_ candidates: [DedupCandidate], now: Date) {
+    private func clearReconnectedDesktopSessions(_ candidates: [SessionRecord], now: Date) {
         for candidate in candidates {
-            guard candidate.session.hostClass == .desktop,
-                  candidate.session.lifecycle == .active,
-                  candidate.session.disconnectedAt != nil else { continue }
+            guard candidate.data.hostClass == .desktop,
+                  candidate.data.lifecycle == .active,
+                  candidate.data.disconnectedAt != nil else { continue }
             withSessionLockForMaintenance(
                 sessionPath: candidate.path,
-                sessionId: candidate.session.sessionId,
+                sessionId: candidate.data.sessionId,
                 action: "desktop reconnect update"
             ) {
-                guard var session = try? Session.fromFile(path: candidate.path),
+                guard var session = try? SessionData.fromFile(path: candidate.path),
                       session.hostClass == .desktop,
                       session.disconnectedAt != nil else {
                     return
@@ -263,17 +271,17 @@ class SessionManager: ObservableObject {
         }
     }
 
-    private func stampDisconnectedDesktopSessions(_ candidates: [DedupCandidate], now: Date) {
+    private func stampDisconnectedDesktopSessions(_ candidates: [SessionRecord], now: Date) {
         for candidate in candidates {
-            guard candidate.session.hostClass == .desktop,
-                  candidate.session.lifecycle == .dormant,
-                  candidate.session.disconnectedAt == nil else { continue }
+            guard candidate.data.hostClass == .desktop,
+                  candidate.data.lifecycle == .dormant,
+                  candidate.data.disconnectedAt == nil else { continue }
             withSessionLockForMaintenance(
                 sessionPath: candidate.path,
-                sessionId: candidate.session.sessionId,
+                sessionId: candidate.data.sessionId,
                 action: "desktop disconnect update"
             ) {
-                guard var session = try? Session.fromFile(path: candidate.path),
+                guard var session = try? SessionData.fromFile(path: candidate.path),
                       session.hostClass == .desktop,
                       session.disconnectedAt == nil else {
                     return
@@ -301,7 +309,7 @@ class SessionManager: ObservableObject {
         let jsonFiles = files.filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasSuffix(".tmp") }
         let manualHides = dataSources.manualSessionVisibility.manualHideEvidence(
             in: jsonFiles.compactMap { url in
-                (try? Data(contentsOf: url)).flatMap { try? JSONDecoder.sessionDecoder.decode(Session.self, from: $0) }
+                (try? Data(contentsOf: url)).flatMap { try? JSONDecoder.sessionDecoder.decode(SessionData.self, from: $0) }
             }
         )
         preloadArchiveStateForFinishedRetainedSessions(in: jsonFiles, now: now)
@@ -314,7 +322,7 @@ class SessionManager: ObservableObject {
                 action: "retained session GC"
             ) {
                 guard let data = try? Data(contentsOf: url),
-                      let session = try? JSONDecoder.sessionDecoder.decode(Session.self, from: data) else {
+                      let session = try? JSONDecoder.sessionDecoder.decode(SessionData.self, from: data) else {
                     return   // decode failure → never treat as finished
                 }
                 guard !session.hidden, !session.shouldAutoHide else { return }
@@ -345,16 +353,16 @@ class SessionManager: ObservableObject {
         }
     }
 
-    private func refreshCleanupSources(from currentSources: [SessionCleanupSource], activeProjectPaths: Set<String>) {
+    private func refreshCleanupSources(from currentSources: [SessionDataCleanupSource], activeProjectPaths: Set<String>) {
         currentClassificationCleanupSources = currentSources
         cleanupSources = historyManager.lastDecodedHistorySessions
-            .compactMap { SessionCleanupSource(endedSession: $0) } + currentSources
+            .compactMap { SessionDataCleanupSource(endedSession: $0) } + currentSources
         cleanupActiveProjectPaths = activeProjectPaths
         cleanupRefreshHandler?(cleanupSources, activeProjectPaths)
     }
 
     /// Apply display-side status adjustments. The session file on disk is NOT modified.
-    private func adjustDisplayStatus(_ session: Session) -> Session {
+    private func adjustDisplayStatus(_ session: SessionData) -> SessionData {
         // A dormant (backgrounded) session isn't actively in any state — render it neutral (idle)
         // so it never shows a false "waiting"/"permission" pill. It's already excluded from counts
         // and notifications; this keeps the card itself honest.
@@ -372,7 +380,7 @@ class SessionManager: ObservableObject {
 
     /// If a session has been in `waitingInput` for over 60 minutes, treat it as
     /// `idle` for display. The user likely walked away.
-    nonisolated static func adjustIdleTimeout(_ session: Session, now: Date) -> Session {
+    nonisolated static func adjustIdleTimeout(_ session: SessionData, now: Date) -> SessionData {
         guard session.status == .waitingInput,
               now.timeIntervalSince(session.lastActivity) > Self.idleTimeoutSeconds else {
             return session
@@ -390,7 +398,7 @@ class SessionManager: ObservableObject {
     /// This distinguishes tool subprocesses from long-lived children like MCP servers
     /// by comparing each child's start time against `lastActivity` (set when
     /// PermissionRequest fired).
-    private func adjustPermissionStatus(_ session: Session) -> Session {
+    private func adjustPermissionStatus(_ session: SessionData) -> SessionData {
         guard session.status == .waitingPermission,
               let pid = session.pid else {
             return session
@@ -399,7 +407,7 @@ class SessionManager: ObservableObject {
         // Small tolerance for clock/serialization jitter; MCP servers started minutes+ before.
         let cutoff = session.lastActivity.timeIntervalSince1970 - 1.0
         for childPid in listChildPids(pid: pid) {
-            if let startTime = Session.processStartTime(pid: UInt32(childPid)),
+            if let startTime = SessionData.processStartTime(pid: UInt32(childPid)),
                startTime > cutoff {
                 var adjusted = session
                 adjusted.status = .working

--- a/menubar/CctopMenubar/Services/UserSession.swift
+++ b/menubar/CctopMenubar/Services/UserSession.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// One user-visible work session formed from one or more related `SessionRecord` values.
+/// A stable-key winner establishes identity. Older related records remain as evidence.
+struct UserSession {
+    let identity: SessionIdentityPolicy.LogicalIdentity
+    let records: [SessionRecord]
+    let displayRecord: SessionRecord
+
+    /// Indirect actions currently follow the same canonical record as the panel.
+    /// Direct row actions continue to use the exact row session they received.
+    var focusTarget: SessionData { displayRecord.data }
+
+    func replacingDisplayData(_ data: SessionData) -> UserSession {
+        UserSession(
+            identity: identity,
+            records: records,
+            displayRecord: displayRecord.replacingData(data)
+        )
+    }
+
+    /// Preserve stable-key dedup before grouping permanent logical identity. The identified
+    /// winner still controls each stable-key group. All retained records stay available for
+    /// later routing decisions.
+    static func grouping(
+        winners: [SessionRecord],
+        records: [SessionRecord]
+    ) -> [UserSession] {
+        let recordsByStableKey = Dictionary(grouping: records) {
+            SessionIdentityPolicy.stableKey(for: $0.data)
+        }
+        var result: [UserSession] = []
+        var indexByIdentity: [SessionIdentityPolicy.LogicalIdentity: Int] = [:]
+
+        for winner in winners {
+            let stableKey = SessionIdentityPolicy.stableKey(for: winner.data)
+            let groupedRecords = (recordsByStableKey[stableKey] ?? [winner]).map {
+                $0.path == winner.path ? winner : $0
+            }
+            let identity = SessionIdentityPolicy.logicalIdentity(for: winner.data)
+
+            if let index = indexByIdentity[identity] {
+                let current = result[index]
+                let display = SessionLifecyclePolicy.prefers(winner, over: current.displayRecord)
+                    ? winner
+                    : current.displayRecord
+                result[index] = UserSession(
+                    identity: identity,
+                    records: current.records + groupedRecords,
+                    displayRecord: display
+                )
+            } else {
+                indexByIdentity[identity] = result.count
+                result.append(UserSession(
+                    identity: identity,
+                    records: groupedRecords,
+                    displayRecord: winner
+                ))
+            }
+        }
+        return result
+    }
+}

--- a/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupManager.swift
@@ -20,7 +20,7 @@ class WorktreeCleanupManager: ObservableObject {
     }
 
     func refresh(
-        from cleanupSources: [SessionCleanupSource],
+        from cleanupSources: [SessionDataCleanupSource],
         activeProjectPaths: Set<String>,
         force: Bool = false,
         onCompletion: (([WorktreeCleanupCandidate]) -> Void)? = nil
@@ -58,7 +58,7 @@ final class WorktreeCleanupRefreshGate: ObservableObject {
     @Published private(set) var hasHiddenCleanupNudge = false
 
     private let manager: WorktreeCleanupManager
-    private var cleanupSources: [SessionCleanupSource] = []
+    private var cleanupSources: [SessionDataCleanupSource] = []
     private var activeProjectPaths: Set<String> = []
     private var isCleanupTabSelected = false
     private var isPanelVisible = false
@@ -69,7 +69,7 @@ final class WorktreeCleanupRefreshGate: ObservableObject {
         self.manager = manager
     }
 
-    func updateSources(_ cleanupSources: [SessionCleanupSource], activeProjectPaths: Set<String>) {
+    func updateSources(_ cleanupSources: [SessionDataCleanupSource], activeProjectPaths: Set<String>) {
         self.cleanupSources = cleanupSources
         self.activeProjectPaths = activeProjectPaths
         if isCleanupVisible {
@@ -158,7 +158,7 @@ struct WorktreeCleanupRefreshSignature: Equatable {
     private let cleanupSources: [CleanupSourceFingerprint]
     private let activeProjectPaths: [String]
 
-    init(cleanupSources: [SessionCleanupSource], activeProjectPaths: Set<String>) {
+    init(cleanupSources: [SessionDataCleanupSource], activeProjectPaths: Set<String>) {
         self.cleanupSources = cleanupSources
             .compactMap {
                 let path = WorktreeCleanupScanner.standardizedPath($0.projectPath)

--- a/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
+++ b/menubar/CctopMenubar/Services/WorktreeCleanupScanner.swift
@@ -3,24 +3,24 @@ import Foundation
 /// Minimal session-derived row that the session classifier has deemed safe to use as a cleanup
 /// starting point. The scanner intentionally knows nothing about cctop lifecycle, archive state,
 /// host metadata, or process liveness; it only validates the filesystem/git worktree from here.
-struct SessionCleanupSource: Equatable {
+struct SessionDataCleanupSource: Equatable {
     let sessionId: String
     let projectPath: String
     let sessionName: String
     let branch: String
     let lastActiveAt: Date
 
-    init(session: Session) {
-        sessionId = session.sessionId
-        projectPath = session.projectPath
-        sessionName = session.displayName
-        branch = session.branch
-        lastActiveAt = session.effectiveEndDate
+    init(data: SessionData) {
+        sessionId = data.sessionId
+        projectPath = data.projectPath
+        sessionName = data.displayName
+        branch = data.branch
+        lastActiveAt = data.effectiveEndDate
     }
 
-    init?(endedSession session: Session) {
-        guard session.endedAt != nil else { return nil }
-        self.init(session: session)
+    init?(endedSession data: SessionData) {
+        guard data.endedAt != nil else { return nil }
+        self.init(data: data)
     }
 }
 
@@ -77,7 +77,7 @@ struct WorktreeCleanupScanner {
     }
 
     func candidates(
-        from cleanupSources: [SessionCleanupSource],
+        from cleanupSources: [SessionDataCleanupSource],
         activeProjectPaths: Set<String>
     ) -> [WorktreeCleanupCandidate] {
         let contexts = candidateContexts(from: cleanupSources)
@@ -93,7 +93,7 @@ struct WorktreeCleanupScanner {
             }
     }
 
-    private func candidateContexts(from cleanupSources: [SessionCleanupSource]) -> [String: CandidateContext] {
+    private func candidateContexts(from cleanupSources: [SessionDataCleanupSource]) -> [String: CandidateContext] {
         var result: [String: CandidateContext] = [:]
         var resolvedPaths: [String: String] = [:]
         for source in cleanupSources {
@@ -380,7 +380,7 @@ struct WorktreeCleanupScanner {
 extension WorktreeCleanupScanner {
     func candidate(
         withID id: String,
-        from cleanupSources: [SessionCleanupSource],
+        from cleanupSources: [SessionDataCleanupSource],
         activeProjectPaths: Set<String>
     ) -> WorktreeCleanupCandidate? {
         let id = Self.standardizedPath(id)
@@ -389,7 +389,7 @@ extension WorktreeCleanupScanner {
         return candidate(from: context, activeProjectPaths: activePaths)
     }
 
-    private func candidateContext(withID id: String, from cleanupSources: [SessionCleanupSource]) -> CandidateContext? {
+    private func candidateContext(withID id: String, from cleanupSources: [SessionDataCleanupSource]) -> CandidateContext? {
         var result: CandidateContext?
         var resolvedPaths: [String: String] = [:]
         for source in cleanupSources {
@@ -452,7 +452,7 @@ private struct CandidateContext {
     let fallbackBranch: String
     let lastActiveAt: Date
 
-    init(source: SessionCleanupSource, path: String? = nil) {
+    init(source: SessionDataCleanupSource, path: String? = nil) {
         self.path = path ?? WorktreeCleanupScanner.standardizedPath(source.projectPath)
         sessionName = source.sessionName
         worktreeName = URL(fileURLWithPath: self.path).lastPathComponent

--- a/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
+++ b/menubar/CctopMenubar/Services/WorktreeRemovalService.swift
@@ -30,7 +30,7 @@ struct WorktreeRemovalService {
 
     func selectedAction(
         for candidate: WorktreeCleanupCandidate,
-        cleanupSources: [SessionCleanupSource],
+        cleanupSources: [SessionDataCleanupSource],
         activeProjectPaths: Set<String>
     ) -> RemovalAction {
         switch readyCandidate(candidate, cleanupSources: cleanupSources, activeProjectPaths: activeProjectPaths) {
@@ -68,7 +68,7 @@ struct WorktreeRemovalService {
 
     func executeConfirmed(
         _ action: RemovalAction,
-        cleanupSources: [SessionCleanupSource],
+        cleanupSources: [SessionDataCleanupSource],
         activeProjectPaths: Set<String>
     ) -> RemovalResult {
         if case .blocked(let candidate, _) = action {
@@ -101,7 +101,7 @@ struct WorktreeRemovalService {
 
     func remove(
         _ candidate: WorktreeCleanupCandidate,
-        cleanupSources: [SessionCleanupSource],
+        cleanupSources: [SessionDataCleanupSource],
         activeProjectPaths: Set<String>
     ) -> RemovalResult {
         executeConfirmed(
@@ -118,7 +118,7 @@ struct WorktreeRemovalService {
 
     private func readyCandidate(
         _ candidate: WorktreeCleanupCandidate,
-        cleanupSources: [SessionCleanupSource],
+        cleanupSources: [SessionDataCleanupSource],
         activeProjectPaths: Set<String>
     ) -> ReadinessResult {
         guard candidate.state.isActionable else {

--- a/menubar/CctopMenubar/Views/HeaderView.swift
+++ b/menubar/CctopMenubar/Views/HeaderView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct HeaderView: View {
-    let sessions: [Session]
+    let sessions: [SessionData]
 
     var body: some View {
         let counts = StatusCounts(sessions: sessions)
@@ -78,5 +78,5 @@ private struct HairlineBrandMark: View {
 }
 
 #Preview("Normal") {
-    HeaderView(sessions: Session.qaShowcase).frame(width: 320).padding()
+    HeaderView(sessions: SessionData.qaShowcase).frame(width: 320).padding()
 }

--- a/menubar/CctopMenubar/Views/PopupView+Sessions.swift
+++ b/menubar/CctopMenubar/Views/PopupView+Sessions.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct PanelSessionRow: Identifiable {
     let slot: Int
-    let session: Session
+    let session: SessionData
     let id: SessionIdentityPolicy.LogicalIdentity
 }
 
@@ -10,7 +10,7 @@ extension PopupView {
     var isNavigateActive: Bool { navigate?.isActive ?? false }
     var hasMultipleSources: Bool { Set(sessions.map(\.agentBadge)).count > 1 }
 
-    var currentActiveSessions: [Session] {
+    var currentActiveSessions: [SessionData] {
         SessionDisplayPolicy.activeSessions(from: sessions)
     }
 
@@ -25,20 +25,17 @@ extension PopupView {
             }
         }
         return identities.enumerated().compactMap { index, identity in
-            guard let session = FocusTargetResolver.currentSession(
-                for: identity,
-                in: currentActiveSessions
-            ) else { return nil }
+            guard let session = currentSession(for: identity, in: .active) else { return nil }
             return PanelSessionRow(slot: index, session: session, id: identity)
         }
     }
 
-    var sortedActiveSessions: [Session] {
+    var sortedActiveSessions: [SessionData] {
         activeSessionRows.map(\.session)
     }
 
-    var sortedIdleSessions: [Session] {
-        Session.sorted(SessionDisplayPolicy.idleSessions(from: sessions))
+    var sortedIdleSessions: [SessionData] {
+        SessionData.sorted(SessionDisplayPolicy.idleSessions(from: sessions))
     }
 
     var idleSessionRows: [PanelSessionRow] {
@@ -99,12 +96,12 @@ extension PopupView {
             Button { requestHideSession(row.session) } label: {
                 Label("Hide Session", systemImage: "eye.slash")
             }
-            .disabled(!Session.isValidCctopSessionId(row.session.cctopSessionId))
+            .disabled(!CctopSessionID.isValid(row.session.cctopSessionId))
         }
         .help("Click to jump to session")
         .accessibilityActions {
             Button("Hide Session") { requestHideSession(row.session) }
-                .disabled(!Session.isValidCctopSessionId(row.session.cctopSessionId))
+                .disabled(!CctopSessionID.isValid(row.session.cctopSessionId))
         }
     }
 
@@ -121,9 +118,24 @@ extension PopupView {
 
     func confirmSessionSelection() {
         guard let identity = selectedSessionIdentity else { return }
-        let observations = selectedTab == .active ? currentActiveSessions : sortedIdleSessions
-        guard let session = FocusTargetResolver.currentSession(for: identity, in: observations) else { return }
+        guard let session = currentSession(for: identity, in: selectedTab) else { return }
         focusSession(session)
         if isNavigateActive { navigate?.didConfirmSubject.send() }
+    }
+
+    func currentSession(
+        for identity: SessionIdentityPolicy.LogicalIdentity,
+        in tab: PopupTab
+    ) -> SessionData? {
+        let candidates: [UserSession]
+        switch tab {
+        case .active:
+            candidates = SessionDisplayPolicy.activeSessions(from: userSessions)
+        case .idle:
+            candidates = SessionDisplayPolicy.idleSessions(from: userSessions)
+        case .recent, .cleanup:
+            return nil
+        }
+        return FocusTargetResolver.currentSession(for: identity, in: candidates)
     }
 }

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -6,7 +6,8 @@ private let overlayAnimationDuration: TimeInterval = 0.2
 private let relativeTimeRefresh = Timer.publish(every: 10, on: .main, in: .common).autoconnect()
 
 struct PopupView: View {
-    let sessions: [Session]
+    let sessions: [SessionData]
+    let userSessions: [UserSession]
     var recentProjects: [RecentProject] = []
     var recentResumeTargets: [RecentResumeTarget]?
     var cleanupCandidates: [WorktreeCleanupCandidate] = []
@@ -19,7 +20,7 @@ struct PopupView: View {
     var initialTab: PopupTab = .active
     var initialCleanupCandidate: WorktreeCleanupCandidate?
     var onOpenUpdater: (() -> Void)?
-    var onHideSession: (Session) -> Void = { _ in }
+    var onHideSession: (SessionData) -> Void = { _ in }
     var onSelectCleanupRemovalAction: ((WorktreeCleanupCandidate) async -> WorktreeRemovalService.RemovalAction)?
     var onExecuteCleanupRemovalAction: ((WorktreeRemovalService.RemovalAction) async -> WorktreeRemovalService.RemovalResult)?
     var onCleanupTabVisible: () -> Void = {}
@@ -351,7 +352,7 @@ extension PopupView {
         PopupTab.allCases
     }
 
-    func focusSession(_ session: Session) {
+    func focusSession(_ session: SessionData) {
         guard Date().timeIntervalSince(lastFocusTime) > 0.5 else { return }
         lastFocusTime = Date()
         focusTerminal(session: session)

--- a/menubar/CctopMenubar/Views/PopupViewHelpers.swift
+++ b/menubar/CctopMenubar/Views/PopupViewHelpers.swift
@@ -2,12 +2,12 @@ import AppKit
 import SwiftUI
 
 struct ManualSessionHideConfirmation: Identifiable, Equatable {
-    let session: Session
+    let session: SessionData
     let cctopSessionID: String
 
-    init?(session: Session) {
+    init?(session: SessionData) {
         guard let cctopSessionID = session.cctopSessionId,
-              Session.isValidCctopSessionId(cctopSessionID) else { return nil }
+              CctopSessionID.isValid(cctopSessionID) else { return nil }
         self.session = session
         self.cctopSessionID = cctopSessionID
     }
@@ -271,7 +271,7 @@ struct FooterUpdateStatusView: View {
 }
 
 extension PopupView {
-    func requestHideSession(_ session: Session) {
+    func requestHideSession(_ session: SessionData) {
         guard let confirmation = ManualSessionHideConfirmation(session: session) else { return }
         pendingConfirmation = .sessionHide(confirmation)
     }
@@ -296,9 +296,9 @@ extension PopupView {
         )
     }
 
-    func hideSession(_ session: Session) {
+    func hideSession(_ session: SessionData) {
         guard let cctopSessionID = session.cctopSessionId,
-              Session.isValidCctopSessionId(cctopSessionID),
+              CctopSessionID.isValid(cctopSessionID),
               sessions.contains(where: { $0.cctopSessionId == cctopSessionID }) else { return }
         onHideSession(session)
         selectedIndex = nil
@@ -329,6 +329,7 @@ struct PanelContentView: View {
     var body: some View {
         PopupView(
             sessions: sessionManager.sessions,
+            userSessions: sessionManager.userSessions,
             recentProjects: historyManager.recentProjects,
             recentResumeTargets: sessionManager.recentResumeTargets,
             cleanupCandidates: cleanupManager.candidates,
@@ -365,50 +366,79 @@ struct PanelContentView: View {
     PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
 }
 
+private func previewUserSessions(from sessions: [SessionData]) -> [UserSession] {
+    let records = sessions.enumerated().map { index, data in
+        SessionRecord(
+            data: data,
+            lifecycleRank: data.lifecycle.rawValue,
+            mtime: .distantPast,
+            path: "/preview-session-\(index).json"
+        )
+    }
+    return UserSession.grouping(
+        winners: SessionIdentityPolicy.dedupedCandidatesByStableKey(records),
+        records: records
+    )
+}
+
 #Preview("With sessions") {
     PopupView(
-        sessions: Session.mockSessions, updater: DisabledUpdater(), pluginManager: previewPluginManager()
+        sessions: SessionData.mockSessions,
+        userSessions: previewUserSessions(from: SessionData.mockSessions),
+        updater: DisabledUpdater(),
+        pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("Mixed sources") {
     PopupView(
-        sessions: Session.qaShowcase, updater: DisabledUpdater(), pluginManager: previewPluginManager()
+        sessions: SessionData.qaShowcase,
+        userSessions: previewUserSessions(from: SessionData.qaShowcase),
+        updater: DisabledUpdater(),
+        pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("Empty") {
     PopupView(
-        sessions: [], updater: DisabledUpdater(), pluginManager: previewPluginManager()
+        sessions: [], userSessions: [], updater: DisabledUpdater(), pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("With Tabs") {
     PopupView(
-        sessions: Session.mockSessions, recentProjects: RecentProject.mockRecents,
+        sessions: SessionData.mockSessions,
+        userSessions: previewUserSessions(from: SessionData.mockSessions),
+        recentProjects: RecentProject.mockRecents,
         updater: DisabledUpdater(), pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("Cleanup") {
     PopupView(
-        sessions: Session.mockSessions, recentProjects: RecentProject.mockRecents,
+        sessions: SessionData.mockSessions,
+        userSessions: previewUserSessions(from: SessionData.mockSessions),
+        recentProjects: RecentProject.mockRecents,
         cleanupCandidates: WorktreeCleanupCandidate.mockCandidates,
         updater: DisabledUpdater(), pluginManager: previewPluginManager(), initialTab: .cleanup
     ).frame(width: 320)
 }
 #Preview("Only Recents") {
     PopupView(
-        sessions: [], recentProjects: RecentProject.mockRecents,
+        sessions: [], userSessions: [], recentProjects: RecentProject.mockRecents,
         updater: DisabledUpdater(), pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("Empty Recents Tab") {
     PopupView(
-        sessions: Session.mockSessions, recentProjects: [RecentProject.mock()],
+        sessions: SessionData.mockSessions,
+        userSessions: previewUserSessions(from: SessionData.mockSessions),
+        recentProjects: [RecentProject.mock()],
         updater: DisabledUpdater(), pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("Navigate") {
     let rc = NavigateController(); rc.isActive = true
     return PopupView(
-        sessions: Session.qaShowcase, recentProjects: RecentProject.mockRecents,
+        sessions: SessionData.qaShowcase,
+        userSessions: previewUserSessions(from: SessionData.qaShowcase),
+        recentProjects: RecentProject.mockRecents,
         updater: DisabledUpdater(), pluginManager: previewPluginManager(), navigate: rc
     ).frame(width: 320)
 }

--- a/menubar/CctopMenubar/Views/SessionCardView.swift
+++ b/menubar/CctopMenubar/Views/SessionCardView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct SessionCardView: View {
-    let session: Session
+    let session: SessionData
     /// 1-based index for navigate mode (1-9). nil = normal mode.
     var navigateIndex: Int?
     var showSourceBadge = false
@@ -218,7 +218,7 @@ struct SessionCardView: View {
     // MARK: - Computed copy
 
     /// Text for the third row when the session is working/compacting — the command stripe.
-    /// Reuses `Session.contextLine` formatting (Reading X.swift, Running: foo, etc.).
+    /// Reuses `SessionData.contextLine` formatting (Reading X.swift, Running: foo, etc.).
     private var workingCommandText: String? {
         guard session.status == .working || session.status == .compacting else { return nil }
         return session.contextLine

--- a/menubar/CctopMenubarTests/AgentBadgeTests.swift
+++ b/menubar/CctopMenubarTests/AgentBadgeTests.swift
@@ -3,12 +3,12 @@ import XCTest
 
 final class AgentBadgeTests: XCTestCase {
     func testExplicitCC_returnsCC() {
-        let session = Session.mock(source: "cc")
+        let session = SessionData.mock(source: "cc")
         XCTAssertEqual(session.agentBadge, .cc)
     }
 
     func testLegacyNilSource_withoutDesktopBundle_returnsCC() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(program: "Code", bundleId: "com.microsoft.VSCode"),
             source: nil
         )
@@ -16,7 +16,7 @@ final class AgentBadgeTests: XCTestCase {
     }
 
     func testClaudeDesktopBundle_withNilSource_returnsClaudeDesktop() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(bundleId: "com.anthropic.claudefordesktop"),
             source: nil
         )
@@ -26,7 +26,7 @@ final class AgentBadgeTests: XCTestCase {
     func testClaudeDesktopBundle_withExplicitCCSource_returnsClaudeDesktop() {
         // Defensive: if Claude Desktop ever starts setting `source: "cc"`,
         // the bundle ID should still win and classify as Desktop.
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(bundleId: "com.anthropic.claudefordesktop"),
             source: "cc"
         )
@@ -34,7 +34,7 @@ final class AgentBadgeTests: XCTestCase {
     }
 
     func testCodexSource_withTerminalBundle_returnsCodex() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(program: "iTerm", bundleId: "com.googlecode.iterm2"),
             source: "codex"
         )
@@ -42,7 +42,7 @@ final class AgentBadgeTests: XCTestCase {
     }
 
     func testCodexSource_withCodexDesktopBundle_returnsCodex() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(bundleId: "com.openai.codex"),
             source: "codex"
         )
@@ -50,7 +50,7 @@ final class AgentBadgeTests: XCTestCase {
     }
 
     func testCodexDesktopBundleWithNilSourceDoesNotInferCodex() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(bundleId: "com.openai.codex"),
             source: nil
         )
@@ -61,7 +61,7 @@ final class AgentBadgeTests: XCTestCase {
         // A cc session is never hosted by Codex Desktop — that bundle id is launcher
         // environment leaked into a Claude Code child process (issue #155). The badge
         // must follow the harness, not the leaked bundle.
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(bundleId: "com.openai.codex"),
             source: "cc"
         )
@@ -69,7 +69,7 @@ final class AgentBadgeTests: XCTestCase {
     }
 
     func testCodexSource_ignoresLeakedClaudeDesktopBundle() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(bundleId: "com.anthropic.claudefordesktop"),
             source: "codex"
         )
@@ -77,12 +77,12 @@ final class AgentBadgeTests: XCTestCase {
     }
 
     func testOpencodeSource_returnsOpencode() {
-        let session = Session.mock(source: "opencode")
+        let session = SessionData.mock(source: "opencode")
         XCTAssertEqual(session.agentBadge, .opencode)
     }
 
     func testOpencodeSource_ignoresLeakedCodexDesktopBundle() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(bundleId: "com.openai.codex"),
             source: "opencode"
         )
@@ -90,12 +90,12 @@ final class AgentBadgeTests: XCTestCase {
     }
 
     func testPiSource_returnsPi() {
-        let session = Session.mock(source: "pi")
+        let session = SessionData.mock(source: "pi")
         XCTAssertEqual(session.agentBadge, .pi)
     }
 
     func testPiSource_ignoresLeakedClaudeDesktopBundle() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(bundleId: "com.anthropic.claudefordesktop"),
             source: "pi"
         )

--- a/menubar/CctopMenubarTests/DisplayStateWriterTests.swift
+++ b/menubar/CctopMenubarTests/DisplayStateWriterTests.swift
@@ -33,13 +33,13 @@ final class DisplayStateWriterTests: XCTestCase {
 
     func testSnapshotPreservesCanonicalPanelAndNavigateOrder() {
         let now = Date()
-        var permission = Session.mock(id: "a", project: "alpha", status: .waitingPermission)
+        var permission = SessionData.mock(id: "a", project: "alpha", status: .waitingPermission)
         permission.lastActivity = now.addingTimeInterval(-30)
-        var workingOld = Session.mock(id: "b", project: "bravo", status: .working)
+        var workingOld = SessionData.mock(id: "b", project: "bravo", status: .working)
         workingOld.lastActivity = now.addingTimeInterval(-300)
-        var workingNew = Session.mock(id: "c", project: "charlie", status: .working)
+        var workingNew = SessionData.mock(id: "c", project: "charlie", status: .working)
         workingNew.lastActivity = now.addingTimeInterval(-10)
-        var idle = Session.mock(id: "d", project: "delta", status: .idle)
+        var idle = SessionData.mock(id: "d", project: "delta", status: .idle)
         idle.lastActivity = now.addingTimeInterval(-60)
         let sessions = [permission, workingOld, workingNew, idle]
 
@@ -62,11 +62,11 @@ final class DisplayStateWriterTests: XCTestCase {
 
     func testSnapshotExcludesSessionsTheAppDoesNotDisplay() {
         let now = Date()
-        var dormant = Session.mock(id: "dormant", status: .working)
+        var dormant = SessionData.mock(id: "dormant", status: .working)
         dormant.lifecycle = .dormant
-        var staleIdle = Session.mock(id: "stale", status: .idle)
+        var staleIdle = SessionData.mock(id: "stale", status: .idle)
         staleIdle.lastActivity = now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 60)
-        let active = Session.mock(id: "active", status: .working)
+        let active = SessionData.mock(id: "active", status: .working)
 
         let snapshot = DisplayStateWriter.snapshot(
             sessions: [dormant, staleIdle, active],
@@ -81,7 +81,7 @@ final class DisplayStateWriterTests: XCTestCase {
 
     func testProjectionContainsOnlyAppOwnedDisplayFields() throws {
         let now = Date()
-        let session = Session.mock(
+        let session = SessionData.mock(
             id: "stable-display-id",
             project: "cctop",
             sessionName: "fix panel drift",
@@ -110,14 +110,14 @@ final class DisplayStateWriterTests: XCTestCase {
         let entry = try XCTUnwrap((object["sessions"] as? [[String: Any]])?.first)
         XCTAssertEqual(Set(entry.keys), ["cctop_session_id", "name", "status", "color"])
         XCTAssertEqual(entry["cctop_session_id"] as? String, session.cctopSessionId)
-        XCTAssertTrue(Session.isValidCctopSessionId(entry["cctop_session_id"] as? String))
+        XCTAssertTrue(CctopSessionID.isValid(entry["cctop_session_id"] as? String))
         XCTAssertEqual(entry["name"] as? String, "fix panel drift")
         XCTAssertEqual(entry["status"] as? String, "working")
         XCTAssertEqual(entry["color"] as? String, "#7EAA6E")
     }
 
     func testStoppedSnapshotPreservesRecentTargetsButDropsProcessIdentity() {
-        let session = Session.mock(id: "stable-display-id", status: .working)
+        let session = SessionData.mock(id: "stable-display-id", status: .working)
         let snapshot = DisplayStateWriter.snapshot(
             sessions: [session],
             theme: .claude,
@@ -135,12 +135,12 @@ final class DisplayStateWriterTests: XCTestCase {
     func testSnapshotKeepsOneOrderedEntryPerVisibleFocusTarget() {
         let now = Date()
         let cctopSessionID = "11111111-2222-4333-8444-555555555555"
-        var original = Session.mock(
+        var original = SessionData.mock(
             id: "conv-1", cctopSessionId: cctopSessionID, harnessSessionId: "conv-1", project: "first",
             status: .working, pid: 111, pidStartTime: 1_000
         )
         original.lastActivity = now.addingTimeInterval(-10)
-        var resumedElsewhere = Session.mock(
+        var resumedElsewhere = SessionData.mock(
             id: "conv-1", cctopSessionId: cctopSessionID, harnessSessionId: "conv-1", project: "second",
             status: .working, pid: 999, pidStartTime: 2_000
         )
@@ -160,9 +160,9 @@ final class DisplayStateWriterTests: XCTestCase {
     }
 
     func testMissingLegacyIdentityLeavesAnEmptySlotWithoutShiftingLaterRows() {
-        var legacy = Session.mock(id: "legacy", project: "first", status: .working)
+        var legacy = SessionData.mock(id: "legacy", project: "first", status: .working)
         legacy.cctopSessionId = nil
-        let current = Session.mock(id: "current", project: "second", status: .working)
+        let current = SessionData.mock(id: "current", project: "second", status: .working)
 
         let snapshot = DisplayStateWriter.snapshot(
             sessions: [legacy, current],

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -13,8 +13,8 @@ final class FocusStrategyTests: XCTestCase {
         socket: String? = nil,
         binaryPaths: [String: String]? = nil,
         sessionUuid: String = "test"
-    ) -> Session {
-        Session.mock(
+    ) -> SessionData {
+        SessionData.mock(
             id: sessionUuid,
             project: "myapp",
             terminal: TerminalInfo(
@@ -336,7 +336,7 @@ final class FocusStrategyTests: XCTestCase {
                 bundleId: bundleID,
                 sessionUuid: threadID
             )
-            session.source = Session.codexSource
+            session.source = SessionData.codexSource
 
             XCTAssertEqual(
                 resolveFocusStrategy(session: session),
@@ -349,7 +349,7 @@ final class FocusStrategyTests: XCTestCase {
     func testCodexProgramNameIsNotDirectHostEvidence() throws {
         let threadID = "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
         var session = makeSession(program: "Codex", sessionUuid: threadID)
-        session.source = Session.codexSource
+        session.source = SessionData.codexSource
 
         XCTAssertEqual(
             resolveFocusStrategy(session: session, multiplexerOverride: nil),
@@ -366,7 +366,7 @@ final class FocusStrategyTests: XCTestCase {
             bundleId: HostAppBundleID.codexDesktop,
             sessionUuid: "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
         )
-        session.source = Session.codexSource
+        session.source = SessionData.codexSource
 
         let strategy = resolveFocusStrategy(session: session, multiplexerOverride: nil)
 
@@ -382,7 +382,7 @@ final class FocusStrategyTests: XCTestCase {
             bundleId: "com.googlecode.iterm2",
             sessionUuid: "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
         )
-        session.source = Session.codexSource
+        session.source = SessionData.codexSource
 
         let strategy = resolveFocusStrategy(session: session, multiplexerOverride: nil)
 
@@ -394,7 +394,7 @@ final class FocusStrategyTests: XCTestCase {
             program: "UnsupportedHost",
             sessionUuid: "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
         )
-        session.source = Session.codexSource
+        session.source = SessionData.codexSource
 
         let strategy = resolveFocusStrategy(session: session, multiplexerOverride: nil)
 
@@ -407,7 +407,7 @@ final class FocusStrategyTests: XCTestCase {
             tty: "/dev/ttys017",
             sessionUuid: "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
         )
-        session.source = Session.codexSource
+        session.source = SessionData.codexSource
 
         let strategy = resolveFocusStrategy(session: session, multiplexerOverride: nil)
 
@@ -420,11 +420,11 @@ final class FocusStrategyTests: XCTestCase {
             paneId: "terminal_1",
             binaryPath: "/usr/bin/zellij"
         )
-        let session = Session.mock(
+        let session = SessionData.mock(
             id: "019e1eff-3374-74b0-8d3d-6fba94e7d75f",
             project: "myapp",
             terminal: TerminalInfo(program: "", multiplexer: multiplexer),
-            source: Session.codexSource
+            source: SessionData.codexSource
         )
 
         let strategy = resolveFocusStrategy(session: session, multiplexerOverride: nil)
@@ -439,19 +439,19 @@ final class FocusStrategyTests: XCTestCase {
     func testCurrentPermanentIDCodexRouteUsesThreadDeepLinkDespiteStalePID() throws {
         let threadID = "019faecb-6e9b-7f41-a51f-bb998875ca77"
         let cctopSessionID = "82498aba-410e-4b6b-b48d-62f7c6a81eae"
-        let observation = Session.mock(
+        let observation = SessionData.mock(
             id: threadID,
             cctopSessionId: cctopSessionID,
             harnessSessionId: threadID,
             project: "cctop",
             pid: 61_870,
             terminal: TerminalInfo(program: ""),
-            source: Session.codexSource
+            source: SessionData.codexSource
         )
         let current = try XCTUnwrap(
             FocusTargetResolver.currentSession(
                 forCctopSessionID: cctopSessionID,
-                in: [observation]
+                in: userSessionProjection(from: [observation])
             )
         )
         let strategy = resolveFocusStrategy(session: current, multiplexerOverride: nil)
@@ -467,7 +467,7 @@ final class FocusStrategyTests: XCTestCase {
         var session = makeSession(
             program: "", bundleId: HostAppBundleID.codexDesktop, sessionUuid: "not-a-uuid"
         )
-        session.source = Session.codexSource
+        session.source = SessionData.codexSource
 
         XCTAssertEqual(
             resolveFocusStrategy(session: session, multiplexerOverride: nil),
@@ -490,15 +490,15 @@ final class FocusStrategyTests: XCTestCase {
     // MARK: - No terminal info falls back to Finder
 
     func testNoTerminalInfoOpensInFinder() {
-        let session = Session.mock(id: "test", project: "myapp", terminal: nil)
+        let session = SessionData.mock(id: "test", project: "myapp", terminal: nil)
         let strategy = resolveFocusStrategy(session: session)
         XCTAssertEqual(strategy, .openInFinder(projectPath))
     }
 
     func testCodexWithoutTerminalInfoUsesThreadDeepLink() throws {
         let threadID = "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
-        var session = Session.mock(id: threadID, project: "myapp", terminal: nil)
-        session.source = Session.codexSource
+        var session = SessionData.mock(id: threadID, project: "myapp", terminal: nil)
+        session.source = SessionData.codexSource
 
         let strategy = resolveFocusStrategy(session: session, multiplexerOverride: nil)
 

--- a/menubar/CctopMenubarTests/FocusTerminalTests.swift
+++ b/menubar/CctopMenubarTests/FocusTerminalTests.swift
@@ -52,16 +52,16 @@ final class FocusTerminalTests: XCTestCase {
         XCTAssertEqual(result, "id")
     }
 
-    // MARK: - Session.mock() terminal parameter
+    // MARK: - SessionData.mock() terminal parameter
 
     func testMockDefaultTerminalIsCode() {
-        let session = Session.mock()
+        let session = SessionData.mock()
         XCTAssertEqual(session.terminal?.program, "Code")
         XCTAssertNil(session.terminal?.sessionId)
     }
 
     func testMockWithITerm2Terminal() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(
                 program: "iTerm.app",
                 sessionId: "w0t0p0:TEST-GUID",
@@ -74,7 +74,7 @@ final class FocusTerminalTests: XCTestCase {
     }
 
     func testMockWithNilTerminal() {
-        let session = Session.mock(terminal: nil)
+        let session = SessionData.mock(terminal: nil)
         XCTAssertNil(session.terminal)
     }
 

--- a/menubar/CctopMenubarTests/ForkSessionTests.swift
+++ b/menubar/CctopMenubarTests/ForkSessionTests.swift
@@ -44,10 +44,10 @@ final class ForkSessionTests: XCTestCase {
         pidStartTime: TimeInterval? = nil,
         status: SessionStatus = .working
     ) {
-        let session = Session(
+        let session = SessionData(
             sessionId: id,
             projectPath: projectPath,
-            projectName: Session.extractProjectName(projectPath),
+            projectName: SessionData.extractProjectName(projectPath),
             branch: "main",
             status: status,
             lastPrompt: nil,
@@ -75,8 +75,8 @@ final class ForkSessionTests: XCTestCase {
         FileManager.default.fileExists(atPath: pidPath(pid))
     }
 
-    private func readPid(_ pid: UInt32) -> Session? {
-        try? Session.fromFile(path: pidPath(pid))
+    private func readPid(_ pid: UInt32) -> SessionData? {
+        try? SessionData.fromFile(path: pidPath(pid))
     }
 
     @discardableResult
@@ -133,7 +133,7 @@ final class ForkSessionTests: XCTestCase {
         for entry in entries where entry.hasSuffix(".json") {
             let path = (sessionsDir as NSString)
                 .appendingPathComponent(entry)
-            guard let session = try? Session.fromFile(path: path),
+            guard let session = try? SessionData.fromFile(path: path),
                   session.sessionId == sessionId
             else { continue }
             return session.pid
@@ -241,7 +241,7 @@ final class ForkSessionTests: XCTestCase {
         // Use PID 1 (launchd) — always alive and different from
         // the hook's resolved PID (which is the test runner)
         let otherPID: UInt32 = 1
-        let otherStart = Session.processStartTime(pid: otherPID)
+        let otherStart = SessionData.processStartTime(pid: otherPID)
         writeSession(
             id: "other-session",
             projectPath: "/tmp/project",
@@ -272,13 +272,13 @@ final class ForkSessionTests: XCTestCase {
     func testCleanupSkipsDesktopAppSessionsButReapsDeadTerminal() throws {
         let project = "/tmp/cctop-gate-\(UUID().uuidString)"
         // PIDs above macOS PID_MAX (99999) can never be live → deterministically "dead".
-        var desktop = Session(sessionId: "desk-1", projectPath: project, branch: "main",
+        var desktop = SessionData(sessionId: "desk-1", projectPath: project, branch: "main",
                               terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop))
         desktop.pid = 999_999
         let desktopPath = sessionsDir + "999999.json"
         try desktop.writeToFile(path: desktopPath)
 
-        var term = Session(sessionId: "term-1", projectPath: project, branch: "main",
+        var term = SessionData(sessionId: "term-1", projectPath: project, branch: "main",
                            terminal: TerminalInfo(bundleId: "com.googlecode.iterm2"))
         term.pid = 999_998
         let termPath = sessionsDir + "999998.json"
@@ -300,7 +300,7 @@ final class ForkSessionTests: XCTestCase {
     func testCleanupLeavesLockFileWhenRemovingDeadTerminalSession() throws {
         let project = "/tmp/cctop-lock-\(UUID().uuidString)"
         let deadPID: UInt32 = 999_997
-        var term = Session(sessionId: "term-lock", projectPath: project, branch: "main",
+        var term = SessionData(sessionId: "term-lock", projectPath: project, branch: "main",
                            terminal: TerminalInfo(bundleId: "com.googlecode.iterm2"))
         term.pid = deadPID
         let termPath = sessionsDir + "\(deadPID).json"

--- a/menubar/CctopMenubarTests/HistoryManagerTests.swift
+++ b/menubar/CctopMenubarTests/HistoryManagerTests.swift
@@ -32,8 +32,8 @@ final class HistoryManagerTests: XCTestCase {
         lastActivity: Date = Date(),
         terminal: TerminalInfo? = TerminalInfo(program: "Code"),
         source: String? = nil
-    ) -> Session {
-        Session(
+    ) -> SessionData {
+        SessionData(
             sessionId: UUID().uuidString,
             projectPath: projectPath ?? "/Users/test/\(project)",
             projectName: project,
@@ -57,7 +57,7 @@ final class HistoryManagerTests: XCTestCase {
         projectPath: String? = nil,
         endedAt: Date? = nil,
         lastActivity: Date = Date()
-    ) -> (url: URL, session: Session) {
+    ) -> (url: URL, session: SessionData) {
         let session = mockSession(
             project: project,
             projectPath: projectPath,
@@ -69,7 +69,7 @@ final class HistoryManagerTests: XCTestCase {
     }
 
     private func filesToPrune(
-        from entries: [(url: URL, session: Session)],
+        from entries: [(url: URL, session: SessionData)],
         existingPaths: Set<String>? = nil
     ) -> [URL] {
         sut.filesToPrune(
@@ -79,7 +79,7 @@ final class HistoryManagerTests: XCTestCase {
     }
 
     private func recentProjects(
-        from sessions: [Session],
+        from sessions: [SessionData],
         excludingActive activePaths: Set<String> = [],
         existingPaths: Set<String>? = nil
     ) -> [RecentProject] {
@@ -132,7 +132,7 @@ final class HistoryManagerTests: XCTestCase {
 
     func testFilesToPruneEnforcesMaxFiles() {
         let now = Date()
-        var entries: [(url: URL, session: Session)] = []
+        var entries: [(url: URL, session: SessionData)] = []
         for i in 0..<55 {
             entries.append(mockEntry(
                 project: "proj-\(i)",
@@ -164,7 +164,7 @@ final class HistoryManagerTests: XCTestCase {
     func testFilesToPruneDoesNotLetNonDurableRowsEvictDurableProjects() {
         let now = Date()
         let durableRoot = "/Users/test/projects"
-        var entries: [(url: URL, session: Session)] = []
+        var entries: [(url: URL, session: SessionData)] = []
         for i in 0..<HistoryManager.maxFiles {
             entries.append(mockEntry(
                 project: "durable-\(i)",
@@ -284,7 +284,7 @@ final class HistoryManagerTests: XCTestCase {
 
     func testBuildRecentProjectsCapsAtTen() {
         let now = Date()
-        var sessions: [Session] = []
+        var sessions: [SessionData] = []
         for i in 0..<15 {
             sessions.append(mockSession(
                 project: "proj-\(i)",
@@ -321,7 +321,7 @@ final class HistoryManagerTests: XCTestCase {
                 endedAt: Date(),
                 terminal: TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
             ),
-            mockSession(project: "source-codex", endedAt: Date(), source: Session.codexSource),
+            mockSession(project: "source-codex", endedAt: Date(), source: SessionData.codexSource),
             mockSession(project: "vscode-thing", endedAt: Date()),
         ]
 
@@ -481,7 +481,7 @@ final class HistoryManagerTests: XCTestCase {
     }
 
     func testBuildRecentProjectsPopulatesLastEditor() {
-        let session = Session(
+        let session = SessionData(
             sessionId: "test",
             projectPath: "/Users/test/app",
             projectName: "app",
@@ -515,7 +515,7 @@ final class HistoryManagerTests: XCTestCase {
         let session = mockSession(
             project: "agent-created",
             terminal: TerminalInfo(program: "Claude Code"),
-            source: Session.ccSource
+            source: SessionData.ccSource
         )
         let result = recentProjects(from: [session])
         XCTAssertNil(result[0].lastEditor)
@@ -714,7 +714,7 @@ final class HistoryManagerTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(atPath: root) }
 
-        var session = Session(
+        var session = SessionData(
             sessionId: "recent-session",
             projectPath: "/tmp/recent",
             branch: "main",

--- a/menubar/CctopMenubarTests/HookEventTests.swift
+++ b/menubar/CctopMenubarTests/HookEventTests.swift
@@ -218,36 +218,36 @@ final class HookEventTests: XCTestCase {
     // MARK: - sanitizeSessionId
 
     func testSanitizeRemovesForwardSlash() {
-        XCTAssertEqual(Session.sanitizeSessionId(raw: "foo/bar"), "foobar")
+        XCTAssertEqual(SessionData.sanitizeSessionId(raw: "foo/bar"), "foobar")
     }
 
     func testSanitizeRemovesBackslash() {
-        XCTAssertEqual(Session.sanitizeSessionId(raw: "foo\\bar"), "foobar")
+        XCTAssertEqual(SessionData.sanitizeSessionId(raw: "foo\\bar"), "foobar")
     }
 
     func testSanitizeRemovesDoubleDot() {
-        XCTAssertEqual(Session.sanitizeSessionId(raw: "../../.bashrc"), "bashrc")
+        XCTAssertEqual(SessionData.sanitizeSessionId(raw: "../../.bashrc"), "bashrc")
     }
 
     func testSanitizePathTraversal() {
-        XCTAssertEqual(Session.sanitizeSessionId(raw: "../etc/passwd"), "etcpasswd")
+        XCTAssertEqual(SessionData.sanitizeSessionId(raw: "../etc/passwd"), "etcpasswd")
     }
 
     func testSanitizeDoubleDotOnly() {
-        XCTAssertEqual(Session.sanitizeSessionId(raw: ".."), "")
+        XCTAssertEqual(SessionData.sanitizeSessionId(raw: ".."), "")
     }
 
     func testSanitizeCapsLength() {
         let long = String(repeating: "a", count: 100)
-        XCTAssertEqual(Session.sanitizeSessionId(raw: long).count, 64)
+        XCTAssertEqual(SessionData.sanitizeSessionId(raw: long).count, 64)
     }
 
     func testSanitizeNormalIdUnchanged() {
-        XCTAssertEqual(Session.sanitizeSessionId(raw: "abc-123-def"), "abc-123-def")
+        XCTAssertEqual(SessionData.sanitizeSessionId(raw: "abc-123-def"), "abc-123-def")
     }
 
     func testSanitizeUUIDUnchanged() {
         let uuid = "550e8400-e29b-41d4-a716-446655440000"
-        XCTAssertEqual(Session.sanitizeSessionId(raw: uuid), uuid)
+        XCTAssertEqual(SessionData.sanitizeSessionId(raw: uuid), uuid)
     }
 }

--- a/menubar/CctopMenubarTests/HookHandlerTests.swift
+++ b/menubar/CctopMenubarTests/HookHandlerTests.swift
@@ -100,8 +100,8 @@ final class HookHandlerTests: XCTestCase {
         (sessionsDir as NSString).appendingPathComponent(fileName)
     }
 
-    private func loadSession(_ fileName: String = "4242.json") throws -> Session {
-        try Session.fromFile(path: sessionFilePath(fileName))
+    private func loadSession(_ fileName: String = "4242.json") throws -> SessionData {
+        try SessionData.fromFile(path: sessionFilePath(fileName))
     }
 
     private func sessionFileExists(_ fileName: String = "4242.json") -> Bool {
@@ -140,7 +140,7 @@ final class HookHandlerTests: XCTestCase {
         XCTAssertEqual(session.projectName, "test-project")
         XCTAssertEqual(session.pid, 4242)
         XCTAssertEqual(session.activeSubagents?.count, 0)
-        XCTAssertTrue(Session.isValidCctopSessionId(session.cctopSessionId))
+        XCTAssertTrue(CctopSessionID.isValid(session.cctopSessionId))
     }
 
     func testNewHookSessionFileRecordsWriterMetadata() throws {
@@ -267,11 +267,11 @@ final class HookHandlerTests: XCTestCase {
     }
 
     func testSessionEndExactMatchWinsOverLegacyPrimaryPath() throws {
-        var legacy = Session.mock(id: "endA", pid: 4242, source: "cc")
+        var legacy = SessionData.mock(id: "endA", pid: 4242, source: "cc")
         legacy.harnessSessionId = nil
         try legacy.writeToFile(path: sessionFilePath())
 
-        let exact = Session.mock(id: "endA", harnessSessionId: "endA", pid: 5002, source: "cc")
+        let exact = SessionData.mock(id: "endA", harnessSessionId: "endA", pid: 5002, source: "cc")
         try exact.writeToFile(path: sessionFilePath("5002.json"))
 
         try handleHook("""
@@ -283,8 +283,8 @@ final class HookHandlerTests: XCTestCase {
     }
 
     func testSessionEndDoesNotUseAmbiguousLegacyFallback() throws {
-        let first = Session.mock(id: "legacy-end", pid: 4242, source: "cc")
-        let second = Session.mock(id: "legacy-end", pid: 5002, source: "cc")
+        let first = SessionData.mock(id: "legacy-end", pid: 4242, source: "cc")
+        let second = SessionData.mock(id: "legacy-end", pid: 5002, source: "cc")
         try first.writeToFile(path: sessionFilePath())
         try second.writeToFile(path: sessionFilePath("5002.json"))
 
@@ -297,7 +297,7 @@ final class HookHandlerTests: XCTestCase {
     }
 
     func testSessionEndDoesNotMatchExactReferenceFromAnotherSource() throws {
-        let opencode = Session.mock(
+        let opencode = SessionData.mock(
             id: "shared-end", harnessSessionId: "shared-end", pid: 5002, source: "opencode"
         )
         try opencode.writeToFile(path: sessionFilePath("5002.json"))
@@ -396,7 +396,7 @@ final class HookHandlerTests: XCTestCase {
         try handleFixture("SessionStart")
 
         let path = sessionFilePath()
-        var legacy = try Session.fromFile(path: path)
+        var legacy = try SessionData.fromFile(path: path)
         legacy.createdByHookVersion = nil
         legacy.lastWrittenByHookVersion = nil
         try legacy.writeToFile(path: path)
@@ -427,7 +427,7 @@ final class HookHandlerTests: XCTestCase {
 
     func testExistingTrustedDesktopSessionWithDifferentIdIsNotReplacedAtSessionStart() throws {
         let path = sessionFilePath()
-        var existing = Session(
+        var existing = SessionData(
             sessionId: "desktop-existing",
             projectPath: "/tmp/desktop-existing",
             projectName: "desktop-existing",
@@ -460,7 +460,7 @@ final class HookHandlerTests: XCTestCase {
 
     func testTrustedDesktopPidReuseMismatchIsNotReplacedAtSessionStart() throws {
         let path = sessionFilePath()
-        var existing = Session(
+        var existing = SessionData(
             sessionId: "desktop-existing",
             projectPath: "/tmp/desktop-existing",
             projectName: "desktop-existing",
@@ -492,7 +492,7 @@ final class HookHandlerTests: XCTestCase {
 
     func testCodexSessionIdKeyedMismatchIsNotReplaced() throws {
         let path = sessionFilePath("codex-incoming-thread.json")
-        var existing = Session(
+        var existing = SessionData(
             sessionId: "existing-thread",
             projectPath: "/tmp/existing-thread",
             projectName: "existing-thread",
@@ -508,7 +508,7 @@ final class HookHandlerTests: XCTestCase {
             lastToolDetail: nil,
             notificationMessage: nil
         )
-        existing.source = Session.codexSource
+        existing.source = SessionData.codexSource
         existing.sessionName = "Existing Codex thread"
         try existing.writeToFile(path: path)
 
@@ -529,7 +529,7 @@ final class HookHandlerTests: XCTestCase {
         try corrupt.write(to: URL(fileURLWithPath: primaryPath))
 
         let stalePath = sessionFilePath("7777.json")
-        let stale = Session(
+        let stale = SessionData(
             sessionId: "stale-same-project",
             projectPath: "/tmp/test-project",
             projectName: "test-project",
@@ -559,7 +559,7 @@ final class HookHandlerTests: XCTestCase {
         try handleFixture("SessionStart")
 
         let path = sessionFilePath()
-        var session = try Session.fromFile(path: path)
+        var session = try SessionData.fromFile(path: path)
         session.lastWrittenByHookVersion = "0.16.0-dev"
         try session.writeToFile(path: path)
 
@@ -896,7 +896,7 @@ final class HookHandlerTests: XCTestCase {
     // file by session_id instead of silently stamping nothing (issue #155 P3).
     func testSessionEndStampsFileFoundBySessionIdWhenPidPathMisses() throws {
         // 7777.json — NOT the fake prober's parent PID (4242), so the primary path misses.
-        let session = Session.mock(id: "end-by-sid", pid: 7777)
+        let session = SessionData.mock(id: "end-by-sid", pid: 7777)
         let path = (sessionsDir as NSString).appendingPathComponent("7777.json")
         try session.writeToFile(path: path)
 
@@ -904,7 +904,7 @@ final class HookHandlerTests: XCTestCase {
         {"session_id":"end-by-sid","cwd":"/tmp/test-project","hook_event_name":"SessionEnd","harness_name":"cc"}
         """, hookName: "SessionEnd")
 
-        XCTAssertNotNil(try Session.fromFile(path: path).endedAt)
+        XCTAssertNotNil(try SessionData.fromFile(path: path).endedAt)
     }
 
     // The PID-derived path can hold a DIFFERENT conversation. SessionEnd must never
@@ -936,18 +936,18 @@ final class HookHandlerTests: XCTestCase {
         try handleFixture("SessionStart")
         let primary = sessionFilePath()
         let twinPath = (sessionsDir as NSString).appendingPathComponent("7777.json")
-        try Session.mock(id: "test-session-001", pid: 7777).writeToFile(path: twinPath)
+        try SessionData.mock(id: "test-session-001", pid: 7777).writeToFile(path: twinPath)
 
         try handleFixture("SessionEnd")
 
-        XCTAssertNotNil(try Session.fromFile(path: primary).endedAt)
-        XCTAssertNil(try Session.fromFile(path: twinPath).endedAt)
+        XCTAssertNotNil(try SessionData.fromFile(path: primary).endedAt)
+        XCTAssertNil(try SessionData.fromFile(path: twinPath).endedAt)
     }
 
     // When the PID-derived path misses, multiple exact raw/source matches prefer the
     // live (un-ended) process generation over a stale already-ended one.
     func testSessionEndStampsUnendedDuplicateWhenPrimaryMisses() throws {
-        var stale = Session.mock(id: "dup-sid", pid: 1111)
+        var stale = SessionData.mock(id: "dup-sid", pid: 1111)
         stale.harnessSessionId = "dup-sid"
         stale.source = "cc"
         let staleEnd = Date(timeIntervalSince1970: 1_000)
@@ -956,7 +956,7 @@ final class HookHandlerTests: XCTestCase {
         try stale.writeToFile(path: stalePath)
 
         let livePath = (sessionsDir as NSString).appendingPathComponent("2222.json")
-        try Session.mock(
+        try SessionData.mock(
             id: "dup-sid", harnessSessionId: "dup-sid", pid: 2222, source: "cc"
         ).writeToFile(path: livePath)
 
@@ -964,8 +964,8 @@ final class HookHandlerTests: XCTestCase {
         {"session_id":"dup-sid","cwd":"/tmp/test-project","hook_event_name":"SessionEnd","harness_name":"cc"}
         """, hookName: "SessionEnd")
 
-        XCTAssertNotNil(try Session.fromFile(path: livePath).endedAt)
-        XCTAssertEqual(try Session.fromFile(path: stalePath).endedAt, staleEnd)
+        XCTAssertNotNil(try SessionData.fromFile(path: livePath).endedAt)
+        XCTAssertEqual(try SessionData.fromFile(path: stalePath).endedAt, staleEnd)
     }
 
     func testSessionStartClearsEndedAndDisconnectedAt() throws {
@@ -1141,7 +1141,7 @@ final class HookHandlerTests: XCTestCase {
     }
 
     func testSessionStartDoesNotInferReplacementProtectionFromCodexBundleAlone() throws {
-        var existing = Session(
+        var existing = SessionData(
             sessionId: "bundle-only-old",
             projectPath: "/tmp/test-project",
             branch: "main",
@@ -1159,7 +1159,7 @@ final class HookHandlerTests: XCTestCase {
     }
 
     func testSessionStartPreservesClaudeDesktopReplacementProtection() throws {
-        var existing = Session(
+        var existing = SessionData(
             sessionId: "claude-desktop-old",
             projectPath: "/tmp/test-project",
             branch: "main",
@@ -1411,7 +1411,7 @@ final class HookHandlerTests: XCTestCase {
 
     func testCodexExplicitlyNullSessionStartStillRunsProjectCleanup() throws {
         let stalePath = sessionFilePath("7777.json")
-        let stale = Session(
+        let stale = SessionData(
             sessionId: "stale-same-project",
             projectPath: "/tmp/ordinary-project",
             projectName: "ordinary-project",
@@ -1785,14 +1785,14 @@ final class HookHandlerTests: XCTestCase {
         let sid = "shared-log-sid"
         let logger = HookLogger(logsDir: logsDir)
 
-        var stale = Session(sessionId: sid, projectPath: project, branch: "main", terminal: TerminalInfo())
+        var stale = SessionData(sessionId: sid, projectPath: project, branch: "main", terminal: TerminalInfo())
         stale.pid = 999_999
         let stalePath = (sessionsDir as NSString).appendingPathComponent("999999.json")
         try stale.writeToFile(path: stalePath)
 
         // Same conversation dual-written under the codex key; its PID is the currentPid,
         // so cleanup skips it and it remains the log's owner.
-        var survivor = Session(sessionId: sid, projectPath: project, branch: "main", terminal: TerminalInfo())
+        var survivor = SessionData(sessionId: sid, projectPath: project, branch: "main", terminal: TerminalInfo())
         survivor.pid = 4242
         let survivorPath = (sessionsDir as NSString).appendingPathComponent("codex-\(sid).json")
         try survivor.writeToFile(path: survivorPath)

--- a/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
+++ b/menubar/CctopMenubarTests/MultiplexerFocusTests.swift
@@ -10,7 +10,7 @@ final class MultiplexerFocusTests: XCTestCase {
     // MARK: - resolveMultiplexerFocus
 
     func testCmuxUUIDSurfaceUsesNavigationURL() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(
                 program: "ghostty",
                 multiplexer: .cmux(
@@ -38,7 +38,7 @@ final class MultiplexerFocusTests: XCTestCase {
     }
 
     func testCmuxUUIDPaneUsesNavigationURL() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(
                 program: "ghostty",
                 multiplexer: .cmux(
@@ -61,7 +61,7 @@ final class MultiplexerFocusTests: XCTestCase {
     }
 
     func testCmuxReturnsSurfaceCliFallbackForReferenceIds() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(
                 program: "ghostty",
                 multiplexer: .cmux(
@@ -88,7 +88,7 @@ final class MultiplexerFocusTests: XCTestCase {
     }
 
     func testCmuxReferencePaneWithoutSurfaceReturnsNil() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(
                 program: "ghostty",
                 multiplexer: .cmux(
@@ -105,7 +105,7 @@ final class MultiplexerFocusTests: XCTestCase {
     }
 
     func testLegacyCmuxSessionUsesLiveProcessEnvironmentForNavigationURL() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "irb",
             pid: 5079,
             terminal: TerminalInfo(
@@ -150,7 +150,7 @@ final class MultiplexerFocusTests: XCTestCase {
     }
 
     func testHerdrReturnsStrategy() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(
                 program: "Ghostty",
                 multiplexer: .herdr(
@@ -172,7 +172,7 @@ final class MultiplexerFocusTests: XCTestCase {
     }
 
     func testHerdrNoBinaryPathReturnsNil() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(
                 program: "Ghostty",
                 multiplexer: .herdr(
@@ -187,7 +187,7 @@ final class MultiplexerFocusTests: XCTestCase {
     }
 
     func testZellijReturnsStrategy() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(
                 program: "Ghostty",
                 multiplexer: .zellij(sessionName: "dev", paneId: "terminal_3", binaryPath: "/usr/bin/zellij")
@@ -198,7 +198,7 @@ final class MultiplexerFocusTests: XCTestCase {
     }
 
     func testTmuxReturnsStrategy() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(
                 program: "Ghostty",
                 multiplexer: .tmux(socket: "/tmp/tmux-501/default", paneId: "%3", binaryPath: "/opt/homebrew/bin/tmux")
@@ -212,7 +212,7 @@ final class MultiplexerFocusTests: XCTestCase {
     }
 
     func testNoBinaryPathReturnsNil() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(
                 program: "Ghostty",
                 multiplexer: .zellij(sessionName: "dev", paneId: "terminal_3", binaryPath: nil)
@@ -223,7 +223,7 @@ final class MultiplexerFocusTests: XCTestCase {
     }
 
     func testCmuxWithoutSurfaceOrPaneReturnsNil() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(
                 program: "ghostty",
                 multiplexer: .cmux(
@@ -240,7 +240,7 @@ final class MultiplexerFocusTests: XCTestCase {
     }
 
     func testNoMultiplexerReturnsNil() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(program: "Ghostty")
         )
         let strategy = resolveMultiplexerFocus(session: session)
@@ -248,7 +248,7 @@ final class MultiplexerFocusTests: XCTestCase {
     }
 
     func testNoTerminalReturnsNil() {
-        let session = Session.mock(terminal: nil)
+        let session = SessionData.mock(terminal: nil)
         let strategy = resolveMultiplexerFocus(session: session)
         XCTAssertNil(strategy)
     }
@@ -415,7 +415,7 @@ final class MultiplexerFocusTests: XCTestCase {
     func testEmulatorStrategyUnaffectedByMultiplexer() {
         // zellij inside Ghostty — emulator strategy and multiplexer focus are
         // resolved independently from the same session.
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(
                 program: "Ghostty",
                 multiplexer: .zellij(sessionName: "dev", paneId: "terminal_1", binaryPath: "/usr/bin/zellij")
@@ -433,7 +433,7 @@ final class MultiplexerFocusTests: XCTestCase {
     }
 
     func testCmuxMultiplexerResolvesCmuxHostDespiteGhosttyProgram() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(
                 program: "ghostty",
                 multiplexer: .cmux(

--- a/menubar/CctopMenubarTests/NavigateControllerTests.swift
+++ b/menubar/CctopMenubarTests/NavigateControllerTests.swift
@@ -30,8 +30,8 @@ final class NavigateControllerTests: XCTestCase {
 
     func testActivateFreezesSessions() {
         let sessions = [
-            Session.mock(id: "1", project: "alpha", status: .idle),
-            Session.mock(id: "2", project: "beta", status: .working),
+            SessionData.mock(id: "1", project: "alpha", status: .idle),
+            SessionData.mock(id: "2", project: "beta", status: .working),
         ]
         sut.activate(sessions: sessions)
         XCTAssertEqual(sut.frozenSessionIdentities.count, 2)
@@ -39,12 +39,12 @@ final class NavigateControllerTests: XCTestCase {
 
     func testActivatePreservesCanonicalSessionOrder() {
         let now = Date()
-        let waiting = Session.mock(id: "1", project: "alpha", status: .waitingInput)
-        var workingOld = Session.mock(id: "2", project: "beta", status: .working)
+        let waiting = SessionData.mock(id: "1", project: "alpha", status: .waitingInput)
+        var workingOld = SessionData.mock(id: "2", project: "beta", status: .working)
         workingOld.lastActivity = now.addingTimeInterval(-600)
-        var workingNew = Session.mock(id: "3", project: "gamma", status: .working)
+        var workingNew = SessionData.mock(id: "3", project: "gamma", status: .working)
         workingNew.lastActivity = now
-        let idle = Session.mock(id: "4", project: "delta", status: .idle)
+        let idle = SessionData.mock(id: "4", project: "delta", status: .idle)
 
         sut.activate(sessions: [waiting, workingOld, workingNew, idle])
 
@@ -95,7 +95,7 @@ final class NavigateControllerTests: XCTestCase {
 
     func testFrozenSessionsAreSnapshot() {
         var sessions = [
-            Session.mock(id: "1", project: "alpha", status: .working),
+            SessionData.mock(id: "1", project: "alpha", status: .working),
         ]
         sut.activate(sessions: sessions)
 
@@ -104,27 +104,30 @@ final class NavigateControllerTests: XCTestCase {
         XCTAssertEqual(sut.frozenSessionIdentities.count, 1)
     }
 
-    func testFrozenSlotResolvesReplacementCurrentObservation() throws {
+    func testFrozenSlotResolvesReplacementCurrentRecord() throws {
         let sharedID = "22222222-2222-4222-8222-222222222222"
-        let first = Session.mock(
+        let first = SessionData.mock(
             id: "first", cctopSessionId: sharedID,
-            status: .working, pid: 100, source: Session.opencodeSource
+            status: .working, pid: 100, source: SessionData.opencodeSource
         )
-        let replacement = Session.mock(
+        let replacement = SessionData.mock(
             id: "replacement", cctopSessionId: sharedID,
-            status: .waitingInput, pid: 200, source: Session.opencodeSource
+            status: .waitingInput, pid: 200, source: SessionData.opencodeSource
         )
         sut.activate(sessions: [first])
 
         let identity = try XCTUnwrap(sut.sessionIdentity(at: 0))
-        let resolved = FocusTargetResolver.currentSession(for: identity, in: [replacement])
+        let resolved = FocusTargetResolver.currentSession(
+            for: identity,
+            in: userSessionProjection(from: [replacement])
+        )
 
         XCTAssertEqual(resolved?.pid, 200)
     }
 
     func testFrozenLegacySlotResolvesSameStableKeyAfterPermanentIDStamp() throws {
-        var legacy = Session.mock(
-            id: "legacy", status: .working, pid: 100, source: Session.opencodeSource
+        var legacy = SessionData.mock(
+            id: "legacy", status: .working, pid: 100, source: SessionData.opencodeSource
         )
         legacy.cctopSessionId = nil
         sut.activate(sessions: [legacy])
@@ -132,49 +135,82 @@ final class NavigateControllerTests: XCTestCase {
         var stamped = legacy
         stamped.cctopSessionId = "22222222-2222-4222-8222-222222222222"
         let identity = try XCTUnwrap(sut.sessionIdentity(at: 0))
-        let resolved = FocusTargetResolver.currentSession(for: identity, in: [stamped])
+        let resolved = FocusTargetResolver.currentSession(
+            for: identity,
+            in: userSessionProjection(from: [stamped])
+        )
 
         XCTAssertEqual(resolved?.cctopSessionId, stamped.cctopSessionId)
         XCTAssertEqual(resolved?.pid, 100)
-        XCTAssertNil(FocusTargetResolver.currentSession(for: identity, in: [stamped, stamped]))
+    }
+
+    func testFrozenLegacySlotResolvesCurrentUserSessionAfterPermanentIDStamp() throws {
+        var legacy = SessionData.mock(
+            id: "legacy", status: .working, pid: 100, source: SessionData.opencodeSource
+        )
+        legacy.cctopSessionId = nil
+        sut.activate(sessions: [legacy])
+
+        var stamped = legacy
+        stamped.cctopSessionId = "22222222-2222-4222-8222-222222222222"
+        let identity = try XCTUnwrap(sut.sessionIdentity(at: 0))
+        let current = userSession(display: stamped, records: [stamped])
+
+        XCTAssertEqual(
+            FocusTargetResolver.currentSession(for: identity, in: [current])?.cctopSessionId,
+            stamped.cctopSessionId
+        )
+
+        var conflicting = stamped
+        conflicting.cctopSessionId = "33333333-3333-4333-8333-333333333333"
+        let conflictingUserSession = userSession(display: conflicting, records: [conflicting])
+        XCTAssertNil(FocusTargetResolver.currentSession(
+            for: identity,
+            in: [current, conflictingUserSession]
+        ))
     }
 
     func testMissingFrozenSlotDoesNotRetargetLaterSlot() throws {
-        let first = Session.mock(
+        let first = SessionData.mock(
             id: "first", cctopSessionId: "11111111-1111-4111-8111-111111111111",
-            status: .working, source: Session.codexSource
+            status: .working, source: SessionData.codexSource
         )
-        let second = Session.mock(
+        let second = SessionData.mock(
             id: "second", cctopSessionId: "22222222-2222-4222-8222-222222222222",
-            status: .working, source: Session.codexSource
+            status: .working, source: SessionData.codexSource
         )
         sut.activate(sessions: [first, second])
 
         let firstIdentity = try XCTUnwrap(sut.sessionIdentity(at: 0))
         let secondIdentity = try XCTUnwrap(sut.sessionIdentity(at: 1))
 
-        XCTAssertNil(FocusTargetResolver.currentSession(for: firstIdentity, in: [second]))
-        XCTAssertEqual(FocusTargetResolver.currentSession(for: secondIdentity, in: [second])?.sessionId, "second")
+        let currentUserSessions = userSessionProjection(from: [second])
+        XCTAssertNil(FocusTargetResolver.currentSession(for: firstIdentity, in: currentUserSessions))
+        XCTAssertEqual(
+            FocusTargetResolver.currentSession(for: secondIdentity, in: currentUserSessions)?.sessionId,
+            "second"
+        )
     }
 
     @MainActor
-    func testPopupRowsPreserveFrozenSlotAndBindReplacementObservation() throws {
-        let missing = Session.mock(
+    func testPopupRowsPreserveFrozenSlotAndBindReplacementRecord() throws {
+        let missing = SessionData.mock(
             id: "missing", cctopSessionId: "11111111-1111-4111-8111-111111111111",
-            status: .working, source: Session.codexSource
+            status: .working, source: SessionData.codexSource
         )
-        let original = Session.mock(
+        let original = SessionData.mock(
             id: "original", cctopSessionId: "22222222-2222-4222-8222-222222222222",
-            status: .working, pid: 100, source: Session.codexSource
+            status: .working, pid: 100, source: SessionData.codexSource
         )
-        let replacement = Session.mock(
+        let replacement = SessionData.mock(
             id: "replacement", cctopSessionId: original.cctopSessionId,
-            status: .waitingInput, pid: 200, source: Session.codexSource
+            status: .waitingInput, pid: 200, source: SessionData.codexSource
         )
         sut.activate(sessions: [missing, original])
 
         let view = PopupView(
             sessions: [replacement],
+            userSessions: userSessionProjection(from: [replacement]),
             updater: DisabledUpdater(),
             pluginManager: inertPluginManager(),
             navigate: sut
@@ -185,6 +221,36 @@ final class NavigateControllerTests: XCTestCase {
         XCTAssertEqual(row.slot, 1)
         XCTAssertEqual(row.id, SessionIdentityPolicy.logicalIdentity(for: original))
         XCTAssertEqual(row.session, replacement)
+    }
+
+    @MainActor
+    func testPopupKeyboardResolutionUsesRetainedLegacyRecordAfterDisplayTargetChanges() throws {
+        var legacy = SessionData.mock(
+            id: "legacy-observation", status: .working, pid: 100, source: SessionData.opencodeSource
+        )
+        legacy.cctopSessionId = nil
+        let current = SessionData.mock(
+            id: "current-observation",
+            cctopSessionId: "22222222-2222-4222-8222-222222222222",
+            status: .waitingInput,
+            pid: 200,
+            source: SessionData.opencodeSource
+        )
+        sut.activate(sessions: [legacy])
+
+        let view = PopupView(
+            sessions: [current],
+            userSessions: [userSession(display: current, records: [legacy, current])],
+            updater: DisabledUpdater(),
+            pluginManager: inertPluginManager(),
+            navigate: sut
+        )
+
+        let row = try XCTUnwrap(view.activeSessionRows.first)
+        let frozenIdentity = try XCTUnwrap(sut.sessionIdentity(at: 0))
+        XCTAssertEqual(row.slot, 0)
+        XCTAssertEqual(row.session, current)
+        XCTAssertEqual(view.currentSession(for: frozenIdentity, in: .active), current)
     }
 
     func testInactiveControllerHasNoActiveSnapshot() {
@@ -261,8 +327,8 @@ final class NavigateControllerTests: XCTestCase {
 
     func testFullActivateDeactivateCycle() {
         let sessions = [
-            Session.mock(id: "1", status: .working),
-            Session.mock(id: "2", status: .idle),
+            SessionData.mock(id: "1", status: .working),
+            SessionData.mock(id: "2", status: .idle),
         ]
 
         // Activate
@@ -280,7 +346,7 @@ final class NavigateControllerTests: XCTestCase {
 
     func testMultipleActivateDeactivateCycles() {
         for i in 0..<3 {
-            let sessions = [Session.mock(id: "\(i)", status: .working)]
+            let sessions = [SessionData.mock(id: "\(i)", status: .working)]
             sut.activate(sessions: sessions)
             XCTAssertTrue(sut.isActive)
             XCTAssertEqual(sut.frozenSessionIdentities.count, 1)
@@ -294,9 +360,9 @@ final class NavigateControllerTests: XCTestCase {
     // MARK: - Canonical order in frozen sessions
 
     func testFrozenSessionsPreserveOrderAcrossActivityTimes() {
-        var older = Session.mock(id: "1", project: "older", status: .working)
+        var older = SessionData.mock(id: "1", project: "older", status: .working)
         older.lastActivity = Date().addingTimeInterval(-120)
-        var newer = Session.mock(id: "2", project: "newer", status: .working)
+        var newer = SessionData.mock(id: "2", project: "newer", status: .working)
         newer.lastActivity = Date()
 
         sut.activate(sessions: [older, newer])

--- a/menubar/CctopMenubarTests/PanelToggleTests.swift
+++ b/menubar/CctopMenubarTests/PanelToggleTests.swift
@@ -41,17 +41,17 @@ final class PanelToggleTests: XCTestCase {
         XCTAssertNil(AppDelegate.focusSessionID(from: try XCTUnwrap(URL(string: "cctop://focus?sid="))))
     }
 
-    func testNotificationActivationResolvesPermanentIDToCurrentCanonicalObservation() {
+    func testNotificationActivationResolvesPermanentIDToCurrentCanonicalRecord() {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
-        var current = Session.mock(
+        var current = SessionData.mock(
             id: "current-observation", cctopSessionId: cctopSessionID,
-            pid: 22_222, source: Session.opencodeSource
+            pid: 22_222, source: SessionData.opencodeSource
         )
         current.lifecycle = .active
 
         let resolved = AppDelegate.notificationFocusSession(
             matchingUserInfo: [SessionIdentityPolicy.notificationCctopSessionIDKey: cctopSessionID],
-            in: [current]
+            in: [userSession(display: current, records: [current])]
         )
 
         XCTAssertEqual(resolved?.sessionId, "current-observation")
@@ -60,26 +60,33 @@ final class PanelToggleTests: XCTestCase {
 
     func testLegacyNotificationActivationResolvesReplacementThroughPermanentID() {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
-        var current = Session.mock(
+        var previous = SessionData.mock(
             id: "codex-thread-1", cctopSessionId: cctopSessionID,
-            pid: 22_222, source: Session.codexSource
+            pid: 11_111, source: SessionData.codexSource
+        )
+        previous.cctopSessionId = nil
+        previous.lifecycle = .dormant
+        var current = SessionData.mock(
+            id: "replacement-observation", cctopSessionId: cctopSessionID,
+            pid: 22_222, source: SessionData.codexSource
         )
         current.lifecycle = .active
 
         let resolved = AppDelegate.notificationFocusSession(
             matchingUserInfo: [SessionIdentityPolicy.notificationSessionIDKey: "codex-thread-1"],
-            in: [current]
+            in: [userSession(display: current, records: [previous, current])]
         )
 
-        XCTAssertEqual(resolved?.id, "codex-thread-1")
+        XCTAssertEqual(resolved?.sessionId, "replacement-observation")
+        XCTAssertEqual(resolved?.pid, 22_222)
     }
 
     func testNotificationActivationFailsClosedForUnknownPermanentID() {
-        let current = Session.mock(
+        let current = SessionData.mock(
             id: "other-session",
             cctopSessionId: "22222222-2222-4222-8222-222222222222",
             pid: 22_222,
-            source: Session.opencodeSource
+            source: SessionData.opencodeSource
         )
         let userInfo: [AnyHashable: Any] = [
             SessionIdentityPolicy.notificationCctopSessionIDKey: "11111111-1111-4111-8111-111111111111",
@@ -87,7 +94,12 @@ final class PanelToggleTests: XCTestCase {
             SessionIdentityPolicy.notificationSessionPIDKey: "22222",
         ]
 
-        XCTAssertNil(AppDelegate.notificationFocusSession(matchingUserInfo: userInfo, in: [current]))
-        XCTAssertNil(AppDelegate.notificationFocusSession(matchingUserInfo: [:], in: [current]))
+        let userSessions = [userSession(display: current, records: [current])]
+        XCTAssertNil(AppDelegate.notificationFocusSession(matchingUserInfo: userInfo, in: userSessions))
+        XCTAssertNil(AppDelegate.notificationFocusSession(
+            matchingUserInfo: [SessionIdentityPolicy.notificationCctopSessionIDKey: "malformed"],
+            in: userSessions
+        ))
+        XCTAssertNil(AppDelegate.notificationFocusSession(matchingUserInfo: [:], in: userSessions))
     }
 }

--- a/menubar/CctopMenubarTests/QASnapshotTests.swift
+++ b/menubar/CctopMenubarTests/QASnapshotTests.swift
@@ -25,53 +25,53 @@ final class QASnapshotTests: XCTestCase {
     }
 
     func testSingleSession() throws {
-        try renderSnapshot(sessions: Session.qaSingle, name: "02-single")
+        try renderSnapshot(sessions: SessionData.qaSingle, name: "02-single")
     }
 
     func testFourSessions() throws {
-        try renderSnapshot(sessions: Session.mockSessions, name: "03-four-sessions")
+        try renderSnapshot(sessions: SessionData.mockSessions, name: "03-four-sessions")
     }
 
     func testFiveSessions() throws {
-        try renderSnapshot(sessions: Session.qaFiveSessions, name: "04-five-sessions")
+        try renderSnapshot(sessions: SessionData.qaFiveSessions, name: "04-five-sessions")
     }
 
     func testSixSessions() throws {
-        try renderSnapshot(sessions: Session.qaSixSessions, name: "05-six-sessions")
+        try renderSnapshot(sessions: SessionData.qaSixSessions, name: "05-six-sessions")
     }
 
     func testEightSessions() throws {
-        try renderSnapshot(sessions: Session.qaEightSessions, name: "06-eight-sessions")
+        try renderSnapshot(sessions: SessionData.qaEightSessions, name: "06-eight-sessions")
     }
 
     // MARK: - Badge count scenarios
 
     func testAllAttention() throws {
-        try renderSnapshot(sessions: Session.qaAllAttention, name: "07-all-attention")
+        try renderSnapshot(sessions: SessionData.qaAllAttention, name: "07-all-attention")
     }
 
     func testAllIdle() throws {
-        try renderSnapshot(sessions: Session.qaAllIdle, name: "08-all-idle")
+        try renderSnapshot(sessions: SessionData.qaAllIdle, name: "08-all-idle")
     }
 
     // MARK: - Edge cases
 
     func testLongNames() throws {
-        try renderSnapshot(sessions: Session.qaLongNames, name: "09-long-names")
+        try renderSnapshot(sessions: SessionData.qaLongNames, name: "09-long-names")
     }
 
     func testLongSessionNames() throws {
-        try renderSnapshot(sessions: Session.qaLongSessionNames, name: "09b-long-session-names")
+        try renderSnapshot(sessions: SessionData.qaLongSessionNames, name: "09b-long-session-names")
     }
 
     func testDesktopProjectNames() throws {
-        try renderSnapshot(sessions: Session.qaShowcase, name: "09c-desktop-project-names")
+        try renderSnapshot(sessions: SessionData.qaShowcase, name: "09c-desktop-project-names")
     }
 
     // MARK: - Dark mode
 
     func testFiveSessionsDark() throws {
-        try renderSnapshot(sessions: Session.qaFiveSessions, name: "10-five-sessions-dark", colorScheme: .dark)
+        try renderSnapshot(sessions: SessionData.qaFiveSessions, name: "10-five-sessions-dark", colorScheme: .dark)
     }
 
     // MARK: - Update UI scenarios
@@ -79,13 +79,13 @@ final class QASnapshotTests: XCTestCase {
     func testFooterUpdateAvailable() throws {
         let updater = DisabledUpdater()
         updater.pendingUpdateVersion = "0.7.0"
-        try renderSnapshot(sessions: Session.qaShowcase, updater: updater, name: "11b-footer-update-available")
+        try renderSnapshot(sessions: SessionData.qaShowcase, updater: updater, name: "11b-footer-update-available")
     }
 
     func testFooterUpdateDownloading() throws {
         let updater = DisabledUpdater()
         updater.downloadingUpdateVersion = "0.7.0"
-        try renderSnapshot(sessions: Session.qaShowcase, updater: updater, name: "11c-footer-update-downloading")
+        try renderSnapshot(sessions: SessionData.qaShowcase, updater: updater, name: "11c-footer-update-downloading")
     }
 
     func testSettingsUpdateAvailable() throws {
@@ -140,7 +140,7 @@ final class QASnapshotTests: XCTestCase {
             ThemeManager.shared.setTheme(theme)
             for (colorScheme, schemeName) in schemes {
                 try renderSnapshot(
-                    sessions: Session.qaShowcase,
+                    sessions: SessionData.qaShowcase,
                     name: "20-active-\(theme.rawValue)-\(schemeName)",
                     colorScheme: colorScheme
                 )
@@ -169,13 +169,19 @@ final class QASnapshotTests: XCTestCase {
         let schemes: [(ColorScheme, String)] = [(.light, "light"), (.dark, "dark")]
         for (colorScheme, schemeName) in schemes {
             try renderRefinedPanelContextSnapshot(
-                PopupView(sessions: Session.qaShowcase, updater: DisabledUpdater(), pluginManager: inertPluginManager()),
+                PopupView(
+                    sessions: SessionData.qaShowcase,
+                    userSessions: userSessionProjection(from: SessionData.qaShowcase),
+                    updater: DisabledUpdater(),
+                    pluginManager: inertPluginManager()
+                ),
                 name: "24-refined-active-tokyoNight-\(schemeName)",
                 colorScheme: colorScheme
             )
             try renderRefinedPanelContextSnapshot(
                 PopupView(
-                    sessions: Session.qaShowcase,
+                    sessions: SessionData.qaShowcase,
+                    userSessions: userSessionProjection(from: SessionData.qaShowcase),
                     recentProjects: RecentProject.mockRecents,
                     updater: DisabledUpdater(),
                     pluginManager: inertPluginManager(),
@@ -207,7 +213,7 @@ final class QASnapshotTests: XCTestCase {
         )
         window.appearance = NSAppearance(named: .aqua)
 
-        let hostingView = NSHostingView(rootView: AnyView(popupView(for: Session.mockSessions)))
+        let hostingView = NSHostingView(rootView: AnyView(popupView(for: SessionData.mockSessions)))
         window.contentView = hostingView
 
         // Render "before" with 4 sessions
@@ -218,7 +224,7 @@ final class QASnapshotTests: XCTestCase {
         try captureToFile(hostingView: hostingView, path: "/tmp/cctop-qa/11-add-fifth-before.png")
 
         // Update to 5 sessions in the same hosting view
-        hostingView.rootView = AnyView(popupView(for: Session.qaFiveSessions))
+        hostingView.rootView = AnyView(popupView(for: SessionData.qaFiveSessions))
         fittingSize = hostingView.fittingSize
         window.setContentSize(fittingSize)
         hostingView.frame = NSRect(origin: .zero, size: fittingSize)
@@ -226,8 +232,13 @@ final class QASnapshotTests: XCTestCase {
         try captureToFile(hostingView: hostingView, path: "/tmp/cctop-qa/11-add-fifth-after.png")
     }
 
-    private func popupView(for sessions: [Session]) -> some View {
-        PopupView(sessions: sessions, updater: DisabledUpdater(), pluginManager: inertPluginManager())
+    private func popupView(for sessions: [SessionData]) -> some View {
+        PopupView(
+            sessions: sessions,
+            userSessions: userSessionProjection(from: sessions),
+            updater: DisabledUpdater(),
+            pluginManager: inertPluginManager()
+        )
             .frame(width: 320)
             .panelSnapshotChrome()
             .environment(\.colorScheme, .light)
@@ -236,12 +247,17 @@ final class QASnapshotTests: XCTestCase {
     // MARK: - Rendering
 
     private func renderSnapshot(
-        sessions: [Session],
+        sessions: [SessionData],
         updater: UpdaterBase? = nil,
         name: String,
         colorScheme: ColorScheme = .light
     ) throws {
-        let view = PopupView(sessions: sessions, updater: updater ?? DisabledUpdater(), pluginManager: inertPluginManager())
+        let view = PopupView(
+            sessions: sessions,
+            userSessions: userSessionProjection(from: sessions),
+            updater: updater ?? DisabledUpdater(),
+            pluginManager: inertPluginManager()
+        )
             .frame(width: 320)
             .panelSnapshotChrome()
             .environment(\.colorScheme, colorScheme)
@@ -271,7 +287,8 @@ final class QASnapshotTests: XCTestCase {
         colorScheme: ColorScheme = .light
     ) throws {
         let view = PopupView(
-            sessions: Session.qaShowcase,
+            sessions: SessionData.qaShowcase,
+            userSessions: userSessionProjection(from: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             updater: DisabledUpdater(),
             pluginManager: inertPluginManager(),

--- a/menubar/CctopMenubarTests/QaShowcaseCoverageTests.swift
+++ b/menubar/CctopMenubarTests/QaShowcaseCoverageTests.swift
@@ -3,14 +3,14 @@ import XCTest
 
 final class QaShowcaseCoverageTests: XCTestCase {
     func testShowcaseCoversPrimaryAgentBadgeVariants() {
-        let badges = Set(Session.qaShowcase.map { $0.agentBadge })
+        let badges = Set(SessionData.qaShowcase.map { $0.agentBadge })
         XCTAssertTrue(badges.contains(.cc), "qaShowcase should include a CC session")
         XCTAssertTrue(badges.contains(.claudeDesktop), "qaShowcase should include a Claude Desktop session")
         XCTAssertTrue(badges.contains(.codex), "qaShowcase should include a Codex session")
     }
 
     func testShowcaseHasMixOfStatuses() {
-        let statuses = Set(Session.qaShowcase.map { $0.status })
+        let statuses = Set(SessionData.qaShowcase.map { $0.status })
         XCTAssertTrue(statuses.contains(.working), "qaShowcase should include a working session")
         XCTAssertTrue(statuses.contains(.idle), "qaShowcase should include an idle session")
         let hasWaiting = statuses.contains(.waitingInput)
@@ -23,7 +23,7 @@ final class QaShowcaseCoverageTests: XCTestCase {
         // Permission is the only status that renders the dedicated red-orange
         // "Permission" pill (everything else uses amber "Waiting"). Lock it
         // into the showcase so README screenshots always demonstrate it.
-        let statuses = Session.qaShowcase.map { $0.status }
+        let statuses = SessionData.qaShowcase.map { $0.status }
         XCTAssertTrue(
             statuses.contains(.waitingPermission),
             "qaShowcase must include a waitingPermission session so the dedicated Permission pill is visible in screenshots"

--- a/menubar/CctopMenubarTests/SessionDedupTests.swift
+++ b/menubar/CctopMenubarTests/SessionDedupTests.swift
@@ -8,9 +8,9 @@ final class SessionDedupTests: XCTestCase {
     /// by PID collapses them. Two Codex conversations sharing a host PID must get
     /// distinct ids (by session_id); non-codex sources keep PID-based identity.
     func testCodexSessionsWithSharedPIDHaveDistinctIDs() {
-        var a = Session(sessionId: "conv-a", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        var a = SessionData(sessionId: "conv-a", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
         a.source = "codex"; a.pid = 31349
-        var b = Session(sessionId: "conv-b", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        var b = SessionData(sessionId: "conv-b", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
         b.source = "codex"; b.pid = 31349
 
         XCTAssertEqual(a.id, "conv-a")
@@ -18,16 +18,16 @@ final class SessionDedupTests: XCTestCase {
         XCTAssertNotEqual(a.id, b.id)
 
         // Non-codex still identified by PID.
-        var cc = Session(sessionId: "conv-c", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        var cc = SessionData(sessionId: "conv-c", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
         cc.source = "cc"; cc.pid = 31349
         XCTAssertEqual(cc.id, "31349")
     }
 
     func testLogicalIdentityPrefersPermanentIDAndFallsBackForLegacyRecords() {
         let sharedID = "11111111-1111-4111-8111-111111111111"
-        let first = Session.mock(id: "first", cctopSessionId: sharedID, pid: 100, source: Session.opencodeSource)
-        let replacement = Session.mock(id: "replacement", cctopSessionId: sharedID, pid: 200, source: Session.opencodeSource)
-        var legacy = Session.mock(id: "legacy", pid: 300, source: Session.opencodeSource)
+        let first = SessionData.mock(id: "first", cctopSessionId: sharedID, pid: 100, source: SessionData.opencodeSource)
+        let replacement = SessionData.mock(id: "replacement", cctopSessionId: sharedID, pid: 200, source: SessionData.opencodeSource)
+        var legacy = SessionData.mock(id: "legacy", pid: 300, source: SessionData.opencodeSource)
         legacy.cctopSessionId = nil
         var invalid = legacy
         invalid.cctopSessionId = "not-a-uuid"
@@ -46,7 +46,7 @@ final class SessionDedupTests: XCTestCase {
         )
     }
 
-    func testLogicalDedupKeepsFirstRowPositionAndPreferredObservation() {
+    func testSharedCctopSessionIDFormsOneUserSessionWithPreferredDisplayAndAllRecords() {
         let sharedID = "11111111-1111-4111-8111-111111111111"
         let old = candidate(
             sessionId: "old", pid: 100, bundleId: nil, lifecycleRank: 1,
@@ -61,17 +61,74 @@ final class SessionDedupTests: XCTestCase {
             lastActivity: Date(timeIntervalSince1970: 20), path: "/current.json"
         ) { $0.cctopSessionId = sharedID }
 
-        let result = SessionIdentityPolicy.dedupedCandidatesByLogicalIdentity([old, other, current])
+        let result = UserSession.grouping(
+            winners: [old, other, current],
+            records: [old, other, current]
+        )
 
-        XCTAssertEqual(result.map(\.session.pid), [300, 200])
+        XCTAssertEqual(result.map(\.displayRecord.data.pid), [300, 200])
+        XCTAssertEqual(result[0].identity.cctopSessionID, sharedID)
+        XCTAssertEqual(result[0].records.map(\.data.pid), [100, 300])
+        XCTAssertEqual(result[0].focusTarget.pid, 300)
+    }
+
+    func testUserSessionRetainsStableKeyRecordsBehindIdentifiedWinner() {
+        let sharedID = "11111111-1111-4111-8111-111111111111"
+        let old = candidate(
+            sessionId: "conversation", pid: 100, bundleId: Self.desktopBundle,
+            lifecycleRank: 1, path: "/old.json"
+        )
+        let current = candidate(
+            sessionId: "conversation", pid: 200, bundleId: Self.desktopBundle,
+            lifecycleRank: 0, path: "/current.json"
+        )
+        let identifiedWinner = current.replacingData({
+            var data = current.data
+            data.cctopSessionId = sharedID
+            return data
+        }())
+
+        let result = UserSession.grouping(
+            winners: [identifiedWinner],
+            records: [old, current]
+        )
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].identity.cctopSessionID, sharedID)
+        XCTAssertEqual(result[0].records.map(\.data.pid), [100, 200])
+        XCTAssertEqual(result[0].displayRecord.data.pid, 200)
+    }
+
+    func testUserSessionKeepsStableKeyWinnerWhenDiscardedRecordHasConflictingID() {
+        let discardedID = "11111111-1111-4111-8111-111111111111"
+        let winnerID = "22222222-2222-4222-8222-222222222222"
+        let discarded = candidate(
+            sessionId: "conversation", pid: 100, bundleId: Self.desktopBundle,
+            lifecycleRank: 1, path: "/old.json"
+        ) { $0.cctopSessionId = discardedID }
+        let winner = candidate(
+            sessionId: "conversation", pid: 200, bundleId: Self.desktopBundle,
+            lifecycleRank: 0, path: "/current.json"
+        ) { $0.cctopSessionId = winnerID }
+
+        let result = UserSession.grouping(
+            winners: [winner],
+            records: [discarded, winner]
+        )
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].identity.cctopSessionID, winnerID)
+        XCTAssertEqual(result[0].records.map(\.data.cctopSessionId), [discardedID, winnerID])
+        XCTAssertNil(FocusTargetResolver.currentSession(forCctopSessionID: discardedID, in: result))
+        XCTAssertEqual(FocusTargetResolver.currentSession(forCctopSessionID: winnerID, in: result)?.pid, 200)
     }
 
     // MARK: - Desktop dedup by session_id (Phase 1, total order)
 
     private static let desktopBundle = "com.anthropic.claudefordesktop"
 
-    private func deduped(_ candidates: [DedupCandidate]) -> [Session] {
-        SessionIdentityPolicy.dedupedCandidatesByStableKey(candidates).map(\.session)
+    private func deduped(_ candidates: [SessionRecord]) -> [SessionData] {
+        SessionIdentityPolicy.dedupedCandidatesByStableKey(candidates).map(\.data)
     }
 
     func testDedupDesktopCollapsesSameSessionIdDifferentPid() {
@@ -152,11 +209,11 @@ final class SessionDedupTests: XCTestCase {
     func testDedupMigratedCodexSessionUsesStableConversationIdAcrossHostClass() {
         let oldPidKeyed = candidate(
             sessionId: "conv-a", pid: 100, bundleId: nil, lifecycleRank: 2,
-            source: Session.codexSource, path: "/100.json"
+            source: SessionData.codexSource, path: "/100.json"
         )
         let desktopKeyed = candidate(
             sessionId: "conv-a", pid: 200, bundleId: HostAppBundleID.codexDesktop,
-            lifecycleRank: 0, source: Session.codexSource, path: "/codex-conv-a.json"
+            lifecycleRank: 0, source: SessionData.codexSource, path: "/codex-conv-a.json"
         )
 
         let result = deduped([oldPidKeyed, desktopKeyed])

--- a/menubar/CctopMenubarTests/SessionDisplayPolicyTests.swift
+++ b/menubar/CctopMenubarTests/SessionDisplayPolicyTests.swift
@@ -45,9 +45,9 @@ final class SessionDisplayPolicyTests: XCTestCase {
 
     func testReconciledActiveOrderKeepsWaitingPeerOrderAcrossSameGroupUpdates() {
         let now = Date(timeIntervalSince1970: 10_000)
-        var first = Session.mock(id: "first", status: .waitingInput, notificationMessage: "old")
+        var first = SessionData.mock(id: "first", status: .waitingInput, notificationMessage: "old")
         first.lastActivity = now.addingTimeInterval(-300)
-        var second = Session.mock(id: "second", status: .needsAttention, notificationMessage: "old")
+        var second = SessionData.mock(id: "second", status: .needsAttention, notificationMessage: "old")
         second.lastActivity = now.addingTimeInterval(-200)
         let previous = [first, second]
 
@@ -71,10 +71,10 @@ final class SessionDisplayPolicyTests: XCTestCase {
 
     func testReconciledActiveOrderKeepsWorkingAndActiveIdlePeerOrderAcrossActivityChanges() {
         let now = Date(timeIntervalSince1970: 20_000)
-        var workA = Session.mock(id: "work-a", status: .working)
-        var workB = Session.mock(id: "work-b", status: .working)
-        var idleA = Session.mock(id: "idle-a", status: .idle)
-        var idleB = Session.mock(id: "idle-b", status: .idle)
+        var workA = SessionData.mock(id: "work-a", status: .working)
+        var workB = SessionData.mock(id: "work-b", status: .working)
+        var idleA = SessionData.mock(id: "idle-a", status: .idle)
+        var idleB = SessionData.mock(id: "idle-b", status: .idle)
         let previous = [workA, workB, idleA, idleB]
 
         workA.lastActivity = now
@@ -93,9 +93,9 @@ final class SessionDisplayPolicyTests: XCTestCase {
 
     func testReconciledActiveOrderMovesWorkingSessionToWaitingGroupTail() {
         let now = Date(timeIntervalSince1970: 30_000)
-        let waitA = Session.mock(id: "wait-a", status: .waitingInput)
-        let waitB = Session.mock(id: "wait-b", status: .needsAttention)
-        var working = Session.mock(id: "working", status: .working)
+        let waitA = SessionData.mock(id: "wait-a", status: .waitingInput)
+        let waitB = SessionData.mock(id: "wait-b", status: .needsAttention)
+        var working = SessionData.mock(id: "working", status: .working)
         let previous = [waitA, waitB, working]
 
         working.status = .waitingInput
@@ -111,9 +111,9 @@ final class SessionDisplayPolicyTests: XCTestCase {
 
     func testReconciledActiveOrderMovesWaitingSessionToWorkingGroupTail() {
         let now = Date(timeIntervalSince1970: 40_000)
-        var waiting = Session.mock(id: "waiting", status: .waitingInput)
-        let workA = Session.mock(id: "work-a", status: .working)
-        let workB = Session.mock(id: "work-b", status: .working)
+        var waiting = SessionData.mock(id: "waiting", status: .waitingInput)
+        let workA = SessionData.mock(id: "work-a", status: .working)
+        let workB = SessionData.mock(id: "work-b", status: .working)
         let previous = [waiting, workA, workB]
 
         waiting.status = .working
@@ -128,16 +128,16 @@ final class SessionDisplayPolicyTests: XCTestCase {
 
     func testReconciledActiveOrderAppendsNewcomersWithinEachPriorityGroup() {
         let now = Date(timeIntervalSince1970: 50_000)
-        let permission = Session.mock(id: "permission", status: .waitingPermission)
-        let waiting = Session.mock(id: "waiting", status: .waitingInput)
-        let working = Session.mock(id: "working", status: .working)
-        let compacting = Session.mock(id: "compacting", status: .compacting)
-        let idle = Session.mock(id: "idle", status: .idle)
-        let newPermission = Session.mock(id: "new-permission", status: .waitingPermission)
-        let newWaiting = Session.mock(id: "new-waiting", status: .waitingInput)
-        let newWorking = Session.mock(id: "new-working", status: .working)
-        let newCompacting = Session.mock(id: "new-compacting", status: .compacting)
-        let newIdle = Session.mock(id: "new-idle", status: .idle)
+        let permission = SessionData.mock(id: "permission", status: .waitingPermission)
+        let waiting = SessionData.mock(id: "waiting", status: .waitingInput)
+        let working = SessionData.mock(id: "working", status: .working)
+        let compacting = SessionData.mock(id: "compacting", status: .compacting)
+        let idle = SessionData.mock(id: "idle", status: .idle)
+        let newPermission = SessionData.mock(id: "new-permission", status: .waitingPermission)
+        let newWaiting = SessionData.mock(id: "new-waiting", status: .waitingInput)
+        let newWorking = SessionData.mock(id: "new-working", status: .working)
+        let newCompacting = SessionData.mock(id: "new-compacting", status: .compacting)
+        let newIdle = SessionData.mock(id: "new-idle", status: .idle)
 
         let result = SessionDisplayPolicy.reconcilingActiveOrder(
             in: [newIdle, newCompacting, newWorking, newWaiting, newPermission, idle, compacting, working, waiting, permission],
@@ -156,11 +156,11 @@ final class SessionDisplayPolicyTests: XCTestCase {
 
     func testReconciledActiveOrderCompactsSurvivorsAndKeepsNonActiveRemainderOrder() {
         let now = Date(timeIntervalSince1970: 60_000)
-        let waitA = Session.mock(id: "wait-a", status: .waitingInput)
-        let waitB = Session.mock(id: "wait-b", status: .waitingInput)
-        let workA = Session.mock(id: "work-a", status: .working)
-        let workB = Session.mock(id: "work-b", status: .working)
-        var dormant = Session.mock(id: "dormant", status: .idle)
+        let waitA = SessionData.mock(id: "wait-a", status: .waitingInput)
+        let waitB = SessionData.mock(id: "wait-b", status: .waitingInput)
+        let workA = SessionData.mock(id: "work-a", status: .working)
+        let workB = SessionData.mock(id: "work-b", status: .working)
+        var dormant = SessionData.mock(id: "dormant", status: .idle)
         dormant.lifecycle = .dormant
 
         let result = SessionDisplayPolicy.reconcilingActiveOrder(
@@ -176,10 +176,10 @@ final class SessionDisplayPolicyTests: XCTestCase {
 
     func testReconciledActiveOrderUsesDeterministicCurrentInputOnInitialLoad() {
         let now = Date(timeIntervalSince1970: 70_000)
-        let workA = Session.mock(id: "a-work", status: .working)
-        let waiting = Session.mock(id: "b-wait", status: .waitingInput)
-        let workB = Session.mock(id: "c-work", status: .working)
-        let idle = Session.mock(id: "d-idle", status: .idle)
+        let workA = SessionData.mock(id: "a-work", status: .working)
+        let waiting = SessionData.mock(id: "b-wait", status: .waitingInput)
+        let workB = SessionData.mock(id: "c-work", status: .working)
+        let idle = SessionData.mock(id: "d-idle", status: .idle)
 
         let result = SessionDisplayPolicy.reconcilingActiveOrder(
             in: [workA, waiting, workB, idle],
@@ -192,8 +192,8 @@ final class SessionDisplayPolicyTests: XCTestCase {
 
     func testReconciledActiveOrderTreatsStaleIdleReentryAsGroupEntrant() {
         let now = Date(timeIntervalSince1970: 80_000)
-        let survivor = Session.mock(id: "survivor", status: .working)
-        var returning = Session.mock(id: "returning", status: .idle)
+        let survivor = SessionData.mock(id: "survivor", status: .working)
+        var returning = SessionData.mock(id: "returning", status: .idle)
         returning.lastActivity = now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 1)
         let previous = [returning, survivor]
 
@@ -211,14 +211,14 @@ final class SessionDisplayPolicyTests: XCTestCase {
     func testReconciledActiveOrderUsesStableConversationIdentityAcrossDesktopPIDChange() {
         let now = Date(timeIntervalSince1970: 90_000)
         let terminal = TerminalInfo(program: "Claude", bundleId: HostAppBundleID.claudeDesktop)
-        var desktop = Session.mock(
+        var desktop = SessionData.mock(
             id: "conversation",
             status: .working,
             pid: 100,
             terminal: terminal,
-            source: Session.ccSource
+            source: SessionData.ccSource
         )
-        let other = Session.mock(id: "other", status: .working, source: Session.codexSource)
+        let other = SessionData.mock(id: "other", status: .working, source: SessionData.codexSource)
         let previous = [desktop, other]
 
         desktop.pid = 200
@@ -236,29 +236,29 @@ final class SessionDisplayPolicyTests: XCTestCase {
         )
     }
 
-    func testReconciledActiveOrderUsesPermanentIdentityAcrossObservationReplacementAndStatusMovement() {
+    func testReconciledActiveOrderUsesPermanentIdentityAcrossRecordReplacementAndStatusMovement() {
         let now = Date(timeIntervalSince1970: 95_000)
         let sharedID = "11111111-1111-4111-8111-111111111111"
-        var logicalSession = Session.mock(
+        var userSession = SessionData.mock(
             id: "old-observation", cctopSessionId: sharedID,
-            status: .working, pid: 100, source: Session.opencodeSource
+            status: .working, pid: 100, source: SessionData.opencodeSource
         )
-        let workingPeer = Session.mock(id: "peer", status: .working, pid: 200, source: Session.opencodeSource)
-        let previous = [logicalSession, workingPeer]
+        let workingPeer = SessionData.mock(id: "peer", status: .working, pid: 200, source: SessionData.opencodeSource)
+        let previous = [userSession, workingPeer]
 
-        logicalSession = Session.mock(
+        userSession = SessionData.mock(
             id: "new-observation", cctopSessionId: sharedID,
-            status: .waitingInput, pid: 300, source: Session.opencodeSource
+            status: .waitingInput, pid: 300, source: SessionData.opencodeSource
         )
         let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [workingPeer, logicalSession], preserving: previous, now: now
+            in: [workingPeer, userSession], preserving: previous, now: now
         )
 
         XCTAssertEqual(result.map(\.pid), [300, 200])
         XCTAssertEqual(
             result.map { SessionIdentityPolicy.logicalIdentity(for: $0) },
             [
-                SessionIdentityPolicy.logicalIdentity(for: logicalSession),
+                SessionIdentityPolicy.logicalIdentity(for: userSession),
                 SessionIdentityPolicy.logicalIdentity(for: workingPeer),
             ]
         )
@@ -267,17 +267,17 @@ final class SessionDisplayPolicyTests: XCTestCase {
     func testReconciledActiveOrderDoesNotReplayDuplicatePreviousLogicalRows() {
         let now = Date(timeIntervalSince1970: 96_000)
         let sharedID = "11111111-1111-4111-8111-111111111111"
-        let previousFirst = Session.mock(
+        let previousFirst = SessionData.mock(
             id: "old-first", cctopSessionId: sharedID,
-            status: .working, pid: 100, source: Session.opencodeSource
+            status: .working, pid: 100, source: SessionData.opencodeSource
         )
-        let previousSecond = Session.mock(
+        let previousSecond = SessionData.mock(
             id: "old-second", cctopSessionId: sharedID,
-            status: .working, pid: 200, source: Session.opencodeSource
+            status: .working, pid: 200, source: SessionData.opencodeSource
         )
-        let current = Session.mock(
+        let current = SessionData.mock(
             id: "current", cctopSessionId: sharedID,
-            status: .working, pid: 300, source: Session.opencodeSource
+            status: .working, pid: 300, source: SessionData.opencodeSource
         )
 
         let result = SessionDisplayPolicy.reconcilingActiveOrder(
@@ -287,22 +287,22 @@ final class SessionDisplayPolicyTests: XCTestCase {
         XCTAssertEqual(result.map(\.pid), [300])
     }
 
-    private func activeIdle(id: String, lastActivity: Date) -> Session {
-        var session = Session.mock(id: id, status: .idle)
+    private func activeIdle(id: String, lastActivity: Date) -> SessionData {
+        var session = SessionData.mock(id: id, status: .idle)
         session.lifecycle = .active
         session.lastActivity = lastActivity
         return session
     }
 
-    private func activeWaiting(id: String, lastActivity: Date) -> Session {
-        var session = Session.mock(id: id, status: .waitingInput)
+    private func activeWaiting(id: String, lastActivity: Date) -> SessionData {
+        var session = SessionData.mock(id: id, status: .waitingInput)
         session.lifecycle = .active
         session.lastActivity = lastActivity
         return session
     }
 
-    private func dormant(id: String) -> Session {
-        var session = Session.mock(id: id, status: .idle)
+    private func dormant(id: String) -> SessionData {
+        var session = SessionData.mock(id: id, status: .idle)
         session.lifecycle = .dormant
         return session
     }

--- a/menubar/CctopMenubarTests/SessionFileFormatTests.swift
+++ b/menubar/CctopMenubarTests/SessionFileFormatTests.swift
@@ -22,7 +22,7 @@ final class SessionFileFormatTests: XCTestCase {
 
         let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
         let sessionURL = URL(fileURLWithPath: (sessionsDir as NSString).appendingPathComponent("cached.json"))
-        try Session(sessionId: "cached-session", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        try SessionData(sessionId: "cached-session", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
             .writeToFile(path: sessionURL.path)
         let originalMtime = Date(timeIntervalSince1970: 1_800_000_000)
         try FileManager.default.setAttributes([.modificationDate: originalMtime], ofItemAtPath: sessionURL.path)
@@ -48,14 +48,14 @@ final class SessionFileFormatTests: XCTestCase {
 
         let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
         let sessionURL = URL(fileURLWithPath: (sessionsDir as NSString).appendingPathComponent("cached.json"))
-        try Session(sessionId: "cached-session", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        try SessionData(sessionId: "cached-session", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
             .writeToFile(path: sessionURL.path)
         let originalMtime = Date(timeIntervalSince1970: 1_800_000_000)
         try FileManager.default.setAttributes([.modificationDate: originalMtime], ofItemAtPath: sessionURL.path)
 
         XCTAssertEqual(manager.decodedSessions(from: [sessionURL]).map(\.session.sessionId), ["cached-session"])
 
-        try Session(sessionId: "changed-session", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        try SessionData(sessionId: "changed-session", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
             .writeToFile(path: sessionURL.path)
         try FileManager.default.setAttributes(
             [.modificationDate: originalMtime.addingTimeInterval(10)],

--- a/menubar/CctopMenubarTests/SessionLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/SessionLifecycleTests.swift
@@ -13,8 +13,8 @@ final class SessionLifecycleTests: XCTestCase {
         source: String? = nil,
         agoSeconds: TimeInterval,
         disconnectedAgoSeconds: TimeInterval? = nil
-    ) -> Session {
-        var session = Session(sessionId: "s", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+    ) -> SessionData {
+        var session = SessionData(sessionId: "s", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
         session.source = source
         session.lastActivity = Self.lifeNow.addingTimeInterval(-agoSeconds)
         if let disconnectedAgoSeconds {
@@ -24,7 +24,7 @@ final class SessionLifecycleTests: XCTestCase {
     }
 
     private func life(
-        _ session: Session,
+        _ session: SessionData,
         _ hostClass: SessionHostClass,
         alive: Bool,
         desktopAppRunning: Bool? = nil
@@ -40,7 +40,7 @@ final class SessionLifecycleTests: XCTestCase {
     }
 
     private func connection(
-        _ session: Session,
+        _ session: SessionData,
         _ hostClass: SessionHostClass,
         alive: Bool,
         desktopAppRunning: Bool? = nil
@@ -58,7 +58,7 @@ final class SessionLifecycleTests: XCTestCase {
         defer { try? FileManager.default.removeItem(atPath: root) }
 
         let sessionPath = (root as NSString).appendingPathComponent("codex-stale.json")
-        var session = lifeSession(source: Session.codexSource, agoSeconds: 10_000, disconnectedAgoSeconds: 10_000)
+        var session = lifeSession(source: SessionData.codexSource, agoSeconds: 10_000, disconnectedAgoSeconds: 10_000)
         session.terminal = TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
         session.pid = nil
         try session.writeToFile(path: sessionPath)
@@ -75,7 +75,7 @@ final class SessionLifecycleTests: XCTestCase {
             processAlive: { _ in false }
         )
 
-        XCTAssertEqual(candidates.map(\.session.lifecycle), [.dormant])
+        XCTAssertEqual(candidates.map(\.data.lifecycle), [.dormant])
     }
 
     func testBuildCandidatesBatchesDesktopAppRunningLookupByBundleID() {
@@ -164,7 +164,7 @@ final class SessionLifecycleTests: XCTestCase {
         }
 
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-reconnected.json")
-        var session = lifeSession(source: Session.codexSource, agoSeconds: 10_000, disconnectedAgoSeconds: 10_000)
+        var session = lifeSession(source: SessionData.codexSource, agoSeconds: 10_000, disconnectedAgoSeconds: 10_000)
         session.terminal = TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
         session.pid = nil
         // SessionManager derives lifecycle against the real clock; keep the session idle
@@ -182,7 +182,7 @@ final class SessionLifecycleTests: XCTestCase {
         )
 
         XCTAssertEqual(manager.sessions.map(\.lifecycle), [.dormant])
-        XCTAssertNotNil(try Session.fromFile(path: sessionPath).disconnectedAt)
+        XCTAssertNotNil(try SessionData.fromFile(path: sessionPath).disconnectedAt)
     }
 
     @MainActor
@@ -202,7 +202,7 @@ final class SessionLifecycleTests: XCTestCase {
         }
 
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-ended.json")
-        var session = lifeSession(source: Session.codexSource, agoSeconds: 10_000, disconnectedAgoSeconds: 10_000)
+        var session = lifeSession(source: SessionData.codexSource, agoSeconds: 10_000, disconnectedAgoSeconds: 10_000)
         session.terminal = TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
         session.pid = nil
         // SessionManager derives lifecycle against the real clock; keep the session idle
@@ -223,7 +223,7 @@ final class SessionLifecycleTests: XCTestCase {
         )
 
         XCTAssertEqual(manager.sessions.map(\.lifecycle), [.dormant])
-        XCTAssertEqual(try Session.fromFile(path: sessionPath).disconnectedAt, disconnectedAt)
+        XCTAssertEqual(try SessionData.fromFile(path: sessionPath).disconnectedAt, disconnectedAt)
     }
 
     // The headline issue #155 file class: a DEAD Claude Code session that inherited
@@ -239,7 +239,7 @@ final class SessionLifecycleTests: XCTestCase {
         defer { try? FileManager.default.removeItem(atPath: root) }
 
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("54321.json")
-        var session = Session(sessionId: "cc-ghost", projectPath: "/tmp/p", branch: "main",
+        var session = SessionData(sessionId: "cc-ghost", projectPath: "/tmp/p", branch: "main",
                               terminal: TerminalInfo(bundleId: HostAppBundleID.codexDesktop))
         session.source = "cc"
         session.pid = 999_999
@@ -285,11 +285,11 @@ final class SessionLifecycleTests: XCTestCase {
 
         let pid = UInt32(process.processIdentifier)
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("\(pid).json")
-        var session = Session(sessionId: "cc-live", projectPath: "/tmp/p", branch: "main",
+        var session = SessionData(sessionId: "cc-live", projectPath: "/tmp/p", branch: "main",
                               terminal: TerminalInfo(bundleId: HostAppBundleID.codexDesktop))
         session.source = "cc"
         session.pid = pid
-        session.pidStartTime = Session.processStartTime(pid: pid)
+        session.pidStartTime = SessionData.processStartTime(pid: pid)
         session.lastActivity = Date().addingTimeInterval(-60)
         try session.writeToFile(path: sessionPath)
 
@@ -307,18 +307,18 @@ final class SessionLifecycleTests: XCTestCase {
     }
 
     func testIdentityPolicyNamesStableGroupingRules() {
-        var codex = Session(sessionId: "codex-conversation", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
-        codex.source = Session.codexSource
+        var codex = SessionData(sessionId: "codex-conversation", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        codex.source = SessionData.codexSource
         codex.lastActivity = Self.lifeNow.addingTimeInterval(-60)
         codex.pid = 31349
 
-        var desktop = Session(sessionId: "desktop-conversation", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        var desktop = SessionData(sessionId: "desktop-conversation", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
         desktop.source = "cc"
         desktop.lastActivity = Self.lifeNow.addingTimeInterval(-60)
         desktop.terminal = TerminalInfo(bundleId: HostAppBundleID.claudeDesktop)
         desktop.pid = 99
 
-        var terminal = Session(sessionId: "terminal-conversation", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        var terminal = SessionData(sessionId: "terminal-conversation", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
         terminal.source = "cc"
         terminal.lastActivity = Self.lifeNow.addingTimeInterval(-60)
         terminal.pid = 42
@@ -396,11 +396,11 @@ final class SessionLifecycleTests: XCTestCase {
 
     func testLifecycleCodexUsesOneFourteenDayPolicyAcrossBundleVariants() {
         for bundleID in [nil, HostAppBundleID.codexDesktop, "com.googlecode.iterm2"] {
-            var expired = lifeSession(source: Session.codexSource, agoSeconds: Self.retentionWin)
+            var expired = lifeSession(source: SessionData.codexSource, agoSeconds: Self.retentionWin)
             expired.terminal = TerminalInfo(bundleId: bundleID)
             XCTAssertEqual(life(expired, expired.hostClass, alive: true, desktopAppRunning: true), .finished)
 
-            var disconnected = lifeSession(source: Session.codexSource, agoSeconds: 600)
+            var disconnected = lifeSession(source: SessionData.codexSource, agoSeconds: 600)
             disconnected.terminal = TerminalInfo(bundleId: bundleID)
             XCTAssertEqual(life(disconnected, disconnected.hostClass, alive: false, desktopAppRunning: false), .dormant)
 
@@ -414,7 +414,7 @@ final class SessionLifecycleTests: XCTestCase {
 
     func testLifecycleFreshCodexHookActivityRevivesEndedSessionAcrossBundleVariants() {
         for bundleID in [nil, HostAppBundleID.codexDesktop, "com.googlecode.iterm2"] {
-            var session = lifeSession(source: Session.codexSource, agoSeconds: Self.retentionWin + 1)
+            var session = lifeSession(source: SessionData.codexSource, agoSeconds: Self.retentionWin + 1)
             session.terminal = TerminalInfo(bundleId: bundleID)
             session.endedAt = Self.lifeNow.addingTimeInterval(-Self.retentionWin)
             XCTAssertEqual(life(session, session.hostClass, alive: true), .finished)
@@ -531,11 +531,11 @@ final class SessionLifecycleTests: XCTestCase {
 
     func testClassificationSnapshotFiltersArchivedSubagentExecHelperAndOrphanedSessions() {
         let archived = candidate(sessionId: "archived-thread", pid: 1, bundleId: HostAppBundleID.codexDesktop,
-                                 lifecycleRank: 0, source: Session.codexSource, path: "/archived.json")
+                                 lifecycleRank: 0, source: SessionData.codexSource, path: "/archived.json")
         let subagent = candidate(sessionId: "subagent-thread", pid: 2, bundleId: "com.googlecode.iterm2",
-                                 lifecycleRank: 0, source: Session.codexSource, path: "/subagent.json")
+                                 lifecycleRank: 0, source: SessionData.codexSource, path: "/subagent.json")
         let execHelper = candidate(sessionId: "exec-helper-thread", pid: 3, bundleId: HostAppBundleID.codexDesktop,
-                                   lifecycleRank: 0, source: Session.codexSource, path: "/exec.json")
+                                   lifecycleRank: 0, source: SessionData.codexSource, path: "/exec.json")
         let archivedClaude = candidate(sessionId: "archived-claude", pid: 4, bundleId: HostAppBundleID.claudeDesktop,
                                        lifecycleRank: 0, source: "cc", path: "/claude-archived.json")
         // Ended, with authoritative metadata that does not know the session -> orphaned, filtered.
@@ -543,7 +543,7 @@ final class SessionLifecycleTests: XCTestCase {
                                      lifecycleRank: 0, source: "cc",
                                      endedAt: Date(timeIntervalSince1970: 2000), path: "/claude-orphan.json")
         let visibleCodex = candidate(sessionId: "visible-thread", pid: 6, bundleId: HostAppBundleID.codexDesktop,
-                                     lifecycleRank: 0, source: Session.codexSource, path: "/visible.json")
+                                     lifecycleRank: 0, source: SessionData.codexSource, path: "/visible.json")
         let visibleClaude = candidate(sessionId: "visible-claude", pid: 7, bundleId: HostAppBundleID.claudeDesktop,
                                       lifecycleRank: 0, source: "cc", path: "/claude-visible.json") { session in
             session.sessionName = "Visible Claude session"
@@ -570,10 +570,10 @@ final class SessionLifecycleTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            classification.displayCandidates.map(\.session.sessionId).sorted(),
+            classification.displayCandidates.map(\.data.sessionId).sorted(),
             ["matched-ended-claude", "visible-claude", "visible-thread"]
         )
-        XCTAssertEqual(classification.codexInternalHelperCandidates.map(\.session.sessionId), [])
+        XCTAssertEqual(classification.codexInternalHelperCandidates.map(\.data.sessionId), [])
         XCTAssertEqual(classification.archivedCodexThreadIDs, ["archived-thread", "subagent-thread"])
         XCTAssertEqual(classification.codexInternalHelperThreadIDs, ["subagent-thread"])
         XCTAssertEqual(classification.codexExecHelperThreadIDs, ["exec-helper-thread"])
@@ -583,19 +583,19 @@ final class SessionLifecycleTests: XCTestCase {
     func testClassificationSnapshotHidesArchivedCodexAcrossHostsWithoutInferringDesktop() {
         let archivedWithoutBundle = candidate(
             sessionId: "archived-no-bundle", pid: 1, bundleId: nil,
-            lifecycleRank: 0, source: Session.codexSource, path: "/archived-no-bundle.json"
+            lifecycleRank: 0, source: SessionData.codexSource, path: "/archived-no-bundle.json"
         )
         let archivedCLI = candidate(
             sessionId: "archived-cli", pid: 2, bundleId: "com.googlecode.iterm2",
-            lifecycleRank: 0, source: Session.codexSource, path: "/archived-cli.json"
+            lifecycleRank: 0, source: SessionData.codexSource, path: "/archived-cli.json"
         )
         let visibleWithoutBundle = candidate(
             sessionId: "visible-no-bundle", pid: 3, bundleId: nil,
-            lifecycleRank: 0, source: Session.codexSource, path: "/visible-no-bundle.json"
+            lifecycleRank: 0, source: SessionData.codexSource, path: "/visible-no-bundle.json"
         )
         let visibleCLI = candidate(
             sessionId: "visible-cli", pid: 4, bundleId: "com.googlecode.iterm2",
-            lifecycleRank: 0, source: Session.codexSource, path: "/visible-cli.json"
+            lifecycleRank: 0, source: SessionData.codexSource, path: "/visible-cli.json"
         )
         let opencodeWithLeakedBundle = candidate(
             sessionId: "opencode", pid: 5, bundleId: HostAppBundleID.codexDesktop,
@@ -611,7 +611,7 @@ final class SessionLifecycleTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            classification.displayCandidates.map(\.session.sessionId).sorted(),
+            classification.displayCandidates.map(\.data.sessionId).sorted(),
             ["opencode", "visible-cli", "visible-no-bundle"]
         )
         XCTAssertEqual(classification.archivedCodexThreadIDs, ["archived-cli", "archived-no-bundle"])
@@ -631,13 +631,13 @@ final class SessionLifecycleTests: XCTestCase {
         let now = Date(timeIntervalSince1970: 10_000)
         let missingWithoutBundle = candidate(
             sessionId: "missing-no-bundle", pid: 1, bundleId: nil,
-            lifecycleRank: 0, source: Session.codexSource,
+            lifecycleRank: 0, source: SessionData.codexSource,
             lastActivity: now.addingTimeInterval(-SessionManager.codexMissingThreadGraceSeconds - 1),
             path: "/missing-no-bundle.json"
         )
         let missingWithBundle = candidate(
             sessionId: "missing-with-bundle", pid: 2, bundleId: HostAppBundleID.codexDesktop,
-            lifecycleRank: 0, source: Session.codexSource,
+            lifecycleRank: 0, source: SessionData.codexSource,
             lastActivity: now.addingTimeInterval(-SessionManager.codexMissingThreadGraceSeconds - 1),
             path: "/missing-with-bundle.json"
         )
@@ -648,7 +648,7 @@ final class SessionLifecycleTests: XCTestCase {
             codexThreads: StubCodexThreadState(existing: []),
             now: now
         )
-        XCTAssertEqual(missing.displayCandidates.map(\.session.sessionId), [])
+        XCTAssertEqual(missing.displayCandidates.map(\.data.sessionId), [])
 
         let unreadable = SessionManager.sessionClassificationSnapshot(
             in: [missingWithoutBundle, missingWithBundle],
@@ -657,7 +657,7 @@ final class SessionLifecycleTests: XCTestCase {
             now: now
         )
         XCTAssertEqual(
-            unreadable.displayCandidates.map(\.session.sessionId).sorted(),
+            unreadable.displayCandidates.map(\.data.sessionId).sorted(),
             ["missing-no-bundle", "missing-with-bundle"]
         )
     }
@@ -665,7 +665,7 @@ final class SessionLifecycleTests: XCTestCase {
     func testArchivedFinishedCodexUsesSourceOnlyHiddenCleanupPath() {
         let finishedCLI = candidate(
             sessionId: "archived-finished-cli", pid: 1, bundleId: "com.googlecode.iterm2",
-            lifecycleRank: SessionLifecycle.finished.rawValue, source: Session.codexSource, path: "/finished.json"
+            lifecycleRank: SessionLifecycle.finished.rawValue, source: SessionData.codexSource, path: "/finished.json"
         ) { session in
             session.lifecycle = .finished
         }
@@ -676,8 +676,8 @@ final class SessionLifecycleTests: XCTestCase {
             codexThreads: StubCodexThreadState(archived: ["archived-finished-cli"])
         )
 
-        XCTAssertEqual(classification.displayCandidates.map(\.session.sessionId), [])
-        XCTAssertEqual(classification.finishedNonDesktopCandidates.map(\.session.sessionId), [])
+        XCTAssertEqual(classification.displayCandidates.map(\.data.sessionId), [])
+        XCTAssertEqual(classification.finishedNonDesktopCandidates.map(\.data.sessionId), [])
         XCTAssertEqual(classification.cleanupSources.map(\.sessionId), ["archived-finished-cli"])
         XCTAssertEqual(classification.protectedProjectPathsForCleanup, [])
     }
@@ -686,7 +686,7 @@ final class SessionLifecycleTests: XCTestCase {
         let persistedHidden = candidate(
             sessionId: "archived-hidden", pid: 1, bundleId: nil,
             lifecycleRank: SessionLifecycle.active.rawValue,
-            source: Session.codexSource,
+            source: SessionData.codexSource,
             path: "/archived-hidden.json"
         ) { $0.hidden = true }
 
@@ -702,13 +702,13 @@ final class SessionLifecycleTests: XCTestCase {
 
     func testClassificationSnapshotEmitsCleanupSourcesForArchivedCodexSessions() {
         let archived = candidate(sessionId: "archived-thread", pid: 1, bundleId: nil,
-                                 lifecycleRank: 0, source: Session.codexSource, path: "/archived.json") { session in
+                                 lifecycleRank: 0, source: SessionData.codexSource, path: "/archived.json") { session in
             session.sessionName = "Archived Codex work"
         }
         let visible = candidate(sessionId: "visible-thread", pid: 2, bundleId: nil,
-                                lifecycleRank: 0, source: Session.codexSource, path: "/visible.json")
+                                lifecycleRank: 0, source: SessionData.codexSource, path: "/visible.json")
         let subagent = candidate(sessionId: "subagent-thread", pid: 3, bundleId: nil,
-                                 lifecycleRank: 0, source: Session.codexSource, path: "/subagent.json")
+                                 lifecycleRank: 0, source: SessionData.codexSource, path: "/subagent.json")
 
         let state = SessionManager.sessionClassificationSnapshot(
             in: [archived, visible, subagent],
@@ -719,24 +719,24 @@ final class SessionLifecycleTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(state.displayCandidates.map(\.session.sessionId), ["visible-thread"])
+        XCTAssertEqual(state.displayCandidates.map(\.data.sessionId), ["visible-thread"])
         XCTAssertEqual(state.cleanupSources.map(\.sessionId), ["archived-thread"])
         XCTAssertEqual(state.cleanupSources.map(\.projectPath), ["/tmp/p"])
         XCTAssertEqual(state.cleanupSources.map(\.sessionName), ["Archived Codex work"])
-        XCTAssertEqual(state.codexInternalHelperCandidates.map(\.session.sessionId), ["subagent-thread"])
+        XCTAssertEqual(state.codexInternalHelperCandidates.map(\.data.sessionId), ["subagent-thread"])
     }
 
     func testClassificationSnapshotMapsDispositionsToAllowedActions() {
         let archivedCodex = candidate(sessionId: "archived-thread", pid: 1, bundleId: HostAppBundleID.codexDesktop,
-                                      lifecycleRank: 0, source: Session.codexSource, path: "/archived.json")
+                                      lifecycleRank: 0, source: SessionData.codexSource, path: "/archived.json")
         let archivedClaude = candidate(sessionId: "archived-claude", pid: 2, bundleId: HostAppBundleID.claudeDesktop,
                                        lifecycleRank: 0, source: "cc", path: "/archived-claude.json")
         let codexSubagent = candidate(sessionId: "subagent-thread", pid: 3, bundleId: HostAppBundleID.codexDesktop,
-                                      lifecycleRank: 0, source: Session.codexSource, path: "/subagent.json")
+                                      lifecycleRank: 0, source: SessionData.codexSource, path: "/subagent.json")
         let codexExecHelper = candidate(sessionId: "exec-helper-thread", pid: 4, bundleId: HostAppBundleID.codexDesktop,
-                                        lifecycleRank: 0, source: Session.codexSource, path: "/exec-helper.json")
+                                        lifecycleRank: 0, source: SessionData.codexSource, path: "/exec-helper.json")
         let autoHidden = candidate(sessionId: "auto-hidden", pid: 5, bundleId: HostAppBundleID.codexDesktop,
-                                   lifecycleRank: 0, source: Session.codexSource, path: "/auto-hidden.json") { session in
+                                   lifecycleRank: 0, source: SessionData.codexSource, path: "/auto-hidden.json") { session in
             session.isSubagentSession = true
         }
         let persistedHidden = candidate(sessionId: "persisted-hidden", pid: 6, bundleId: "com.googlecode.iterm2",
@@ -746,7 +746,7 @@ final class SessionLifecycleTests: XCTestCase {
         let terminalFinished = candidate(sessionId: "terminal-finished", pid: 7, bundleId: "com.googlecode.iterm2",
                                          lifecycleRank: 2, source: "cc", path: "/terminal-finished.json")
         let visible = candidate(sessionId: "visible-thread", pid: 8, bundleId: HostAppBundleID.codexDesktop,
-                                lifecycleRank: 0, source: Session.codexSource, path: "/visible.json")
+                                lifecycleRank: 0, source: SessionData.codexSource, path: "/visible.json")
 
         let state = SessionManager.sessionClassificationSnapshot(
             in: [
@@ -772,16 +772,16 @@ final class SessionLifecycleTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            state.displayCandidates.map(\.session.sessionId).sorted(),
+            state.displayCandidates.map(\.data.sessionId).sorted(),
             ["terminal-finished", "visible-thread"]
         )
-        XCTAssertEqual(state.finishedNonDesktopCandidates.map(\.session.sessionId), ["terminal-finished"])
+        XCTAssertEqual(state.finishedNonDesktopCandidates.map(\.data.sessionId), ["terminal-finished"])
         XCTAssertEqual(
             state.cleanupSources.map(\.sessionId).sorted(),
             ["archived-claude", "archived-thread"]
         )
         XCTAssertEqual(state.autoHiddenSessions.map(\.1.sessionId), ["auto-hidden"])
-        XCTAssertEqual(state.codexInternalHelperCandidates.map(\.session.sessionId), ["subagent-thread"])
+        XCTAssertEqual(state.codexInternalHelperCandidates.map(\.data.sessionId), ["subagent-thread"])
         XCTAssertEqual(state.protectedProjectPathsForCleanup, ["/tmp/p"])
     }
 
@@ -793,7 +793,7 @@ final class SessionLifecycleTests: XCTestCase {
             pid: 1,
             bundleId: HostAppBundleID.codexDesktop,
             lifecycleRank: SessionLifecycle.dormant.rawValue,
-            source: Session.codexSource,
+            source: SessionData.codexSource,
             lastActivity: Date(timeIntervalSince1970: 3000),
             path: "/codex.json"
         ) { session in
@@ -805,7 +805,7 @@ final class SessionLifecycleTests: XCTestCase {
             pid: 2,
             bundleId: HostAppBundleID.claudeDesktop,
             lifecycleRank: SessionLifecycle.dormant.rawValue,
-            source: Session.ccSource,
+            source: SessionData.ccSource,
             lastActivity: Date(timeIntervalSince1970: 2000),
             path: "/claude.json"
         ) { session in
@@ -832,7 +832,7 @@ final class SessionLifecycleTests: XCTestCase {
         XCTAssertFalse(targets.contains { $0.showsCopyPathAction })
     }
 
-    func testRecentResumeTargetsUsePermanentIdentityAndDeterministicArchivedObservation() throws {
+    func testRecentResumeTargetsUsePermanentIdentityAndDeterministicArchivedRecord() throws {
         let permanentID = "11111111-1111-4111-8111-111111111111"
         let preferredSessionID = "preferred-archived-observation"
         let otherSessionID = "other-archived-observation"
@@ -841,7 +841,7 @@ final class SessionLifecycleTests: XCTestCase {
             pid: 1,
             bundleId: HostAppBundleID.claudeDesktop,
             lifecycleRank: SessionLifecycle.dormant.rawValue,
-            source: Session.ccSource,
+            source: SessionData.ccSource,
             lastActivity: Date(timeIntervalSince1970: 3_000),
             mtime: Date(timeIntervalSince1970: 4_000),
             path: "/a-preferred.json"
@@ -855,7 +855,7 @@ final class SessionLifecycleTests: XCTestCase {
             pid: 2,
             bundleId: HostAppBundleID.claudeDesktop,
             lifecycleRank: SessionLifecycle.dormant.rawValue,
-            source: Session.ccSource,
+            source: SessionData.ccSource,
             lastActivity: Date(timeIntervalSince1970: 3_000),
             mtime: Date(timeIntervalSince1970: 4_000),
             path: "/z-other.json"
@@ -902,7 +902,7 @@ final class SessionLifecycleTests: XCTestCase {
         )
     }
 
-    func testRecentResumeTargetPermanentIdentityIsStableAcrossObservationMetadataChanges() throws {
+    func testRecentResumeTargetPermanentIdentityIsStableAcrossRecordMetadataChanges() throws {
         let permanentID = "22222222-2222-4222-8222-222222222222"
         let sessionID = "archived-observation"
         func target(title: String, projectName: String) throws -> RecentResumeTarget {
@@ -911,7 +911,7 @@ final class SessionLifecycleTests: XCTestCase {
                 pid: 1,
                 bundleId: HostAppBundleID.claudeDesktop,
                 lifecycleRank: SessionLifecycle.dormant.rawValue,
-                source: Session.ccSource,
+                source: SessionData.ccSource,
                 path: "/archived.json"
             ) { session in
                 session.cctopSessionId = permanentID
@@ -950,7 +950,7 @@ final class SessionLifecycleTests: XCTestCase {
             pid: 1,
             bundleId: HostAppBundleID.claudeDesktop,
             lifecycleRank: SessionLifecycle.dormant.rawValue,
-            source: Session.ccSource,
+            source: SessionData.ccSource,
             path: "/legacy-without-id.json"
         ) { session in
             session.cctopSessionId = nil
@@ -961,15 +961,15 @@ final class SessionLifecycleTests: XCTestCase {
             pid: 2,
             bundleId: HostAppBundleID.claudeDesktop,
             lifecycleRank: SessionLifecycle.dormant.rawValue,
-            source: Session.ccSource,
+            source: SessionData.ccSource,
             path: "/legacy-invalid-id.json"
         ) { session in
             session.cctopSessionId = "not-a-permanent-id"
             session.sessionName = "Legacy invalid ID"
         }
         let metadata = ClaudeDesktopSessionMetadataSnapshot(
-            matchedSessionIDs: [nilID.session.sessionId, invalidID.session.sessionId],
-            archivedSessionIDs: [nilID.session.sessionId, invalidID.session.sessionId],
+            matchedSessionIDs: [nilID.data.sessionId, invalidID.data.sessionId],
+            archivedSessionIDs: [nilID.data.sessionId, invalidID.data.sessionId],
             isAuthoritative: true
         )
         let classification = SessionManager.sessionClassificationSnapshot(
@@ -992,7 +992,7 @@ final class SessionLifecycleTests: XCTestCase {
             pid: 1,
             bundleId: nil,
             lifecycleRank: SessionLifecycle.dormant.rawValue,
-            source: Session.codexSource,
+            source: SessionData.codexSource,
             path: "/missing.json"
         )
         let classification = SessionManager.sessionClassificationSnapshot(
@@ -1083,15 +1083,15 @@ final class SessionLifecycleTests: XCTestCase {
     }
 
     func testClassificationSnapshotDoesNotEmitCleanupSourceForArchivedDesktopWithoutKnownPath() {
-        var session = Session(
+        var session = SessionData(
             sessionId: "archived-root",
             projectPath: "/",
             branch: "main",
             terminal: TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
         )
-        session.source = Session.codexSource
-        let archived = DedupCandidate(
-            session: session,
+        session.source = SessionData.codexSource
+        let archived = SessionRecord(
+            data: session,
             lifecycleRank: SessionLifecycle.active.rawValue,
             mtime: .distantPast,
             path: "/archived-root.json"
@@ -1102,28 +1102,28 @@ final class SessionLifecycleTests: XCTestCase {
             codexThreads: StubCodexThreadState(archived: ["archived-root"])
         )
 
-        XCTAssertEqual(state.displayCandidates.map(\.session.sessionId), [])
+        XCTAssertEqual(state.displayCandidates.map(\.data.sessionId), [])
         XCTAssertEqual(state.cleanupSources.map(\.sessionId), [])
     }
 
     func testClassificationSnapshotDoesNotEmitCleanupSourcesForNonArchivedHiddenDesktopReasons() {
-        var missingCodexSession = Session(
+        var missingCodexSession = SessionData(
             sessionId: "missing-codex",
             projectPath: "/Users/dev/.codex/worktrees/missing-codex",
             branch: "main",
             terminal: TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
         )
         missingCodexSession.pid = 1
-        missingCodexSession.source = Session.codexSource
+        missingCodexSession.source = SessionData.codexSource
         missingCodexSession.lastActivity = Date(timeIntervalSinceNow: -86_400)
-        let missingCodex = DedupCandidate(
-            session: missingCodexSession,
+        let missingCodex = SessionRecord(
+            data: missingCodexSession,
             lifecycleRank: SessionLifecycle.active.rawValue,
             mtime: .distantPast,
             path: "/missing-codex.json"
         )
 
-        var orphanClaudeSession = Session(
+        var orphanClaudeSession = SessionData(
             sessionId: "orphan-claude",
             projectPath: "/Users/dev/.codex/worktrees/orphan-claude",
             branch: "main",
@@ -1132,14 +1132,14 @@ final class SessionLifecycleTests: XCTestCase {
         orphanClaudeSession.pid = 2
         orphanClaudeSession.source = "cc"
         orphanClaudeSession.endedAt = Date(timeIntervalSince1970: 2000)
-        let orphanClaude = DedupCandidate(
-            session: orphanClaudeSession,
+        let orphanClaude = SessionRecord(
+            data: orphanClaudeSession,
             lifecycleRank: SessionLifecycle.active.rawValue,
             mtime: .distantPast,
             path: "/orphan-claude.json"
         )
 
-        var startupPlaceholderSession = Session(
+        var startupPlaceholderSession = SessionData(
             sessionId: "startup-placeholder",
             projectPath: "/Users/dev/.codex/worktrees/startup-placeholder",
             branch: "main",
@@ -1147,8 +1147,8 @@ final class SessionLifecycleTests: XCTestCase {
         )
         startupPlaceholderSession.pid = 3
         startupPlaceholderSession.source = "cc"
-        let startupPlaceholder = DedupCandidate(
-            session: startupPlaceholderSession,
+        let startupPlaceholder = SessionRecord(
+            data: startupPlaceholderSession,
             lifecycleRank: SessionLifecycle.active.rawValue,
             mtime: .distantPast,
             path: "/startup-placeholder.json"
@@ -1164,7 +1164,7 @@ final class SessionLifecycleTests: XCTestCase {
             codexThreads: StubCodexThreadState(existing: [])
         )
 
-        XCTAssertEqual(state.displayCandidates.map(\.session.sessionId), [String]())
+        XCTAssertEqual(state.displayCandidates.map(\.data.sessionId), [String]())
         XCTAssertEqual(state.cleanupSources.map(\.sessionId), [String]())
     }
 
@@ -1205,7 +1205,7 @@ final class SessionLifecycleTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            classification.displayCandidates.map(\.session.sessionId).sorted(),
+            classification.displayCandidates.map(\.data.sessionId).sorted(),
             ["named-idle", "notification-idle", "prompted-idle", "subagent-idle", "tool-detail-idle", "tool-idle"]
         )
     }
@@ -1214,7 +1214,7 @@ final class SessionLifecycleTests: XCTestCase {
     // sessions stay visible for the pass rather than vanishing on lookup uncertainty.
     func testClassificationSnapshotFailsOpenWhenExternalStoresAreUnreadable() {
         let codexThread = candidate(sessionId: "maybe-archived", pid: 1, bundleId: HostAppBundleID.codexDesktop,
-                                    lifecycleRank: 0, source: Session.codexSource, path: "/maybe.json")
+                                    lifecycleRank: 0, source: SessionData.codexSource, path: "/maybe.json")
         let claudeSession = candidate(sessionId: "maybe-orphaned", pid: 2, bundleId: HostAppBundleID.claudeDesktop,
                                       lifecycleRank: 0, source: "cc",
                                       endedAt: Date(timeIntervalSince1970: 2000), path: "/claude-maybe.json")
@@ -1228,10 +1228,10 @@ final class SessionLifecycleTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            classification.displayCandidates.map(\.session.sessionId).sorted(),
+            classification.displayCandidates.map(\.data.sessionId).sorted(),
             ["maybe-archived", "maybe-orphaned", "maybe-startup-only"]
         )
-        XCTAssertEqual(classification.codexInternalHelperCandidates.map(\.session.sessionId), [])
+        XCTAssertEqual(classification.codexInternalHelperCandidates.map(\.data.sessionId), [])
         XCTAssertEqual(classification.cleanupSources.map(\.sessionId), [])
     }
 
@@ -1270,7 +1270,7 @@ final class SessionLifecycleTests: XCTestCase {
             startMonitoring: false
         )
 
-        func record(_ sessionID: String, terminalHosted: Bool = false) -> (url: URL, session: Session) {
+        func record(_ sessionID: String, terminalHosted: Bool = false) -> (url: URL, session: SessionData) {
             var session = terminalHosted
                 ? codexTerminalSession(sessionId: sessionID, projectPath: "/tmp/\(sessionID)")
                 : codexSession(sessionId: sessionID, projectPath: "/tmp/\(sessionID)")
@@ -1290,10 +1290,10 @@ final class SessionLifecycleTests: XCTestCase {
             record("visible"),
         ]
         let first = manager.deriveSessionClassification(from: initialRecords)
-        XCTAssertEqual(first.displayCandidates.map(\.session.sessionId), ["visible"])
+        XCTAssertEqual(first.displayCandidates.map(\.data.sessionId), ["visible"])
 
         let second = manager.deriveSessionClassification(from: initialRecords + [record("new")])
-        XCTAssertEqual(second.displayCandidates.map(\.session.sessionId), ["visible", "new"])
+        XCTAssertEqual(second.displayCandidates.map(\.data.sessionId), ["visible", "new"])
         XCTAssertEqual(second.archivedCodexThreadIDs, ["archived", "archived-cli"])
         XCTAssertEqual(second.missingCodexThreadIDs, ["missing"])
         XCTAssertEqual(second.codexInternalHelperThreadIDs, ["internal"])
@@ -1301,7 +1301,7 @@ final class SessionLifecycleTests: XCTestCase {
 
         let third = manager.deriveSessionClassification(from: initialRecords + [record("new")])
         XCTAssertEqual(
-            third.displayCandidates.map(\.session.sessionId),
+            third.displayCandidates.map(\.data.sessionId),
             ["archived", "archived-cli", "missing", "internal", "exec-helper", "visible", "new"]
         )
         XCTAssertEqual(third.archivedCodexThreadIDs, [])
@@ -1344,7 +1344,7 @@ final class SessionLifecycleTests: XCTestCase {
     // Lifecycle used to be testable only by fabricating PIDs that could not exist; with liveness
     // injected, the same session flips between finished and active purely by the injected answer.
     func testBuildCandidatesDerivesLifecycleFromInjectedProcessAlive() {
-        var session = Session(
+        var session = SessionData(
             sessionId: "terminal-session", projectPath: "/tmp/p", branch: "main",
             terminal: TerminalInfo(program: "zsh", bundleId: "com.googlecode.iterm2")
         )
@@ -1360,7 +1360,7 @@ final class SessionLifecycleTests: XCTestCase {
             claudeMetadata: nil,
             processAlive: { _ in false }
         )
-        XCTAssertEqual(dead.map(\.session.lifecycle), [.finished])
+        XCTAssertEqual(dead.map(\.data.lifecycle), [.finished])
 
         let alive = SessionManager.buildCandidates(
             files, now: Self.lifeNow,
@@ -1368,7 +1368,7 @@ final class SessionLifecycleTests: XCTestCase {
             claudeMetadata: nil,
             processAlive: { _ in true }
         )
-        XCTAssertEqual(alive.map(\.session.lifecycle), [.active])
+        XCTAssertEqual(alive.map(\.data.lifecycle), [.active])
     }
 
     func testChildProcessProbeTreatsProcListChildPidsResultAsPIDCount() {
@@ -1380,7 +1380,7 @@ final class SessionLifecycleTests: XCTestCase {
     // MARK: - Idle timeout with an injected clock
 
     func testAdjustIdleTimeoutUsesInjectedNow() {
-        var session = Session(sessionId: "s", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
+        var session = SessionData(sessionId: "s", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo())
         session.status = .waitingInput
         session.lastActivity = Date(timeIntervalSince1970: 1_000_000)
 

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -32,7 +32,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
 
         for pid in 4_201...4_203 {
-            var session = Session(
+            var session = SessionData(
                 sessionId: "session-\(pid)",
                 projectPath: (root as NSString).appendingPathComponent("worktrees/\(pid)"),
                 branch: "main",
@@ -56,6 +56,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         manager.hideSession(hidden)
 
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data), manager.sessions)
+        XCTAssertFalse(manager.userSessions.contains { $0.identity.cctopSessionID == hiddenSessionID })
         XCTAssertEqual(
             manager.sessions.map { SessionIdentityPolicy.stableKey(for: $0) },
             originalOrder.filter { $0 != hiddenStableKey }
@@ -73,7 +75,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         XCTAssertTrue(manager.cleanupActiveProjectPaths.contains(hidden.projectPath))
         let hiddenPath = (sessionsDir as NSString).appendingPathComponent("\(hidden.pid!).json")
-        XCTAssertFalse(try Session.fromFile(path: hiddenPath).hidden)
+        XCTAssertFalse(try SessionData.fromFile(path: hiddenPath).hidden)
 
         manager.loadSessions()
         XCTAssertEqual(
@@ -96,6 +98,104 @@ final class SessionManagerVisibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testUserSessionProjectionRetainsCurrentSessionRecordsAndCanonicalOrder() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-logical-projection-\(UUID().uuidString)", isDirectory: true)
+        let sessionsDir = root.appendingPathComponent("sessions", isDirectory: true)
+        let historyDir = root.appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let now = Date(timeIntervalSince1970: 10_000)
+        let sharedID = "11111111-1111-4111-8111-111111111111"
+        var previous = SessionData.mock(
+            id: "previous", cctopSessionId: sharedID,
+            status: .working, pid: 11_111, source: SessionData.opencodeSource
+        )
+        previous.lastActivity = now.addingTimeInterval(-30)
+        var current = SessionData.mock(
+            id: "current", cctopSessionId: sharedID,
+            status: .waitingPermission, pid: 22_222, source: SessionData.opencodeSource
+        )
+        current.lastActivity = now.addingTimeInterval(-10)
+        var other = SessionData.mock(
+            id: "other", cctopSessionId: "22222222-2222-4222-8222-222222222222",
+            status: .waitingInput, pid: 33_333, source: SessionData.opencodeSource
+        )
+        other.lastActivity = now.addingTimeInterval(-20)
+
+        let previousURL = sessionsDir.appendingPathComponent("11111.json")
+        try previous.writeToFile(path: previousURL.path)
+        try current.writeToFile(path: sessionsDir.appendingPathComponent("22222.json").path)
+        try other.writeToFile(path: sessionsDir.appendingPathComponent("33333.json").path)
+
+        var sources = isolatedSessionDataSources(
+            sessionsDir: sessionsDir,
+            visibilityPrefix: "cctop-logical-projection"
+        )
+        sources.processAlive = { (_: SessionData) in true }
+        sources.now = { now }
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: historyDir),
+            dataSources: sources,
+            startMonitoring: false
+        )
+
+        XCTAssertEqual(manager.sessions.count, 2)
+        XCTAssertEqual(manager.userSessions.map { $0.displayRecord.data }, manager.sessions)
+        let shared = try XCTUnwrap(manager.userSessions.first { $0.identity.cctopSessionID == sharedID })
+        XCTAssertEqual(shared.displayRecord.data.pid, 22_222)
+        XCTAssertEqual(Set(shared.records.compactMap { $0.data.pid }), [11_111, 22_222])
+
+        previous.sessionName = "Updated non-winning observation"
+        try previous.writeToFile(path: previousURL.path)
+        manager.loadSessions()
+
+        XCTAssertEqual(manager.userSessions.map { $0.displayRecord.data }, manager.sessions)
+        let refreshed = try XCTUnwrap(manager.userSessions.first { $0.identity.cctopSessionID == sharedID })
+        XCTAssertEqual(refreshed.displayRecord.data.pid, 22_222)
+        XCTAssertTrue(refreshed.records.contains { $0.data.sessionName == previous.sessionName })
+
+        manager.hideSession(current)
+        XCTAssertEqual(manager.userSessions.map { $0.displayRecord.data }, manager.sessions)
+        XCTAssertFalse(manager.userSessions.contains { $0.identity.cctopSessionID == sharedID })
+    }
+
+    @MainActor
+    func testUnreadableSessionDirectoryClearsRowsAndUserSessionsTogether() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-logical-read-failure-\(UUID().uuidString)", isDirectory: true)
+        let sessionsDir = root.appendingPathComponent("sessions", isDirectory: true)
+        let historyDir = root.appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: historyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var session = SessionData.mock(id: "visible", pid: 44_444, source: SessionData.opencodeSource)
+        session.status = .working
+        try session.writeToFile(path: sessionsDir.appendingPathComponent("44444.json").path)
+        var sources = isolatedSessionDataSources(
+            sessionsDir: sessionsDir,
+            visibilityPrefix: "cctop-logical-read-failure"
+        )
+        sources.processAlive = { (_: SessionData) in true }
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: historyDir),
+            dataSources: sources,
+            startMonitoring: false
+        )
+        XCTAssertEqual(manager.sessions.count, 1)
+        XCTAssertEqual(manager.userSessions.count, 1)
+
+        try FileManager.default.removeItem(at: sessionsDir)
+        manager.loadSessions()
+
+        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
+    }
+
+    @MainActor
     func testLegacyCodexManualHideMigratesBeforePublishingAndSurvivesReloads() throws {
         let root = NSTemporaryDirectory() + "cctop-legacy-manual-hide-\(UUID().uuidString)"
         let sessionsDir = (root as NSString).appendingPathComponent("sessions")
@@ -107,11 +207,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let identityBlockerPath = (root as NSString).appendingPathComponent("session-identities")
         try Data("not a directory".utf8).write(to: URL(fileURLWithPath: identityBlockerPath))
         let threadID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
-        let currentObservationID = "current-observation"
-        let conflictingObservationID = "conflicting-observation"
+        let currentRecordID = "current-observation"
+        let conflictingRecordID = "conflicting-observation"
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
         let conflictingCctopSessionID = "22222222-2222-4222-8222-222222222222"
-        var session = Session(
+        var session = SessionData(
             sessionId: threadID,
             projectPath: "/tmp/legacy-hidden",
             branch: "main",
@@ -119,29 +219,29 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         session.cctopSessionId = nil
         session.harnessSessionId = threadID
-        session.source = Session.codexSource
+        session.source = SessionData.codexSource
         session.pid = 4_204
         session.status = .waitingInput
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
         try session.writeToFile(path: sessionPath)
-        var current = Session(
-            sessionId: currentObservationID,
+        var current = SessionData(
+            sessionId: currentRecordID,
             projectPath: "/tmp/legacy-hidden",
             branch: "main",
             terminal: TerminalInfo(program: "zsh")
         )
         current.cctopSessionId = cctopSessionID
         current.harnessSessionId = threadID
-        current.source = Session.codexSource
+        current.source = SessionData.codexSource
         current.pid = 4_205
         current.status = .waitingInput
         try current.writeToFile(
-            path: (sessionsDir as NSString).appendingPathComponent("codex-\(currentObservationID).json")
+            path: (sessionsDir as NSString).appendingPathComponent("codex-\(currentRecordID).json")
         )
         var conflicting = current
-        conflicting.sessionId = conflictingObservationID
+        conflicting.sessionId = conflictingRecordID
         conflicting.cctopSessionId = conflictingCctopSessionID
-        let conflictingPath = (sessionsDir as NSString).appendingPathComponent("codex-\(conflictingObservationID).json")
+        let conflictingPath = (sessionsDir as NSString).appendingPathComponent("codex-\(conflictingRecordID).json")
         try conflicting.writeToFile(path: conflictingPath)
 
         let suiteName = "cctop-legacy-manual-hide-\(UUID().uuidString)"
@@ -152,7 +252,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         var sources = isolatedSessionDataSources(sessionsDir: URL(fileURLWithPath: sessionsDir), manualSessionVisibility: visibility)
         sources.codexThreads = StubCodexThreadState(
-            existing: [threadID, currentObservationID, conflictingObservationID],
+            existing: [threadID, currentRecordID, conflictingRecordID],
             archived: []
         )
         sources.processAlive = { _ in true }
@@ -172,7 +272,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertTrue(manager.sessions.isEmpty)
         XCTAssertTrue(postedNotificationIDs.isEmpty)
         XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
-        XCTAssertNil(try Session.fromFile(path: sessionPath).cctopSessionId)
+        XCTAssertNil(try SessionData.fromFile(path: sessionPath).cctopSessionId)
         XCTAssertEqual(
             defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
             ["codex:\(threadID)"]
@@ -184,7 +284,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertTrue(manager.sessions.isEmpty)
         XCTAssertTrue(postedNotificationIDs.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [cctopSessionID])
-        XCTAssertNil(try Session.fromFile(path: sessionPath).cctopSessionId)
+        XCTAssertNil(try SessionData.fromFile(path: sessionPath).cctopSessionId)
         XCTAssertEqual(
             defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
             ["codex:\(threadID)"]
@@ -239,7 +339,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let unrelatedThreadID = "cccccccc-dddd-4eee-8fff-000000000001"
         let unrelatedProjectPath = (root as NSString).appendingPathComponent("unrelated-project")
         try FileManager.default.createDirectory(atPath: unrelatedProjectPath, withIntermediateDirectories: true)
-        var previous = Session(
+        var previous = SessionData(
             sessionId: "previous-hidden-project",
             projectPath: projectPath,
             branch: "main",
@@ -374,7 +474,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .path
-        var history = Session(
+        var history = SessionData(
             sessionId: "previous-finished-project",
             projectPath: projectPath,
             branch: "main",
@@ -384,7 +484,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try history.writeToFile(path: (historyDir as NSString).appendingPathComponent("history.json"))
 
         let threadID = "11111111-2222-4333-8444-555555555555"
-        var finished = Session(
+        var finished = SessionData(
             sessionId: threadID,
             projectPath: projectPath,
             branch: "main",
@@ -392,7 +492,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         finished.cctopSessionId = nil
         finished.harnessSessionId = threadID
-        finished.source = Session.codexSource
+        finished.source = SessionData.codexSource
         finished.pid = 4_205
         finished.status = .working
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
@@ -490,7 +590,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         let migratedSessionIDs = visibility.hiddenSessionIDs
         XCTAssertEqual(migratedSessionIDs.count, 1)
-        XCTAssertNil(try Session.fromFile(path: sessionPath).cctopSessionId)
+        XCTAssertNil(try SessionData.fromFile(path: sessionPath).cctopSessionId)
         XCTAssertEqual(
             defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
             ["codex:\(threadID)"]
@@ -505,7 +605,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertEqual(visibility.hiddenSessionIDs, migratedSessionIDs)
-        XCTAssertNil(try Session.fromFile(path: sessionPath).cctopSessionId)
+        XCTAssertNil(try SessionData.fromFile(path: sessionPath).cctopSessionId)
         XCTAssertEqual(
             defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
             ["codex:\(threadID)"]
@@ -518,7 +618,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         terminateProcess(lockHolder)
         manager.loadSessions()
         waitForIdentityMigrationQueue(manager)
-        XCTAssertEqual(try Session.fromFile(path: sessionPath).cctopSessionId, migratedSessionIDs.first)
+        XCTAssertEqual(try SessionData.fromFile(path: sessionPath).cctopSessionId, migratedSessionIDs.first)
 
         manager.loadSessions()
 
@@ -588,14 +688,14 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let hiddenURL = sessionsURL.appendingPathComponent("codex-\(hiddenThreadID).json")
         try hidden.writeToFile(path: hiddenURL.path)
 
-        var finished = Session(
+        var finished = SessionData(
             sessionId: "unrelated-finished",
             projectPath: finishedProjectURL.path,
             branch: "main",
             terminal: TerminalInfo(program: "zsh")
         )
         finished.cctopSessionId = "22222222-2222-4222-8222-222222222222"
-        finished.source = Session.opencodeSource
+        finished.source = SessionData.opencodeSource
         finished.pid = 4_208
         finished.status = .working
         let finishedURL = sessionsURL.appendingPathComponent("unrelated-finished.json")
@@ -647,7 +747,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
         let sharedID = "22222222-2222-4222-8222-222222222222"
         let durableConversationID = "39253133-4a65-48fb-af2b-844463d3b5bb"
-        var live = Session(
+        var live = SessionData(
             sessionId: "live-terminal",
             projectPath: "/tmp/live-terminal",
             branch: "main",
@@ -655,7 +755,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         live.cctopSessionId = sharedID
         live.harnessSessionId = durableConversationID
-        live.source = Session.ccSource
+        live.source = SessionData.ccSource
         live.pid = 4_204
         live.status = .working
         try live.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("live-terminal.json"))
@@ -706,7 +806,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
     }
 
     @MainActor
-    func testPublishedSessionSuppressesArchivedRecentTargetUntilObservationEnds() throws {
+    func testPublishedSessionSuppressesArchivedRecentTargetUntilRecordEnds() throws {
         let root = NSTemporaryDirectory() + "cctop-recent-live-suppression-\(UUID().uuidString)"
         let sessionsURL = URL(fileURLWithPath: root).appendingPathComponent("sessions", isDirectory: true)
         let historyURL = URL(fileURLWithPath: root).appendingPathComponent("history", isDirectory: true)
@@ -716,7 +816,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         let sharedID = "33333333-3333-4333-8333-333333333333"
         let durableConversationID = "59253133-4a65-48fb-af2b-844463d3b5bb"
-        var live = Session(
+        var live = SessionData(
             sessionId: "live-terminal-observation",
             projectPath: "/tmp/live-terminal",
             branch: "main",
@@ -724,7 +824,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         live.cctopSessionId = sharedID
         live.harnessSessionId = durableConversationID
-        live.source = Session.ccSource
+        live.source = SessionData.ccSource
         live.pid = 4_205
         live.status = .working
         let liveURL = sessionsURL.appendingPathComponent("live-terminal.json")
@@ -781,7 +881,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let sharedID = "33333333-3333-4333-8333-333333333333"
         let durableConversationID = "49253133-4a65-48fb-af2b-844463d3b5bb"
         _ = try CctopSessionIdentityStore(sessionsDir: sessionsURL).resolve(
-            source: Session.ccSource,
+            source: SessionData.ccSource,
             harnessSessionId: durableConversationID,
             legacySessionId: durableConversationID,
             knownExistingIDs: [sharedID]
@@ -834,8 +934,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
         let durableSessionID = "59253133-4a65-48fb-af2b-844463d3b5bb"
-        let terminalObservationID = "busy-terminal-observation"
-        let bundlelessObservationID = "busy-desktop-observation"
+        let terminalRecordID = "busy-terminal-observation"
+        let bundlelessRecordID = "busy-desktop-observation"
         let projectPath = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -843,22 +943,22 @@ final class SessionManagerVisibilityTests: XCTestCase {
             .path
         let initialNow = Date(timeIntervalSince1970: 2_000_000_000)
 
-        var terminal = Session(
-            sessionId: terminalObservationID,
+        var terminal = SessionData(
+            sessionId: terminalRecordID,
             projectPath: projectPath,
             branch: "main",
             terminal: TerminalInfo(program: "zsh")
         )
         terminal.cctopSessionId = nil
         terminal.harnessSessionId = durableSessionID
-        terminal.source = Session.codexSource
+        terminal.source = SessionData.codexSource
         terminal.pid = 4_207
         terminal.status = .waitingInput
         terminal.lastActivity = initialNow
-        let terminalURL = sessionsURL.appendingPathComponent("codex-\(terminalObservationID).json")
+        let terminalURL = sessionsURL.appendingPathComponent("codex-\(terminalRecordID).json")
         try terminal.writeToFile(path: terminalURL.path)
 
-        var desktop = codexSession(sessionId: bundlelessObservationID, projectPath: projectPath)
+        var desktop = codexSession(sessionId: bundlelessRecordID, projectPath: projectPath)
         desktop.cctopSessionId = nil
         desktop.harnessSessionId = durableSessionID
         desktop.lastActivity = initialNow
@@ -883,7 +983,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         var postedNotificationIDs: [String] = []
         var sources = isolatedSessionDataSources(sessionsDir: sessionsURL, manualSessionVisibility: visibility)
         sources.codexThreads = StubCodexThreadState(
-            existing: [terminalObservationID, bundlelessObservationID],
+            existing: [terminalRecordID, bundlelessRecordID],
             archived: []
         )
         sources.desktopAppConnection = DesktopAppConnectionLookup { _ in false }
@@ -908,8 +1008,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let hidden = try XCTUnwrap(manager.sessions.first)
         let hiddenID = try XCTUnwrap(hidden.cctopSessionId)
         XCTAssertEqual(manager.sessions.count, 1)
-        XCTAssertNil(try Session.fromFile(path: terminalURL.path).cctopSessionId)
-        XCTAssertNil(try Session.fromFile(path: desktopURL.path).cctopSessionId)
+        XCTAssertNil(try SessionData.fromFile(path: terminalURL.path).cctopSessionId)
+        XCTAssertNil(try SessionData.fromFile(path: desktopURL.path).cctopSessionId)
 
         manager.hideSession(hidden)
         XCTAssertTrue(manager.sessions.isEmpty)
@@ -925,7 +1025,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(visibility.hiddenSessionIDs, [hiddenID])
         XCTAssertEqual(
             Set(manager.cleanupSources.map(\.sessionId)),
-            [terminalObservationID, bundlelessObservationID]
+            [terminalRecordID, bundlelessRecordID]
         )
         XCTAssertTrue(manager.historyManager.recentProjects.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
@@ -940,8 +1040,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         manager.loadSessions()
         waitForIdentityMigrationQueue(manager)
-        XCTAssertEqual(try Session.fromFile(path: terminalURL.path).cctopSessionId, hiddenID)
-        XCTAssertEqual(try Session.fromFile(path: desktopURL.path).cctopSessionId, hiddenID)
+        XCTAssertEqual(try SessionData.fromFile(path: terminalURL.path).cctopSessionId, hiddenID)
+        XCTAssertEqual(try SessionData.fromFile(path: desktopURL.path).cctopSessionId, hiddenID)
 
         processAlive = true
         now = initialNow
@@ -999,7 +1099,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         XCTAssertTrue(missingManager.sessions.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [mappedID])
-        XCTAssertEqual(try Session.fromFile(path: sessionURL.path).cctopSessionId, mappedID)
+        XCTAssertEqual(try SessionData.fromFile(path: sessionURL.path).cctopSessionId, mappedID)
 
         var restoredSources = missingSources
         restoredSources.codexThreads = StubCodexThreadState(existing: [durableSessionID], archived: [])
@@ -1033,7 +1133,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
         let hiddenID = "44444444-4444-4444-8444-444444444444"
 
-        var previous = Session(
+        var previous = SessionData(
             sessionId: "previous",
             projectPath: projectPath,
             branch: "main",
@@ -1044,7 +1144,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let historyManager = HistoryManager(historyDir: historyURL)
         XCTAssertEqual(historyManager.recentProjects.map(\.projectPath), [projectPath])
 
-        var finished = Session(
+        var finished = SessionData(
             sessionId: "hidden-finished",
             projectPath: projectPath,
             branch: "main",
@@ -1083,7 +1183,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
-        let hidden = Session.mock(id: "hidden-thread", source: Session.codexSource)
+        let hidden = SessionData.mock(id: "hidden-thread", source: SessionData.codexSource)
         visibility.hide(hidden)
         try Data("not valid session json".utf8).write(
             to: URL(fileURLWithPath: (sessionsDir as NSString).appendingPathComponent("broken.json"))
@@ -1115,13 +1215,13 @@ final class SessionManagerVisibilityTests: XCTestCase {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .path
-        var hidden = Session(
+        var hidden = SessionData(
             sessionId: "hidden-live-project",
             projectPath: projectPath,
             branch: "main",
             terminal: TerminalInfo(program: "zsh")
         )
-        hidden.source = Session.codexSource
+        hidden.source = SessionData.codexSource
         hidden.pid = 4_204
         hidden.status = .working
         let hiddenURL = URL(fileURLWithPath: sessionsDir).appendingPathComponent("codex-hidden-live-project.json")
@@ -1155,7 +1255,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         try Data("not valid session json".utf8).write(to: hiddenURL)
         let newActivePath = (root as NSString).appendingPathComponent("worktrees/new-active")
-        var newActive = Session(
+        var newActive = SessionData(
             sessionId: "new-active-during-partial-read",
             projectPath: newActivePath,
             branch: "main",
@@ -1198,7 +1298,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try FileManager.default.createDirectory(atPath: historyDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(atPath: root) }
 
-        var hidden = Session(
+        var hidden = SessionData(
             sessionId: "already-hidden",
             projectPath: hiddenProjectPath,
             branch: "main",
@@ -1214,7 +1314,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             ("target-history", targetProjectPath),
             ("unrelated-history", unrelatedProjectPath),
         ] {
-            var history = Session(
+            var history = SessionData(
                 sessionId: sessionID,
                 projectPath: projectPath,
                 branch: "main",
@@ -1238,7 +1338,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(Set(manager.recentResumeTargets.map(\.projectPath)), [targetProjectPath, unrelatedProjectPath])
 
         try Data("not valid session json".utf8).write(to: hiddenURL)
-        var live = Session(
+        var live = SessionData(
             sessionId: "live-target",
             projectPath: targetProjectAlias,
             branch: "main",
@@ -1272,13 +1372,13 @@ final class SessionManagerVisibilityTests: XCTestCase {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .path
-        var hidden = Session(
+        var hidden = SessionData(
             sessionId: "hidden-directory-session",
             projectPath: projectPath,
             branch: "main",
             terminal: TerminalInfo(program: "zsh")
         )
-        hidden.source = Session.codexSource
+        hidden.source = SessionData.codexSource
 
         var history = hidden
         history.sessionId = "ended-hidden-directory-project"
@@ -1337,7 +1437,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
-        let vanished = Session.mock(id: "vanished", source: Session.codexSource)
+        let vanished = SessionData.mock(id: "vanished", source: SessionData.codexSource)
         let manager = makeManager(
             sessionsDir: sessionsDir,
             historyDir: historyDir,
@@ -1384,13 +1484,13 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         XCTAssertFalse(normalProject.isCodexMemoryMaintenanceSession)
 
-        var userLaunchedMemoryTask = Session(
+        var userLaunchedMemoryTask = SessionData(
             sessionId: "user-launched-memory-task",
             projectPath: memoriesDir,
             branch: "main",
             terminal: TerminalInfo(program: "zsh")
         )
-        userLaunchedMemoryTask.source = Session.codexSource
+        userLaunchedMemoryTask.source = SessionData.codexSource
         XCTAssertTrue(userLaunchedMemoryTask.isCodexMemoryMaintenanceSession)
 
         var nonCodexMemory = codexSession(sessionId: "other-memory", projectPath: memoriesDir)
@@ -1422,13 +1522,13 @@ final class SessionManagerVisibilityTests: XCTestCase {
         namedTitleGeneration.sessionName = "Generated title"
         XCTAssertFalse(namedTitleGeneration.isCodexTitleGenerationSession)
 
-        var nonDesktopTitleGeneration = Session(
+        var nonDesktopTitleGeneration = SessionData(
             sessionId: "terminal-title-helper",
             projectPath: projectPath,
             branch: "main",
             terminal: TerminalInfo(program: "zsh")
         )
-        nonDesktopTitleGeneration.source = Session.codexSource
+        nonDesktopTitleGeneration.source = SessionData.codexSource
         nonDesktopTitleGeneration.lastPrompt = codexTitleGenerationPrompt()
         XCTAssertTrue(nonDesktopTitleGeneration.isCodexTitleGenerationSession)
 
@@ -1463,7 +1563,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(manager.sessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: memoryPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: memoryPath + ".lock"))
-        XCTAssertTrue(try Session.fromFile(path: memoryPath).hidden)
+        XCTAssertTrue(try SessionData.fromFile(path: memoryPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
     }
 
@@ -1492,7 +1592,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(manager.sessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: titleHelperPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: titleHelperPath + ".lock"))
-        XCTAssertTrue(try Session.fromFile(path: titleHelperPath).hidden)
+        XCTAssertTrue(try SessionData.fromFile(path: titleHelperPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
     }
 
@@ -1556,7 +1656,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         defer { try? FileManager.default.removeItem(atPath: root) }
 
-        var hidden = Session(
+        var hidden = SessionData(
             sessionId: "hidden-review",
             projectPath: (root as NSString).appendingPathComponent("reviews/cctop"),
             branch: "main",
@@ -1586,7 +1686,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         defer { try? FileManager.default.removeItem(atPath: root) }
 
-        var hidden = Session(
+        var hidden = SessionData(
             sessionId: "hidden-live",
             projectPath: worktreePath,
             branch: "main",
@@ -1636,7 +1736,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         XCTAssertEqual(manager.sessions, [])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [worktreePath])
-        XCTAssertTrue(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertTrue(try SessionData.fromFile(path: sessionPath).hidden)
     }
 
     @MainActor
@@ -1657,7 +1757,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
 
-        var hidden = Session(
+        var hidden = SessionData(
             sessionId: "late-hidden",
             projectPath: worktreePath,
             branch: "main",
@@ -1683,7 +1783,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         defer { try? FileManager.default.removeItem(atPath: root) }
 
-        var hidden = Session(
+        var hidden = SessionData(
             sessionId: "hidden-live",
             projectPath: protectedPath,
             branch: "main",
@@ -1712,7 +1812,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [protectedPath])
 
-        var history = Session(
+        var history = SessionData(
             sessionId: "history",
             projectPath: "/tmp/history",
             branch: "main",
@@ -1808,7 +1908,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(manager.sessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath + ".lock"))
-        XCTAssertTrue(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertTrue(try SessionData.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
     }
 
@@ -1857,8 +1957,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: desktopPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: cliPath + ".lock"))
         XCTAssertTrue(FileManager.default.fileExists(atPath: desktopPath + ".lock"))
-        XCTAssertTrue(try Session.fromFile(path: cliPath).hidden)
-        XCTAssertTrue(try Session.fromFile(path: desktopPath).hidden)
+        XCTAssertTrue(try SessionData.fromFile(path: cliPath).hidden)
+        XCTAssertTrue(try SessionData.fromFile(path: desktopPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
     }
 
@@ -1896,7 +1996,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), ["delegated-visible"])
-        let persisted = try Session.fromFile(path: sessionPath)
+        let persisted = try SessionData.fromFile(path: sessionPath)
         XCTAssertFalse(persisted.hidden)
         XCTAssertFalse(persisted.isSubagentSession)
     }
@@ -1947,10 +2047,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), ["delegated-sticky"])
-        let persisted = try Session.fromFile(path: sessionPath)
+        let persisted = try SessionData.fromFile(path: sessionPath)
         XCTAssertFalse(persisted.hidden)
         XCTAssertFalse(persisted.isSubagentSession)
-        let persistedMemory = try Session.fromFile(path: memoryPath)
+        let persistedMemory = try SessionData.fromFile(path: memoryPath)
         XCTAssertTrue(persistedMemory.hidden)
         XCTAssertTrue(persistedMemory.isSubagentSession)
     }
@@ -1996,7 +2096,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions, [])
-        let persisted = try Session.fromFile(path: sessionPath)
+        let persisted = try SessionData.fromFile(path: sessionPath)
         XCTAssertTrue(persisted.hidden)
         XCTAssertTrue(persisted.isSubagentSession)
     }
@@ -2039,7 +2139,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions, [])
-        let persisted = try Session.fromFile(path: sessionPath)
+        let persisted = try SessionData.fromFile(path: sessionPath)
         XCTAssertTrue(persisted.hidden)
         XCTAssertTrue(persisted.isSubagentSession)
     }
@@ -2082,7 +2182,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(manager.sessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath + ".lock"))
-        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
     }
 
@@ -2132,7 +2232,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(manager.sessions.map(\.sessionId), ["visible-thread"])
         XCTAssertTrue(FileManager.default.fileExists(atPath: missingPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: missingPath + ".lock"))
-        XCTAssertFalse(try Session.fromFile(path: missingPath).hidden)
+        XCTAssertFalse(try SessionData.fromFile(path: missingPath).hidden)
         XCTAssertTrue(FileManager.default.fileExists(atPath: visiblePath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: visiblePath + ".lock"))
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
@@ -2195,9 +2295,9 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let betaPath = (sessionsDir as NSString).appendingPathComponent("202.json")
         let gammaPath = (sessionsDir as NSString).appendingPathComponent("303.json")
         let deltaPath = (sessionsDir as NSString).appendingPathComponent("404.json")
-        var alpha = Session.mock(id: "alpha", status: .working, pid: 101, source: Session.opencodeSource)
+        var alpha = SessionData.mock(id: "alpha", status: .working, pid: 101, source: SessionData.opencodeSource)
         alpha.lastActivity = now.addingTimeInterval(-60)
-        var beta = Session.mock(id: "beta", status: .working, pid: 202, source: Session.opencodeSource)
+        var beta = SessionData.mock(id: "beta", status: .working, pid: 202, source: SessionData.opencodeSource)
         beta.lastActivity = now.addingTimeInterval(-10)
         try alpha.writeToFile(path: alphaPath)
         try beta.writeToFile(path: betaPath)
@@ -2210,9 +2310,9 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["101", "202"])
 
-        var gamma = Session.mock(id: "gamma", status: .waitingInput, pid: 303, source: Session.opencodeSource)
+        var gamma = SessionData.mock(id: "gamma", status: .waitingInput, pid: 303, source: SessionData.opencodeSource)
         gamma.lastActivity = now.addingTimeInterval(-30)
-        var delta = Session.mock(id: "delta", status: .waitingInput, pid: 404, source: Session.opencodeSource)
+        var delta = SessionData.mock(id: "delta", status: .waitingInput, pid: 404, source: SessionData.opencodeSource)
         delta.lastActivity = now.addingTimeInterval(-20)
         try gamma.writeToFile(path: gammaPath)
         try delta.writeToFile(path: deltaPath)
@@ -2244,7 +2344,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             activeAfterUpdates.map { $0.cctopSessionId ?? "" }
         )
         XCTAssertEqual(snapshot.sessions.count, activeAfterUpdates.count)
-        XCTAssertTrue(activeAfterUpdates.allSatisfy { Session.isValidCctopSessionId($0.cctopSessionId) })
+        XCTAssertTrue(activeAfterUpdates.allSatisfy { CctopSessionID.isValid($0.cctopSessionId) })
 
         alpha.hidden = true
         try alpha.writeToFile(path: alphaPath)
@@ -2267,7 +2367,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         defer { try? FileManager.default.removeItem(atPath: root) }
 
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("4242.json")
-        var legacy = Session.mock(id: "legacy", pid: 4242, source: Session.opencodeSource)
+        var legacy = SessionData.mock(id: "legacy", pid: 4242, source: SessionData.opencodeSource)
         legacy.cctopSessionId = nil
         try legacy.writeToFile(path: sessionPath)
 
@@ -2286,7 +2386,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         XCTAssertNil(manager.sessions.first?.cctopSessionId)
         waitForIdentityMigrationQueue(manager)
-        XCTAssertNil(try Session.fromFile(path: sessionPath).cctopSessionId)
+        XCTAssertNil(try SessionData.fromFile(path: sessionPath).cctopSessionId)
 
         terminateProcess(lockHolder)
         let hookInput = try JSONDecoder().decode(HookInput.self, from: Data("""
@@ -2301,11 +2401,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
             logger: HookLogger(logsDir: (root as NSString).appendingPathComponent("logs"))
         )
         try HookHandler.handleHook(hookName: "PreToolUse", input: hookInput, deps: hookDeps)
-        let hookAssignedID = try XCTUnwrap(Session.fromFile(path: sessionPath).cctopSessionId)
+        let hookAssignedID = try XCTUnwrap(SessionData.fromFile(path: sessionPath).cctopSessionId)
         manager.loadSessions()
         waitForIdentityMigrationQueue(manager)
 
-        XCTAssertEqual(try Session.fromFile(path: sessionPath).cctopSessionId, hookAssignedID)
+        XCTAssertEqual(try SessionData.fromFile(path: sessionPath).cctopSessionId, hookAssignedID)
         XCTAssertEqual(manager.sessions.first?.cctopSessionId, hookAssignedID)
     }
 
@@ -2320,7 +2420,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         let reference = "11111111-2222-4333-8444-555555555555"
         for pid: UInt32 in [4242, 5002] {
-            var session = Session.mock(id: reference, pid: pid, source: Session.ccSource)
+            var session = SessionData.mock(id: reference, pid: pid, source: SessionData.ccSource)
             session.cctopSessionId = nil
             session.harnessSessionId = reference
             try session.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("\(pid).json"))
@@ -2334,11 +2434,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let publishedIDs = Set(manager.sessions.compactMap(\.cctopSessionId))
         XCTAssertEqual(manager.sessions.count, 1)
         XCTAssertEqual(publishedIDs.count, 1)
-        XCTAssertTrue(publishedIDs.allSatisfy(Session.isValidCctopSessionId))
+        XCTAssertTrue(publishedIDs.allSatisfy(CctopSessionID.isValid))
 
         waitForIdentityMigrationQueue(manager)
         let persistedIDs = try Set([4242, 5002].map { pid in
-            try XCTUnwrap(Session.fromFile(path: (sessionsDir as NSString).appendingPathComponent("\(pid).json")).cctopSessionId)
+            try XCTUnwrap(SessionData.fromFile(path: (sessionsDir as NSString).appendingPathComponent("\(pid).json")).cctopSessionId)
         })
         XCTAssertEqual(persistedIDs, publishedIDs)
     }
@@ -2358,7 +2458,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
         ]
         for (index, pid) in [4242, 5002, 6003].enumerated() {
-            var session = Session.mock(id: reference, pid: UInt32(pid), source: Session.ccSource)
+            var session = SessionData.mock(id: reference, pid: UInt32(pid), source: SessionData.ccSource)
             session.cctopSessionId = index < existingIDs.count ? existingIDs[index] : nil
             session.harnessSessionId = reference
             try session.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("\(pid).json"))
@@ -2371,7 +2471,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
 
         XCTAssertNil(manager.sessions.first(where: { $0.pid == 6003 })?.cctopSessionId)
-        XCTAssertNil(try Session.fromFile(
+        XCTAssertNil(try SessionData.fromFile(
             path: (sessionsDir as NSString).appendingPathComponent("6003.json")
         ).cctopSessionId)
     }
@@ -2411,7 +2511,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), ["codex-user-exec"])
-        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
     }
 
     @MainActor
@@ -2449,7 +2549,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), ["codex-exec-first-message"])
-        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
     }
 
     @MainActor
@@ -2487,7 +2587,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), ["parent-thread"])
-        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
     }
 
     @MainActor
@@ -2506,21 +2606,21 @@ final class SessionManagerVisibilityTests: XCTestCase {
             try? FileManager.default.removeItem(atPath: root)
         }
 
-        var oldPidKeyed = Session(
+        var oldPidKeyed = SessionData(
             sessionId: "conv-a", projectPath: "/tmp/p", branch: "main", terminal: TerminalInfo()
         )
-        oldPidKeyed.source = Session.codexSource
+        oldPidKeyed.source = SessionData.codexSource
         oldPidKeyed.pid = 999_999
         oldPidKeyed.lastActivity = Date(timeIntervalSince1970: 100)
         oldPidKeyed.endedAt = Date(timeIntervalSince1970: 100)
         let oldPath = (sessionsDir as NSString).appendingPathComponent("999999.json")
         try oldPidKeyed.writeToFile(path: oldPath)
 
-        var desktopKeyed = Session(
+        var desktopKeyed = SessionData(
             sessionId: "conv-a", projectPath: "/tmp/p", branch: "main",
             terminal: TerminalInfo(bundleId: HostAppBundleID.codexDesktop)
         )
-        desktopKeyed.source = Session.codexSource
+        desktopKeyed.source = SessionData.codexSource
         desktopKeyed.lastActivity = Date()
         let desktopPath = (sessionsDir as NSString).appendingPathComponent("codex-conv-a.json")
         try desktopKeyed.writeToFile(path: desktopPath)
@@ -2572,7 +2672,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(manager.cleanupSources.map(\.projectPath), ["/tmp/p"])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
-        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
 
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [], userExecThreads: ["archived-thread"])
@@ -2598,13 +2698,13 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [], userExecThreads: [threadID])
 
         let sessionPath = (sessionsDir as NSString).appendingPathComponent("codex-\(threadID).json")
-        var session = Session(
+        var session = SessionData(
             sessionId: threadID,
             projectPath: "/tmp/p",
             branch: "main",
             terminal: TerminalInfo(bundleId: nil)
         )
-        session.source = Session.codexSource
+        session.source = SessionData.codexSource
         session.lastActivity = Date()
         try session.writeToFile(path: sessionPath)
 
@@ -2623,7 +2723,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(manager.cleanupSources.map(\.sessionId), [threadID])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
-        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
 
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [], userExecThreads: [threadID])
         manager.loadSessions()
@@ -2666,7 +2766,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(manager.cleanupSources.map(\.sessionId), [])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, ["/tmp/p"])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
-        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
 
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [])
@@ -2715,7 +2815,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(manager.cleanupSources.map(\.projectPath), ["/tmp/p"])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
-        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
 
         try FileManager.default.removeItem(atPath: claudeDir)
@@ -2770,7 +2870,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(manager.cleanupSources.map(\.projectPath), ["/tmp/p"])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
-        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
     }
 
@@ -2812,7 +2912,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         XCTAssertEqual(manager.sessions.map(\.sessionId), [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
-        XCTAssertFalse(try Session.fromFile(path: sessionPath).hidden)
+        XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
     }
 
@@ -2855,11 +2955,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
             try? FileManager.default.removeItem(atPath: root)
         }
 
-        var terminalSession = Session(
+        var terminalSession = SessionData(
             sessionId: "shared-id", projectPath: "/tmp/p", branch: "main",
             terminal: TerminalInfo(bundleId: "com.googlecode.iterm2")
         )
-        terminalSession.source = Session.codexSource
+        terminalSession.source = SessionData.codexSource
         XCTAssertTrue(SessionManager.isCodexThreadArchived(
             terminalSession,
             codexThreads: CodexThreadArchiveLookup(stateDatabasePath: stateDB)
@@ -2877,7 +2977,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             try? FileManager.default.removeItem(atPath: root)
         }
 
-        var session = Session(
+        var session = SessionData(
             sessionId: "opencode-39189", projectPath: "/tmp/p", branch: "main",
             terminal: TerminalInfo(bundleId: "com.openai.codex")
         )
@@ -2901,7 +3001,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             try? FileManager.default.removeItem(atPath: root)
         }
 
-        var terminalSession = Session(
+        var terminalSession = SessionData(
             sessionId: "shared-id", projectPath: "/tmp/p", branch: "main",
             terminal: TerminalInfo(bundleId: "com.googlecode.iterm2")
         )
@@ -3221,7 +3321,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             desktopAppConnectionLookup: DesktopAppConnectionLookup { _ in true },
             claudeDesktopSessions: ClaudeDesktopSessionArchiveLookup(sessionsDirectory: claudeDir)
         )
-        let namesByID = Dictionary(uniqueKeysWithValues: candidates.map { ($0.session.sessionId, $0.session.desktopProjectName) })
+        let namesByID = Dictionary(uniqueKeysWithValues: candidates.map { ($0.data.sessionId, $0.data.desktopProjectName) })
 
         XCTAssertEqual(namesByID["claude-desktop-project"]!, "cctop")
     }

--- a/menubar/CctopMenubarTests/SessionTestSupport.swift
+++ b/menubar/CctopMenubarTests/SessionTestSupport.swift
@@ -199,34 +199,34 @@ extension XCTestCase {
         try executeSQLite(sql, path: path)
     }
 
-    func codexTerminalSession(sessionId: String, projectPath: String) -> Session {
-        var session = Session(
+    func codexTerminalSession(sessionId: String, projectPath: String) -> SessionData {
+        var session = SessionData(
             sessionId: sessionId,
             projectPath: projectPath,
             branch: "main",
             terminal: TerminalInfo(program: "zsh", bundleId: "com.googlecode.iterm2")
         )
-        session.source = Session.codexSource
+        session.source = SessionData.codexSource
         session.pid = UInt32(ProcessInfo.processInfo.processIdentifier)
         session.status = .waitingInput
         return session
     }
 
-    func codexSession(sessionId: String, projectPath: String) -> Session {
-        var session = Session(
+    func codexSession(sessionId: String, projectPath: String) -> SessionData {
+        var session = SessionData(
             sessionId: sessionId,
             projectPath: projectPath,
             branch: "main",
             terminal: TerminalInfo()
         )
-        session.source = Session.codexSource
+        session.source = SessionData.codexSource
         session.pid = UInt32(ProcessInfo.processInfo.processIdentifier)
         session.status = .waitingInput
         return session
     }
 
-    func claudeDesktopSession(sessionId: String, projectPath: String) -> Session {
-        var session = Session(
+    func claudeDesktopSession(sessionId: String, projectPath: String) -> SessionData {
+        var session = SessionData(
             sessionId: sessionId,
             projectPath: projectPath,
             branch: "main",
@@ -278,7 +278,7 @@ extension XCTestCase {
         codexThreads: (any CodexThreadStateProviding)? = nil,
         claudeDesktopSessions: (any ClaudeDesktopSessionStateProviding)? = nil,
         desktopAppConnection: DesktopAppConnectionLookup? = nil,
-        processAlive: ((Session) -> Bool)? = nil,
+        processAlive: ((SessionData) -> Bool)? = nil,
         manualSessionVisibility: ManualSessionVisibilityStore? = nil,
         now: (() -> Date)? = nil
     ) -> SessionManager {
@@ -315,9 +315,9 @@ extension XCTestCase {
         source: String? = nil,
         lastActivity: Date = Date(timeIntervalSince1970: 1000),
         endedAt: Date? = nil, disconnectedAt: Date? = nil, mtime: Date = .distantPast, path: String = "/x.json",
-        update: (inout Session) -> Void = { _ in }
-    ) -> DedupCandidate {
-        var s = Session(sessionId: sessionId, projectPath: "/tmp/p", branch: "main",
+        update: (inout SessionData) -> Void = { _ in }
+    ) -> SessionRecord {
+        var s = SessionData(sessionId: sessionId, projectPath: "/tmp/p", branch: "main",
                         terminal: TerminalInfo(bundleId: bundleId))
         s.pid = pid
         s.source = source
@@ -325,7 +325,50 @@ extension XCTestCase {
         s.endedAt = endedAt
         s.disconnectedAt = disconnectedAt
         update(&s)
-        return DedupCandidate(session: s, lifecycleRank: lifecycleRank, mtime: mtime, path: path)
+        return SessionRecord(data: s, lifecycleRank: lifecycleRank, mtime: mtime, path: path)
+    }
+
+    @MainActor
+    func setSessionProjection(_ sessions: [SessionData], on manager: SessionManager) {
+        manager.updateSessionProjection(userSessionProjection(from: sessions))
+    }
+
+    func userSessionProjection(from sessions: [SessionData]) -> [UserSession] {
+        let records = sessions.enumerated().map { index, session in
+            SessionRecord(
+                data: session,
+                lifecycleRank: session.lifecycle.rawValue,
+                mtime: .distantPast,
+                path: "/test-projection-\(index).json"
+            )
+        }
+        return UserSession.grouping(
+            winners: SessionIdentityPolicy.dedupedCandidatesByStableKey(records),
+            records: records
+        )
+    }
+
+    func userSession(display: SessionData, records: [SessionData]) -> UserSession {
+        let sessionRecords = records.enumerated().map { index, data in
+            SessionRecord(
+                data: data,
+                lifecycleRank: data.lifecycle.rawValue,
+                mtime: .distantPast,
+                path: "/test-user-session-\(index).json"
+            )
+        }
+        let displayRecord = sessionRecords.first { $0.data == display }
+            ?? SessionRecord(
+                data: display,
+                lifecycleRank: display.lifecycle.rawValue,
+                mtime: .distantPast,
+                path: "/test-user-session-display.json"
+            )
+        return UserSession(
+            identity: SessionIdentityPolicy.logicalIdentity(for: display),
+            records: sessionRecords,
+            displayRecord: displayRecord
+        )
     }
 }
 

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -23,7 +23,7 @@ final class SessionTests: XCTestCase {
             "notification_message": null
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
 
         XCTAssertEqual(session.sessionId, "abc-123")
         XCTAssertEqual(session.projectName, "myapp")
@@ -48,7 +48,7 @@ final class SessionTests: XCTestCase {
             "hidden": true
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
         XCTAssertTrue(session.hidden)
     }
 
@@ -65,32 +65,32 @@ final class SessionTests: XCTestCase {
             "terminal": {"program": "Code"}
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
         XCTAssertEqual(session.sessionId, "frac-test")
     }
 
     func testContextLineIdle() {
-        let session = Session.mock(status: .idle)
+        let session = SessionData.mock(status: .idle)
         XCTAssertNil(session.contextLine)
     }
 
     func testContextLineWorking() {
-        let session = Session.mock(status: .working, lastTool: "Bash", lastToolDetail: "npm test")
+        let session = SessionData.mock(status: .working, lastTool: "Bash", lastToolDetail: "npm test")
         XCTAssertEqual(session.contextLine, "Running: npm test")
     }
 
     func testContextLinePermission() {
-        let session = Session.mock(status: .waitingPermission, notificationMessage: "Allow Bash: rm -rf /")
+        let session = SessionData.mock(status: .waitingPermission, notificationMessage: "Allow Bash: rm -rf /")
         XCTAssertEqual(session.contextLine, "Allow Bash: rm -rf /")
     }
 
     func testContextLinePermissionDefault() {
-        let session = Session.mock(status: .waitingPermission)
+        let session = SessionData.mock(status: .waitingPermission)
         XCTAssertEqual(session.contextLine, "Permission needed")
     }
 
     func testContextLineWaitingInputPrefersNotificationMessage() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             status: .waitingInput,
             lastPrompt: "Original user prompt",
             notificationMessage: "Which direction should I take?"
@@ -99,7 +99,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testContextLineWaitingInputFallsBackToPromptSnippet() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             status: .waitingInput,
             lastPrompt: "Original user prompt"
         )
@@ -107,17 +107,17 @@ final class SessionTests: XCTestCase {
     }
 
     func testContextLineNeedsAttentionFallsBackToNeedsAttention() {
-        let session = Session.mock(status: .needsAttention)
+        let session = SessionData.mock(status: .needsAttention)
         XCTAssertEqual(session.contextLine, "Needs attention")
     }
 
     func testContextLineCompacting() {
-        let session = Session.mock(status: .compacting)
+        let session = SessionData.mock(status: .compacting)
         XCTAssertEqual(session.contextLine, "Compacting context...")
     }
 
     func testNotificationContentPrefixesDistinctSessionTitleWithProject() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "cctop",
             sessionName: "Handle notification permission flow",
             status: .waitingInput,
@@ -134,7 +134,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationContentDoesNotDuplicateProjectTitle() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "cctop",
             status: .waitingInput,
             lastPrompt: "How can I watch it",
@@ -147,7 +147,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationContentUsesDesktopProjectPrefix() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "generated-worktree",
             sessionName: "Handle notification permission flow",
             status: .waitingPermission,
@@ -163,7 +163,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationContentPrefixesTitleStartingWithProjectName() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "optimistic-mestorf-1d360b",
             sessionName: "CCTOP promotional video",
             status: .waitingInput,
@@ -178,7 +178,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationContentCleansAndTruncatesBody() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "rdoc",
             sessionName: "Identify RDoc plugin incompatibility",
             status: .waitingInput,
@@ -193,7 +193,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationBodyPreservesUserTextCasing() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "cctop",
             sessionName: "Brand wording",
             status: .waitingInput,
@@ -206,7 +206,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationBodyPrefersNotificationMessageForWaitingInput() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "cctop",
             sessionName: "Elicitation dialog",
             status: .waitingInput,
@@ -219,7 +219,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationBodyPreservesMachineLikeNotificationMessage() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "cctop",
             sessionName: "Elicitation dialog",
             status: .waitingInput,
@@ -232,7 +232,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationBodyFallsBackToLastPromptForWaitingInput() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "cctop",
             sessionName: "Generic idle prompt",
             status: .waitingInput,
@@ -244,7 +244,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationBodyPreservesNonCodexPromptFallback() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "cctop",
             sessionName: "Generic idle prompt",
             status: .waitingInput,
@@ -256,7 +256,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationBodyPreservesCodexPromptFallbackStartingWithScaffoldHeading() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "cctop",
             sessionName: "Generic idle prompt",
             status: .waitingInput,
@@ -268,7 +268,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationBodyExtractsUserRequestFromCodexScaffold() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "cctop",
             sessionName: "Chief driver",
             status: .waitingInput,
@@ -289,7 +289,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationBodyFallsBackForMachineOnlyCodexScaffoldWithMultipleSections() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "cctop",
             sessionName: "Generated context",
             status: .waitingInput,
@@ -307,7 +307,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationBodyFallsBackForMachineWrapperPrompts() {
-        let heartbeat = Session.mock(
+        let heartbeat = SessionData.mock(
             project: "cctop",
             sessionName: "Chief watchdog",
             status: .waitingInput,
@@ -318,7 +318,7 @@ final class SessionTests: XCTestCase {
             """,
             source: "codex"
         )
-        let delegation = Session.mock(
+        let delegation = SessionData.mock(
             project: "cctop",
             sessionName: "Driver task",
             status: .waitingInput,
@@ -335,7 +335,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationBodyRejectsMachineWrapperBeforeExtractingCodexMarker() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "cctop",
             sessionName: "Driver task",
             status: .waitingInput,
@@ -354,7 +354,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationBodyDoesNotExtractCodexMarkerFromOrdinaryPrompt() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             project: "cctop",
             sessionName: "Docs edit",
             status: .waitingInput,
@@ -386,7 +386,7 @@ final class SessionTests: XCTestCase {
             "session_name": "refactor auth"
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
         XCTAssertEqual(session.sessionName, "refactor auth")
         XCTAssertEqual(session.displayName, "refactor auth")
     }
@@ -406,7 +406,7 @@ final class SessionTests: XCTestCase {
             "source": "codex"
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
         XCTAssertEqual(session.desktopProjectName, "cctop")
         XCTAssertEqual(session.displayName, "codex-worktree")
     }
@@ -424,48 +424,48 @@ final class SessionTests: XCTestCase {
             "terminal": {"program": "Code"}
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
         XCTAssertNil(session.sessionName)
         XCTAssertEqual(session.displayName, "myapp")
     }
 
     func testDisplayNameReturnsSessionNameWhenSet() {
-        let session = Session.mock(sessionName: "my task")
+        let session = SessionData.mock(sessionName: "my task")
         XCTAssertEqual(session.displayName, "my task")
     }
 
     func testDisplayNameFallsBackToProjectName() {
-        let session = Session.mock(project: "myapp")
+        let session = SessionData.mock(project: "myapp")
         XCTAssertEqual(session.displayName, "myapp")
     }
 
     // MARK: - PID-keyed identity
 
     func testIdUsesPIDWhenAvailable() {
-        let session = Session.mock(pid: 12345)
+        let session = SessionData.mock(pid: 12345)
         XCTAssertEqual(session.id, "12345")
     }
 
     func testIdFallsBackToSessionIdWhenNoPID() {
-        let session = Session.mock(id: "abc-123")
+        let session = SessionData.mock(id: "abc-123")
         XCTAssertEqual(session.id, "abc-123")
     }
 
     func testIdentifiableIDUsesHarnessSpecificDisplayIdentity() {
-        let cases: [(name: String, session: Session, expectedID: String)] = [
+        let cases: [(name: String, session: SessionData, expectedID: String)] = [
             (
                 "codex conversations use session id even with a shared host pid",
-                Session.mock(id: "codex-thread-1", pid: 12345, source: Session.codexSource),
+                SessionData.mock(id: "codex-thread-1", pid: 12345, source: SessionData.codexSource),
                 "codex-thread-1"
             ),
             (
                 "non-codex sessions use pid when available",
-                Session.mock(id: "claude-thread-1", pid: 12345, source: Session.ccSource),
+                SessionData.mock(id: "claude-thread-1", pid: 12345, source: SessionData.ccSource),
                 "12345"
             ),
             (
                 "non-codex sessions fall back to session id when pid is missing",
-                Session.mock(id: "claude-thread-2", source: Session.ccSource),
+                SessionData.mock(id: "claude-thread-2", source: SessionData.ccSource),
                 "claude-thread-2"
             ),
         ]
@@ -493,31 +493,31 @@ final class SessionTests: XCTestCase {
         XCTAssertNil(SessionIdentityPolicy.notificationUserInfo(forCctopSessionID: "not-a-uuid"))
     }
 
-    func testNotificationMetadataFindsPriorProcessObservationByPermanentIdentity() throws {
+    func testNotificationMetadataFindsPriorProcessRecordByPermanentIdentity() throws {
         let sharedID = "11111111-1111-4111-8111-111111111111"
-        let oldObservation = Session.mock(
+        let oldRecord = SessionData.mock(
             id: "old-process", cctopSessionId: sharedID,
-            status: .waitingPermission, pid: 11_111, source: Session.opencodeSource
+            status: .waitingPermission, pid: 11_111, source: SessionData.opencodeSource
         )
-        let currentObservation = Session.mock(
+        let currentRecord = SessionData.mock(
             id: "new-process", cctopSessionId: sharedID,
-            status: .waitingPermission, pid: 22_222, source: Session.opencodeSource
+            status: .waitingPermission, pid: 22_222, source: SessionData.opencodeSource
         )
-        let unrelated = Session.mock(
+        let unrelated = SessionData.mock(
             id: "unrelated", cctopSessionId: "22222222-2222-4222-8222-222222222222",
-            status: .waitingPermission, pid: 33_333, source: Session.opencodeSource
+            status: .waitingPermission, pid: 33_333, source: SessionData.opencodeSource
         )
-        let oldRequest = try XCTUnwrap(SessionManager.notificationRequest(for: oldObservation))
-        let currentRequest = try XCTUnwrap(SessionManager.notificationRequest(for: currentObservation))
+        let oldRequest = try XCTUnwrap(SessionManager.notificationRequest(for: oldRecord))
+        let currentRequest = try XCTUnwrap(SessionManager.notificationRequest(for: currentRecord))
         let unrelatedRequest = try XCTUnwrap(SessionManager.notificationRequest(for: unrelated))
         let preMigrationContent = UNMutableNotificationContent()
         preMigrationContent.userInfo = [
             SessionIdentityPolicy.notificationCctopSessionIDKey: sharedID,
-            SessionIdentityPolicy.notificationSessionIDKey: oldObservation.sessionId,
-            SessionIdentityPolicy.notificationSessionPIDKey: String(try XCTUnwrap(oldObservation.pid)),
+            SessionIdentityPolicy.notificationSessionIDKey: oldRecord.sessionId,
+            SessionIdentityPolicy.notificationSessionPIDKey: String(try XCTUnwrap(oldRecord.pid)),
         ]
         let preMigrationRequest = UNNotificationRequest(
-            identifier: "session-active:\(oldObservation.id)",
+            identifier: "session-active:\(oldRecord.id)",
             content: preMigrationContent,
             trigger: nil
         )
@@ -542,8 +542,8 @@ final class SessionTests: XCTestCase {
     func testNotificationPayloadPermanentIDOverridesStaleLegacyFields() {
         let firstID = "11111111-1111-4111-8111-111111111111"
         let secondID = "22222222-2222-4222-8222-222222222222"
-        let first = Session.mock(id: "codex-thread-1", cctopSessionId: firstID, pid: 12345, source: "codex")
-        let second = Session.mock(id: "codex-thread-2", cctopSessionId: secondID, pid: 12345, source: "codex")
+        let first = SessionData.mock(id: "codex-thread-1", cctopSessionId: firstID, pid: 12345, source: "codex")
+        let second = SessionData.mock(id: "codex-thread-2", cctopSessionId: secondID, pid: 12345, source: "codex")
         let userInfo: [AnyHashable: Any] = [
             SessionIdentityPolicy.notificationCctopSessionIDKey: secondID,
             SessionIdentityPolicy.notificationSessionIDKey: "codex-thread-1",
@@ -552,14 +552,14 @@ final class SessionTests: XCTestCase {
 
         let resolvedID = SessionIdentityPolicy.notificationCctopSessionID(
             matchingNotificationUserInfo: userInfo,
-            in: [first, second]
+            in: userSessionProjection(from: [first, second])
         )
 
         XCTAssertEqual(resolvedID, secondID)
     }
 
     func testNotificationPayloadWithMalformedPermanentIDDoesNotFallBack() {
-        let session = Session.mock(id: "codex-thread-1", pid: 12345, source: "codex")
+        let session = SessionData.mock(id: "codex-thread-1", pid: 12345, source: "codex")
         let userInfo: [AnyHashable: Any] = [
             SessionIdentityPolicy.notificationCctopSessionIDKey: "not-a-uuid",
             SessionIdentityPolicy.notificationSessionIDKey: "codex-thread-1",
@@ -568,7 +568,7 @@ final class SessionTests: XCTestCase {
 
         let resolvedID = SessionIdentityPolicy.notificationCctopSessionID(
             matchingNotificationUserInfo: userInfo,
-            in: [session]
+            in: userSessionProjection(from: [session])
         )
 
         XCTAssertNil(resolvedID)
@@ -576,7 +576,7 @@ final class SessionTests: XCTestCase {
 
     func testLegacyNotificationPayloadRecoversOnePermanentLogicalID() {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
-        let currentObservation = Session.mock(
+        let currentRecord = SessionData.mock(
             id: "codex-thread-1", cctopSessionId: cctopSessionID, pid: 67890, source: "codex"
         )
         let userInfo: [AnyHashable: Any] = [
@@ -586,34 +586,57 @@ final class SessionTests: XCTestCase {
 
         let resolvedID = SessionIdentityPolicy.notificationCctopSessionID(
             matchingNotificationUserInfo: userInfo,
-            in: [currentObservation]
+            in: userSessionProjection(from: [currentRecord])
         )
 
         XCTAssertEqual(resolvedID, cctopSessionID)
     }
 
     func testLegacyNotificationPayloadFailsClosedForAmbiguousPermanentIdentity() {
-        let first = Session.mock(
+        let first = SessionData.mock(
             id: "codex-thread-1", cctopSessionId: "11111111-1111-4111-8111-111111111111",
-            pid: 12_345, source: Session.codexSource
+            pid: 12_345, source: SessionData.codexSource
         )
-        let second = Session.mock(
+        let second = SessionData.mock(
             id: "codex-thread-1", cctopSessionId: "22222222-2222-4222-8222-222222222222",
-            pid: 67_890, source: Session.codexSource
+            pid: 67_890, source: SessionData.codexSource
         )
 
         XCTAssertNil(
             SessionIdentityPolicy.notificationCctopSessionID(
                 matchingNotificationUserInfo: [SessionIdentityPolicy.notificationSessionIDKey: "codex-thread-1"],
-                in: [first, second]
+                in: userSessionProjection(from: [first, second])
+            )
+        )
+    }
+
+    func testLegacyNotificationPayloadFailsClosedWhenOneMatchingUserSessionIsUnstamped() {
+        var unstampedCodex = SessionData.mock(
+            id: "shared-session", pid: 12_345, source: SessionData.codexSource
+        )
+        unstampedCodex.cctopSessionId = nil
+        let stampedDesktop = SessionData.mock(
+            id: "shared-session",
+            cctopSessionId: "22222222-2222-4222-8222-222222222222",
+            pid: 67_890,
+            terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop),
+            source: SessionData.ccSource
+        )
+
+        XCTAssertNil(
+            SessionIdentityPolicy.notificationCctopSessionID(
+                matchingNotificationUserInfo: [
+                    SessionIdentityPolicy.notificationSessionIDKey: "shared-session",
+                ],
+                in: userSessionProjection(from: [unstampedCodex, stampedDesktop])
             )
         )
     }
 
     func testLegacyNotificationSessionIDMissDoesNotFallThroughToPID() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             id: "current-session", cctopSessionId: "11111111-1111-4111-8111-111111111111",
-            pid: 12345, source: Session.opencodeSource
+            pid: 12345, source: SessionData.opencodeSource
         )
         let userInfo: [AnyHashable: Any] = [
             SessionIdentityPolicy.notificationSessionIDKey: "stale-session",
@@ -623,15 +646,15 @@ final class SessionTests: XCTestCase {
         XCTAssertNil(
             SessionIdentityPolicy.notificationCctopSessionID(
                 matchingNotificationUserInfo: userInfo,
-                in: [session]
+                in: userSessionProjection(from: [session])
             )
         )
     }
 
     func testLegacyNotificationPayloadFailsClosedForUniquePID() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             id: "current-process", cctopSessionId: "11111111-1111-4111-8111-111111111111",
-            pid: 12345, source: Session.opencodeSource
+            pid: 12345, source: SessionData.opencodeSource
         )
         let userInfo: [AnyHashable: Any] = [
             SessionIdentityPolicy.notificationSessionPIDKey: "12345",
@@ -640,15 +663,15 @@ final class SessionTests: XCTestCase {
         XCTAssertNil(
             SessionIdentityPolicy.notificationCctopSessionID(
                 matchingNotificationUserInfo: userInfo,
-                in: [session]
+                in: userSessionProjection(from: [session])
             )
         )
     }
 
     func testLegacyNotificationPayloadFailsClosedForProcessSessionID() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             id: "12345", cctopSessionId: "11111111-1111-4111-8111-111111111111",
-            pid: 12345, source: Session.opencodeSource
+            pid: 12345, source: SessionData.opencodeSource
         )
         let userInfo: [AnyHashable: Any] = [
             SessionIdentityPolicy.notificationSessionIDKey: "12345",
@@ -657,7 +680,7 @@ final class SessionTests: XCTestCase {
         XCTAssertNil(
             SessionIdentityPolicy.notificationCctopSessionID(
                 matchingNotificationUserInfo: userInfo,
-                in: [session]
+                in: userSessionProjection(from: [session])
             )
         )
     }
@@ -677,7 +700,7 @@ final class SessionTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = ManualSessionVisibilityStore(defaults: defaults)
 
-        var terminal = Session(
+        var terminal = SessionData(
             sessionId: "private-terminal-conversation",
             projectPath: "/private/project/path",
             branch: "secret-branch",
@@ -686,10 +709,10 @@ final class SessionTests: XCTestCase {
         terminal.cctopSessionId = "11111111-1111-4111-8111-111111111111"
         terminal.pid = 42
         terminal.sessionName = "Private session title"
-        let codex = Session.mock(
+        let codex = SessionData.mock(
             id: "codex-thread",
             cctopSessionId: "22222222-2222-4222-8222-222222222222",
-            source: Session.codexSource
+            source: SessionData.codexSource
         )
 
         store.hide(terminal)
@@ -712,11 +735,11 @@ final class SessionTests: XCTestCase {
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = ManualSessionVisibilityStore(defaults: defaults)
-        let first = Session.mock(
+        let first = SessionData.mock(
             id: "first", cctopSessionId: "11111111-1111-4111-8111-111111111111"
         )
         let secondID = "22222222-2222-4222-8222-222222222222"
-        let second = Session.mock(id: "second", cctopSessionId: secondID)
+        let second = SessionData.mock(id: "second", cctopSessionId: secondID)
 
         store.hide(first)
         store.hide(second)
@@ -737,14 +760,14 @@ final class SessionTests: XCTestCase {
             forKey: ManualSessionVisibilityStore.legacyDefaultsKey
         )
         let store = ManualSessionVisibilityStore(defaults: defaults)
-        let codex = Session.mock(id: "durable-codex", cctopSessionId: codexID, source: Session.codexSource)
-        let desktop = Session.mock(
+        let codex = SessionData.mock(id: "durable-codex", cctopSessionId: codexID, source: SessionData.codexSource)
+        let desktop = SessionData.mock(
             id: "durable-desktop",
             cctopSessionId: desktopID,
             terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop),
-            source: Session.ccSource
+            source: SessionData.ccSource
         )
-        let active = Session.mock(id: "terminal", cctopSessionId: activeID, pid: 42, source: Session.ccSource)
+        let active = SessionData.mock(id: "terminal", cctopSessionId: activeID, pid: 42, source: SessionData.ccSource)
         var unstampedCodex = codex
         unstampedCodex.cctopSessionId = nil
 
@@ -816,7 +839,7 @@ final class SessionTests: XCTestCase {
         let store = ManualSessionVisibilityStore(defaults: defaults)
         let firstID = "11111111-1111-4111-8111-111111111111"
         let secondID = "22222222-2222-4222-8222-222222222222"
-        var legacy = Session.mock(id: threadID, harnessSessionId: threadID, source: Session.codexSource)
+        var legacy = SessionData.mock(id: threadID, harnessSessionId: threadID, source: SessionData.codexSource)
         legacy.cctopSessionId = nil
         let unresolvedIDs = store.migrateLegacyStableKeys(
             using: [legacy],
@@ -828,17 +851,17 @@ final class SessionTests: XCTestCase {
         XCTAssertTrue(store.hiddenSessionIDs.isEmpty)
         XCTAssertEqual(store.unresolvedDurableLegacyKeys, [legacyKey])
 
-        let first = Session.mock(
+        let first = SessionData.mock(
             id: "first-observation",
             cctopSessionId: firstID,
             harnessSessionId: threadID,
-            source: Session.codexSource
+            source: SessionData.codexSource
         )
-        let second = Session.mock(
+        let second = SessionData.mock(
             id: "second-observation",
             cctopSessionId: secondID,
             harnessSessionId: threadID,
-            source: Session.codexSource
+            source: SessionData.codexSource
         )
         let ambiguousIDs = store.migrateLegacyStableKeys(
             using: [legacy, first, second],
@@ -856,7 +879,7 @@ final class SessionTests: XCTestCase {
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = ManualSessionVisibilityStore(defaults: defaults)
-        var legacy = Session.mock(id: "legacy")
+        var legacy = SessionData.mock(id: "legacy")
         legacy.cctopSessionId = nil
 
         store.hide(legacy)
@@ -867,12 +890,12 @@ final class SessionTests: XCTestCase {
     }
 
     func testManualSessionHideConfirmationDescribesIrreversibleVisibleEffect() throws {
-        let session = Session.mock(
+        let session = SessionData.mock(
             id: "private-session",
             cctopSessionId: "11111111-1111-4111-8111-111111111111",
             project: "cctop",
             sessionName: "Investigate lifecycle",
-            source: Session.codexSource
+            source: SessionData.codexSource
         )
 
         let confirmation = try XCTUnwrap(ManualSessionHideConfirmation(session: session))
@@ -897,7 +920,7 @@ final class SessionTests: XCTestCase {
             session: .mock(
                 id: "private-session",
                 cctopSessionId: "11111111-1111-4111-8111-111111111111",
-                source: Session.codexSource
+                source: SessionData.codexSource
             )
         ))
         let cleanupRoute = PopupConfirmation.cleanup(cleanupConfirmation)
@@ -920,7 +943,7 @@ final class SessionTests: XCTestCase {
 
     func testNotificationRequestDoesNotUseVisibleThreadGrouping() throws {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
-        let session = Session.mock(
+        let session = SessionData.mock(
             id: "claude-desktop-thread-1",
             cctopSessionId: cctopSessionID,
             pid: 12345,
@@ -935,7 +958,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationRequestFailsClosedWithoutPermanentIdentity() {
-        var missing = Session.mock(id: "legacy", status: .waitingInput)
+        var missing = SessionData.mock(id: "legacy", status: .waitingInput)
         missing.cctopSessionId = nil
         var malformed = missing
         malformed.cctopSessionId = "not-a-uuid"
@@ -965,7 +988,7 @@ final class SessionTests: XCTestCase {
             }
         )
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
-        let session = Session.mock(
+        let session = SessionData.mock(
             id: "claude-desktop-thread-1",
             cctopSessionId: cctopSessionID,
             status: .waitingPermission,
@@ -978,7 +1001,7 @@ final class SessionTests: XCTestCase {
             dataSources: sources,
             startMonitoring: false
         )
-        manager.sessions = [session]
+        setSessionProjection([session], on: manager)
 
         manager.postNotification(for: session)
 
@@ -1010,9 +1033,9 @@ final class SessionTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = ManualSessionVisibilityStore(defaults: defaults)
-        let session = Session.mock(
+        let session = SessionData.mock(
             id: "hidden-attention", status: .waitingPermission,
-            source: Session.codexSource
+            source: SessionData.codexSource
         )
 
         let recorder = Recorder()
@@ -1032,15 +1055,15 @@ final class SessionTests: XCTestCase {
         )
         var noLongerNeedsAttention = session
         noLongerNeedsAttention.status = .working
-        manager.sessions = [noLongerNeedsAttention]
+        setSessionProjection([noLongerNeedsAttention], on: manager)
         manager.postNotification(for: session)
 
-        manager.sessions = [session]
+        setSessionProjection([session], on: manager)
         store.hide(session)
 
         manager.postNotification(for: session)
         store.prune(retaining: [])
-        manager.sessions = []
+        setSessionProjection([], on: manager)
         manager.postNotification(for: session)
 
         XCTAssertEqual(recorder.events, [])
@@ -1062,20 +1085,20 @@ final class SessionTests: XCTestCase {
             removePending: { _ in recorder.events.append("removePending") },
             removeDelivered: { _ in recorder.events.append("removeDelivered") }
         )
-        let original = Session.mock(
+        let original = SessionData.mock(
             id: "reused-pid", cctopSessionId: "11111111-1111-4111-8111-111111111111",
-            pid: 42_042, source: Session.ccSource
+            pid: 42_042, source: SessionData.ccSource
         )
-        let replacement = Session.mock(
+        let replacement = SessionData.mock(
             id: "reused-pid", cctopSessionId: "22222222-2222-4222-8222-222222222222",
-            pid: 42_042, source: Session.ccSource
+            pid: 42_042, source: SessionData.ccSource
         )
         let manager = SessionManager(
             historyManager: HistoryManager(historyDir: FileManager.default.temporaryDirectory),
             dataSources: sources,
             startMonitoring: false
         )
-        manager.sessions = [replacement]
+        setSessionProjection([replacement], on: manager)
 
         manager.postNotification(for: original)
 
@@ -1098,10 +1121,10 @@ final class SessionTests: XCTestCase {
             removePending: { _ in recorder.events.append("removePending") },
             removeDelivered: { _ in recorder.events.append("removeDelivered") }
         )
-        var missingIdentity = Session.mock(
+        var missingIdentity = SessionData.mock(
             id: "legacy-session", harnessSessionId: "legacy-session",
             status: .waitingInput, pid: 42_042, pidStartTime: 1_000,
-            source: Session.opencodeSource
+            source: SessionData.opencodeSource
         )
         missingIdentity.cctopSessionId = nil
         missingIdentity.lifecycle = .active
@@ -1110,7 +1133,7 @@ final class SessionTests: XCTestCase {
             dataSources: sources,
             startMonitoring: false
         )
-        manager.sessions = [missingIdentity]
+        setSessionProjection([missingIdentity], on: manager)
 
         manager.postNotification(for: missingIdentity)
 
@@ -1118,7 +1141,7 @@ final class SessionTests: XCTestCase {
     }
 
     @MainActor
-    func testPostNotificationMatchesCurrentCanonicalObservationForPendingRequest() throws {
+    func testPostNotificationMatchesCurrentCanonicalRecordForPendingRequest() throws {
         final class Recorder {
             var requests: [UNNotificationRequest] = []
             var removals: [String] = []
@@ -1135,14 +1158,14 @@ final class SessionTests: XCTestCase {
             removeDelivered: { recorder.removals.append("delivered:\($0.joined(separator: ","))") }
         )
         let sharedID = "11111111-1111-4111-8111-111111111111"
-        var working = Session.mock(
+        var working = SessionData.mock(
             id: "first", cctopSessionId: sharedID,
-            status: .working, pid: 11_111, source: Session.opencodeSource
+            status: .working, pid: 11_111, source: SessionData.opencodeSource
         )
         working.lifecycle = .active
-        var waiting = Session.mock(
+        var waiting = SessionData.mock(
             id: "second", cctopSessionId: sharedID,
-            status: .waitingPermission, pid: 22_222, source: Session.opencodeSource
+            status: .waitingPermission, pid: 22_222, source: SessionData.opencodeSource
         )
         waiting.lifecycle = .active
         let manager = SessionManager(
@@ -1154,7 +1177,7 @@ final class SessionTests: XCTestCase {
         staleWaitingSnapshot.status = .waitingPermission
         staleWaitingSnapshot.notificationMessage = "Stale observation"
         waiting.notificationMessage = "Current observation"
-        manager.sessions = [waiting]
+        setSessionProjection([waiting], on: manager)
 
         manager.postNotification(for: staleWaitingSnapshot)
 
@@ -1168,7 +1191,7 @@ final class SessionTests: XCTestCase {
 
         recorder.requests.removeAll()
         recorder.removals.removeAll()
-        manager.sessions = [working]
+        setSessionProjection([working], on: manager)
         manager.postNotification(for: staleWaitingSnapshot)
         XCTAssertTrue(recorder.requests.isEmpty)
         XCTAssertTrue(recorder.removals.isEmpty)
@@ -1192,24 +1215,35 @@ final class SessionTests: XCTestCase {
             removeByCctopSessionID: { recorder.cctopSessionIDs.append($0) }
         )
         let sharedID = "11111111-1111-4111-8111-111111111111"
-        let first = Session.mock(
-            id: "codex-thread-1", cctopSessionId: sharedID,
-            status: .working, pid: 11_111, source: Session.codexSource
+        var unstamped = SessionData.mock(
+            id: "legacy-codex-thread", cctopSessionId: sharedID,
+            status: .idle, pid: 10_000, source: SessionData.codexSource
         )
-        let processScoped = Session.mock(
+        unstamped.cctopSessionId = nil
+        let first = SessionData.mock(
+            id: "current-codex-thread", cctopSessionId: sharedID,
+            status: .working, pid: 11_111, source: SessionData.codexSource
+        )
+        let processScoped = SessionData.mock(
             id: "11111", cctopSessionId: sharedID,
-            status: .working, pid: 11_111, source: Session.opencodeSource
+            status: .working, pid: 11_111, source: SessionData.opencodeSource
         )
         let manager = SessionManager(
             historyManager: HistoryManager(historyDir: FileManager.default.temporaryDirectory),
             dataSources: sources,
             startMonitoring: false
         )
-        manager.sessions = [first]
+        manager.updateSessionProjection([
+            userSession(display: first, records: [unstamped, first]),
+        ])
 
         manager.hideSession(first)
 
-        let expectedIdentifiers = ["session-\(sharedID)", "session-codex:codex-thread-1"]
+        let expectedIdentifiers = [
+            "session-\(sharedID)",
+            "session-codex:current-codex-thread",
+            "session-codex:legacy-codex-thread",
+        ]
         XCTAssertTrue(manager.sessions.isEmpty)
         XCTAssertEqual(recorder.pending, [expectedIdentifiers])
         XCTAssertEqual(recorder.delivered, [expectedIdentifiers])
@@ -1255,12 +1289,12 @@ final class SessionTests: XCTestCase {
             startMonitoring: false
         )
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
-        var attention = Session.mock(
+        var attention = SessionData.mock(
             id: "attention", cctopSessionId: cctopSessionID,
-            status: .waitingInput, source: Session.codexSource
+            status: .waitingInput, source: SessionData.codexSource
         )
         attention.lifecycle = .active
-        manager.sessions = [attention]
+        setSessionProjection([attention], on: manager)
 
         manager.hideSession(attention)
 
@@ -1273,16 +1307,16 @@ final class SessionTests: XCTestCase {
 
     func testNotificationActionsRemoveResolvedAttentionSession() {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
-        let oldSession = Session.mock(
+        let oldSession = SessionData.mock(
             id: "old-observation", cctopSessionId: cctopSessionID,
             status: .waitingInput,
             lastPrompt: "Waiting",
-            pid: 11_111, source: Session.opencodeSource
+            pid: 11_111, source: SessionData.opencodeSource
         )
-        let resolvedSession = Session.mock(
+        let resolvedSession = SessionData.mock(
             id: "new-observation", cctopSessionId: cctopSessionID,
             status: .working,
-            pid: 22_222, source: Session.opencodeSource
+            pid: 22_222, source: SessionData.opencodeSource
         )
 
         XCTAssertEqual(
@@ -1297,7 +1331,7 @@ final class SessionTests: XCTestCase {
 
     func testNotificationActionsRemoveMissingAttentionSession() {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
-        let oldSession = Session.mock(
+        let oldSession = SessionData.mock(
             id: "codex-thread-1", cctopSessionId: cctopSessionID,
             status: .waitingInput,
             lastPrompt: "Waiting",
@@ -1336,13 +1370,13 @@ final class SessionTests: XCTestCase {
             startMonitoring: false
         )
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
-        let oldSession = Session.mock(
+        let oldSession = SessionData.mock(
             id: "codex-thread-1", cctopSessionId: cctopSessionID,
-            status: .waitingPermission, pid: 11_111, source: Session.codexSource
+            status: .waitingPermission, pid: 11_111, source: SessionData.codexSource
         )
-        let currentSession = Session.mock(
+        let currentSession = SessionData.mock(
             id: "codex-thread-1", cctopSessionId: cctopSessionID,
-            status: .working, pid: 22_222, source: Session.codexSource
+            status: .working, pid: 22_222, source: SessionData.codexSource
         )
 
         manager.syncTransitionNotifications(for: [currentSession], oldSessions: [oldSession])
@@ -1353,17 +1387,17 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(recorder.cctopSessionIDs, [cctopSessionID])
     }
 
-    func testNotificationActionsPostOneTransitionAcrossReplacementObservation() {
+    func testNotificationActionsPostOneTransitionAcrossReplacementRecord() {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
-        let oldSession = Session.mock(
+        let oldSession = SessionData.mock(
             id: "old-observation", cctopSessionId: cctopSessionID,
-            status: .working, pid: 11_111, source: Session.opencodeSource
+            status: .working, pid: 11_111, source: SessionData.opencodeSource
         )
-        let waitingSession = Session.mock(
+        let waitingSession = SessionData.mock(
             id: "new-observation", cctopSessionId: cctopSessionID,
             status: .waitingInput,
             lastPrompt: "Waiting",
-            pid: 22_222, source: Session.opencodeSource
+            pid: 22_222, source: SessionData.opencodeSource
         )
 
         XCTAssertEqual(
@@ -1376,15 +1410,15 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testNotificationActionsDoNotRepostWaitingTransitionAcrossReplacementObservation() {
+    func testNotificationActionsDoNotRepostWaitingTransitionAcrossReplacementRecord() {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
-        let oldSession = Session.mock(
+        let oldSession = SessionData.mock(
             id: "old-observation", cctopSessionId: cctopSessionID,
-            status: .waitingPermission, pid: 11_111, source: Session.opencodeSource
+            status: .waitingPermission, pid: 11_111, source: SessionData.opencodeSource
         )
-        let replacement = Session.mock(
+        let replacement = SessionData.mock(
             id: "new-observation", cctopSessionId: cctopSessionID,
-            status: .waitingPermission, pid: 22_222, source: Session.opencodeSource
+            status: .waitingPermission, pid: 22_222, source: SessionData.opencodeSource
         )
 
         XCTAssertEqual(
@@ -1396,7 +1430,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationActionsFailClosedWithoutPermanentIdentity() {
-        var oldSession = Session.mock(id: "legacy", status: .working)
+        var oldSession = SessionData.mock(id: "legacy", status: .working)
         var waitingSession = oldSession
         oldSession.cctopSessionId = nil
         waitingSession.cctopSessionId = nil
@@ -1412,8 +1446,8 @@ final class SessionTests: XCTestCase {
     }
 
     private func notificationActions(
-        newSession: Session,
-        oldSession: Session,
+        newSession: SessionData,
+        oldSession: SessionData,
         notificationsEnabled: Bool = true
     ) -> [SessionNotificationAction] {
         XCTAssertEqual(newSession.cctopSessionId, oldSession.cctopSessionId)
@@ -1425,13 +1459,13 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationActionsSuppressMachineOnlyCodexEnvelopeWaitingInput() {
-        let oldSession = Session.mock(
+        let oldSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .working,
             source: "codex"
         )
-        let heartbeatSession = Session.mock(
+        let heartbeatSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .waitingInput,
@@ -1442,7 +1476,7 @@ final class SessionTests: XCTestCase {
             """,
             source: "codex"
         )
-        let delegationSession = Session.mock(
+        let delegationSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .waitingInput,
@@ -1465,13 +1499,13 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationActionsSuppressCodexScaffoldWithoutUserRequest() {
-        let oldSession = Session.mock(
+        let oldSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .working,
             source: "codex"
         )
-        let browserScaffoldSession = Session.mock(
+        let browserScaffoldSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .waitingInput,
@@ -1481,7 +1515,7 @@ final class SessionTests: XCTestCase {
             """,
             source: "codex"
         )
-        let fileScaffoldSession = Session.mock(
+        let fileScaffoldSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .waitingInput,
@@ -1491,7 +1525,7 @@ final class SessionTests: XCTestCase {
             """,
             source: "codex"
         )
-        let multiSectionScaffoldSession = Session.mock(
+        let multiSectionScaffoldSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .waitingInput,
@@ -1520,14 +1554,14 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationActionsDoNotApplyCodexSuppressionToLeakedDesktopBundle() {
-        let oldSession = Session.mock(
+        let oldSession = SessionData.mock(
             id: "cc-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .working,
             terminal: TerminalInfo(bundleId: HostAppBundleID.codexDesktop),
             source: "cc",
         )
-        let waitingSession = Session.mock(
+        let waitingSession = SessionData.mock(
             id: "cc-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .waitingInput,
@@ -1546,13 +1580,13 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationActionsPostUserFacingCodexWaitingInput() {
-        let oldSession = Session.mock(
+        let oldSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .working,
             source: "codex"
         )
-        let explicitMessageSession = Session.mock(
+        let explicitMessageSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .waitingInput,
@@ -1564,7 +1598,7 @@ final class SessionTests: XCTestCase {
             notificationMessage: "Which option should I choose?",
             source: "codex"
         )
-        let scaffoldWithRequestSession = Session.mock(
+        let scaffoldWithRequestSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .waitingInput,
@@ -1577,14 +1611,14 @@ final class SessionTests: XCTestCase {
             """,
             source: "codex"
         )
-        let promptStartingWithScaffoldHeading = Session.mock(
+        let promptStartingWithScaffoldHeading = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .waitingInput,
             lastPrompt: "# Files: draft a changelog entry",
             source: "codex"
         )
-        let multilinePromptStartingWithScaffoldHeading = Session.mock(
+        let multilinePromptStartingWithScaffoldHeading = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .waitingInput,
@@ -1614,13 +1648,13 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationActionsPostCodexPermissionAndErrorAttention() {
-        let oldSession = Session.mock(
+        let oldSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .working,
             source: "codex"
         )
-        let permissionSession = Session.mock(
+        let permissionSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .waitingPermission,
@@ -1628,7 +1662,7 @@ final class SessionTests: XCTestCase {
             notificationMessage: "Allow Bash: make all",
             source: "codex"
         )
-        let errorSession = Session.mock(
+        let errorSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .needsAttention,
@@ -1648,14 +1682,14 @@ final class SessionTests: XCTestCase {
     }
 
     func testNotificationActionsPostWhenSuppressedCodexWaitingInputBecomesUserFacing() {
-        let oldMachineOnlySession = Session.mock(
+        let oldMachineOnlySession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .waitingInput,
             lastPrompt: "<heartbeat></heartbeat>",
             source: "codex"
         )
-        let userFacingSession = Session.mock(
+        let userFacingSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: notificationTestCctopSessionID,
             status: .waitingInput,
@@ -1671,14 +1705,14 @@ final class SessionTests: XCTestCase {
 
     func testNotificationActionsRemoveWhenUserFacingCodexWaitingInputBecomesMachineOnly() {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
-        let oldUserFacingSession = Session.mock(
+        let oldUserFacingSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: cctopSessionID,
             status: .waitingInput,
             lastPrompt: "Can you check this?",
             source: "codex"
         )
-        let machineOnlySession = Session.mock(
+        let machineOnlySession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: cctopSessionID,
             status: .waitingInput,
@@ -1694,13 +1728,13 @@ final class SessionTests: XCTestCase {
 
     func testNotificationActionsDoNotPostWhenNotificationsDisabled() {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
-        let oldSession = Session.mock(
+        let oldSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: cctopSessionID,
             status: .working,
             source: "codex"
         )
-        let waitingSession = Session.mock(
+        let waitingSession = SessionData.mock(
             id: "codex-thread-1",
             cctopSessionId: cctopSessionID,
             status: .waitingInput,
@@ -1733,7 +1767,7 @@ final class SessionTests: XCTestCase {
             "pid_start_time": 1707400000.123
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
         XCTAssertEqual(session.pid, 9999)
         XCTAssertEqual(session.pidStartTime!, 1707400000.123, accuracy: 0.001)
     }
@@ -1752,7 +1786,7 @@ final class SessionTests: XCTestCase {
             "pid": 5555
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
         XCTAssertEqual(session.pid, 5555)
         XCTAssertNil(session.pidStartTime)
     }
@@ -1770,13 +1804,13 @@ final class SessionTests: XCTestCase {
             "terminal": {"program": "Code"}
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
         XCTAssertNil(session.createdByHookVersion)
         XCTAssertNil(session.lastWrittenByHookVersion)
     }
 
     func testEncodesHookWriterMetadata() throws {
-        var session = Session.mock()
+        var session = SessionData.mock()
         session.createdByHookVersion = "0.16.0"
         session.lastWrittenByHookVersion = "0.16.1"
 
@@ -1788,7 +1822,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testMarkWrittenByHookDoesNotBackfillLegacyCreator() {
-        var session = Session.mock()
+        var session = SessionData.mock()
         session.markWrittenByHook(version: "0.16.0", isNewSessionFile: false)
 
         XCTAssertNil(session.createdByHookVersion)
@@ -1796,7 +1830,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testMarkWrittenByHookStampsNewSessionCreator() {
-        var session = Session.mock()
+        var session = SessionData.mock()
         session.markWrittenByHook(version: "0.16.0", isNewSessionFile: true)
 
         XCTAssertEqual(session.createdByHookVersion, "0.16.0")
@@ -1817,7 +1851,7 @@ final class SessionTests: XCTestCase {
             "disconnected_at": "2026-02-08T12:05:00Z"
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
         XCTAssertEqual(
             session.disconnectedAt,
             ISO8601DateFormatter().date(from: "2026-02-08T12:05:00Z")
@@ -1826,7 +1860,7 @@ final class SessionTests: XCTestCase {
 
     func testEncodesDisconnectedAt() throws {
         let disconnectedAt = ISO8601DateFormatter().date(from: "2026-02-08T12:05:00Z")!
-        var session = Session.mock(terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop))
+        var session = SessionData.mock(terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop))
         session.disconnectedAt = disconnectedAt
 
         let data = try JSONEncoder.sessionEncoder.encode(session)
@@ -1836,7 +1870,7 @@ final class SessionTests: XCTestCase {
 
     func testProcessStartTimeReturnsValueForCurrentProcess() {
         let pid = UInt32(getpid())
-        let startTime = Session.processStartTime(pid: pid)
+        let startTime = SessionData.processStartTime(pid: pid)
         XCTAssertNotNil(startTime, "Should get start time for current process")
         XCTAssertGreaterThan(startTime ?? 0, 0)
     }
@@ -1867,16 +1901,16 @@ final class SessionTests: XCTestCase {
     func testIsAliveRejectsPidOwnedByForeignHarnessBinary() throws {
         let process = try spawnProcess(named: "codex")
         let pid = UInt32(process.processIdentifier)
-        let start = try XCTUnwrap(Session.processStartTime(pid: pid))
-        let session = Session.mock(pid: pid, pidStartTime: start, source: "cc")
+        let start = try XCTUnwrap(SessionData.processStartTime(pid: pid))
+        let session = SessionData.mock(pid: pid, pidStartTime: start, source: "cc")
         XCTAssertFalse(session.isAlive)
     }
 
     func testIsAliveAcceptsPidOwnedByOwnHarnessBinary() throws {
         let process = try spawnProcess(named: "codex")
         let pid = UInt32(process.processIdentifier)
-        let start = try XCTUnwrap(Session.processStartTime(pid: pid))
-        let session = Session.mock(pid: pid, pidStartTime: start, source: "codex")
+        let start = try XCTUnwrap(SessionData.processStartTime(pid: pid))
+        let session = SessionData.mock(pid: pid, pidStartTime: start, source: "codex")
         XCTAssertTrue(session.isAlive)
     }
 
@@ -1884,8 +1918,8 @@ final class SessionTests: XCTestCase {
     func testIsAliveAcceptsUnrecognizedProcessName() throws {
         let process = try spawnProcess(named: "sleepyhead")
         let pid = UInt32(process.processIdentifier)
-        let start = try XCTUnwrap(Session.processStartTime(pid: pid))
-        let session = Session.mock(pid: pid, pidStartTime: start, source: "cc")
+        let start = try XCTUnwrap(SessionData.processStartTime(pid: pid))
+        let session = SessionData.mock(pid: pid, pidStartTime: start, source: "cc")
         XCTAssertTrue(session.isAlive)
     }
 
@@ -1893,16 +1927,16 @@ final class SessionTests: XCTestCase {
     func testIsAliveTreatsNilSourceAsClaudeCodeForIdentityCheck() throws {
         let process = try spawnProcess(named: "codex")
         let pid = UInt32(process.processIdentifier)
-        let start = try XCTUnwrap(Session.processStartTime(pid: pid))
-        let session = Session.mock(pid: pid, pidStartTime: start, source: nil)
+        let start = try XCTUnwrap(SessionData.processStartTime(pid: pid))
+        let session = SessionData.mock(pid: pid, pidStartTime: start, source: nil)
         XCTAssertFalse(session.isAlive)
     }
 
     func testHarnessOwningCommRecognizesTruncatedArchSuffixedCodexBinary() {
         // Kernel p_comm of codex-aarch64-apple-darwin, truncated to MAXCOMLEN (16).
-        XCTAssertEqual(Session.harnessOwningComm("codex-aarch64-ap"), Session.codexSource)
-        XCTAssertTrue(Session.isForeignHarnessComm("codex-aarch64-ap", source: Session.ccSource))
-        XCTAssertFalse(Session.isForeignHarnessComm("codex-aarch64-ap", source: Session.codexSource))
+        XCTAssertEqual(SessionData.harnessOwningComm("codex-aarch64-ap"), SessionData.codexSource)
+        XCTAssertTrue(SessionData.isForeignHarnessComm("codex-aarch64-ap", source: SessionData.ccSource))
+        XCTAssertFalse(SessionData.isForeignHarnessComm("codex-aarch64-ap", source: SessionData.codexSource))
     }
 
     // Codex also ships arch-suffixed binaries; the kernel truncates p_comm to MAXCOMLEN.
@@ -1910,10 +1944,10 @@ final class SessionTests: XCTestCase {
     func testIsAliveRejectsPidOwnedByTruncatedArchSuffixedCodexBinary() throws {
         let process = try spawnProcess(named: "codex-aarch64-apple-darwin")
         let pid = UInt32(process.processIdentifier)
-        XCTAssertEqual(Session.processCommandName(pid: pid), "codex-aarch64-ap")
-        let start = try XCTUnwrap(Session.processStartTime(pid: pid))
-        XCTAssertFalse(Session.mock(pid: pid, pidStartTime: start, source: "cc").isAlive)
-        XCTAssertTrue(Session.mock(pid: pid, pidStartTime: start, source: "codex").isAlive)
+        XCTAssertEqual(SessionData.processCommandName(pid: pid), "codex-aarch64-ap")
+        let start = try XCTUnwrap(SessionData.processStartTime(pid: pid))
+        XCTAssertFalse(SessionData.mock(pid: pid, pidStartTime: start, source: "cc").isAlive)
+        XCTAssertTrue(SessionData.mock(pid: pid, pidStartTime: start, source: "codex").isAlive)
     }
 
     func testDecodesWorkspaceFile() throws {
@@ -1930,7 +1964,7 @@ final class SessionTests: XCTestCase {
             "workspace_file": "/Users/test/projects/myapp/myapp.code-workspace"
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
         XCTAssertEqual(session.workspaceFile, "/Users/test/projects/myapp/myapp.code-workspace")
     }
 
@@ -1947,7 +1981,7 @@ final class SessionTests: XCTestCase {
             "terminal": {"program": "Code"}
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
         XCTAssertNil(session.workspaceFile)
     }
 
@@ -1975,7 +2009,7 @@ final class SessionTests: XCTestCase {
             "source": "opencode"
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
 
         XCTAssertEqual(session.sessionId, "oc-session-1")
         XCTAssertEqual(session.projectName, "api-server")
@@ -1999,33 +2033,33 @@ final class SessionTests: XCTestCase {
             "terminal": {"program": "Code"}
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
         XCTAssertNil(session.source)
         XCTAssertEqual(session.agentBadge.label, "CC")
     }
 
     func testAgentBadgeLabelOpencode() {
-        let session = Session.mock(source: "opencode")
+        let session = SessionData.mock(source: "opencode")
         XCTAssertEqual(session.agentBadge.label, "OC")
     }
 
     func testAgentBadgeLabelDefault() {
-        let session = Session.mock()
+        let session = SessionData.mock()
         XCTAssertEqual(session.agentBadge.label, "CC")
     }
 
     func testAgentBadgeLabelPi() {
-        let session = Session.mock(source: "pi")
+        let session = SessionData.mock(source: "pi")
         XCTAssertEqual(session.agentBadge.label, "Pi")
     }
 
     func testAgentBadgeLabelUnknownValue() {
-        let session = Session.mock(source: "aider")
+        let session = SessionData.mock(source: "aider")
         XCTAssertEqual(session.agentBadge.label, "CC")
     }
 
     func testSourceCarriedInWithSessionId() {
-        let session = Session.mock(source: "opencode")
+        let session = SessionData.mock(source: "opencode")
         let carried = session.withSessionId("new-id")
         XCTAssertEqual(carried.source, "opencode")
         XCTAssertEqual(carried.sessionId, "new-id")
@@ -2034,17 +2068,17 @@ final class SessionTests: XCTestCase {
     // MARK: - Case-insensitive tool display
 
     func testContextLineLowercaseToolName() {
-        let session = Session.mock(status: .working, lastTool: "bash", lastToolDetail: "go test ./...")
+        let session = SessionData.mock(status: .working, lastTool: "bash", lastToolDetail: "go test ./...")
         XCTAssertEqual(session.contextLine, "Running: go test ./...")
     }
 
     func testContextLineLowercaseEdit() {
-        let session = Session.mock(status: .working, lastTool: "edit", lastToolDetail: "/src/main.go")
+        let session = SessionData.mock(status: .working, lastTool: "edit", lastToolDetail: "/src/main.go")
         XCTAssertEqual(session.contextLine, "Editing main.go")
     }
 
     func testContextLineLowercaseRead() {
-        let session = Session.mock(status: .working, lastTool: "read", lastToolDetail: "/src/config.ts")
+        let session = SessionData.mock(status: .working, lastTool: "read", lastToolDetail: "/src/config.ts")
         XCTAssertEqual(session.contextLine, "Reading config.ts")
     }
 
@@ -2062,7 +2096,7 @@ final class SessionTests: XCTestCase {
             "context_compacted": true
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
         XCTAssertEqual(session.sessionId, "old-session")
         XCTAssertEqual(session.status, .working)
     }
@@ -2070,12 +2104,12 @@ final class SessionTests: XCTestCase {
     // MARK: - Host classification (Phase 1, file-local, bundle-id only)
 
     func testHostClassClaudeDesktopIsDesktop() {
-        let session = Session.mock(terminal: TerminalInfo(bundleId: "com.anthropic.claudefordesktop"))
+        let session = SessionData.mock(terminal: TerminalInfo(bundleId: "com.anthropic.claudefordesktop"))
         XCTAssertEqual(session.hostClass, .desktop)
     }
 
     func testCodexDesktopBundleWithoutSourceIsOnlyFocusEvidence() {
-        let session = Session.mock(terminal: TerminalInfo(bundleId: "com.openai.codex"))
+        let session = SessionData.mock(terminal: TerminalInfo(bundleId: "com.openai.codex"))
         XCTAssertEqual(session.hostClass, .ambiguous)
         XCTAssertEqual(session.trustedHostApp, .codexDesktop)
     }
@@ -2083,7 +2117,7 @@ final class SessionTests: XCTestCase {
     // A `cc` session is never hosted by Codex Desktop: that bundle id can only be
     // launcher environment leaked into a Claude Code child process (issue #155).
     func testHostClassCcIgnoresLeakedCodexDesktopBundle() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(bundleId: "com.openai.codex"),
             source: "cc"
         )
@@ -2093,7 +2127,7 @@ final class SessionTests: XCTestCase {
 
     // Symmetric: a `codex` session is never hosted by Claude Desktop.
     func testHostClassCodexIgnoresLeakedClaudeDesktopBundle() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(bundleId: "com.anthropic.claudefordesktop"),
             source: "codex"
         )
@@ -2104,7 +2138,7 @@ final class SessionTests: XCTestCase {
 
     // Claude Desktop remains trusted for its matching `cc` source.
     func testHostClassCcWithClaudeDesktopBundleIsDesktop() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(bundleId: "com.anthropic.claudefordesktop"),
             source: "cc"
         )
@@ -2113,7 +2147,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testCodexPersistedAppBundleIsNotFocusEvidence() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(bundleId: "com.openai.codex"),
             source: "codex"
         )
@@ -2122,7 +2156,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testHostClassOpencodeIgnoresLeakedCodexDesktopBundle() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(bundleId: "com.openai.codex"),
             source: "opencode"
         )
@@ -2131,7 +2165,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testHostClassPiIgnoresLeakedClaudeDesktopBundle() {
-        let session = Session.mock(
+        let session = SessionData.mock(
             terminal: TerminalInfo(bundleId: "com.anthropic.claudefordesktop"),
             source: "pi"
         )
@@ -2141,49 +2175,49 @@ final class SessionTests: XCTestCase {
     }
 
     func testHostClassITerm2IsTerminal() {
-        let session = Session.mock(terminal: TerminalInfo(bundleId: "com.googlecode.iterm2"))
+        let session = SessionData.mock(terminal: TerminalInfo(bundleId: "com.googlecode.iterm2"))
         XCTAssertEqual(session.hostClass, .terminal)
     }
 
     func testHostClassVSCodeIsTerminal() {
-        let session = Session.mock(terminal: TerminalInfo(bundleId: "com.microsoft.VSCode"))
+        let session = SessionData.mock(terminal: TerminalInfo(bundleId: "com.microsoft.VSCode"))
         XCTAssertEqual(session.hostClass, .terminal)
     }
 
     func testHostClassNilTerminalIsAmbiguous() {
-        let session = Session.mock(terminal: nil)
+        let session = SessionData.mock(terminal: nil)
         XCTAssertEqual(session.hostClass, .ambiguous)
     }
 
     func testHostClassMissingBundleIdIsAmbiguous() {
-        let session = Session.mock(terminal: TerminalInfo(program: "weird-term"))
+        let session = SessionData.mock(terminal: TerminalInfo(program: "weird-term"))
         XCTAssertEqual(session.hostClass, .ambiguous)
     }
 
     func testHostClassEmptyBundleIdIsAmbiguous() {
-        let session = Session.mock(terminal: TerminalInfo(bundleId: ""))
+        let session = SessionData.mock(terminal: TerminalInfo(bundleId: ""))
         XCTAssertEqual(session.hostClass, .ambiguous)
     }
 
     func testHostClassUnknownBundleIdIsAmbiguous() {
-        let session = Session.mock(terminal: TerminalInfo(bundleId: "com.example.unknownterm"))
+        let session = SessionData.mock(terminal: TerminalInfo(bundleId: "com.example.unknownterm"))
         XCTAssertEqual(session.hostClass, .ambiguous)
     }
 
     // `source` must NEVER classify: it cannot tell desktop from CLI.
     func testHostClassSourceCodexWithoutBundleIdIsAmbiguous() {
-        let session = Session.mock(terminal: nil, source: "codex")
+        let session = SessionData.mock(terminal: nil, source: "codex")
         XCTAssertEqual(session.hostClass, .ambiguous)
     }
 
     func testHostClassSourceCcWithoutBundleIdIsAmbiguous() {
-        let session = Session.mock(terminal: nil, source: "cc")
+        let session = SessionData.mock(terminal: nil, source: "cc")
         XCTAssertEqual(session.hostClass, .ambiguous)
     }
 
     // bundle id wins over source: Codex CLI running inside iTerm2 is terminal.
     func testHostClassCodexCliInTerminalIsTerminal() {
-        let session = Session.mock(terminal: TerminalInfo(bundleId: "com.googlecode.iterm2"), source: "codex")
+        let session = SessionData.mock(terminal: TerminalInfo(bundleId: "com.googlecode.iterm2"), source: "codex")
         XCTAssertEqual(session.hostClass, .terminal)
     }
 
@@ -2191,18 +2225,18 @@ final class SessionTests: XCTestCase {
     func testHostClassDesktopBundleIdWinsOverMultiplexer() {
         let term = TerminalInfo(bundleId: "com.anthropic.claudefordesktop",
                                 multiplexer: .tmux(socket: "/tmp/s", paneId: "%1", binaryPath: nil))
-        XCTAssertEqual(Session.mock(terminal: term).hostClass, .desktop)
+        XCTAssertEqual(SessionData.mock(terminal: term).hostClass, .desktop)
     }
 
     // A multiplexer is hard terminal evidence (desktop is returned first, so this can't be desktop).
     func testHostClassTmuxWithoutBundleIdIsTerminal() {
         let term = TerminalInfo(multiplexer: .tmux(socket: "/tmp/s", paneId: "%1", binaryPath: nil))
-        XCTAssertEqual(Session.mock(terminal: term).hostClass, .terminal)
+        XCTAssertEqual(SessionData.mock(terminal: term).hostClass, .terminal)
     }
 
     func testHostClassZellijWithoutBundleIdIsTerminal() {
         let term = TerminalInfo(multiplexer: .zellij(sessionName: "main", paneId: "0", binaryPath: nil))
-        XCTAssertEqual(Session.mock(terminal: term).hostClass, .terminal)
+        XCTAssertEqual(SessionData.mock(terminal: term).hostClass, .terminal)
     }
 
     func testHostClassCmuxWithoutBundleIdIsTerminal() {
@@ -2215,24 +2249,24 @@ final class SessionTests: XCTestCase {
                 binaryPath: nil
             )
         )
-        XCTAssertEqual(Session.mock(terminal: term).hostClass, .terminal)
+        XCTAssertEqual(SessionData.mock(terminal: term).hostClass, .terminal)
     }
 
     func testHostClassCmuxBundleIdIsTerminal() {
         let term = TerminalInfo(bundleId: "com.cmuxterm.app")
-        XCTAssertEqual(Session.mock(terminal: term).hostClass, .terminal)
+        XCTAssertEqual(SessionData.mock(terminal: term).hostClass, .terminal)
     }
 
     // tty alone is NOT hard evidence — it can be env-copied (env["TTY"]) and inherited by GUI children.
     func testHostClassTtyOnlyIsAmbiguous() {
         let term = TerminalInfo(tty: "/dev/ttys003")
-        XCTAssertEqual(Session.mock(terminal: term).hostClass, .ambiguous)
+        XCTAssertEqual(SessionData.mock(terminal: term).hostClass, .ambiguous)
     }
 
     // program name alone is env-only and leaks to GUI children → must not classify terminal.
     func testHostClassProgramOnlyIsAmbiguous() {
         let term = TerminalInfo(program: "iTerm.app")
-        XCTAssertEqual(Session.mock(terminal: term).hostClass, .ambiguous)
+        XCTAssertEqual(SessionData.mock(terminal: term).hostClass, .ambiguous)
     }
 
     // MARK: - Transient lifecycle field
@@ -2247,13 +2281,13 @@ final class SessionTests: XCTestCase {
             "terminal": {"program": "Code"}
         }
         """
-        let session = try JSONDecoder.sessionDecoder.decode(Session.self, from: Data(json.utf8))
+        let session = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: Data(json.utf8))
         XCTAssertEqual(session.lifecycle, .active)
     }
 
     // The transient field participates in Equatable, so a dormant flip re-renders the card.
     func testLifecycleParticipatesInEquatable() {
-        let base = Session.mock(id: "life-eq")
+        let base = SessionData.mock(id: "life-eq")
         var dormant = base
         dormant.lifecycle = .dormant
         XCTAssertNotEqual(base, dormant)
@@ -2262,12 +2296,12 @@ final class SessionTests: XCTestCase {
 
     // MARK: - Schema tripwire
 
-    /// A `Session` with every optional field populated, both Bools true, and distinct values
+    /// A `SessionData` with every optional field populated, both Bools true, and distinct values
     /// per field. Dates carry whole milliseconds so the sessionEncoder's fractional-second
     /// ISO 8601 format round-trips them exactly. `lifecycle` is deliberately left at `.active`
     /// because it is transient and never persisted.
-    private func makeFullyPopulatedSession() -> Session {
-        Session(
+    private func makeFullyPopulatedSession() -> SessionData {
+        SessionData(
             sessionId: "full-fixture-1",
             harnessSessionId: "full-fixture-1|raw",
             projectPath: "/Users/test/projects/full-fixture",
@@ -2313,7 +2347,7 @@ final class SessionTests: XCTestCase {
         return formatter.date(from: string)!
     }
 
-    private func encodeToDictionary(_ session: Session) throws -> [String: Any] {
+    private func encodeToDictionary(_ session: SessionData) throws -> [String: Any] {
         let data = try JSONEncoder.sessionEncoder.encode(session)
         return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
@@ -2330,11 +2364,11 @@ final class SessionTests: XCTestCase {
     func testFullyPopulatedSessionRoundTripsThroughSessionCoders() throws {
         let session = makeFullyPopulatedSession()
         let data = try JSONEncoder.sessionEncoder.encode(session)
-        let decoded = try JSONDecoder.sessionDecoder.decode(Session.self, from: data)
+        let decoded = try JSONDecoder.sessionDecoder.decode(SessionData.self, from: data)
         XCTAssertEqual(decoded, session)
     }
 
-    // Session-id rotation must be lossless: the rotated copy's persisted JSON differs from the
+    // Session ID rotation must be lossless: the rotated copy's persisted JSON differs from the
     // original in session_id only, so a future field forgotten in withSessionId fails loudly
     // instead of silently resetting on every Claude Code resume.
     func testWithSessionIdPreservesEveryPersistedField() throws {
@@ -2361,15 +2395,15 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(rotated.terminal, newTerminal)
     }
 
-    func testPermanentIDFocusResolverReturnsCurrentObservation() throws {
+    func testPermanentIDFocusResolverReturnsCurrentRecord() throws {
         let targetID = "11111111-2222-4333-8444-555555555555"
-        let target = Session.mock(id: "abc", cctopSessionId: targetID, harnessSessionId: "abc", pid: 111)
-        let other = Session.mock(id: "def", harnessSessionId: "def", pid: 222)
+        let target = SessionData.mock(id: "abc", cctopSessionId: targetID, harnessSessionId: "abc", pid: 111)
+        let other = SessionData.mock(id: "def", harnessSessionId: "def", pid: 222)
 
         let resolved = try XCTUnwrap(
             FocusTargetResolver.currentSession(
                 forCctopSessionID: targetID,
-                in: [other, target]
+                in: userSessionProjection(from: [other, target])
             )
         )
         XCTAssertEqual(resolved.sessionId, "abc")
@@ -2377,51 +2411,57 @@ final class SessionTests: XCTestCase {
 
     func testPermanentIDFocusResolverRejectsInvalidIdentity() {
         let currentID = "11111111-2222-4333-8444-555555555555"
-        let current = Session.mock(id: "current", cctopSessionId: currentID)
+        let current = SessionData.mock(id: "current", cctopSessionId: currentID)
 
-        XCTAssertNil(FocusTargetResolver.currentSession(forCctopSessionID: "111", in: [current]))
+        XCTAssertNil(FocusTargetResolver.currentSession(
+            forCctopSessionID: "111",
+            in: userSessionProjection(from: [current])
+        ))
     }
 
-    func testPermanentIDFocusResolverReturnsNilForMissingObservation() {
+    func testPermanentIDFocusResolverReturnsNilForMissingRecord() {
         let currentID = "11111111-2222-4333-8444-555555555555"
         let missingID = "22222222-3333-4444-8555-666666666666"
-        let current = Session.mock(id: "current", cctopSessionId: currentID)
+        let current = SessionData.mock(id: "current", cctopSessionId: currentID)
 
-        XCTAssertNil(FocusTargetResolver.currentSession(forCctopSessionID: missingID, in: [current]))
+        let userSessions = userSessionProjection(from: [current])
+        XCTAssertNil(FocusTargetResolver.currentSession(forCctopSessionID: missingID, in: userSessions))
         XCTAssertNil(FocusTargetResolver.currentSession(forCctopSessionID: currentID, in: []))
     }
 
-    func testLogicalFocusResolverUsesFirstCanonicalPermanentObservation() {
+    func testLogicalFocusResolverUsesUserSessionDisplayRecord() {
         let cctopSessionID = "11111111-2222-4333-8444-555555555555"
-        let first = Session.mock(id: "first", cctopSessionId: cctopSessionID, pid: 111)
-        let second = Session.mock(id: "second", cctopSessionId: cctopSessionID, pid: 222)
+        let first = SessionData.mock(id: "first", cctopSessionId: cctopSessionID, pid: 111)
+        let second = SessionData.mock(id: "second", cctopSessionId: cctopSessionID, pid: 222)
         let identity = SessionIdentityPolicy.logicalIdentity(for: first)
+        let current = userSession(display: second, records: [first, second])
 
-        XCTAssertEqual(FocusTargetResolver.currentSession(for: identity, in: [first, second])?.pid, 111)
-        XCTAssertEqual(FocusTargetResolver.currentSession(for: identity, in: [second, first])?.pid, 222)
+        XCTAssertEqual(FocusTargetResolver.currentSession(for: identity, in: [current])?.pid, 222)
     }
 
     func testLogicalFocusResolverKeepsLegacyFallbackUniqueAndFailsClosedWhenAmbiguous() {
-        var first = Session.mock(id: "first", pid: 111, source: Session.opencodeSource)
+        var first = SessionData.mock(id: "first", pid: 111, source: SessionData.opencodeSource)
         first.cctopSessionId = nil
-        var duplicate = Session.mock(id: "duplicate", pid: 111, source: Session.opencodeSource)
-        duplicate.cctopSessionId = nil
         let identity = SessionIdentityPolicy.logicalIdentity(for: first)
+        let current = userSession(display: first, records: [first])
+        var conflicting = first
+        conflicting.cctopSessionId = "22222222-3333-4444-8555-666666666666"
+        let conflictingUserSession = userSession(display: conflicting, records: [conflicting])
 
-        XCTAssertEqual(FocusTargetResolver.currentSession(for: identity, in: [first])?.sessionId, "first")
-        XCTAssertNil(FocusTargetResolver.currentSession(for: identity, in: [first, duplicate]))
+        XCTAssertEqual(FocusTargetResolver.currentSession(for: identity, in: [current])?.sessionId, "first")
+        XCTAssertNil(FocusTargetResolver.currentSession(for: identity, in: [current, conflictingUserSession]))
         XCTAssertNil(FocusTargetResolver.currentSession(for: identity, in: []))
     }
 
-    func testRepeatedCctopSessionIDKeepsRowsAndResolvesFirstCanonicalObservation() {
+    func testRepeatedCctopSessionIDKeepsRows() {
         let now = Date()
         let cctopSessionID = "11111111-2222-4333-8444-555555555555"
-        var working = Session.mock(
+        var working = SessionData.mock(
             id: "conv-1", cctopSessionId: cctopSessionID, harnessSessionId: "conv-1", status: .working,
             pid: 111, pidStartTime: 1_000
         )
         working.lastActivity = now.addingTimeInterval(-10)
-        var idle = Session.mock(
+        var idle = SessionData.mock(
             id: "conv-1", cctopSessionId: cctopSessionID, harnessSessionId: "conv-1", status: .idle,
             pid: 999, pidStartTime: 2_000
         )
@@ -2439,27 +2479,19 @@ final class SessionTests: XCTestCase {
         let ordered = SessionDisplayPolicy.activeSessions(from: [idle, working], now: now)
         XCTAssertEqual(ordered.count, 2)
         XCTAssertEqual(snapshot.sessions.map(\.cctopSessionId), [cctopSessionID, cctopSessionID])
-        XCTAssertEqual(
-            FocusTargetResolver.currentSession(forCctopSessionID: cctopSessionID, in: ordered)?.pid,
-            ordered.first?.pid
-        )
-        XCTAssertEqual(
-            FocusTargetResolver.currentSession(forCctopSessionID: cctopSessionID, in: Array(ordered.reversed()))?.pid,
-            ordered.last?.pid
-        )
     }
 
     // MARK: - Cctop session identity
 
     func testNewSessionsReceiveIndependentLowercaseUUIDs() throws {
         let terminal = TerminalInfo(program: "Terminal")
-        let first = Session(sessionId: "same", projectPath: "/tmp/project", branch: "main", terminal: terminal)
-        let second = Session(sessionId: "same", projectPath: "/tmp/project", branch: "main", terminal: terminal)
+        let first = SessionData(sessionId: "same", projectPath: "/tmp/project", branch: "main", terminal: terminal)
+        let second = SessionData(sessionId: "same", projectPath: "/tmp/project", branch: "main", terminal: terminal)
         let firstID = try XCTUnwrap(first.cctopSessionId)
         let secondID = try XCTUnwrap(second.cctopSessionId)
 
-        XCTAssertTrue(Session.isValidCctopSessionId(firstID))
-        XCTAssertTrue(Session.isValidCctopSessionId(secondID))
+        XCTAssertTrue(CctopSessionID.isValid(firstID))
+        XCTAssertTrue(CctopSessionID.isValid(secondID))
         XCTAssertNotEqual(firstID, secondID)
         XCTAssertEqual(firstID, firstID.lowercased())
         XCTAssertEqual(secondID, secondID.lowercased())
@@ -2467,8 +2499,8 @@ final class SessionTests: XCTestCase {
 
     func testCctopSessionIDDoesNotChangeWithFocusTargetMetadata() {
         let cctopSessionID = "11111111-2222-4333-8444-555555555555"
-        let original = Session.mock(cctopSessionId: cctopSessionID, pid: 111, pidStartTime: 1_000)
-        let resumed = Session.mock(cctopSessionId: cctopSessionID, pid: 999, pidStartTime: 2_000)
+        let original = SessionData.mock(cctopSessionId: cctopSessionID, pid: 111, pidStartTime: 1_000)
+        let resumed = SessionData.mock(cctopSessionId: cctopSessionID, pid: 999, pidStartTime: 2_000)
 
         XCTAssertEqual(original.cctopSessionId, resumed.cctopSessionId)
     }
@@ -2494,35 +2526,35 @@ final class CctopSessionIdentityStoreTests: XCTestCase {
         let store = CctopSessionIdentityStore(sessionsDir: sessionsURL)
 
         let codexFirst = try store.resolve(
-            source: Session.codexSource, harnessSessionId: reference, legacySessionId: reference
+            source: SessionData.codexSource, harnessSessionId: reference, legacySessionId: reference
         )
         let codexAgain = try store.resolve(
-            source: Session.codexSource, harnessSessionId: reference, legacySessionId: reference
+            source: SessionData.codexSource, harnessSessionId: reference, legacySessionId: reference
         )
         let claude = try store.resolve(
-            source: Session.ccSource, harnessSessionId: reference, legacySessionId: reference
+            source: SessionData.ccSource, harnessSessionId: reference, legacySessionId: reference
         )
 
         XCTAssertEqual(codexFirst, codexAgain)
         XCTAssertNotEqual(codexFirst, claude)
         XCTAssertNotEqual(codexFirst, reference)
-        XCTAssertTrue(Session.isValidCctopSessionId(codexFirst))
-        XCTAssertTrue(Session.isValidCctopSessionId(claude))
+        XCTAssertTrue(CctopSessionID.isValid(codexFirst))
+        XCTAssertTrue(CctopSessionID.isValid(claude))
     }
 
     func testUnsupportedAndSyntheticReferencesRemainRecordLocal() throws {
         let store = CctopSessionIdentityStore(sessionsDir: sessionsURL)
         let opencodeFirst = try store.resolve(
-            source: Session.opencodeSource, harnessSessionId: "ses_abc", legacySessionId: "ses_abc"
+            source: SessionData.opencodeSource, harnessSessionId: "ses_abc", legacySessionId: "ses_abc"
         )
         let opencodeSecond = try store.resolve(
-            source: Session.opencodeSource, harnessSessionId: "ses_abc", legacySessionId: "ses_abc"
+            source: SessionData.opencodeSource, harnessSessionId: "ses_abc", legacySessionId: "ses_abc"
         )
         let piFirst = try store.resolve(
-            source: Session.piSource, harnessSessionId: "pi-123", legacySessionId: "pi-123"
+            source: SessionData.piSource, harnessSessionId: "pi-123", legacySessionId: "pi-123"
         )
         let piSecond = try store.resolve(
-            source: Session.piSource, harnessSessionId: "pi-123", legacySessionId: "pi-123"
+            source: SessionData.piSource, harnessSessionId: "pi-123", legacySessionId: "pi-123"
         )
 
         XCTAssertNotEqual(opencodeFirst, opencodeSecond)
@@ -2534,10 +2566,10 @@ final class CctopSessionIdentityStoreTests: XCTestCase {
         let store = CctopSessionIdentityStore(sessionsDir: sessionsURL)
 
         let first = try store.resolve(
-            source: Session.piSource, harnessSessionId: reference, legacySessionId: reference
+            source: SessionData.piSource, harnessSessionId: reference, legacySessionId: reference
         )
         let resumed = try store.resolve(
-            source: Session.piSource, harnessSessionId: reference, legacySessionId: reference
+            source: SessionData.piSource, harnessSessionId: reference, legacySessionId: reference
         )
 
         XCTAssertEqual(first, resumed)
@@ -2551,7 +2583,7 @@ final class CctopSessionIdentityStoreTests: XCTestCase {
             source: nil, harnessSessionId: nil, legacySessionId: reference
         )
         let stamped = try store.resolve(
-            source: Session.ccSource, harnessSessionId: reference, legacySessionId: reference
+            source: SessionData.ccSource, harnessSessionId: reference, legacySessionId: reference
         )
 
         XCTAssertEqual(legacy, stamped)
@@ -2571,7 +2603,7 @@ final class CctopSessionIdentityStoreTests: XCTestCase {
                 defer { group.leave() }
                 do {
                     let id = try CctopSessionIdentityStore(sessionsDir: self.sessionsURL).resolve(
-                        source: Session.codexSource,
+                        source: SessionData.codexSource,
                         harnessSessionId: reference,
                         legacySessionId: reference
                     )
@@ -2608,7 +2640,7 @@ final class CctopSessionIdentityStoreTests: XCTestCase {
         let reference = "11111111-2222-4333-8444-555555555555"
         let store = CctopSessionIdentityStore(sessionsDir: sessionsURL)
         _ = try store.resolve(
-            source: Session.codexSource, harnessSessionId: reference, legacySessionId: reference
+            source: SessionData.codexSource, harnessSessionId: reference, legacySessionId: reference
         )
         let identityDirectory = rootURL.appendingPathComponent("session-identities", isDirectory: true)
         let mapping = try XCTUnwrap(
@@ -2619,7 +2651,7 @@ final class CctopSessionIdentityStoreTests: XCTestCase {
 
         XCTAssertThrowsError(
             try store.resolve(
-                source: Session.codexSource, harnessSessionId: reference, legacySessionId: reference
+                source: SessionData.codexSource, harnessSessionId: reference, legacySessionId: reference
             )
         )
     }

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -599,7 +599,9 @@ final class SessionTests: XCTestCase {
         )
         let second = SessionData.mock(
             id: "codex-thread-1", cctopSessionId: "22222222-2222-4222-8222-222222222222",
-            pid: 67_890, source: SessionData.codexSource
+            pid: 67_890,
+            terminal: TerminalInfo(bundleId: HostAppBundleID.claudeDesktop),
+            source: SessionData.ccSource
         )
 
         XCTAssertNil(
@@ -608,6 +610,26 @@ final class SessionTests: XCTestCase {
                 in: userSessionProjection(from: [first, second])
             )
         )
+    }
+
+    func testLegacyNotificationPayloadUsesAuthoritativeIdentityWhenRetainedRecordConflicts() {
+        let stale = SessionData.mock(
+            id: "codex-thread-1", cctopSessionId: "11111111-1111-4111-8111-111111111111",
+            pid: 12_345, source: SessionData.codexSource
+        )
+        let current = SessionData.mock(
+            id: "codex-thread-1", cctopSessionId: "22222222-2222-4222-8222-222222222222",
+            pid: 67_890, source: SessionData.codexSource
+        )
+
+        let resolvedID = SessionIdentityPolicy.notificationCctopSessionID(
+            matchingNotificationUserInfo: [
+                SessionIdentityPolicy.notificationSessionIDKey: "codex-thread-1",
+            ],
+            in: [userSession(display: current, records: [stale, current])]
+        )
+
+        XCTAssertEqual(resolvedID, current.cctopSessionId)
     }
 
     func testLegacyNotificationPayloadFailsClosedWhenOneMatchingUserSessionIsUnstamped() {

--- a/menubar/CctopMenubarTests/SnapshotTests.swift
+++ b/menubar/CctopMenubarTests/SnapshotTests.swift
@@ -127,7 +127,10 @@ final class SnapshotTests: XCTestCase {
     ///   make snapshots
     func testGenerateMenubarScreenshot() throws {
         let view = PopupView(
-            sessions: Session.qaShowcase, updater: DisabledUpdater(), pluginManager: inertPluginManager()
+            sessions: SessionData.qaShowcase,
+            userSessions: userSessionProjection(from: SessionData.qaShowcase),
+            updater: DisabledUpdater(),
+            pluginManager: inertPluginManager()
         )
         try renderScreenshot(view: view, colorScheme: .light, filename: "menubar-light.png")
         try renderScreenshot(view: view, colorScheme: .dark, filename: "menubar-dark.png")
@@ -137,7 +140,9 @@ final class SnapshotTests: XCTestCase {
         let rc = NavigateController()
         rc.isActive = true
         let view = PopupView(
-            sessions: Array(Session.qaShowcase.prefix(4)), updater: DisabledUpdater(),
+            sessions: Array(SessionData.qaShowcase.prefix(4)),
+            userSessions: userSessionProjection(from: Array(SessionData.qaShowcase.prefix(4))),
+            updater: DisabledUpdater(),
             pluginManager: inertPluginManager(), navigate: rc
         )
         try renderScreenshot(view: view, colorScheme: .dark, filename: "menubar-navigate.png")
@@ -185,7 +190,9 @@ final class SnapshotTests: XCTestCase {
 
     func testGenerateRecentProjectsScreenshot() throws {
         let view = PopupView(
-            sessions: Session.qaShowcase, recentProjects: RecentProject.mockRecents,
+            sessions: SessionData.qaShowcase,
+            userSessions: userSessionProjection(from: SessionData.qaShowcase),
+            recentProjects: RecentProject.mockRecents,
             updater: DisabledUpdater(), pluginManager: inertPluginManager(), initialTab: .recent
         )
         try renderScreenshot(view: view, colorScheme: .dark, filename: "menubar-recent.png")
@@ -204,73 +211,73 @@ final class SnapshotTests: XCTestCase {
         let sessions = [
             recentProofSession(
                 projectPath: "/", projectName: "root",
-                branch: "main", source: Session.ccSource,
+                branch: "main", source: SessionData.ccSource,
                 terminal: TerminalInfo(program: "Terminal", bundleId: "com.apple.Terminal"),
                 endedAt: now
             ),
             recentProofSession(
                 projectPath: home, projectName: URL(fileURLWithPath: home).lastPathComponent,
-                branch: "main", source: Session.ccSource,
+                branch: "main", source: SessionData.ccSource,
                 terminal: TerminalInfo(program: "ghostty", bundleId: "com.mitchellh.ghostty"),
                 endedAt: now.addingTimeInterval(-30)
             ),
             recentProofSession(
                 projectPath: projectContainerPath, projectName: "projects",
-                branch: "main", source: Session.codexSource,
+                branch: "main", source: SessionData.codexSource,
                 terminal: TerminalInfo(program: "Cursor"),
                 endedAt: now.addingTimeInterval(-60)
             ),
             recentProofSession(
                 projectPath: "/tmp/cctop-noise", projectName: "cctop-noise",
-                branch: "main", source: Session.codexSource,
+                branch: "main", source: SessionData.codexSource,
                 terminal: TerminalInfo(program: "Cursor"),
                 endedAt: now.addingTimeInterval(-90)
             ),
             recentProofSession(
                 projectPath: "/private/tmp/cctop-noise", projectName: "private-noise",
-                branch: "main", source: Session.ccSource,
+                branch: "main", source: SessionData.ccSource,
                 terminal: TerminalInfo(program: "ghostty", bundleId: "com.mitchellh.ghostty"),
                 endedAt: now.addingTimeInterval(-120)
             ),
             recentProofSession(
                 projectPath: "/var/folders/zz/cctop-noise", projectName: "var-noise",
-                branch: "main", source: Session.opencodeSource,
+                branch: "main", source: SessionData.opencodeSource,
                 terminal: TerminalInfo(program: "Terminal", bundleId: "com.apple.Terminal"),
                 endedAt: now.addingTimeInterval(-150)
             ),
             recentProofSession(
                 projectPath: cachePath, projectName: "cache-noise",
-                branch: "main", source: Session.piSource,
+                branch: "main", source: SessionData.piSource,
                 terminal: TerminalInfo(program: "Zed"),
                 endedAt: now.addingTimeInterval(-180)
             ),
             recentProofSession(
                 projectPath: missingPath, projectName: "missing-noise",
-                branch: "main", source: Session.codexSource,
+                branch: "main", source: SessionData.codexSource,
                 terminal: TerminalInfo(program: "Code"),
                 endedAt: now.addingTimeInterval(-210)
             ),
             recentProofSession(
                 projectPath: durableEditorPath, projectName: "cctop",
-                branch: "codex/recent-projects-open-project", source: Session.codexSource,
+                branch: "codex/recent-projects-open-project", source: SessionData.codexSource,
                 terminal: TerminalInfo(program: "Cursor", bundleId: "com.todesktop.230313mzl4w4u92"),
                 endedAt: now.addingTimeInterval(-240)
             ),
             recentProofSession(
                 projectPath: durableEditorPath, projectName: "cctop",
-                branch: "codex/recent-projects-open-project", source: Session.ccSource,
+                branch: "codex/recent-projects-open-project", source: SessionData.ccSource,
                 terminal: TerminalInfo(program: "Cursor"),
                 endedAt: now.addingTimeInterval(-300)
             ),
             recentProofSession(
                 projectPath: durableTerminalPath, projectName: "irb",
-                branch: "master", source: Session.ccSource,
+                branch: "master", source: SessionData.ccSource,
                 terminal: TerminalInfo(program: "ghostty", bundleId: "com.mitchellh.ghostty"),
                 endedAt: now.addingTimeInterval(-360)
             ),
             recentProofSession(
                 projectPath: durableFallbackPath, projectName: "rdoc",
-                branch: "unknown", source: Session.codexSource,
+                branch: "unknown", source: SessionData.codexSource,
                 terminal: TerminalInfo(program: "Codex"),
                 endedAt: now.addingTimeInterval(-420)
             ),
@@ -296,6 +303,7 @@ final class SnapshotTests: XCTestCase {
 
         let view = PopupView(
             sessions: [],
+            userSessions: [],
             recentProjects: recentProjects,
             updater: DisabledUpdater(),
             pluginManager: inertPluginManager(),
@@ -314,19 +322,19 @@ final class SnapshotTests: XCTestCase {
         let sessions = [
             recentProofSession(
                 projectPath: "/tmp/cctop-noise", projectName: "tmp-noise",
-                branch: "main", source: Session.codexSource,
+                branch: "main", source: SessionData.codexSource,
                 terminal: TerminalInfo(program: "Cursor"),
                 endedAt: Date()
             ),
             recentProofSession(
                 projectPath: "\(home)/Library/Caches/cctop-noise", projectName: "cache-noise",
-                branch: "main", source: Session.ccSource,
+                branch: "main", source: SessionData.ccSource,
                 terminal: TerminalInfo(program: "Ghostty"),
                 endedAt: Date().addingTimeInterval(-60)
             ),
             recentProofSession(
                 projectPath: "\(home)/projects/missing-recent-proof", projectName: "missing-noise",
-                branch: "main", source: Session.codexSource,
+                branch: "main", source: SessionData.codexSource,
                 terminal: TerminalInfo(program: "Code"),
                 endedAt: Date().addingTimeInterval(-120)
             ),
@@ -337,6 +345,7 @@ final class SnapshotTests: XCTestCase {
 
         let view = PopupView(
             sessions: [],
+            userSessions: [],
             recentProjects: recentProjects,
             updater: DisabledUpdater(),
             pluginManager: inertPluginManager(),
@@ -403,6 +412,7 @@ final class SnapshotTests: XCTestCase {
 
         let view = PopupView(
             sessions: [],
+            userSessions: [],
             recentResumeTargets: targets,
             updater: DisabledUpdater(),
             pluginManager: inertPluginManager(),
@@ -419,7 +429,8 @@ final class SnapshotTests: XCTestCase {
 
     func testGenerateCleanupScreenshot() throws {
         let view = PopupView(
-            sessions: Session.qaShowcase,
+            sessions: SessionData.qaShowcase,
+            userSessions: userSessionProjection(from: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: WorktreeCleanupCandidate.mockCandidates.filter(\.state.isActionable),
             updater: DisabledUpdater(),
@@ -433,7 +444,8 @@ final class SnapshotTests: XCTestCase {
         let candidates = WorktreeCleanupCandidate.mockCandidates.filter(\.state.isActionable)
         let directoryName = "cctop-cleanup-discoverability-proof-\(Int(Date().timeIntervalSince1970))"
         let normalView = PopupView(
-            sessions: Session.qaShowcase,
+            sessions: SessionData.qaShowcase,
+            userSessions: userSessionProjection(from: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: candidates,
             updater: DisabledUpdater(),
@@ -441,7 +453,8 @@ final class SnapshotTests: XCTestCase {
             initialTab: .cleanup
         )
         let scanningView = PopupView(
-            sessions: Session.qaShowcase,
+            sessions: SessionData.qaShowcase,
+            userSessions: userSessionProjection(from: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: candidates,
             cleanupIsScanning: true,
@@ -450,7 +463,8 @@ final class SnapshotTests: XCTestCase {
             initialTab: .cleanup
         )
         let nudgedView = PopupView(
-            sessions: Session.qaShowcase,
+            sessions: SessionData.qaShowcase,
+            userSessions: userSessionProjection(from: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: candidates,
             cleanupHasUnseenCandidates: true,
@@ -494,7 +508,8 @@ final class SnapshotTests: XCTestCase {
         let candidates = [clean, review]
 
         let cleanView = PopupView(
-            sessions: Session.qaShowcase,
+            sessions: SessionData.qaShowcase,
+            userSessions: userSessionProjection(from: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: candidates,
             updater: DisabledUpdater(),
@@ -503,7 +518,8 @@ final class SnapshotTests: XCTestCase {
             initialCleanupCandidate: clean
         )
         let reviewView = PopupView(
-            sessions: Session.qaShowcase,
+            sessions: SessionData.qaShowcase,
+            userSessions: userSessionProjection(from: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: candidates,
             updater: DisabledUpdater(),
@@ -533,7 +549,10 @@ final class SnapshotTests: XCTestCase {
         for theme in AppTheme.allCases {
             ThemeManager.shared.setTheme(theme)
             let view = PopupView(
-                sessions: Session.qaShowcase, updater: DisabledUpdater(), pluginManager: inertPluginManager()
+                sessions: SessionData.qaShowcase,
+                userSessions: userSessionProjection(from: SessionData.qaShowcase),
+                updater: DisabledUpdater(),
+                pluginManager: inertPluginManager()
             )
             try renderScreenshot(view: view, colorScheme: .dark, filename: "theme-\(theme.rawValue)-dark.png")
             try renderScreenshot(view: view, colorScheme: .light, filename: "theme-\(theme.rawValue)-light.png")
@@ -559,8 +578,8 @@ final class SnapshotTests: XCTestCase {
         source: String?,
         terminal: TerminalInfo?,
         endedAt: Date
-    ) -> Session {
-        Session(
+    ) -> SessionData {
+        SessionData(
             sessionId: UUID().uuidString,
             projectPath: projectPath,
             projectName: projectName,

--- a/menubar/CctopMenubarTests/StatusCountsSessionInitTests.swift
+++ b/menubar/CctopMenubarTests/StatusCountsSessionInitTests.swift
@@ -8,7 +8,7 @@ final class StatusCountsSessionInitTests: XCTestCase {
     }
 
     func testIdle_countsAsIdle() {
-        let sessions = [Session.mock(status: .idle)]
+        let sessions = [SessionData.mock(status: .idle)]
         let counts = StatusCounts(sessions: sessions)
         XCTAssertEqual(counts.idle, 1)
         XCTAssertEqual(counts.working, 0)
@@ -16,7 +16,7 @@ final class StatusCountsSessionInitTests: XCTestCase {
 
     func testFreshActiveIdle_countsAsIdle() {
         let now = Date()
-        var session = Session.mock(status: .idle)
+        var session = SessionData.mock(status: .idle)
         session.lifecycle = .active
         session.lastActivity = now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval + 60)
 
@@ -28,7 +28,7 @@ final class StatusCountsSessionInitTests: XCTestCase {
 
     func testStaleActiveIdle_isExcludedFromCounts() {
         let now = Date()
-        var session = Session.mock(status: .idle)
+        var session = SessionData.mock(status: .idle)
         session.lifecycle = .active
         session.lastActivity = now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 60)
 
@@ -39,7 +39,7 @@ final class StatusCountsSessionInitTests: XCTestCase {
     }
 
     func testDormantSession_isExcludedFromCounts() {
-        var session = Session.mock(status: .waitingPermission)
+        var session = SessionData.mock(status: .waitingPermission)
         session.lifecycle = .dormant
 
         let counts = StatusCounts(sessions: [session])
@@ -49,44 +49,44 @@ final class StatusCountsSessionInitTests: XCTestCase {
     }
 
     func testWorking_countsAsWorking() {
-        let sessions = [Session.mock(status: .working)]
+        let sessions = [SessionData.mock(status: .working)]
         let counts = StatusCounts(sessions: sessions)
         XCTAssertEqual(counts.working, 1)
     }
 
     func testCompacting_countsAsWorking() {
-        let sessions = [Session.mock(status: .compacting)]
+        let sessions = [SessionData.mock(status: .compacting)]
         let counts = StatusCounts(sessions: sessions)
         XCTAssertEqual(counts.working, 1)
     }
 
     func testWaitingPermission_countsAsPermission() {
-        let sessions = [Session.mock(status: .waitingPermission)]
+        let sessions = [SessionData.mock(status: .waitingPermission)]
         let counts = StatusCounts(sessions: sessions)
         XCTAssertEqual(counts.permission, 1)
     }
 
     func testWaitingInput_countsAsAttention() {
-        let sessions = [Session.mock(status: .waitingInput)]
+        let sessions = [SessionData.mock(status: .waitingInput)]
         let counts = StatusCounts(sessions: sessions)
         XCTAssertEqual(counts.attention, 1)
     }
 
     func testNeedsAttention_countsAsAttention() {
-        let sessions = [Session.mock(status: .needsAttention)]
+        let sessions = [SessionData.mock(status: .needsAttention)]
         let counts = StatusCounts(sessions: sessions)
         XCTAssertEqual(counts.attention, 1)
     }
 
     func testMixedStatuses_aggregatesCorrectly() {
         let sessions = [
-            Session.mock(id: "1", status: .idle),
-            Session.mock(id: "2", status: .idle),
-            Session.mock(id: "3", status: .working),
-            Session.mock(id: "4", status: .compacting),
-            Session.mock(id: "5", status: .waitingPermission),
-            Session.mock(id: "6", status: .waitingInput),
-            Session.mock(id: "7", status: .needsAttention),
+            SessionData.mock(id: "1", status: .idle),
+            SessionData.mock(id: "2", status: .idle),
+            SessionData.mock(id: "3", status: .working),
+            SessionData.mock(id: "4", status: .compacting),
+            SessionData.mock(id: "5", status: .waitingPermission),
+            SessionData.mock(id: "6", status: .waitingInput),
+            SessionData.mock(id: "7", status: .needsAttention),
         ]
         let counts = StatusCounts(sessions: sessions)
         XCTAssertEqual(counts.idle, 2)

--- a/menubar/CctopMenubarTests/WorkspaceFileTests.swift
+++ b/menubar/CctopMenubarTests/WorkspaceFileTests.swift
@@ -19,17 +19,17 @@ final class WorkspaceFileTests: XCTestCase {
         let wsPath = (tempDir as NSString).appendingPathComponent("project.code-workspace")
         FileManager.default.createFile(atPath: wsPath, contents: Data("{}".utf8))
 
-        let result = Session.findWorkspaceFile(in: tempDir)
+        let result = SessionData.findWorkspaceFile(in: tempDir)
         XCTAssertEqual(result, wsPath)
     }
 
     func testReturnsNilWhenNoWorkspaceFile() {
-        let result = Session.findWorkspaceFile(in: tempDir)
+        let result = SessionData.findWorkspaceFile(in: tempDir)
         XCTAssertNil(result)
     }
 
     func testReturnsNilForNonexistentDirectory() {
-        let result = Session.findWorkspaceFile(in: "/nonexistent/path/\(UUID().uuidString)")
+        let result = SessionData.findWorkspaceFile(in: "/nonexistent/path/\(UUID().uuidString)")
         XCTAssertNil(result)
     }
 
@@ -40,7 +40,7 @@ final class WorkspaceFileTests: XCTestCase {
         FileManager.default.createFile(atPath: matchPath, contents: Data("{}".utf8))
         FileManager.default.createFile(atPath: otherPath, contents: Data("{}".utf8))
 
-        let result = Session.findWorkspaceFile(in: tempDir)
+        let result = SessionData.findWorkspaceFile(in: tempDir)
         XCTAssertEqual(result, matchPath)
     }
 
@@ -50,7 +50,7 @@ final class WorkspaceFileTests: XCTestCase {
         FileManager.default.createFile(atPath: path1, contents: Data("{}".utf8))
         FileManager.default.createFile(atPath: path2, contents: Data("{}".utf8))
 
-        let result = Session.findWorkspaceFile(in: tempDir)
+        let result = SessionData.findWorkspaceFile(in: tempDir)
         XCTAssertNil(result)
     }
 
@@ -60,7 +60,7 @@ final class WorkspaceFileTests: XCTestCase {
         FileManager.default.createFile(atPath: txtPath, contents: Data("".utf8))
         FileManager.default.createFile(atPath: swiftPath, contents: Data("".utf8))
 
-        let result = Session.findWorkspaceFile(in: tempDir)
+        let result = SessionData.findWorkspaceFile(in: tempDir)
         XCTAssertNil(result)
     }
 }

--- a/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
@@ -310,11 +310,12 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
     private func cleanupPopup(
         candidates: [WorktreeCleanupCandidate],
         selectedCandidate: WorktreeCleanupCandidate? = nil,
-        sessions: [Session] = Session.qaShowcase,
+        sessions: [SessionData] = SessionData.qaShowcase,
         isScanning: Bool = false
     ) -> PopupView {
         PopupView(
             sessions: sessions,
+            userSessions: userSessionProjection(from: sessions),
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: candidates,
             cleanupIsScanning: isScanning,

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -43,7 +43,7 @@ final class WorktreeCleanupTests: XCTestCase {
             existingPaths: [path],
             inspections: [path: cleanInspection(branch: "codex/archived-desktop")]
         ).candidates(
-            from: [SessionCleanupSource(session: session)],
+            from: [SessionDataCleanupSource(data: session)],
             activeProjectPaths: []
         )
 
@@ -73,7 +73,7 @@ final class WorktreeCleanupTests: XCTestCase {
 
         let result = service.remove(
             staleCleanCandidate,
-            cleanupSources: [SessionCleanupSource(session: session)],
+            cleanupSources: [SessionDataCleanupSource(data: session)],
             activeProjectPaths: [worktreePath]
         )
 
@@ -5172,9 +5172,9 @@ final class WorktreeCleanupTests: XCTestCase {
         name: String = "Generate invoice retry path",
         branch: String = "feature/invoices",
         endedAt: Date? = nil
-    ) -> SessionCleanupSource {
+    ) -> SessionDataCleanupSource {
         let lastActivity = endedAt ?? now
-        let session = Session(
+        let session = SessionData(
             sessionId: id,
             projectPath: path,
             projectName: URL(fileURLWithPath: path).lastPathComponent,
@@ -5191,9 +5191,9 @@ final class WorktreeCleanupTests: XCTestCase {
             sessionName: name,
             endedAt: endedAt ?? lastActivity
         )
-        guard let source = SessionCleanupSource(endedSession: session) else {
+        guard let source = SessionDataCleanupSource(endedSession: session) else {
             XCTFail("historySession helper must create an ended cleanup source")
-            return SessionCleanupSource(session: session)
+            return SessionDataCleanupSource(data: session)
         }
         return source
     }
@@ -5203,8 +5203,8 @@ final class WorktreeCleanupTests: XCTestCase {
         path: String,
         name: String = "Active feature work",
         branch: String = "feature/active"
-    ) -> Session {
-        Session(
+    ) -> SessionData {
+        SessionData(
             sessionId: id,
             projectPath: path,
             projectName: URL(fileURLWithPath: path).lastPathComponent,
@@ -5276,6 +5276,7 @@ final class WorktreeCleanupTests: XCTestCase {
     ) -> PopupView {
         PopupView(
             sessions: [],
+            userSessions: [],
             cleanupCandidates: cleanupCandidates,
             updater: DisabledUpdater(),
             pluginManager: pluginManager ?? inertPluginManager(),


### PR DESCRIPTION
cctop now separates one session file's data from the work session that the user sees. Several current records can represent one work session without changing panel order.

- Renames the decoded payload model to `SessionData`, adds file and runtime evidence in `SessionRecord`, and groups related records in `UserSession`.
- Keeps `SessionManager.sessions` as the canonical visible order while indirect actions resolve the current `UserSession`.
- Makes URL, notification, hiding, and keyboard routing fail closed when identity evidence is invalid, missing, or ambiguous.
- Keeps direct row actions bound to the exact rendered `SessionData` and removes notifications for all applicable retained records.
- Defines `SessionDataCleanupSource` as a cleanup-only projection and documents each model boundary.

## Verification

- `make all`
- Focused navigation and resolver tests: 219 passed
- Exact-worktree app, hook, display-state, and URL-registration parity
