### PR TITLE
Make UserSession the presentation authority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Keep canonical repository guidance in this file. Pointer files, such as `CLAUDE.
 - Keep app liveness, client liveness, visibility, archive state, hidden state, subagent state, and hook provenance separate.
 - If a shared source changes, update all owners in the same change. Shared sources include schemas, hook versions, install paths, and release tooling.
 - For every version change, run `scripts/bump-version.sh <version>`. Do not edit version values separately.
-- Preserve the canonical order from `SessionManager.sessions`. A direct row action must use the exact `SessionData` value that the row shows.
+- Preserve canonical identity and order in `SessionManager.userSessions`. Derive `SessionData` only at the final presentation or direct-action boundary. A direct row action must use the exact `SessionData` value that the row shows.
 - Keep Stream Deck downstream of the app. It reads `~/.cctop/display-state.json` and must not recreate session policy.
 
 ## Driver Workflow

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -122,8 +122,16 @@ Stable-key selection first chooses one authoritative record for each host
 conversation. That record sets the group identity. Older related records remain
 attached as evidence, even when their identity data is stale.
 
-`SessionManager.sessions` remains the canonical visible row order. It contains
-the selected `SessionData` from each visible `UserSession`.
+`SessionManager.userSessions` owns the canonical visible identity and row order.
+It preserves prior `UserSession` order by `LogicalIdentity` while applying the
+existing status-group rules. A presentation or direct-action leaf can read
+`UserSession.displayRecord.data`, but it must not use that value to assign
+identity, control order, or rebuild a `UserSession`.
+
+Every session-file change starts a fresh forward rebuild: decode `SessionData`,
+wrap it in `SessionRecord`, group records into `UserSession`, reconcile group
+order, and then derive presentation data. cctop never flattens an existing
+`UserSession` and uses that data to recreate identity or grouping.
 
 Direct row actions keep the exact rendered `SessionData`. Indirect URL,
 notification, hide, and keyboard actions resolve the current `UserSession` and
@@ -144,12 +152,15 @@ a privacy-safe stale-state diagnostic. It performs one canonical reload and one
 re-resolution, then fails closed if the target is still missing. It never falls
 back to a client conversation reference, PID, or display slot.
 
-`SessionManager` collapses visible records with the same logical identity
-into one panel row before applying its existing status-group ordering. The first
-user-session row position is retained while the existing lifecycle preference
-chooses the display record. Panel, URL focus, DisplayStateWriter, and Stream Deck
-then consume that canonical order. DisplayStateWriter never independently sorts,
-deduplicates, or removes manager rows, so its slots remain a one-to-one projection.
+`SessionManager` collapses visible records with the same logical identity into
+one `UserSession` before applying its existing status-group ordering. It
+reconciles current groups with the prior `UserSession` order by identity. The
+existing lifecycle preference chooses `displayRecord`; it does not choose row
+identity or order. Panel navigation, URL focus, notifications, hiding, and
+`DisplayStateWriter` consume the ordered groups. Presentation code derives
+`SessionData` only from `displayRecord.data`. `DisplayStateWriter` never sorts,
+deduplicates, or removes manager groups, so Stream Deck slots remain a one-to-one
+projection.
 
 A direct pointer or context-menu action focuses the exact current record
 rendered in that row. Keyboard selection instead retains logical identity and

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -19,7 +19,8 @@ The key split is intentional:
 
 This pipeline uses the internal model from
 [`session-files.md`](session-files.md#internal-session-model). The grouping step
-does not change lifecycle, persistence, or canonical row order.
+does not change lifecycle or persistence. Ordered `UserSession` values own the
+canonical visible identity and row order.
 
 ```mermaid
 flowchart TD
@@ -39,10 +40,10 @@ flowchart TD
     H -->|finished| O["Do not publish"]
     H -->|active| I["Group current records into UserSession<br/>using the winner's cctop ID or legacy fallback"]
     H -->|dormant| I
-    I --> J["Choose displayRecord<br/>and preserve canonical row order"]
-    J --> K{"Display lifecycle"}
-    K -->|active| N["Publish through SessionManager.sessions<br/>as active"]
-    K -->|dormant| P["Publish through SessionManager.sessions<br/>as dormant, with neutral status"]
+    I --> J["Choose displayRecord<br/>and apply the existing display-only status adjustment"]
+    J --> K["Reconcile UserSession order<br/>by LogicalIdentity and status group"]
+    K --> N["Publish SessionManager.userSessions"]
+    N --> P["At presentation boundaries, derive SessionData<br/>from each displayRecord.data"]
 ```
 
 ## Lifecycle Derivation

--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -125,7 +125,7 @@
 		SCN000010000000000000001 /* StatusCounts.swift in Sources */ = {isa = PBXBuildFile; fileRef = SCN000020000000000000001 /* StatusCounts.swift */; };
 		MRT000010000000000000001 /* MenubarIconRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MRT000020000000000000001 /* MenubarIconRendererTests.swift */; };
 		SCT000010000000000000001 /* StatusCountsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SCT000020000000000000001 /* StatusCountsTests.swift */; };
-		HVT000010000000000000001 /* StatusCountsSessionInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = HVT000020000000000000001 /* StatusCountsSessionInitTests.swift */; };
+		HVT000010000000000000001 /* StatusCountsUserSessionInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = HVT000020000000000000001 /* StatusCountsUserSessionInitTests.swift */; };
 		SDPT00010000000000000001 /* SessionDisplayPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDPT00020000000000000001 /* SessionDisplayPolicyTests.swift */; };
 		NVT000010000000000000001 /* NotchVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = NVT000020000000000000001 /* NotchVisibilityTests.swift */; };
 		PPO000010000000000000001 /* PanelPositioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = PPO000020000000000000001 /* PanelPositioning.swift */; };
@@ -310,7 +310,7 @@
 		NROW00020000000000000001 /* NotificationSettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsRow.swift; sourceTree = "<group>"; };
 		MRT000020000000000000001 /* MenubarIconRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarIconRendererTests.swift; sourceTree = "<group>"; };
 		SCT000020000000000000001 /* StatusCountsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusCountsTests.swift; sourceTree = "<group>"; };
-		HVT000020000000000000001 /* StatusCountsSessionInitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusCountsSessionInitTests.swift; sourceTree = "<group>"; };
+		HVT000020000000000000001 /* StatusCountsUserSessionInitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusCountsUserSessionInitTests.swift; sourceTree = "<group>"; };
 		SDPT00020000000000000001 /* SessionDisplayPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDisplayPolicyTests.swift; sourceTree = "<group>"; };
 		NVT000020000000000000001 /* NotchVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchVisibilityTests.swift; sourceTree = "<group>"; };
 		PPO000020000000000000001 /* PanelPositioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelPositioning.swift; sourceTree = "<group>"; };
@@ -569,7 +569,7 @@
 				PHV000020000000000000001 /* FloatingPanelMouseEventTests.swift */,
 				MRT000020000000000000001 /* MenubarIconRendererTests.swift */,
 				SCT000020000000000000001 /* StatusCountsTests.swift */,
-				HVT000020000000000000001 /* StatusCountsSessionInitTests.swift */,
+				HVT000020000000000000001 /* StatusCountsUserSessionInitTests.swift */,
 				SDPT00020000000000000001 /* SessionDisplayPolicyTests.swift */,
 				NVT000020000000000000001 /* NotchVisibilityTests.swift */,
 				PLT000020000000000000001 /* PanelLifecycleTests.swift */,
@@ -863,7 +863,7 @@
 				PHV000010000000000000001 /* FloatingPanelMouseEventTests.swift in Sources */,
 				MRT000010000000000000001 /* MenubarIconRendererTests.swift in Sources */,
 				SCT000010000000000000001 /* StatusCountsTests.swift in Sources */,
-				HVT000010000000000000001 /* StatusCountsSessionInitTests.swift in Sources */,
+				HVT000010000000000000001 /* StatusCountsUserSessionInitTests.swift in Sources */,
 				SDPT00010000000000000001 /* SessionDisplayPolicyTests.swift in Sources */,
 				NVT000010000000000000001 /* NotchVisibilityTests.swift in Sources */,
 				PLT000010000000000000001 /* PanelLifecycleTests.swift in Sources */,

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -237,14 +237,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     }
 
     @MainActor private func observeSessionUpdates() {
-        sessionManager.$sessions
+        sessionManager.$userSessions
             .receive(on: RunLoop.main)
-            .sink { [weak self] sessions in
+            .sink { [weak self] userSessions in
                 guard let self else { return }
-                let counts = StatusCounts(sessions: sessions)
+                let counts = StatusCounts(userSessions: userSessions)
 
                 self.displayStateWriter.write(
-                    sessions: sessions,
+                    userSessions: userSessions,
                     theme: ThemeManager.shared.current,
                     appRunning: true
                 )
@@ -269,7 +269,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             .sink { [weak self] _ in
                 guard let self else { return }
                 self.displayStateWriter.write(
-                    sessions: self.sessionManager.sessions,
+                    userSessions: self.sessionManager.userSessions,
                     theme: ThemeManager.shared.current,
                     appRunning: true
                 )
@@ -282,7 +282,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     func applicationWillTerminate(_ notification: Notification) {
         guard let sessionManager else { return }
         displayStateWriter.write(
-            sessions: sessionManager.sessions,
+            userSessions: sessionManager.userSessions,
             theme: ThemeManager.shared.current,
             appRunning: false
         )
@@ -415,11 +415,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             sessionManager.loadSessions()
-            if let session = Self.notificationFocusSession(
+            if let focusTarget = Self.notificationFocusTarget(
                 matchingUserInfo: userInfo,
                 in: sessionManager.userSessions
             ) {
-                focusTerminal(session: session)
+                focusTerminal(session: focusTarget)
             }
         }
         completionHandler()
@@ -433,7 +433,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         completionHandler([.banner, .sound])
     }
 
-    nonisolated static func notificationFocusSession(
+    nonisolated static func notificationFocusTarget(
         matchingUserInfo userInfo: [AnyHashable: Any],
         in userSessions: [UserSession]
     ) -> SessionData? {
@@ -441,10 +441,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             matchingNotificationUserInfo: userInfo,
             in: userSessions
         ) else { return nil }
-        return FocusTargetResolver.currentSession(
+        return FocusTargetResolver.currentUserSession(
             forCctopSessionID: cctopSessionID,
             in: SessionDisplayPolicy.activeSessions(from: userSessions)
-        )
+        )?.focusTarget
     }
 
     private var screenLayouts: [ScreenLayout] {
@@ -504,7 +504,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             guard let self else { return }
             self.suppressResize = false
             self.hasNotch = NSScreen.builtin?.hasPhysicalNotch == true
-            self.refreshStatusDisplay(counts: StatusCounts(sessions: self.sessionManager.sessions))
+            self.refreshStatusDisplay(counts: StatusCounts(userSessions: self.sessionManager.userSessions))
             guard self.panel.isVisible else { return }
             // A click location captured before the debounce must not drive
             // screen-change repositioning; clearing it keeps the key below
@@ -623,7 +623,9 @@ extension AppDelegate {
                     lastExternalApp = prev
                 }
             case .startNavigateMode:
-                navigateController.activate(sessions: SessionDisplayPolicy.activeSessions(from: sessionManager.sessions))
+                navigateController.activate(
+                    userSessions: SessionDisplayPolicy.activeSessions(from: sessionManager.userSessions)
+                )
                 navigateController.startTimeout { [weak self] in
                     self?.handleEvent(.navigateTimedOut)
                 }
@@ -654,9 +656,12 @@ extension AppDelegate {
 
     @MainActor private func jumpToSession(index: Int) {
         guard let identity = navigateController.sessionIdentity(at: index) else { return }
-        let currentSessions = SessionDisplayPolicy.activeSessions(from: sessionManager.userSessions)
-        guard let session = FocusTargetResolver.currentSession(for: identity, in: currentSessions) else { return }
-        focusTerminal(session: session)
+        let currentUserSessions = SessionDisplayPolicy.activeSessions(from: sessionManager.userSessions)
+        guard let userSession = FocusTargetResolver.currentUserSession(
+            for: identity,
+            in: currentUserSessions
+        ) else { return }
+        focusTerminal(session: userSession.focusTarget)
         handleEvent(.navigateConfirmed)
     }
 
@@ -784,41 +789,41 @@ extension AppDelegate {
                 Self.urlLogger.notice("Ignored malformed cctop focus command")
                 return
             }
-            let initialSessions = sessionManager.sessions
-            let initialActiveSessions = SessionDisplayPolicy.activeSessions(from: initialSessions)
-            if let session = FocusTargetResolver.currentSession(
+            let initialUserSessions = sessionManager.userSessions
+            let initialActiveUserSessions = SessionDisplayPolicy.activeSessions(from: initialUserSessions)
+            if let userSession = FocusTargetResolver.currentUserSession(
                 forCctopSessionID: cctopSessionID,
-                in: SessionDisplayPolicy.activeSessions(from: sessionManager.userSessions)
+                in: initialActiveUserSessions
             ) {
-                focusTerminal(session: session)
+                focusTerminal(session: userSession.focusTarget)
                 return
             }
             let displayState = DisplayStateWriter.currentPublishedState()
             logFocusTargetMissBeforeRefresh(
                 requestedID: cctopSessionID,
-                canonicalSessions: initialSessions,
-                activeSessions: initialActiveSessions,
+                userSessions: initialUserSessions,
+                activeUserSessions: initialActiveUserSessions,
                 displayState: displayState
             )
 
             let refreshStart = ProcessInfo.processInfo.systemUptime
             sessionManager.loadSessions()
             let refreshElapsedMilliseconds = (ProcessInfo.processInfo.systemUptime - refreshStart) * 1_000
-            let refreshedSessions = sessionManager.sessions
-            let refreshedActiveSessions = SessionDisplayPolicy.activeSessions(from: refreshedSessions)
-            let resolvedSession = FocusTargetResolver.currentSession(
+            let refreshedUserSessions = sessionManager.userSessions
+            let refreshedActiveUserSessions = SessionDisplayPolicy.activeSessions(from: refreshedUserSessions)
+            let resolvedUserSession = FocusTargetResolver.currentUserSession(
                 forCctopSessionID: cctopSessionID,
-                in: SessionDisplayPolicy.activeSessions(from: sessionManager.userSessions)
+                in: refreshedActiveUserSessions
             )
             logFocusTargetRefreshOutcome(
-                outcome: resolvedSession == nil ? "final_missing" : "recovered_after_refresh",
+                outcome: resolvedUserSession == nil ? "final_missing" : "recovered_after_refresh",
                 requestedID: cctopSessionID,
-                canonicalSessions: refreshedSessions,
-                activeSessions: refreshedActiveSessions,
+                userSessions: refreshedUserSessions,
+                activeUserSessions: refreshedActiveUserSessions,
                 refreshElapsedMilliseconds: refreshElapsedMilliseconds
             )
-            guard let resolvedSession else { return }
-            focusTerminal(session: resolvedSession)
+            guard let resolvedUserSession else { return }
+            focusTerminal(session: resolvedUserSession.focusTarget)
         default:
             break
         }
@@ -840,14 +845,14 @@ extension AppDelegate {
 
     private func logFocusTargetMissBeforeRefresh(
         requestedID: String,
-        canonicalSessions: [SessionData],
-        activeSessions: [SessionData],
+        userSessions: [UserSession],
+        activeUserSessions: [UserSession],
         displayState: DisplayState?
     ) {
         let processPID = ProcessInfo.processInfo.processIdentifier
         let processStartTime = SessionData.processStartTime(pid: UInt32(processPID))
         let appVersion = Bundle.main.appVersion.isEmpty ? "unavailable" : Bundle.main.appVersion
-        let canonicalMatches = canonicalSessions.filter { $0.cctopSessionId == requestedID }
+        let userSessionMatches = userSessions.filter { $0.identity.cctopSessionID == requestedID }
         let processStartValue = processStartTime.map { String($0) } ?? "unavailable"
         let displayGeneratedAt = displayState?.generatedAt ?? "unavailable"
         let displayOwnerPID = displayState.flatMap(\.appPID).map { String($0) } ?? "unavailable"
@@ -863,9 +868,9 @@ extension AppDelegate {
             requested_cctop_session_id=\(requestedID, privacy: .private(mask: .hash)) \
             app_version=\(appVersion, privacy: .public) app_pid=\(processPID, privacy: .public) \
             app_start_time=\(processStartValue, privacy: .public) \
-            canonical_record_count=\(canonicalSessions.count, privacy: .public) \
-            focus_eligible_record_count=\(activeSessions.count, privacy: .public) \
-            requested_id_canonical_matches=\(canonicalMatches.count, privacy: .public) \
+            user_session_count=\(userSessions.count, privacy: .public) \
+            focus_eligible_user_session_count=\(activeUserSessions.count, privacy: .public) \
+            requested_id_user_session_matches=\(userSessionMatches.count, privacy: .public) \
             display_state_generated_at=\(displayGeneratedAt, privacy: .public) \
             display_state_owner_pid=\(displayOwnerPID, privacy: .public) \
             display_state_owner_start_time=\(displayOwnerStartTime, privacy: .public) \
@@ -878,12 +883,12 @@ extension AppDelegate {
     private func logFocusTargetRefreshOutcome(
         outcome: String,
         requestedID: String,
-        canonicalSessions: [SessionData],
-        activeSessions: [SessionData],
+        userSessions: [UserSession],
+        activeUserSessions: [UserSession],
         refreshElapsedMilliseconds: Double
     ) {
-        let canonicalMatchCount = canonicalSessions.count { $0.cctopSessionId == requestedID }
-        let activeMatchCount = activeSessions.count { $0.cctopSessionId == requestedID }
+        let userSessionMatchCount = userSessions.count { $0.identity.cctopSessionID == requestedID }
+        let activeUserSessionMatchCount = activeUserSessions.count { $0.identity.cctopSessionID == requestedID }
         let elapsed = String(format: "%.3f", refreshElapsedMilliseconds)
 
         Self.urlLogger.notice(
@@ -892,10 +897,10 @@ extension AppDelegate {
             outcome=\(outcome, privacy: .public) \
             requested_cctop_session_id=\(requestedID, privacy: .private(mask: .hash)) \
             refresh_elapsed_ms=\(elapsed, privacy: .public) \
-            canonical_record_count=\(canonicalSessions.count, privacy: .public) \
-            focus_eligible_record_count=\(activeSessions.count, privacy: .public) \
-            requested_id_canonical_matches=\(canonicalMatchCount, privacy: .public) \
-            requested_id_active_matches=\(activeMatchCount, privacy: .public)
+            user_session_count=\(userSessions.count, privacy: .public) \
+            focus_eligible_user_session_count=\(activeUserSessions.count, privacy: .public) \
+            requested_id_user_session_matches=\(userSessionMatchCount, privacy: .public) \
+            requested_id_active_user_session_matches=\(activeUserSessionMatchCount, privacy: .public)
             """
         )
     }

--- a/menubar/CctopMenubar/Models/SessionData.swift
+++ b/menubar/CctopMenubar/Models/SessionData.swift
@@ -528,14 +528,6 @@ struct SessionData: Codable, Identifiable, Equatable {
         return nil
     }
 
-    static func sorted(_ sessions: [SessionData]) -> [SessionData] {
-        // Live (active) sessions first, then dormant; within each tier by status, then recency.
-        sessions.sorted {
-            ($0.lifecycle.rawValue, $0.status.sortOrder, $1.lastActivity)
-                < ($1.lifecycle.rawValue, $1.status.sortOrder, $0.lastActivity)
-        }
-    }
-
     static func extractProjectName(_ path: String) -> String {
         URL(fileURLWithPath: path).lastPathComponent
     }

--- a/menubar/CctopMenubar/Models/SessionDisplayPolicy.swift
+++ b/menubar/CctopMenubar/Models/SessionDisplayPolicy.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// Presentation-only grouping for visible retained sessions.
-/// This does not change lifecycle or cleanup semantics.
+/// Selects display buckets and reconciles canonical order on `UserSession` values.
+/// It reads `displayRecord.data` only for lifecycle and status; identity stays on the group.
 enum SessionDisplayPolicy {
     struct Signature: Equatable {
         let activeIDs: [SessionIdentityPolicy.LogicalIdentity]
@@ -12,16 +12,8 @@ enum SessionDisplayPolicy {
 
     static let staleIdleInterval: TimeInterval = 172_800 // 48 hours
 
-    static func activeSessions(from sessions: [SessionData], now: Date = Date()) -> [SessionData] {
-        sessions.filter { isActive($0, now: now) }
-    }
-
     static func activeSessions(from userSessions: [UserSession], now: Date = Date()) -> [UserSession] {
         userSessions.filter { isActive($0.displayRecord.data, now: now) }
-    }
-
-    static func idleSessions(from sessions: [SessionData], now: Date = Date()) -> [SessionData] {
-        sessions.filter { isIdle($0, now: now) }
     }
 
     static func idleSessions(from userSessions: [UserSession], now: Date = Date()) -> [UserSession] {
@@ -29,47 +21,74 @@ enum SessionDisplayPolicy {
     }
 
     /// Keeps Active status groups in priority order while preserving the relative order of peers
-    /// that remain in a group. Sessions entering a group append after its surviving members, and
-    /// the full-array return value leaves the current non-Active remainder unchanged.
-    static func reconcilingActiveOrder(
-        in sessions: [SessionData],
-        preserving previousSessions: [SessionData],
+    /// that remain in a group. Sessions entering a group append after its surviving members.
+    /// Idle groups keep the existing lifecycle, status, and recency order at the manager boundary.
+    static func reconcilingOrder(
+        in userSessions: [UserSession],
+        preserving previousUserSessions: [UserSession],
         now: Date = Date()
-    ) -> [SessionData] {
-        let active = activeSessions(from: sessions, now: now)
-        let activeByKey = Dictionary(
-            active.map { (SessionIdentityPolicy.logicalIdentity(for: $0), $0) },
+    ) -> [UserSession] {
+        let active = activeSessions(from: userSessions, now: now)
+        let activeByIdentity = Dictionary(
+            active.map { ($0.identity, $0) },
             uniquingKeysWith: { first, _ in first }
         )
-        let activeKeys = Set(activeByKey.keys)
-        var groups = Array(repeating: [SessionData](), count: SessionStatus.idle.sortOrder + 1)
-        var placedKeys: Set<SessionIdentityPolicy.LogicalIdentity> = []
+        let activeIdentities = Set(activeByIdentity.keys)
+        var groups = Array(repeating: [UserSession](), count: SessionStatus.idle.sortOrder + 1)
+        var placedIdentities: Set<SessionIdentityPolicy.LogicalIdentity> = []
 
-        for previous in activeSessions(from: previousSessions, now: now) {
-            let key = SessionIdentityPolicy.logicalIdentity(for: previous)
-            guard !placedKeys.contains(key),
-                  let current = activeByKey[key],
+        for previous in activeSessions(from: previousUserSessions, now: now) {
+            guard let current = matchingCurrentUserSession(
+                for: previous,
+                active: active,
+                activeByIdentity: activeByIdentity
+            ),
+                  !placedIdentities.contains(current.identity),
                   current.status.sortOrder == previous.status.sortOrder else { continue }
             groups[current.status.sortOrder].append(current)
-            placedKeys.insert(key)
+            placedIdentities.insert(current.identity)
         }
 
         for current in active {
-            let key = SessionIdentityPolicy.logicalIdentity(for: current)
-            guard placedKeys.insert(key).inserted else { continue }
+            guard placedIdentities.insert(current.identity).inserted else { continue }
             groups[current.status.sortOrder].append(current)
         }
 
         let orderedActive = groups.flatMap { $0 }
-        let nonActive = sessions.filter { !activeKeys.contains(SessionIdentityPolicy.logicalIdentity(for: $0)) }
-        return orderedActive + nonActive
+        let orderedIdle = userSessions
+            .filter { !activeIdentities.contains($0.identity) }
+            .sorted(by: precedesInIdleOrder)
+        return orderedActive + orderedIdle
     }
 
-    static func signature(for sessions: [SessionData], now: Date = Date()) -> Signature {
+    static func signature(for userSessions: [UserSession], now: Date = Date()) -> Signature {
         Signature(
-            activeIDs: activeSessions(from: sessions, now: now).map(SessionIdentityPolicy.logicalIdentity),
-            idleIDs: idleSessions(from: sessions, now: now).map(SessionIdentityPolicy.logicalIdentity)
+            activeIDs: activeSessions(from: userSessions, now: now).map(\.identity),
+            idleIDs: idleSessions(from: userSessions, now: now).map(\.identity)
         )
+    }
+
+    private static func matchingCurrentUserSession(
+        for previous: UserSession,
+        active: [UserSession],
+        activeByIdentity: [SessionIdentityPolicy.LogicalIdentity: UserSession]
+    ) -> UserSession? {
+        if let exact = activeByIdentity[previous.identity] { return exact }
+        guard case .legacy(let stableKey) = previous.identity else { return nil }
+        let matches = active.filter { userSession in
+            userSession.records.contains {
+                SessionIdentityPolicy.stableKey(for: $0.data) == stableKey
+            }
+        }
+        guard matches.count == 1 else { return nil }
+        return matches[0]
+    }
+
+    private static func precedesInIdleOrder(_ left: UserSession, _ right: UserSession) -> Bool {
+        let leftData = left.displayRecord.data
+        let rightData = right.displayRecord.data
+        return (leftData.lifecycle.rawValue, left.status.sortOrder, rightData.lastActivity)
+            < (rightData.lifecycle.rawValue, right.status.sortOrder, leftData.lastActivity)
     }
 
     private static func isStaleActiveIdle(_ session: SessionData, now: Date) -> Bool {

--- a/menubar/CctopMenubar/Models/StatusCounts.swift
+++ b/menubar/CctopMenubar/Models/StatusCounts.swift
@@ -25,13 +25,13 @@ struct StatusCounts: Equatable {
         self.idle = idle
     }
 
-    /// Create counts by aggregating session statuses.
-    init(sessions: [SessionData], now: Date = Date()) {
+    /// Create counts by aggregating user-session statuses.
+    init(userSessions: [UserSession], now: Date = Date()) {
         var perm = 0, attn = 0, work = 0, idleCount = 0
         // Only presentation-active sessions drive the menubar badge. Dormant and stale-idle
         // cards are retained for reachability, not live work, so they never inflate counts.
-        for session in SessionDisplayPolicy.activeSessions(from: sessions, now: now) {
-            switch session.status {
+        for userSession in SessionDisplayPolicy.activeSessions(from: userSessions, now: now) {
+            switch userSession.status {
             case .idle: idleCount += 1
             case .working, .compacting: work += 1
             case .waitingPermission: perm += 1

--- a/menubar/CctopMenubar/Services/DisplayStateWriter.swift
+++ b/menubar/CctopMenubar/Services/DisplayStateWriter.swift
@@ -73,7 +73,7 @@ final class DisplayStateWriter {
 
     private var lastSnapshot: Data?
 
-    func write(sessions: [SessionData], theme: AppTheme, appRunning: Bool, now: Date = Date()) {
+    func write(userSessions: [UserSession], theme: AppTheme, appRunning: Bool, now: Date = Date()) {
         // An Xcode test host launches the app executable but is not a user-facing
         // cctop instance. It must not claim liveness or overwrite the user's surface.
         guard !Self.isXcodeTestHost else { return }
@@ -83,7 +83,7 @@ final class DisplayStateWriter {
             return DisplayState.ProcessIdentity(pid: pid, startTime: startTime)
         }
         let snapshot = Self.snapshot(
-            sessions: sessions,
+            userSessions: userSessions,
             theme: theme,
             appRunning: appRunning,
             appIdentity: appIdentity,
@@ -109,30 +109,30 @@ final class DisplayStateWriter {
     }
 
     static func snapshot(
-        sessions: [SessionData],
+        userSessions: [UserSession],
         theme: AppTheme,
         appRunning: Bool,
         appIdentity: DisplayState.ProcessIdentity?,
         now: Date
     ) -> DisplayState {
-        let ordered = SessionDisplayPolicy.activeSessions(from: sessions, now: now)
+        let ordered = SessionDisplayPolicy.activeSessions(from: userSessions, now: now)
         return DisplayState(
             version: schemaVersion,
             generatedAt: timestampFormatter.string(from: now),
             appRunning: appRunning,
             appPID: appRunning ? appIdentity?.pid : nil,
             appStartTime: appRunning ? appIdentity?.startTime : nil,
-            sessions: ordered.map { session in
-                // SessionManager assigns every publishable legacy record an id before
-                // reaching this boundary. Keep an invalid record in its original slot if
-                // that invariant is ever broken; the consumer renders an empty key rather
-                // than shifting later targets forward.
-                let cctopSessionId = session.cctopSessionId ?? ""
+            sessions: ordered.map { userSession in
+                let data = userSession.displayRecord.data
+                // Permanent identities supply the published key. If a legacy group reaches
+                // this boundary, keep an empty key in its original slot rather than shifting
+                // later targets forward.
+                let cctopSessionId = userSession.identity.cctopSessionID ?? ""
                 return DisplayState.Entry(
                     cctopSessionId: cctopSessionId,
-                    name: session.displayName,
-                    status: session.status.rawValue,
-                    color: hexColor(for: session.status, theme: theme)
+                    name: data.displayName,
+                    status: userSession.status.rawValue,
+                    color: hexColor(for: userSession.status, theme: theme)
                 )
             }
         )

--- a/menubar/CctopMenubar/Services/FocusTargetResolver.swift
+++ b/menubar/CctopMenubar/Services/FocusTargetResolver.swift
@@ -2,22 +2,22 @@ import Foundation
 
 enum FocusTargetResolver {
     /// Resolve permanent identity through the canonical user-session projection.
-    static func currentSession(
+    static func currentUserSession(
         forCctopSessionID cctopSessionID: String,
         in userSessions: [UserSession]
-    ) -> SessionData? {
+    ) -> UserSession? {
         guard CctopSessionID.isValid(cctopSessionID) else { return nil }
-        return userSessions.first { $0.identity.cctopSessionID == cctopSessionID }?.focusTarget
+        return userSessions.first { $0.identity.cctopSessionID == cctopSessionID }
     }
 
     /// Resolve panel/navigation identity through the canonical user-session projection.
     /// Permanent IDs use the canonical group; legacy identities remain unique or fail closed.
-    static func currentSession(
+    static func currentUserSession(
         for identity: SessionIdentityPolicy.LogicalIdentity,
         in userSessions: [UserSession]
-    ) -> SessionData? {
+    ) -> UserSession? {
         if let cctopSessionID = identity.cctopSessionID {
-            return currentSession(forCctopSessionID: cctopSessionID, in: userSessions)
+            return currentUserSession(forCctopSessionID: cctopSessionID, in: userSessions)
         }
 
         guard case .legacy(let stableKey) = identity else { return nil }
@@ -27,6 +27,6 @@ enum FocusTargetResolver {
             }
         }
         guard matches.count == 1 else { return nil }
-        return matches[0].focusTarget
+        return matches[0]
     }
 }

--- a/menubar/CctopMenubar/Services/NavigateController.swift
+++ b/menubar/CctopMenubar/Services/NavigateController.swift
@@ -14,8 +14,8 @@ class NavigateController: ObservableObject {
     }
     private var timeoutWork: DispatchWorkItem?
 
-    func activate(sessions: [SessionData]) {
-        frozenSessionIdentities = sessions.map(SessionIdentityPolicy.logicalIdentity)
+    func activate(userSessions: [UserSession]) {
+        frozenSessionIdentities = userSessions.map(\.identity)
         isActive = true
         didActivateSubject.send()
     }

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -37,9 +37,10 @@ enum SessionIdentityPolicy {
         return .legacy(stableKey(for: session))
     }
 
-    /// The validated permanent cctop session ID, if the session carries one.
-    static func permanentSessionID(for session: SessionData) -> String? {
-        logicalIdentity(for: session).cctopSessionID
+    /// Source-inventory migration helper. Current routing reads identity from `UserSession`.
+    fileprivate static func permanentSessionID(for session: SessionData) -> String? {
+        guard CctopSessionID.isValid(session.cctopSessionId) else { return nil }
+        return session.cctopSessionId
     }
 
     static func notificationRequestIdentifier(forCctopSessionID cctopSessionID: String) -> String? {
@@ -190,15 +191,13 @@ struct ManualSessionVisibilityStore {
         )
     }
 
-    func isHidden(_ session: SessionData) -> Bool {
-        guard let cctopSessionID = session.cctopSessionId,
-              CctopSessionID.isValid(cctopSessionID) else { return false }
+    func isHidden(cctopSessionID: String) -> Bool {
+        guard CctopSessionID.isValid(cctopSessionID) else { return false }
         return hiddenSessionIDs.contains(cctopSessionID)
     }
 
-    func hide(_ session: SessionData) {
-        guard let cctopSessionID = session.cctopSessionId,
-              CctopSessionID.isValid(cctopSessionID) else { return }
+    func hide(cctopSessionID: String) {
+        guard CctopSessionID.isValid(cctopSessionID) else { return }
         var sessionIDs = hiddenSessionIDs
         sessionIDs.insert(cctopSessionID)
         save(sessionIDs)

--- a/menubar/CctopMenubar/Services/SessionLifecyclePolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionLifecyclePolicy.swift
@@ -3,7 +3,7 @@ import Foundation
 /// One `SessionData` value plus the file and runtime evidence for that value.
 /// This in-memory record is not part of the persisted JSON schema.
 /// `mtime` is `.distantPast` when unknown so lifecycle preference remains a total order.
-struct SessionRecord {
+struct SessionRecord: Equatable {
     let data: SessionData
     let lifecycleRank: Int   // 0 = active, 1 = dormant, 2 = finished (lower = preferred)
     let mtime: Date

--- a/menubar/CctopMenubar/Services/SessionManager+Loading.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Loading.swift
@@ -75,8 +75,8 @@ extension SessionManager {
     func assigningCctopSessionIdentities(
         to candidates: [SessionRecord],
         knownRecords: [(url: URL, session: SessionData)]
-    ) -> [SessionData] {
-        var records = candidates.map { (url: URL(fileURLWithPath: $0.path), session: $0.data) }
+    ) -> [SessionRecord] {
+        var records = candidates
         var idsByEvidence: [String: Set<String>] = [:]
         for record in knownRecords where CctopSessionID.isValid(record.session.cctopSessionId) {
             guard let evidence = CctopSessionIdentityStore.durableEvidence(for: record.session),
@@ -85,11 +85,12 @@ extension SessionManager {
         }
 
         let identityStore = CctopSessionIdentityStore(sessionsDir: dataSources.sessionsDir)
-        for index in records.indices where !CctopSessionID.isValid(records[index].session.cctopSessionId) {
-            var data = records[index].session
+        for index in records.indices where !CctopSessionID.isValid(records[index].data.cctopSessionId) {
+            let url = URL(fileURLWithPath: records[index].path)
+            var data = records[index].data
             guard let evidence = CctopSessionIdentityStore.durableEvidence(for: data) else {
                 scheduleCctopSessionIdentityStamp(
-                    url: records[index].url,
+                    url: url,
                     snapshot: data,
                     resolvedID: nil
                 )
@@ -104,22 +105,22 @@ extension SessionManager {
                     knownExistingIDs: knownIDs
                 )
                 data.cctopSessionId = cctopSessionId
-                records[index].session = data
+                records[index] = records[index].replacingData(data)
                 idsByEvidence[evidence, default: []].insert(cctopSessionId)
                 scheduleCctopSessionIdentityStamp(
-                    url: records[index].url,
-                    snapshot: records[index].session,
+                    url: url,
+                    snapshot: records[index].data,
                     resolvedID: cctopSessionId
                 )
             } catch {
-                let fileName = records[index].url.lastPathComponent
+                let fileName = url.lastPathComponent
                 let reason = error.localizedDescription
                 sessionManagerLogger.error(
                     "loadSessions: identity migration failed for \(fileName, privacy: .public): \(reason, privacy: .public)"
                 )
             }
         }
-        return records.map(\.session)
+        return records
     }
 
     func identifiedPublishableCandidates(
@@ -127,15 +128,7 @@ extension SessionManager {
         knownRecords: [(url: URL, session: SessionData)]
     ) -> [SessionRecord] {
         let publishableWinners = winners.filter { $0.data.lifecycle != .finished }
-        let identified = assigningCctopSessionIdentities(to: publishableWinners, knownRecords: knownRecords)
-        return zip(publishableWinners, identified).map { candidate, data in
-            SessionRecord(
-                data: data,
-                lifecycleRank: candidate.lifecycleRank,
-                mtime: candidate.mtime,
-                path: candidate.path
-            )
-        }
+        return assigningCctopSessionIdentities(to: publishableWinners, knownRecords: knownRecords)
     }
 
     func identifyingPersistedRecords(
@@ -146,7 +139,8 @@ extension SessionManager {
         let indices = classification.records.indices.filter { index in
             let record = classification.records[index]
             let data = record.candidate.data
-            guard case .legacy(let stableKey) = SessionIdentityPolicy.logicalIdentity(for: data) else { return false }
+            guard !CctopSessionID.isValid(data.cctopSessionId) else { return false }
+            let stableKey = SessionIdentityPolicy.stableKey(for: data)
             if hasExistingMappedManualHide(data) { return true }
             if legacyKeys.contains(stableKey) { return true }
             guard case .hidden(let reason) = record.disposition else { return false }
@@ -166,17 +160,11 @@ extension SessionManager {
             knownRecords: knownRecords
         )
         var records = classification.records
-        for (index, data) in zip(indices, identified) {
+        for (index, candidate) in zip(indices, identified) {
             let record = records[index]
-            let candidate = record.candidate
             records[index] = ClassifiedSessionRecord(
                 url: record.url,
-                candidate: SessionRecord(
-                    data: data,
-                    lifecycleRank: candidate.lifecycleRank,
-                    mtime: candidate.mtime,
-                    path: candidate.path
-                ),
+                candidate: candidate,
                 disposition: record.disposition
             )
         }

--- a/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
@@ -67,96 +67,100 @@ struct SessionNotificationClient {
 
 enum SessionNotificationAction: Equatable {
     case remove(cctopSessionID: String)
-    case post(session: SessionData)
+    case post(cctopSessionID: String)
 }
 
 @MainActor
 extension SessionManager {
-    func hideSession(_ session: SessionData) {
-        guard let cctopSessionID = session.cctopSessionId,
-              CctopSessionID.isValid(cctopSessionID),
-              sessions.contains(where: { $0.cctopSessionId == cctopSessionID }),
-              let hiddenUserSession = userSessions.first(where: {
-                  $0.identity.cctopSessionID == cctopSessionID
-              }) else { return }
+    func hideSession(_ identity: SessionIdentityPolicy.LogicalIdentity) {
+        guard let cctopSessionID = identity.cctopSessionID,
+              let hiddenUserSession = userSessions.first(where: { $0.identity == identity }) else { return }
 
-        let hiddenSessions = hiddenUserSession.records.map(\.data)
-        let hiddenProjectPaths = Set(hiddenSessions.map { HistoryManager.canonicalRecentProjectPath($0.projectPath) })
-        dataSources.manualSessionVisibility.hide(session)
+        let hiddenRecords = hiddenUserSession.records
+        let hiddenProjectPaths = Set(hiddenRecords.map {
+            HistoryManager.canonicalRecentProjectPath($0.data.projectPath)
+        })
+        dataSources.manualSessionVisibility.hide(cctopSessionID: cctopSessionID)
         recentResumeTargets.removeAll { target in
             if target.cctopSessionId == cctopSessionID { return true }
             guard case .project = target else { return false }
             return hiddenProjectPaths.contains(HistoryManager.canonicalRecentProjectPath(target.projectPath))
         }
-        removeNotification(cctopSessionID: cctopSessionID, matching: hiddenSessions)
-        updateSessionProjection(userSessions.filter { $0.identity.cctopSessionID != cctopSessionID })
+        removeNotification(cctopSessionID: cctopSessionID, matching: hiddenRecords)
+        updateSessionProjection(userSessions.filter { $0.identity != identity })
     }
 
-    func isManuallyHidden(_ session: SessionData) -> Bool {
-        dataSources.manualSessionVisibility.isHidden(session)
-    }
-
-    func syncTransitionNotifications(for newSessions: [SessionData], oldSessions: [SessionData]) {
+    func syncTransitionNotifications(
+        for newUserSessions: [UserSession],
+        oldUserSessions: [UserSession]
+    ) {
         for action in Self.notificationActions(
-            newSessions: newSessions,
-            oldSessions: oldSessions,
+            newUserSessions: newUserSessions,
+            oldUserSessions: oldUserSessions,
             notificationsEnabled: dataSources.notificationsEnabled()
         ) {
             switch action {
             case .remove(let cctopSessionID):
+                let oldRecords = oldUserSessions.first {
+                    $0.identity.cctopSessionID == cctopSessionID
+                }?.records ?? []
                 removeNotification(
                     cctopSessionID: cctopSessionID,
-                    matching: oldSessions.filter {
-                        SessionIdentityPolicy.permanentSessionID(for: $0) == cctopSessionID
-                    }
+                    matching: oldRecords
                 )
-            case .post(let session):
-                sendNotification(for: session)
+            case .post(let cctopSessionID):
+                sendNotification(forCctopSessionID: cctopSessionID)
             }
         }
     }
 
     nonisolated static func notificationActions(
-        newSessions: [SessionData],
-        oldSessions: [SessionData],
+        newUserSessions: [UserSession],
+        oldUserSessions: [UserSession],
         notificationsEnabled: Bool
     ) -> [SessionNotificationAction] {
-        let newByCctopSessionID: [String: SessionData] = Dictionary(
-            newSessions.compactMap { session in
-                SessionIdentityPolicy.permanentSessionID(for: session).map { ($0, session) }
+        let newByCctopSessionID: [String: UserSession] = Dictionary(
+            newUserSessions.compactMap { userSession in
+                userSession.identity.cctopSessionID.map { ($0, userSession) }
             },
             uniquingKeysWith: { first, _ in first }
         )
-        let oldByCctopSessionID: [String: SessionData] = Dictionary(
-            oldSessions.compactMap { session in
-                SessionIdentityPolicy.permanentSessionID(for: session).map { ($0, session) }
+        let oldByCctopSessionID: [String: UserSession] = Dictionary(
+            oldUserSessions.compactMap { userSession in
+                userSession.identity.cctopSessionID.map { ($0, userSession) }
             },
             uniquingKeysWith: { first, _ in first }
         )
 
         var actions: [SessionNotificationAction] = []
-        for (cctopSessionID, oldSession) in oldByCctopSessionID where oldSession.shouldPostAttentionNotification {
-            guard let newSession = newByCctopSessionID[cctopSessionID],
-                  newSession.lifecycle == .active,
-                  newSession.shouldPostAttentionNotification else {
+        for oldUserSession in oldUserSessions
+        where oldUserSession.displayRecord.data.shouldPostAttentionNotification {
+            guard let cctopSessionID = oldUserSession.identity.cctopSessionID else { continue }
+            guard let newData = newByCctopSessionID[cctopSessionID]?.displayRecord.data,
+                  newData.lifecycle == .active,
+                  newData.shouldPostAttentionNotification else {
                 actions.append(.remove(cctopSessionID: cctopSessionID))
                 continue
             }
         }
 
         guard notificationsEnabled else { return actions }
-        for (cctopSessionID, newSession) in newByCctopSessionID
-        where newSession.lifecycle == .active && newSession.shouldPostAttentionNotification {
-            guard let oldSession = oldByCctopSessionID[cctopSessionID],
-                  !oldSession.shouldPostAttentionNotification else { continue }
-            actions.append(.post(session: newSession))
+        for newUserSession in newUserSessions {
+            guard let cctopSessionID = newUserSession.identity.cctopSessionID else { continue }
+            let newData = newUserSession.displayRecord.data
+            guard newData.lifecycle == .active, newData.shouldPostAttentionNotification else { continue }
+            guard let oldData = oldByCctopSessionID[cctopSessionID]?.displayRecord.data,
+                  !oldData.shouldPostAttentionNotification else { continue }
+            actions.append(.post(cctopSessionID: cctopSessionID))
         }
         return actions
     }
 
-    nonisolated static func notificationRequest(for session: SessionData) -> UNNotificationRequest? {
-        guard let cctopSessionID = SessionIdentityPolicy.permanentSessionID(for: session),
-              let identifier = SessionIdentityPolicy.notificationRequestIdentifier(
+    nonisolated static func notificationRequest(
+        forCctopSessionID cctopSessionID: String,
+        displayData: SessionData
+    ) -> UNNotificationRequest? {
+        guard let identifier = SessionIdentityPolicy.notificationRequestIdentifier(
                   forCctopSessionID: cctopSessionID
               ),
               let userInfo = SessionIdentityPolicy.notificationUserInfo(
@@ -164,7 +168,7 @@ extension SessionManager {
               ) else { return nil }
 
         let content = UNMutableNotificationContent()
-        let notification = session.notificationContent
+        let notification = displayData.notificationContent
         content.title = notification.title
         content.subtitle = notification.subtitle
         content.body = notification.body
@@ -178,15 +182,19 @@ extension SessionManager {
         )
     }
 
-    func postNotification(for session: SessionData) {
-        guard let cctopSessionID = SessionIdentityPolicy.permanentSessionID(for: session),
-              let currentSession = FocusTargetResolver.currentSession(
+    func postNotification(forCctopSessionID cctopSessionID: String) {
+        guard CctopSessionID.isValid(cctopSessionID),
+              let currentUserSession = FocusTargetResolver.currentUserSession(
                   forCctopSessionID: cctopSessionID,
                   in: SessionDisplayPolicy.activeSessions(from: userSessions)
-              ),
-              currentSession.shouldPostAttentionNotification,
-              !isManuallyHidden(currentSession),
-              let request = Self.notificationRequest(for: currentSession) else { return }
+              ) else { return }
+        let displayData = currentUserSession.focusTarget
+        guard displayData.shouldPostAttentionNotification,
+              !dataSources.manualSessionVisibility.isHidden(cctopSessionID: cctopSessionID),
+              let request = Self.notificationRequest(
+                  forCctopSessionID: cctopSessionID,
+                  displayData: displayData
+              ) else { return }
 
         let client = dataSources.notificationClient
         client.removePending([request.identifier])
@@ -198,7 +206,7 @@ extension SessionManager {
         }
     }
 
-    private func sendNotification(for session: SessionData) {
+    private func sendNotification(forCctopSessionID cctopSessionID: String) {
         let center = UNUserNotificationCenter.current()
         center.getNotificationSettings { settings in
             switch settings.authorizationStatus {
@@ -208,30 +216,26 @@ extension SessionManager {
                         sessionManagerLogger.error("Notification permission error: \(error, privacy: .public)")
                     }
                     if granted {
-                        self.postNotification(for: session)
+                        self.postNotification(forCctopSessionID: cctopSessionID)
                     }
                 }
             case .authorized, .provisional, .ephemeral:
-                self.postNotification(for: session)
+                self.postNotification(forCctopSessionID: cctopSessionID)
             default:
                 break
             }
         }
     }
 
-    private func removeNotification(cctopSessionID: String, matching sessions: [SessionData]) {
+    private func removeNotification(cctopSessionID: String, matching records: [SessionRecord]) {
         guard let identifier = SessionIdentityPolicy.notificationRequestIdentifier(
             forCctopSessionID: cctopSessionID
         ) else { return }
         var identifiers = Set([identifier])
         identifiers.formUnion(
-            sessions
-                .filter { session in
-                    SessionIdentityPolicy.permanentSessionID(for: session).map {
-                        $0 == cctopSessionID
-                    } ?? true
-                }
-                .compactMap(SessionIdentityPolicy.legacyNotificationRequestIdentifier)
+            records.compactMap {
+                SessionIdentityPolicy.legacyNotificationRequestIdentifier(for: $0.data)
+            }
         )
         let sortedIdentifiers = identifiers.sorted()
         let client = dataSources.notificationClient

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -14,9 +14,8 @@ struct WorktreeCleanupSessionSnapshot {
 @MainActor
 // swiftlint:disable:next type_body_length
 class SessionManager: ObservableObject {
-    @Published private(set) var sessions: [SessionData] = []
+    @Published private(set) var userSessions: [UserSession] = []
     @Published var recentResumeTargets: [RecentResumeTarget] = []
-    private(set) var userSessions: [UserSession] = []
 
     let historyManager: HistoryManager
     let dataSources: SessionDataSources
@@ -81,7 +80,7 @@ class SessionManager: ObservableObject {
             return
         }
 
-        let oldSessions = sessions
+        let oldUserSessions = userSessions
 
         let jsonFiles = sessionJSONFiles(in: files)
         let allDecoded = decodedSessions(from: jsonFiles)
@@ -123,21 +122,16 @@ class SessionManager: ObservableObject {
         let loadedUserSessions = groupedUserSessions.map {
             $0.replacingDisplayData(adjustDisplayStatus($0.displayRecord.data))
         }
-        let loadedSessions = loadedUserSessions.map(\.displayRecord.data)
-        let orderedSessions = SessionDisplayPolicy.reconcilingActiveOrder(in: loadedSessions, preserving: oldSessions, now: now)
-        let userSessionsByID = Dictionary(
-            uniqueKeysWithValues: loadedUserSessions.map { ($0.identity, $0) }
+        let newUserSessions = SessionDisplayPolicy.reconcilingOrder(
+            in: loadedUserSessions,
+            preserving: oldUserSessions,
+            now: now
         )
-        let newUserSessions = orderedSessions.compactMap { data in
-            let identity = SessionIdentityPolicy.logicalIdentity(for: data)
-            return userSessionsByID[identity]?.replacingDisplayData(data)
-        }
-        let newSessions = newUserSessions.map(\.displayRecord.data)
-        let displaySignature = SessionDisplayPolicy.signature(for: newSessions, now: now)
+        let displaySignature = SessionDisplayPolicy.signature(for: newUserSessions, now: now)
         updateSessionProjection(
             newUserSessions,
             displaySignature: displaySignature,
-            syncNotificationsFrom: oldSessions
+            syncNotificationsFrom: oldUserSessions
         )
 
         hideAutoHiddenSessions(autoHidden)
@@ -154,9 +148,7 @@ class SessionManager: ObservableObject {
         )
         let activeProjectPaths = classification.protectedProjectPathsForCleanup
         let recentExcludedPaths = activeProjectPaths.union(classification.manualHiddenProjectPaths(hiddenSessionIDs))
-        let publishedSessionIDs = Set(newSessions.compactMap {
-            SessionIdentityPolicy.permanentSessionID(for: $0)
-        })
+        let publishedSessionIDs = Set(newUserSessions.compactMap { $0.identity.cctopSessionID })
         let shouldFreezeVisibilityProjections = manualHides.hasUnresolvedLegacyKeys
             || (!inventoryComplete && !hiddenSessionIDs.isEmpty)
         if !shouldFreezeVisibilityProjections {
@@ -195,23 +187,21 @@ class SessionManager: ObservableObject {
     func updateSessionProjection(
         _ newUserSessions: [UserSession],
         displaySignature: SessionDisplayPolicy.Signature? = nil,
-        syncNotificationsFrom oldSessions: [SessionData]? = nil
+        syncNotificationsFrom oldUserSessions: [UserSession]? = nil
     ) {
-        let newSessions = newUserSessions.map(\.displayRecord.data)
-        userSessions = newUserSessions
-        if let oldSessions {
-            syncTransitionNotifications(for: newSessions, oldSessions: oldSessions)
-        }
-
+        let oldCount = userSessions.count
         let displayChanged = displaySignature.map { $0 != lastDisplaySignature } ?? false
-        guard newSessions != sessions || displayChanged else { return }
-        if newSessions.count != sessions.count {
-            sessionManagerLogger.info("loadSessions: session count \(self.sessions.count) -> \(newSessions.count)")
+        guard newUserSessions != userSessions || displayChanged else { return }
+        if newUserSessions.count != oldCount {
+            sessionManagerLogger.info("loadSessions: session count \(oldCount) -> \(newUserSessions.count)")
         }
         if let displaySignature {
             lastDisplaySignature = displaySignature
         }
-        sessions = newSessions
+        userSessions = newUserSessions
+        if let oldUserSessions {
+            syncTransitionNotifications(for: newUserSessions, oldUserSessions: oldUserSessions)
+        }
     }
 
     func cleanupSnapshotForRemoval() -> WorktreeCleanupSessionSnapshot {

--- a/menubar/CctopMenubar/Services/UserSession.swift
+++ b/menubar/CctopMenubar/Services/UserSession.swift
@@ -2,10 +2,16 @@ import Foundation
 
 /// One user-visible work session formed from one or more related `SessionRecord` values.
 /// A stable-key winner establishes identity. Older related records remain as evidence.
-struct UserSession {
+struct UserSession: Equatable {
     let identity: SessionIdentityPolicy.LogicalIdentity
     let records: [SessionRecord]
     let displayRecord: SessionRecord
+
+    /// The current visible status supplied by the selected display record.
+    var status: SessionStatus { displayRecord.data.status }
+
+    /// The current visible source badge supplied by the selected display record.
+    var agentBadge: AgentBadge { displayRecord.data.agentBadge }
 
     /// Indirect actions currently follow the same canonical record as the panel.
     /// Direct row actions continue to use the exact row session they received.

--- a/menubar/CctopMenubar/Views/HeaderView.swift
+++ b/menubar/CctopMenubar/Views/HeaderView.swift
@@ -1,11 +1,9 @@
 import SwiftUI
 
 struct HeaderView: View {
-    let sessions: [SessionData]
+    let counts: StatusCounts
 
     var body: some View {
-        let counts = StatusCounts(sessions: sessions)
-
         HStack(spacing: 0) {
             HStack(alignment: .center, spacing: 7) {
                 HairlineBrandMark()
@@ -78,5 +76,7 @@ private struct HairlineBrandMark: View {
 }
 
 #Preview("Normal") {
-    HeaderView(sessions: SessionData.qaShowcase).frame(width: 320).padding()
+    HeaderView(counts: StatusCounts(permission: 1, attention: 1, working: 2, idle: 1))
+        .frame(width: 320)
+        .padding()
 }

--- a/menubar/CctopMenubar/Views/PopupView+Sessions.swift
+++ b/menubar/CctopMenubar/Views/PopupView+Sessions.swift
@@ -2,48 +2,51 @@ import SwiftUI
 
 struct PanelSessionRow: Identifiable {
     let slot: Int
-    let session: SessionData
+    let userSession: UserSession
     let id: SessionIdentityPolicy.LogicalIdentity
+
+    /// Direct actions use the exact data selected for this rendered row.
+    var session: SessionData { userSession.displayRecord.data }
 }
 
 extension PopupView {
     var isNavigateActive: Bool { navigate?.isActive ?? false }
-    var hasMultipleSources: Bool { Set(sessions.map(\.agentBadge)).count > 1 }
+    var hasMultipleSources: Bool { Set(userSessions.map(\.agentBadge)).count > 1 }
 
-    var currentActiveSessions: [SessionData] {
-        SessionDisplayPolicy.activeSessions(from: sessions)
+    var currentActiveUserSessions: [UserSession] {
+        SessionDisplayPolicy.activeSessions(from: userSessions)
     }
 
     var activeSessionRows: [PanelSessionRow] {
         guard let identities = navigate?.activeSessionIdentitySnapshot else {
-            return currentActiveSessions.enumerated().map { index, session in
+            return currentActiveUserSessions.enumerated().map { index, userSession in
                 PanelSessionRow(
                     slot: index,
-                    session: session,
-                    id: SessionIdentityPolicy.logicalIdentity(for: session)
+                    userSession: userSession,
+                    id: userSession.identity
                 )
             }
         }
         return identities.enumerated().compactMap { index, identity in
-            guard let session = currentSession(for: identity, in: .active) else { return nil }
-            return PanelSessionRow(slot: index, session: session, id: identity)
+            guard let userSession = currentUserSession(for: identity, in: .active) else { return nil }
+            return PanelSessionRow(
+                slot: index,
+                userSession: userSession,
+                id: identity
+            )
         }
     }
 
-    var sortedActiveSessions: [SessionData] {
-        activeSessionRows.map(\.session)
-    }
-
-    var sortedIdleSessions: [SessionData] {
-        SessionData.sorted(SessionDisplayPolicy.idleSessions(from: sessions))
+    var currentIdleUserSessions: [UserSession] {
+        SessionDisplayPolicy.idleSessions(from: userSessions)
     }
 
     var idleSessionRows: [PanelSessionRow] {
-        sortedIdleSessions.enumerated().map { index, session in
+        currentIdleUserSessions.enumerated().map { index, userSession in
             PanelSessionRow(
                 slot: index,
-                session: session,
-                id: SessionIdentityPolicy.logicalIdentity(for: session)
+                userSession: userSession,
+                id: userSession.identity
             )
         }
     }
@@ -93,15 +96,15 @@ extension PopupView {
                 Label("Copy Project Path", systemImage: "doc.on.doc")
             }
             Divider()
-            Button { requestHideSession(row.session) } label: {
+            Button { requestHideSession(row) } label: {
                 Label("Hide Session", systemImage: "eye.slash")
             }
-            .disabled(!CctopSessionID.isValid(row.session.cctopSessionId))
+            .disabled(row.userSession.identity.cctopSessionID == nil)
         }
         .help("Click to jump to session")
         .accessibilityActions {
-            Button("Hide Session") { requestHideSession(row.session) }
-                .disabled(!CctopSessionID.isValid(row.session.cctopSessionId))
+            Button("Hide Session") { requestHideSession(row) }
+                .disabled(row.userSession.identity.cctopSessionID == nil)
         }
     }
 
@@ -118,15 +121,15 @@ extension PopupView {
 
     func confirmSessionSelection() {
         guard let identity = selectedSessionIdentity else { return }
-        guard let session = currentSession(for: identity, in: selectedTab) else { return }
-        focusSession(session)
+        guard let userSession = currentUserSession(for: identity, in: selectedTab) else { return }
+        focusSession(userSession.focusTarget)
         if isNavigateActive { navigate?.didConfirmSubject.send() }
     }
 
-    func currentSession(
+    func currentUserSession(
         for identity: SessionIdentityPolicy.LogicalIdentity,
         in tab: PopupTab
-    ) -> SessionData? {
+    ) -> UserSession? {
         let candidates: [UserSession]
         switch tab {
         case .active:
@@ -136,6 +139,6 @@ extension PopupView {
         case .recent, .cleanup:
             return nil
         }
-        return FocusTargetResolver.currentSession(for: identity, in: candidates)
+        return FocusTargetResolver.currentUserSession(for: identity, in: candidates)
     }
 }

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -6,7 +6,6 @@ private let overlayAnimationDuration: TimeInterval = 0.2
 private let relativeTimeRefresh = Timer.publish(every: 10, on: .main, in: .common).autoconnect()
 
 struct PopupView: View {
-    let sessions: [SessionData]
     let userSessions: [UserSession]
     var recentProjects: [RecentProject] = []
     var recentResumeTargets: [RecentResumeTarget]?
@@ -20,7 +19,7 @@ struct PopupView: View {
     var initialTab: PopupTab = .active
     var initialCleanupCandidate: WorktreeCleanupCandidate?
     var onOpenUpdater: (() -> Void)?
-    var onHideSession: (SessionData) -> Void = { _ in }
+    var onHideSession: (SessionIdentityPolicy.LogicalIdentity) -> Void = { _ in }
     var onSelectCleanupRemovalAction: ((WorktreeCleanupCandidate) async -> WorktreeRemovalService.RemovalAction)?
     var onExecuteCleanupRemovalAction: ((WorktreeRemovalService.RemovalAction) async -> WorktreeRemovalService.RemovalResult)?
     var onCleanupTabVisible: () -> Void = {}
@@ -56,7 +55,7 @@ struct PopupView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HeaderView(sessions: sessions)
+            HeaderView(counts: StatusCounts(userSessions: userSessions))
             if showTabs {
                 tabPicker
             }
@@ -106,7 +105,6 @@ struct PopupView: View {
         }
         .onReceive(relativeTimeRefresh) { relativeTimeNow = $0 }
         .onChange(of: selectedTab) { handleSelectedTabChanged($0) }
-        .onChange(of: sessions) { _ in ensureSelectedTabAvailable() }
         .onChange(of: recentTargets.map(\.id)) { _ in ensureSelectedTabAvailable() }
         .onChange(of: actionableCleanupCandidates) { _ in handleCleanupCandidatesChanged() }
         .onChange(of: cleanupIsScanning) { _ in handleCleanupScanningChanged() }
@@ -150,8 +148,8 @@ struct PopupView: View {
 
     private func count(for tab: PopupTab) -> Int {
         switch tab {
-        case .active: return sortedActiveSessions.count
-        case .idle: return sortedIdleSessions.count
+        case .active: return activeSessionRows.count
+        case .idle: return idleSessionRows.count
         case .recent: return recentTargets.count
         case .cleanup: return actionableCleanupCandidates.count
         }
@@ -180,9 +178,9 @@ struct PopupView: View {
     // MARK: - Active tab
     private var activeContent: some View {
         Group {
-            if sessions.isEmpty {
+            if userSessions.isEmpty {
                 EmptyStateView(pluginManager: pluginManager)
-            } else if sortedActiveSessions.isEmpty {
+            } else if activeSessionRows.isEmpty {
                 noActiveSessionsContent
             } else {
                 VStack(spacing: 0) {
@@ -206,7 +204,7 @@ struct PopupView: View {
     // MARK: - Idle tab
     @ViewBuilder
     private var idleContent: some View {
-        if sortedIdleSessions.isEmpty {
+        if idleSessionRows.isEmpty {
             noIdleSessionsContent
         } else {
             sessionList(idleSessionRows, tab: .idle)

--- a/menubar/CctopMenubar/Views/PopupViewHelpers.swift
+++ b/menubar/CctopMenubar/Views/PopupViewHelpers.swift
@@ -2,22 +2,21 @@ import AppKit
 import SwiftUI
 
 struct ManualSessionHideConfirmation: Identifiable, Equatable {
-    let session: SessionData
-    let cctopSessionID: String
+    let identity: SessionIdentityPolicy.LogicalIdentity
+    let displayName: String
 
-    init?(session: SessionData) {
-        guard let cctopSessionID = session.cctopSessionId,
-              CctopSessionID.isValid(cctopSessionID) else { return nil }
-        self.session = session
-        self.cctopSessionID = cctopSessionID
+    init?(identity: SessionIdentityPolicy.LogicalIdentity, displayName: String) {
+        guard identity.cctopSessionID != nil else { return nil }
+        self.identity = identity
+        self.displayName = displayName
     }
 
     var id: String {
-        "hide:\(cctopSessionID)"
+        "hide:\(identity.cctopSessionID ?? "")"
     }
 
     var title: String {
-        "Hide “\(session.displayName)” from cctop?"
+        "Hide “\(displayName)” from cctop?"
     }
 
     let message = "It will disappear from the panel, notifications, Navigate mode, and Stream Deck. "
@@ -271,8 +270,11 @@ struct FooterUpdateStatusView: View {
 }
 
 extension PopupView {
-    func requestHideSession(_ session: SessionData) {
-        guard let confirmation = ManualSessionHideConfirmation(session: session) else { return }
+    func requestHideSession(_ row: PanelSessionRow) {
+        guard let confirmation = ManualSessionHideConfirmation(
+            identity: row.userSession.identity,
+            displayName: row.session.displayName
+        ) else { return }
         pendingConfirmation = .sessionHide(confirmation)
     }
 
@@ -290,17 +292,16 @@ extension PopupView {
             title: Text(confirmation.title),
             message: Text(confirmation.message),
             primaryButton: .destructive(Text(confirmation.primaryButtonTitle)) {
-                hideSession(confirmation.session)
+                hideSession(confirmation.identity)
             },
             secondaryButton: .cancel()
         )
     }
 
-    func hideSession(_ session: SessionData) {
-        guard let cctopSessionID = session.cctopSessionId,
-              CctopSessionID.isValid(cctopSessionID),
-              sessions.contains(where: { $0.cctopSessionId == cctopSessionID }) else { return }
-        onHideSession(session)
+    func hideSession(_ identity: SessionIdentityPolicy.LogicalIdentity) {
+        guard identity.cctopSessionID != nil,
+              userSessions.contains(where: { $0.identity == identity }) else { return }
+        onHideSession(identity)
         selectedIndex = nil
         selectedSessionIdentity = nil
     }
@@ -328,7 +329,6 @@ struct PanelContentView: View {
 
     var body: some View {
         PopupView(
-            sessions: sessionManager.sessions,
             userSessions: sessionManager.userSessions,
             recentProjects: historyManager.recentProjects,
             recentResumeTargets: sessionManager.recentResumeTargets,
@@ -366,8 +366,9 @@ struct PanelContentView: View {
     PluginManager(homeDirectory: URL(fileURLWithPath: "/nonexistent"), refreshOnInit: false)
 }
 
-private func previewUserSessions(from sessions: [SessionData]) -> [UserSession] {
-    let records = sessions.enumerated().map { index, data in
+/// Runs raw preview fixtures forward through the production record and grouping stages.
+private func previewUserSessions(fromDataFixtures dataFixtures: [SessionData]) -> [UserSession] {
+    let records = dataFixtures.enumerated().map { index, data in
         SessionRecord(
             data: data,
             lifecycleRank: data.lifecycle.rawValue,
@@ -383,37 +384,33 @@ private func previewUserSessions(from sessions: [SessionData]) -> [UserSession] 
 
 #Preview("With sessions") {
     PopupView(
-        sessions: SessionData.mockSessions,
-        userSessions: previewUserSessions(from: SessionData.mockSessions),
+        userSessions: previewUserSessions(fromDataFixtures: SessionData.mockSessions),
         updater: DisabledUpdater(),
         pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("Mixed sources") {
     PopupView(
-        sessions: SessionData.qaShowcase,
-        userSessions: previewUserSessions(from: SessionData.qaShowcase),
+        userSessions: previewUserSessions(fromDataFixtures: SessionData.qaShowcase),
         updater: DisabledUpdater(),
         pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("Empty") {
     PopupView(
-        sessions: [], userSessions: [], updater: DisabledUpdater(), pluginManager: previewPluginManager()
+        userSessions: [], updater: DisabledUpdater(), pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("With Tabs") {
     PopupView(
-        sessions: SessionData.mockSessions,
-        userSessions: previewUserSessions(from: SessionData.mockSessions),
+        userSessions: previewUserSessions(fromDataFixtures: SessionData.mockSessions),
         recentProjects: RecentProject.mockRecents,
         updater: DisabledUpdater(), pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("Cleanup") {
     PopupView(
-        sessions: SessionData.mockSessions,
-        userSessions: previewUserSessions(from: SessionData.mockSessions),
+        userSessions: previewUserSessions(fromDataFixtures: SessionData.mockSessions),
         recentProjects: RecentProject.mockRecents,
         cleanupCandidates: WorktreeCleanupCandidate.mockCandidates,
         updater: DisabledUpdater(), pluginManager: previewPluginManager(), initialTab: .cleanup
@@ -421,23 +418,23 @@ private func previewUserSessions(from sessions: [SessionData]) -> [UserSession] 
 }
 #Preview("Only Recents") {
     PopupView(
-        sessions: [], userSessions: [], recentProjects: RecentProject.mockRecents,
+        userSessions: [], recentProjects: RecentProject.mockRecents,
         updater: DisabledUpdater(), pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("Empty Recents Tab") {
     PopupView(
-        sessions: SessionData.mockSessions,
-        userSessions: previewUserSessions(from: SessionData.mockSessions),
+        userSessions: previewUserSessions(fromDataFixtures: SessionData.mockSessions),
         recentProjects: [RecentProject.mock()],
         updater: DisabledUpdater(), pluginManager: previewPluginManager()
     ).frame(width: 320)
 }
 #Preview("Navigate") {
-    let rc = NavigateController(); rc.isActive = true
+    let userSessions = previewUserSessions(fromDataFixtures: SessionData.qaShowcase)
+    let rc = NavigateController()
+    rc.activate(userSessions: SessionDisplayPolicy.activeSessions(from: userSessions))
     return PopupView(
-        sessions: SessionData.qaShowcase,
-        userSessions: previewUserSessions(from: SessionData.qaShowcase),
+        userSessions: userSessions,
         recentProjects: RecentProject.mockRecents,
         updater: DisabledUpdater(), pluginManager: previewPluginManager(), navigate: rc
     ).frame(width: 320)

--- a/menubar/CctopMenubarTests/DisplayStateWriterTests.swift
+++ b/menubar/CctopMenubarTests/DisplayStateWriterTests.swift
@@ -42,20 +42,21 @@ final class DisplayStateWriterTests: XCTestCase {
         var idle = SessionData.mock(id: "d", project: "delta", status: .idle)
         idle.lastActivity = now.addingTimeInterval(-60)
         let sessions = [permission, workingOld, workingNew, idle]
+        let userSessions = userSessions(fromDataFixtures: sessions)
 
         let snapshot = DisplayStateWriter.snapshot(
-            sessions: sessions,
+            userSessions: userSessions,
             theme: .claude,
             appRunning: true,
             appIdentity: DisplayState.ProcessIdentity(pid: 123, startTime: 1_000),
             now: now
         )
 
-        let expected = SessionDisplayPolicy.activeSessions(from: sessions, now: now)
+        let expected = SessionDisplayPolicy.activeSessions(from: userSessions, now: now)
         XCTAssertEqual(snapshot.sessions.count, expected.count)
         XCTAssertEqual(
             snapshot.sessions.map(\.cctopSessionId),
-            expected.map { $0.cctopSessionId ?? "" }
+            expected.map { $0.identity.cctopSessionID ?? "" }
         )
         XCTAssertEqual(snapshot.sessions.map(\.name), ["alpha", "bravo", "charlie", "delta"])
     }
@@ -69,7 +70,7 @@ final class DisplayStateWriterTests: XCTestCase {
         let active = SessionData.mock(id: "active", status: .working)
 
         let snapshot = DisplayStateWriter.snapshot(
-            sessions: [dormant, staleIdle, active],
+            userSessions: userSessions(fromDataFixtures: [dormant, staleIdle, active]),
             theme: .claude,
             appRunning: true,
             appIdentity: DisplayState.ProcessIdentity(pid: 123, startTime: 1_000),
@@ -89,7 +90,7 @@ final class DisplayStateWriterTests: XCTestCase {
             source: "codex"
         )
         let snapshot = DisplayStateWriter.snapshot(
-            sessions: [session],
+            userSessions: userSessions(fromDataFixtures: [session]),
             theme: .claude,
             appRunning: true,
             appIdentity: DisplayState.ProcessIdentity(pid: 456, startTime: 1_234.5),
@@ -119,7 +120,7 @@ final class DisplayStateWriterTests: XCTestCase {
     func testStoppedSnapshotPreservesRecentTargetsButDropsProcessIdentity() {
         let session = SessionData.mock(id: "stable-display-id", status: .working)
         let snapshot = DisplayStateWriter.snapshot(
-            sessions: [session],
+            userSessions: userSessions(fromDataFixtures: [session]),
             theme: .claude,
             appRunning: false,
             appIdentity: DisplayState.ProcessIdentity(pid: 456, startTime: 1_234.5),
@@ -132,7 +133,7 @@ final class DisplayStateWriterTests: XCTestCase {
         XCTAssertEqual(snapshot.sessions.map(\.cctopSessionId), [session.cctopSessionId ?? ""])
     }
 
-    func testSnapshotKeepsOneOrderedEntryPerVisibleFocusTarget() {
+    func testSnapshotKeepsOneEntryForOneUserSessionWithRetainedRecords() {
         let now = Date()
         let cctopSessionID = "11111111-2222-4333-8444-555555555555"
         var original = SessionData.mock(
@@ -145,18 +146,22 @@ final class DisplayStateWriterTests: XCTestCase {
             status: .working, pid: 999, pidStartTime: 2_000
         )
         resumedElsewhere.lastActivity = now.addingTimeInterval(-20)
-        let canonical = [original, resumedElsewhere]
+        let userSession = userSession(
+            identity: SessionIdentityPolicy.logicalIdentity(for: original),
+            display: original,
+            records: [original, resumedElsewhere]
+        )
 
         let snapshot = DisplayStateWriter.snapshot(
-            sessions: canonical,
+            userSessions: [userSession],
             theme: .claude,
             appRunning: true,
             appIdentity: DisplayState.ProcessIdentity(pid: 123, startTime: 1_000),
             now: now
         )
 
-        XCTAssertEqual(snapshot.sessions.map(\.cctopSessionId), [cctopSessionID, cctopSessionID])
-        XCTAssertEqual(snapshot.sessions.map(\.name), ["first", "second"])
+        XCTAssertEqual(snapshot.sessions.map(\.cctopSessionId), [cctopSessionID])
+        XCTAssertEqual(snapshot.sessions.map(\.name), ["first"])
     }
 
     func testMissingLegacyIdentityLeavesAnEmptySlotWithoutShiftingLaterRows() {
@@ -165,7 +170,18 @@ final class DisplayStateWriterTests: XCTestCase {
         let current = SessionData.mock(id: "current", project: "second", status: .working)
 
         let snapshot = DisplayStateWriter.snapshot(
-            sessions: [legacy, current],
+            userSessions: [
+                userSession(
+                    identity: SessionIdentityPolicy.logicalIdentity(for: legacy),
+                    display: legacy,
+                    records: [legacy]
+                ),
+                userSession(
+                    identity: SessionIdentityPolicy.logicalIdentity(for: current),
+                    display: current,
+                    records: [current]
+                ),
+            ],
             theme: .claude,
             appRunning: true,
             appIdentity: nil,

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -439,7 +439,7 @@ final class FocusStrategyTests: XCTestCase {
     func testCurrentPermanentIDCodexRouteUsesThreadDeepLinkDespiteStalePID() throws {
         let threadID = "019faecb-6e9b-7f41-a51f-bb998875ca77"
         let cctopSessionID = "82498aba-410e-4b6b-b48d-62f7c6a81eae"
-        let observation = SessionData.mock(
+        let record = SessionData.mock(
             id: threadID,
             cctopSessionId: cctopSessionID,
             harnessSessionId: threadID,
@@ -449,10 +449,10 @@ final class FocusStrategyTests: XCTestCase {
             source: SessionData.codexSource
         )
         let current = try XCTUnwrap(
-            FocusTargetResolver.currentSession(
+            FocusTargetResolver.currentUserSession(
                 forCctopSessionID: cctopSessionID,
-                in: userSessionProjection(from: [observation])
-            )
+                in: userSessions(fromDataFixtures: [record])
+            )?.focusTarget
         )
         let strategy = resolveFocusStrategy(session: current, multiplexerOverride: nil)
         let intended = FocusStrategy.openURL(

--- a/menubar/CctopMenubarTests/NavigateControllerTests.swift
+++ b/menubar/CctopMenubarTests/NavigateControllerTests.swift
@@ -24,7 +24,7 @@ final class NavigateControllerTests: XCTestCase {
     // MARK: - Activate
 
     func testActivateSetsIsActive() {
-        sut.activate(sessions: [])
+        sut.activate(userSessions: [])
         XCTAssertTrue(sut.isActive)
     }
 
@@ -33,7 +33,10 @@ final class NavigateControllerTests: XCTestCase {
             SessionData.mock(id: "1", project: "alpha", status: .idle),
             SessionData.mock(id: "2", project: "beta", status: .working),
         ]
-        sut.activate(sessions: sessions)
+        let userSessions = sessions.map {
+            userSession(identity: SessionIdentityPolicy.logicalIdentity(for: $0), display: $0, records: [$0])
+        }
+        sut.activate(userSessions: userSessions)
         XCTAssertEqual(sut.frozenSessionIdentities.count, 2)
     }
 
@@ -46,16 +49,19 @@ final class NavigateControllerTests: XCTestCase {
         workingNew.lastActivity = now
         let idle = SessionData.mock(id: "4", project: "delta", status: .idle)
 
-        sut.activate(sessions: [waiting, workingOld, workingNew, idle])
+        let userSessions = [waiting, workingOld, workingNew, idle].map {
+            userSession(identity: SessionIdentityPolicy.logicalIdentity(for: $0), display: $0, records: [$0])
+        }
+        sut.activate(userSessions: userSessions)
 
         XCTAssertEqual(
             sut.frozenSessionIdentities,
-            [waiting, workingOld, workingNew, idle].map { SessionIdentityPolicy.logicalIdentity(for: $0) }
+            userSessions.map(\.identity)
         )
     }
 
     func testActivateWithEmptySessions() {
-        sut.activate(sessions: [])
+        sut.activate(userSessions: [])
         XCTAssertTrue(sut.isActive)
         XCTAssertTrue(sut.frozenSessionIdentities.isEmpty)
     }
@@ -63,13 +69,21 @@ final class NavigateControllerTests: XCTestCase {
     // MARK: - Deactivate
 
     func testDeactivateClearsIsActive() {
-        sut.activate(sessions: [.mock()])
+        let data = SessionData.mock()
+        sut.activate(userSessions: [userSession(
+            identity: SessionIdentityPolicy.logicalIdentity(for: data),
+            display: data,
+            records: [data]
+        )])
         sut.deactivate()
         XCTAssertFalse(sut.isActive)
     }
 
     func testDeactivateClearsFrozenSessions() {
-        sut.activate(sessions: [.mock(), .mock(id: "2")])
+        let data = [SessionData.mock(), SessionData.mock(id: "2")]
+        sut.activate(userSessions: data.map {
+            userSession(identity: SessionIdentityPolicy.logicalIdentity(for: $0), display: $0, records: [$0])
+        })
         sut.deactivate()
         XCTAssertTrue(sut.frozenSessionIdentities.isEmpty)
     }
@@ -78,7 +92,7 @@ final class NavigateControllerTests: XCTestCase {
         let expectation = expectation(description: "timeout should not fire")
         expectation.isInverted = true
 
-        sut.activate(sessions: [])
+        sut.activate(userSessions: [])
         sut.startTimeout(duration: 0.05) { expectation.fulfill() }
         sut.deactivate()
 
@@ -97,7 +111,9 @@ final class NavigateControllerTests: XCTestCase {
         var sessions = [
             SessionData.mock(id: "1", project: "alpha", status: .working),
         ]
-        sut.activate(sessions: sessions)
+        sut.activate(userSessions: sessions.map {
+            userSession(identity: SessionIdentityPolicy.logicalIdentity(for: $0), display: $0, records: [$0])
+        })
 
         // Mutating the original array shouldn't affect frozen sessions
         sessions.append(.mock(id: "2", project: "beta", status: .idle))
@@ -114,15 +130,22 @@ final class NavigateControllerTests: XCTestCase {
             id: "replacement", cctopSessionId: sharedID,
             status: .waitingInput, pid: 200, source: SessionData.opencodeSource
         )
-        sut.activate(sessions: [first])
+        let permanentIdentity = SessionIdentityPolicy.LogicalIdentity.permanent(
+            try XCTUnwrap(UUID(uuidString: sharedID))
+        )
+        sut.activate(userSessions: [userSession(
+            identity: permanentIdentity,
+            display: first,
+            records: [first]
+        )])
 
         let identity = try XCTUnwrap(sut.sessionIdentity(at: 0))
-        let resolved = FocusTargetResolver.currentSession(
+        let resolved = FocusTargetResolver.currentUserSession(
             for: identity,
-            in: userSessionProjection(from: [replacement])
+            in: [userSession(identity: permanentIdentity, display: replacement, records: [replacement])]
         )
 
-        XCTAssertEqual(resolved?.pid, 200)
+        XCTAssertEqual(resolved?.focusTarget.pid, 200)
     }
 
     func testFrozenLegacySlotResolvesSameStableKeyAfterPermanentIDStamp() throws {
@@ -130,18 +153,25 @@ final class NavigateControllerTests: XCTestCase {
             id: "legacy", status: .working, pid: 100, source: SessionData.opencodeSource
         )
         legacy.cctopSessionId = nil
-        sut.activate(sessions: [legacy])
+        let legacyIdentity = SessionIdentityPolicy.LogicalIdentity.legacy(
+            SessionIdentityPolicy.stableKey(for: legacy)
+        )
+        sut.activate(userSessions: [userSession(identity: legacyIdentity, display: legacy, records: [legacy])])
 
         var stamped = legacy
         stamped.cctopSessionId = "22222222-2222-4222-8222-222222222222"
+        let stampedIdentity = SessionIdentityPolicy.LogicalIdentity.permanent(
+            try XCTUnwrap(UUID(uuidString: try XCTUnwrap(stamped.cctopSessionId)))
+        )
         let identity = try XCTUnwrap(sut.sessionIdentity(at: 0))
-        let resolved = FocusTargetResolver.currentSession(
+        let resolved = FocusTargetResolver.currentUserSession(
             for: identity,
-            in: userSessionProjection(from: [stamped])
+            in: [userSession(identity: stampedIdentity, display: stamped, records: [legacy, stamped])]
         )
 
-        XCTAssertEqual(resolved?.cctopSessionId, stamped.cctopSessionId)
-        XCTAssertEqual(resolved?.pid, 100)
+        XCTAssertEqual(resolved?.identity, stampedIdentity)
+        XCTAssertEqual(resolved?.focusTarget.cctopSessionId, stamped.cctopSessionId)
+        XCTAssertEqual(resolved?.focusTarget.pid, 100)
     }
 
     func testFrozenLegacySlotResolvesCurrentUserSessionAfterPermanentIDStamp() throws {
@@ -149,22 +179,36 @@ final class NavigateControllerTests: XCTestCase {
             id: "legacy", status: .working, pid: 100, source: SessionData.opencodeSource
         )
         legacy.cctopSessionId = nil
-        sut.activate(sessions: [legacy])
+        let legacyIdentity = SessionIdentityPolicy.LogicalIdentity.legacy(
+            SessionIdentityPolicy.stableKey(for: legacy)
+        )
+        sut.activate(userSessions: [userSession(identity: legacyIdentity, display: legacy, records: [legacy])])
 
         var stamped = legacy
         stamped.cctopSessionId = "22222222-2222-4222-8222-222222222222"
+        let stampedIdentity = SessionIdentityPolicy.LogicalIdentity.permanent(
+            try XCTUnwrap(UUID(uuidString: try XCTUnwrap(stamped.cctopSessionId)))
+        )
         let identity = try XCTUnwrap(sut.sessionIdentity(at: 0))
-        let current = userSession(display: stamped, records: [stamped])
+        let current = userSession(
+            identity: stampedIdentity,
+            display: stamped,
+            records: [legacy, stamped]
+        )
 
         XCTAssertEqual(
-            FocusTargetResolver.currentSession(for: identity, in: [current])?.cctopSessionId,
+            FocusTargetResolver.currentUserSession(for: identity, in: [current])?.focusTarget.cctopSessionId,
             stamped.cctopSessionId
         )
 
         var conflicting = stamped
         conflicting.cctopSessionId = "33333333-3333-4333-8333-333333333333"
-        let conflictingUserSession = userSession(display: conflicting, records: [conflicting])
-        XCTAssertNil(FocusTargetResolver.currentSession(
+        let conflictingUserSession = userSession(
+            identity: .permanent(try XCTUnwrap(UUID(uuidString: try XCTUnwrap(conflicting.cctopSessionId)))),
+            display: conflicting,
+            records: [conflicting]
+        )
+        XCTAssertNil(FocusTargetResolver.currentUserSession(
             for: identity,
             in: [current, conflictingUserSession]
         ))
@@ -179,15 +223,20 @@ final class NavigateControllerTests: XCTestCase {
             id: "second", cctopSessionId: "22222222-2222-4222-8222-222222222222",
             status: .working, source: SessionData.codexSource
         )
-        sut.activate(sessions: [first, second])
+        let firstIdentity = SessionIdentityPolicy.logicalIdentity(for: first)
+        let secondIdentity = SessionIdentityPolicy.logicalIdentity(for: second)
+        sut.activate(userSessions: [
+            userSession(identity: firstIdentity, display: first, records: [first]),
+            userSession(identity: secondIdentity, display: second, records: [second]),
+        ])
 
-        let firstIdentity = try XCTUnwrap(sut.sessionIdentity(at: 0))
-        let secondIdentity = try XCTUnwrap(sut.sessionIdentity(at: 1))
+        XCTAssertEqual(try XCTUnwrap(sut.sessionIdentity(at: 0)), firstIdentity)
+        XCTAssertEqual(try XCTUnwrap(sut.sessionIdentity(at: 1)), secondIdentity)
 
-        let currentUserSessions = userSessionProjection(from: [second])
-        XCTAssertNil(FocusTargetResolver.currentSession(for: firstIdentity, in: currentUserSessions))
+        let currentUserSessions = [userSession(identity: secondIdentity, display: second, records: [second])]
+        XCTAssertNil(FocusTargetResolver.currentUserSession(for: firstIdentity, in: currentUserSessions))
         XCTAssertEqual(
-            FocusTargetResolver.currentSession(for: secondIdentity, in: currentUserSessions)?.sessionId,
+            FocusTargetResolver.currentUserSession(for: secondIdentity, in: currentUserSessions)?.focusTarget.sessionId,
             "second"
         )
     }
@@ -206,11 +255,19 @@ final class NavigateControllerTests: XCTestCase {
             id: "replacement", cctopSessionId: original.cctopSessionId,
             status: .waitingInput, pid: 200, source: SessionData.codexSource
         )
-        sut.activate(sessions: [missing, original])
+        let missingIdentity = SessionIdentityPolicy.logicalIdentity(for: missing)
+        let originalIdentity = SessionIdentityPolicy.logicalIdentity(for: original)
+        sut.activate(userSessions: [
+            userSession(identity: missingIdentity, display: missing, records: [missing]),
+            userSession(identity: originalIdentity, display: original, records: [original]),
+        ])
 
         let view = PopupView(
-            sessions: [replacement],
-            userSessions: userSessionProjection(from: [replacement]),
+            userSessions: [userSession(
+                identity: originalIdentity,
+                display: replacement,
+                records: [replacement]
+            )],
             updater: DisabledUpdater(),
             pluginManager: inertPluginManager(),
             navigate: sut
@@ -219,28 +276,55 @@ final class NavigateControllerTests: XCTestCase {
 
         XCTAssertEqual(view.activeSessionRows.count, 1)
         XCTAssertEqual(row.slot, 1)
-        XCTAssertEqual(row.id, SessionIdentityPolicy.logicalIdentity(for: original))
+        XCTAssertEqual(row.id, originalIdentity)
         XCTAssertEqual(row.session, replacement)
     }
 
     @MainActor
-    func testPopupKeyboardResolutionUsesRetainedLegacyRecordAfterDisplayTargetChanges() throws {
+    func testPopupDirectRowUsesExactUserSessionDisplayRecord() throws {
+        let sharedID = "22222222-2222-4222-8222-222222222222"
+        let stale = SessionData.mock(
+            id: "stale", cctopSessionId: sharedID,
+            status: .working, pid: 100, source: SessionData.opencodeSource
+        )
+        let current = SessionData.mock(
+            id: "current", cctopSessionId: sharedID,
+            status: .working, pid: 200, source: SessionData.opencodeSource
+        )
+        let view = PopupView(
+            userSessions: [userSession(
+                identity: SessionIdentityPolicy.logicalIdentity(for: current),
+                display: current,
+                records: [stale, current]
+            )],
+            updater: DisabledUpdater(),
+            pluginManager: inertPluginManager()
+        )
+
+        XCTAssertEqual(try XCTUnwrap(view.activeSessionRows.first).session, current)
+    }
+
+    @MainActor
+    func testPopupFrozenLegacyRowResolvesCurrentTargetAndHideIdentityAfterStamping() throws {
         var legacy = SessionData.mock(
-            id: "legacy-observation", status: .working, pid: 100, source: SessionData.opencodeSource
+            id: "legacy-record", status: .working, pid: 100, source: SessionData.opencodeSource
         )
         legacy.cctopSessionId = nil
         let current = SessionData.mock(
-            id: "current-observation",
+            id: "current-record",
             cctopSessionId: "22222222-2222-4222-8222-222222222222",
             status: .waitingInput,
             pid: 200,
             source: SessionData.opencodeSource
         )
-        sut.activate(sessions: [legacy])
+        let legacyIdentity = SessionIdentityPolicy.LogicalIdentity.legacy(
+            SessionIdentityPolicy.stableKey(for: legacy)
+        )
+        let currentIdentity = SessionIdentityPolicy.logicalIdentity(for: current)
+        sut.activate(userSessions: [userSession(identity: legacyIdentity, display: legacy, records: [legacy])])
 
         let view = PopupView(
-            sessions: [current],
-            userSessions: [userSession(display: current, records: [legacy, current])],
+            userSessions: [userSession(identity: currentIdentity, display: current, records: [legacy, current])],
             updater: DisabledUpdater(),
             pluginManager: inertPluginManager(),
             navigate: sut
@@ -249,8 +333,10 @@ final class NavigateControllerTests: XCTestCase {
         let row = try XCTUnwrap(view.activeSessionRows.first)
         let frozenIdentity = try XCTUnwrap(sut.sessionIdentity(at: 0))
         XCTAssertEqual(row.slot, 0)
+        XCTAssertEqual(row.id, legacyIdentity)
+        XCTAssertEqual(row.userSession.identity, currentIdentity)
         XCTAssertEqual(row.session, current)
-        XCTAssertEqual(view.currentSession(for: frozenIdentity, in: .active), current)
+        XCTAssertEqual(view.currentUserSession(for: frozenIdentity, in: .active)?.focusTarget, current)
     }
 
     func testInactiveControllerHasNoActiveSnapshot() {
@@ -263,7 +349,7 @@ final class NavigateControllerTests: XCTestCase {
     func testTimeoutFiresWhenActive() {
         let expectation = expectation(description: "timeout fires")
 
-        sut.activate(sessions: [])
+        sut.activate(userSessions: [])
         sut.startTimeout(duration: 0.05) { expectation.fulfill() }
 
         waitForExpectations(timeout: 1.0)
@@ -273,7 +359,7 @@ final class NavigateControllerTests: XCTestCase {
         let expectation = expectation(description: "timeout should not fire")
         expectation.isInverted = true
 
-        sut.activate(sessions: [])
+        sut.activate(userSessions: [])
         sut.startTimeout(duration: 0.1) { expectation.fulfill() }
         sut.deactivate()
 
@@ -284,7 +370,7 @@ final class NavigateControllerTests: XCTestCase {
         let expectation = expectation(description: "timeout should not fire")
         expectation.isInverted = true
 
-        sut.activate(sessions: [])
+        sut.activate(userSessions: [])
         sut.startTimeout(duration: 0.05) {
             expectation.fulfill()
         }
@@ -298,7 +384,7 @@ final class NavigateControllerTests: XCTestCase {
         let expectation = expectation(description: "timeout should not fire")
         expectation.isInverted = true
 
-        sut.activate(sessions: [])
+        sut.activate(userSessions: [])
         sut.startTimeout(duration: 0.05) { expectation.fulfill() }
         sut.cancelTimeout()
 
@@ -315,7 +401,7 @@ final class NavigateControllerTests: XCTestCase {
         first.isInverted = true
         let second = expectation(description: "second timeout fires")
 
-        sut.activate(sessions: [])
+        sut.activate(userSessions: [])
         sut.startTimeout(duration: 0.05) { first.fulfill() }
         // Starting a new timeout cancels the previous one
         sut.startTimeout(duration: 0.05) { second.fulfill() }
@@ -332,7 +418,9 @@ final class NavigateControllerTests: XCTestCase {
         ]
 
         // Activate
-        sut.activate(sessions: sessions)
+        sut.activate(userSessions: sessions.map {
+            userSession(identity: SessionIdentityPolicy.logicalIdentity(for: $0), display: $0, records: [$0])
+        })
 
         XCTAssertTrue(sut.isActive)
         XCTAssertEqual(sut.frozenSessionIdentities.count, 2)
@@ -347,7 +435,9 @@ final class NavigateControllerTests: XCTestCase {
     func testMultipleActivateDeactivateCycles() {
         for i in 0..<3 {
             let sessions = [SessionData.mock(id: "\(i)", status: .working)]
-            sut.activate(sessions: sessions)
+            sut.activate(userSessions: sessions.map {
+                userSession(identity: SessionIdentityPolicy.logicalIdentity(for: $0), display: $0, records: [$0])
+            })
             XCTAssertTrue(sut.isActive)
             XCTAssertEqual(sut.frozenSessionIdentities.count, 1)
 
@@ -365,11 +455,14 @@ final class NavigateControllerTests: XCTestCase {
         var newer = SessionData.mock(id: "2", project: "newer", status: .working)
         newer.lastActivity = Date()
 
-        sut.activate(sessions: [older, newer])
+        let userSessions = [older, newer].map {
+            userSession(identity: SessionIdentityPolicy.logicalIdentity(for: $0), display: $0, records: [$0])
+        }
+        sut.activate(userSessions: userSessions)
 
         XCTAssertEqual(
             sut.frozenSessionIdentities,
-            [older, newer].map { SessionIdentityPolicy.logicalIdentity(for: $0) }
+            userSessions.map(\.identity)
         )
     }
 }

--- a/menubar/CctopMenubarTests/PanelToggleTests.swift
+++ b/menubar/CctopMenubarTests/PanelToggleTests.swift
@@ -44,17 +44,21 @@ final class PanelToggleTests: XCTestCase {
     func testNotificationActivationResolvesPermanentIDToCurrentCanonicalRecord() {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
         var current = SessionData.mock(
-            id: "current-observation", cctopSessionId: cctopSessionID,
+            id: "current-record", cctopSessionId: cctopSessionID,
             pid: 22_222, source: SessionData.opencodeSource
         )
         current.lifecycle = .active
 
-        let resolved = AppDelegate.notificationFocusSession(
+        let resolved = AppDelegate.notificationFocusTarget(
             matchingUserInfo: [SessionIdentityPolicy.notificationCctopSessionIDKey: cctopSessionID],
-            in: [userSession(display: current, records: [current])]
+            in: [userSession(
+                identity: SessionIdentityPolicy.logicalIdentity(for: current),
+                display: current,
+                records: [current]
+            )]
         )
 
-        XCTAssertEqual(resolved?.sessionId, "current-observation")
+        XCTAssertEqual(resolved?.sessionId, "current-record")
         XCTAssertEqual(resolved?.pid, 22_222)
     }
 
@@ -67,17 +71,21 @@ final class PanelToggleTests: XCTestCase {
         previous.cctopSessionId = nil
         previous.lifecycle = .dormant
         var current = SessionData.mock(
-            id: "replacement-observation", cctopSessionId: cctopSessionID,
+            id: "replacement-record", cctopSessionId: cctopSessionID,
             pid: 22_222, source: SessionData.codexSource
         )
         current.lifecycle = .active
 
-        let resolved = AppDelegate.notificationFocusSession(
+        let resolved = AppDelegate.notificationFocusTarget(
             matchingUserInfo: [SessionIdentityPolicy.notificationSessionIDKey: "codex-thread-1"],
-            in: [userSession(display: current, records: [previous, current])]
+            in: [userSession(
+                identity: SessionIdentityPolicy.logicalIdentity(for: current),
+                display: current,
+                records: [previous, current]
+            )]
         )
 
-        XCTAssertEqual(resolved?.sessionId, "replacement-observation")
+        XCTAssertEqual(resolved?.sessionId, "replacement-record")
         XCTAssertEqual(resolved?.pid, 22_222)
     }
 
@@ -94,12 +102,16 @@ final class PanelToggleTests: XCTestCase {
             SessionIdentityPolicy.notificationSessionPIDKey: "22222",
         ]
 
-        let userSessions = [userSession(display: current, records: [current])]
-        XCTAssertNil(AppDelegate.notificationFocusSession(matchingUserInfo: userInfo, in: userSessions))
-        XCTAssertNil(AppDelegate.notificationFocusSession(
+        let userSessions = [userSession(
+            identity: SessionIdentityPolicy.logicalIdentity(for: current),
+            display: current,
+            records: [current]
+        )]
+        XCTAssertNil(AppDelegate.notificationFocusTarget(matchingUserInfo: userInfo, in: userSessions))
+        XCTAssertNil(AppDelegate.notificationFocusTarget(
             matchingUserInfo: [SessionIdentityPolicy.notificationCctopSessionIDKey: "malformed"],
             in: userSessions
         ))
-        XCTAssertNil(AppDelegate.notificationFocusSession(matchingUserInfo: [:], in: userSessions))
+        XCTAssertNil(AppDelegate.notificationFocusTarget(matchingUserInfo: [:], in: userSessions))
     }
 }

--- a/menubar/CctopMenubarTests/QASnapshotTests.swift
+++ b/menubar/CctopMenubarTests/QASnapshotTests.swift
@@ -170,8 +170,7 @@ final class QASnapshotTests: XCTestCase {
         for (colorScheme, schemeName) in schemes {
             try renderRefinedPanelContextSnapshot(
                 PopupView(
-                    sessions: SessionData.qaShowcase,
-                    userSessions: userSessionProjection(from: SessionData.qaShowcase),
+                    userSessions: userSessions(fromDataFixtures: SessionData.qaShowcase),
                     updater: DisabledUpdater(),
                     pluginManager: inertPluginManager()
                 ),
@@ -180,8 +179,7 @@ final class QASnapshotTests: XCTestCase {
             )
             try renderRefinedPanelContextSnapshot(
                 PopupView(
-                    sessions: SessionData.qaShowcase,
-                    userSessions: userSessionProjection(from: SessionData.qaShowcase),
+                    userSessions: userSessions(fromDataFixtures: SessionData.qaShowcase),
                     recentProjects: RecentProject.mockRecents,
                     updater: DisabledUpdater(),
                     pluginManager: inertPluginManager(),
@@ -234,8 +232,7 @@ final class QASnapshotTests: XCTestCase {
 
     private func popupView(for sessions: [SessionData]) -> some View {
         PopupView(
-            sessions: sessions,
-            userSessions: userSessionProjection(from: sessions),
+            userSessions: userSessions(fromDataFixtures: sessions),
             updater: DisabledUpdater(),
             pluginManager: inertPluginManager()
         )
@@ -253,8 +250,7 @@ final class QASnapshotTests: XCTestCase {
         colorScheme: ColorScheme = .light
     ) throws {
         let view = PopupView(
-            sessions: sessions,
-            userSessions: userSessionProjection(from: sessions),
+            userSessions: userSessions(fromDataFixtures: sessions),
             updater: updater ?? DisabledUpdater(),
             pluginManager: inertPluginManager()
         )
@@ -287,8 +283,7 @@ final class QASnapshotTests: XCTestCase {
         colorScheme: ColorScheme = .light
     ) throws {
         let view = PopupView(
-            sessions: SessionData.qaShowcase,
-            userSessions: userSessionProjection(from: SessionData.qaShowcase),
+            userSessions: userSessions(fromDataFixtures: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             updater: DisabledUpdater(),
             pluginManager: inertPluginManager(),
@@ -548,7 +543,7 @@ private struct RefinedPanelContextScene: View {
             "  PanelAccentHairline(cornerRadius: 16)",
             "}",
             "cardSelectionStyle(isSelected: true)",
-            "HeaderView(sessions: sessions)",
+            "HeaderView(counts: statusCounts)",
             "renderPanelScreenshot(...)",
         ]
     }

--- a/menubar/CctopMenubarTests/SessionDedupTests.swift
+++ b/menubar/CctopMenubarTests/SessionDedupTests.swift
@@ -119,8 +119,11 @@ final class SessionDedupTests: XCTestCase {
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result[0].identity.cctopSessionID, winnerID)
         XCTAssertEqual(result[0].records.map(\.data.cctopSessionId), [discardedID, winnerID])
-        XCTAssertNil(FocusTargetResolver.currentSession(forCctopSessionID: discardedID, in: result))
-        XCTAssertEqual(FocusTargetResolver.currentSession(forCctopSessionID: winnerID, in: result)?.pid, 200)
+        XCTAssertNil(FocusTargetResolver.currentUserSession(forCctopSessionID: discardedID, in: result))
+        XCTAssertEqual(
+            FocusTargetResolver.currentUserSession(forCctopSessionID: winnerID, in: result)?.focusTarget.pid,
+            200
+        )
     }
 
     // MARK: - Desktop dedup by session_id (Phase 1, total order)

--- a/menubar/CctopMenubarTests/SessionDisplayPolicyTests.swift
+++ b/menubar/CctopMenubarTests/SessionDisplayPolicyTests.swift
@@ -10,8 +10,12 @@ final class SessionDisplayPolicyTests: XCTestCase {
             dormant(id: "dormant"),
             activeWaiting(id: "waiting", lastActivity: now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 60)),
         ]
+        let userSessions = userSessions(fromDataFixtures: sessions)
 
-        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: sessions, now: now).map(\.id), ["fresh", "waiting"])
+        XCTAssertEqual(
+            SessionDisplayPolicy.activeSessions(from: userSessions, now: now).map(\.displayRecord.data.id),
+            ["fresh", "waiting"]
+        )
     }
 
     func testIdleSessionsIncludesDormantAndStaleActiveIdleOnly() {
@@ -22,8 +26,34 @@ final class SessionDisplayPolicyTests: XCTestCase {
             dormant(id: "dormant"),
             activeWaiting(id: "waiting", lastActivity: now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 60)),
         ]
+        let userSessions = sessions.map {
+            userSession(identity: SessionIdentityPolicy.logicalIdentity(for: $0), display: $0, records: [$0])
+        }
 
-        XCTAssertEqual(SessionDisplayPolicy.idleSessions(from: sessions, now: now).map(\.id), ["stale", "dormant"])
+        XCTAssertEqual(
+            SessionDisplayPolicy.idleSessions(from: userSessions, now: now).map(\.displayRecord.data.id),
+            ["stale", "dormant"]
+        )
+    }
+
+    func testReconciledOrderOwnsIdleRecencyOrder() {
+        let now = Date(timeIntervalSince1970: 5_000)
+        var older = dormant(id: "a-older")
+        older.lastActivity = now.addingTimeInterval(-300)
+        var newer = dormant(id: "z-newer")
+        newer.lastActivity = now.addingTimeInterval(-10)
+
+        let result = SessionDisplayPolicy.reconcilingOrder(
+            in: userSessions(fromDataFixtures: [older, newer]),
+            preserving: [],
+            now: now
+        )
+
+        XCTAssertEqual(result.map(\.displayRecord.data.id), ["z-newer", "a-older"])
+        XCTAssertEqual(
+            SessionDisplayPolicy.idleSessions(from: result, now: now).map(\.identity),
+            result.map(\.identity)
+        )
     }
 
     func testSignatureTracksDisplayBuckets() {
@@ -33,17 +63,20 @@ final class SessionDisplayPolicyTests: XCTestCase {
             activeIdle(id: "stale", lastActivity: now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 60)),
             dormant(id: "dormant"),
         ]
+        let userSessions = sessions.map {
+            userSession(identity: SessionIdentityPolicy.logicalIdentity(for: $0), display: $0, records: [$0])
+        }
 
         XCTAssertEqual(
-            SessionDisplayPolicy.signature(for: sessions, now: now),
+            SessionDisplayPolicy.signature(for: userSessions, now: now),
             .init(
-                activeIDs: [SessionIdentityPolicy.logicalIdentity(for: sessions[0])],
-                idleIDs: sessions[1...].map { SessionIdentityPolicy.logicalIdentity(for: $0) }
+                activeIDs: [userSessions[0].identity],
+                idleIDs: Array(userSessions[1...]).map(\.identity)
             )
         )
     }
 
-    func testReconciledActiveOrderKeepsWaitingPeerOrderAcrossSameGroupUpdates() {
+    func testReconciledOrderKeepsWaitingPeerOrderAcrossSameGroupUpdates() {
         let now = Date(timeIntervalSince1970: 10_000)
         var first = SessionData.mock(id: "first", status: .waitingInput, notificationMessage: "old")
         first.lastActivity = now.addingTimeInterval(-300)
@@ -58,18 +91,18 @@ final class SessionDisplayPolicyTests: XCTestCase {
         second.lastActivity = now.addingTimeInterval(-600)
         second.notificationMessage = "Continue?"
 
-        let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [second, first],
-            preserving: previous,
+        let result = SessionDisplayPolicy.reconcilingOrder(
+            in: userSessions(fromDataFixtures: [second, first]),
+            preserving: userSessions(fromDataFixtures: previous),
             now: now
         )
 
-        XCTAssertEqual(result.map(\.id), ["first", "second"])
+        XCTAssertEqual(result.map(\.displayRecord.data.id), ["first", "second"])
         XCTAssertEqual(result.map(\.status), [.needsAttention, .waitingInput])
-        XCTAssertEqual(result.map(\.notificationMessage), ["Review failure", "Continue?"])
+        XCTAssertEqual(result.map(\.displayRecord.data.notificationMessage), ["Review failure", "Continue?"])
     }
 
-    func testReconciledActiveOrderKeepsWorkingAndActiveIdlePeerOrderAcrossActivityChanges() {
+    func testReconciledOrderKeepsWorkingAndActiveIdlePeerOrderAcrossActivityChanges() {
         let now = Date(timeIntervalSince1970: 20_000)
         var workA = SessionData.mock(id: "work-a", status: .working)
         var workB = SessionData.mock(id: "work-b", status: .working)
@@ -82,16 +115,16 @@ final class SessionDisplayPolicyTests: XCTestCase {
         idleA.lastActivity = now.addingTimeInterval(-60)
         idleB.lastActivity = now.addingTimeInterval(-1_200)
 
-        let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [idleB, workB, idleA, workA],
-            preserving: previous,
+        let result = SessionDisplayPolicy.reconcilingOrder(
+            in: userSessions(fromDataFixtures: [idleB, workB, idleA, workA]),
+            preserving: userSessions(fromDataFixtures: previous),
             now: now
         )
 
-        XCTAssertEqual(result.map(\.id), ["work-a", "work-b", "idle-a", "idle-b"])
+        XCTAssertEqual(result.map(\.displayRecord.data.id), ["work-a", "work-b", "idle-a", "idle-b"])
     }
 
-    func testReconciledActiveOrderMovesWorkingSessionToWaitingGroupTail() {
+    func testReconciledOrderMovesWorkingSessionToWaitingGroupTail() {
         let now = Date(timeIntervalSince1970: 30_000)
         let waitA = SessionData.mock(id: "wait-a", status: .waitingInput)
         let waitB = SessionData.mock(id: "wait-b", status: .needsAttention)
@@ -100,16 +133,16 @@ final class SessionDisplayPolicyTests: XCTestCase {
 
         working.status = .waitingInput
 
-        let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [working, waitB, waitA],
-            preserving: previous,
+        let result = SessionDisplayPolicy.reconcilingOrder(
+            in: userSessions(fromDataFixtures: [working, waitB, waitA]),
+            preserving: userSessions(fromDataFixtures: previous),
             now: now
         )
 
-        XCTAssertEqual(result.map(\.id), ["wait-a", "wait-b", "working"])
+        XCTAssertEqual(result.map(\.displayRecord.data.id), ["wait-a", "wait-b", "working"])
     }
 
-    func testReconciledActiveOrderMovesWaitingSessionToWorkingGroupTail() {
+    func testReconciledOrderMovesWaitingSessionToWorkingGroupTail() {
         let now = Date(timeIntervalSince1970: 40_000)
         var waiting = SessionData.mock(id: "waiting", status: .waitingInput)
         let workA = SessionData.mock(id: "work-a", status: .working)
@@ -117,16 +150,16 @@ final class SessionDisplayPolicyTests: XCTestCase {
         let previous = [waiting, workA, workB]
 
         waiting.status = .working
-        let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [waiting, workB, workA],
-            preserving: previous,
+        let result = SessionDisplayPolicy.reconcilingOrder(
+            in: userSessions(fromDataFixtures: [waiting, workB, workA]),
+            preserving: userSessions(fromDataFixtures: previous),
             now: now
         )
 
-        XCTAssertEqual(result.map(\.id), ["work-a", "work-b", "waiting"])
+        XCTAssertEqual(result.map(\.displayRecord.data.id), ["work-a", "work-b", "waiting"])
     }
 
-    func testReconciledActiveOrderAppendsNewcomersWithinEachPriorityGroup() {
+    func testReconciledOrderAppendsNewcomersWithinEachPriorityGroup() {
         let now = Date(timeIntervalSince1970: 50_000)
         let permission = SessionData.mock(id: "permission", status: .waitingPermission)
         let waiting = SessionData.mock(id: "waiting", status: .waitingInput)
@@ -139,14 +172,17 @@ final class SessionDisplayPolicyTests: XCTestCase {
         let newCompacting = SessionData.mock(id: "new-compacting", status: .compacting)
         let newIdle = SessionData.mock(id: "new-idle", status: .idle)
 
-        let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [newIdle, newCompacting, newWorking, newWaiting, newPermission, idle, compacting, working, waiting, permission],
-            preserving: [permission, waiting, working, compacting, idle],
+        let result = SessionDisplayPolicy.reconcilingOrder(
+            in: userSessions(fromDataFixtures: [
+                newIdle, newCompacting, newWorking, newWaiting, newPermission,
+                idle, compacting, working, waiting, permission,
+            ]),
+            preserving: userSessions(fromDataFixtures: [permission, waiting, working, compacting, idle]),
             now: now
         )
 
         XCTAssertEqual(
-            result.map(\.id),
+            result.map(\.displayRecord.data.id),
             [
                 "permission", "new-permission", "waiting", "new-waiting", "working", "new-working",
                 "compacting", "new-compacting", "idle", "new-idle",
@@ -154,7 +190,7 @@ final class SessionDisplayPolicyTests: XCTestCase {
         )
     }
 
-    func testReconciledActiveOrderCompactsSurvivorsAndKeepsNonActiveRemainderOrder() {
+    func testReconciledOrderCompactsActiveSurvivorsAndAppendsCanonicalIdleRows() {
         let now = Date(timeIntervalSince1970: 60_000)
         let waitA = SessionData.mock(id: "wait-a", status: .waitingInput)
         let waitB = SessionData.mock(id: "wait-b", status: .waitingInput)
@@ -163,34 +199,40 @@ final class SessionDisplayPolicyTests: XCTestCase {
         var dormant = SessionData.mock(id: "dormant", status: .idle)
         dormant.lifecycle = .dormant
 
-        let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [workB, dormant, waitB],
-            preserving: [waitA, waitB, workA, workB],
+        let result = SessionDisplayPolicy.reconcilingOrder(
+            in: userSessions(fromDataFixtures: [workB, dormant, waitB]),
+            preserving: userSessions(fromDataFixtures: [waitA, waitB, workA, workB]),
             now: now
         )
 
-        XCTAssertEqual(result.map(\.id), ["wait-b", "work-b", "dormant"])
-        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: result, now: now).map(\.id), ["wait-b", "work-b"])
-        XCTAssertEqual(SessionDisplayPolicy.idleSessions(from: result, now: now).map(\.id), ["dormant"])
+        XCTAssertEqual(result.map(\.displayRecord.data.id), ["wait-b", "work-b", "dormant"])
+        XCTAssertEqual(
+            SessionDisplayPolicy.activeSessions(from: result, now: now).map(\.displayRecord.data.id),
+            ["wait-b", "work-b"]
+        )
+        XCTAssertEqual(
+            SessionDisplayPolicy.idleSessions(from: result, now: now).map(\.displayRecord.data.id),
+            ["dormant"]
+        )
     }
 
-    func testReconciledActiveOrderUsesDeterministicCurrentInputOnInitialLoad() {
+    func testReconciledOrderUsesDeterministicCurrentInputOnInitialLoad() {
         let now = Date(timeIntervalSince1970: 70_000)
         let workA = SessionData.mock(id: "a-work", status: .working)
         let waiting = SessionData.mock(id: "b-wait", status: .waitingInput)
         let workB = SessionData.mock(id: "c-work", status: .working)
         let idle = SessionData.mock(id: "d-idle", status: .idle)
 
-        let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [workA, waiting, workB, idle],
+        let result = SessionDisplayPolicy.reconcilingOrder(
+            in: userSessions(fromDataFixtures: [workA, waiting, workB, idle]),
             preserving: [],
             now: now
         )
 
-        XCTAssertEqual(result.map(\.id), ["b-wait", "a-work", "c-work", "d-idle"])
+        XCTAssertEqual(result.map(\.displayRecord.data.id), ["b-wait", "a-work", "c-work", "d-idle"])
     }
 
-    func testReconciledActiveOrderTreatsStaleIdleReentryAsGroupEntrant() {
+    func testReconciledOrderTreatsStaleIdleReentryAsGroupEntrant() {
         let now = Date(timeIntervalSince1970: 80_000)
         let survivor = SessionData.mock(id: "survivor", status: .working)
         var returning = SessionData.mock(id: "returning", status: .idle)
@@ -199,16 +241,16 @@ final class SessionDisplayPolicyTests: XCTestCase {
 
         returning.status = .working
         returning.lastActivity = now
-        let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [returning, survivor],
-            preserving: previous,
+        let result = SessionDisplayPolicy.reconcilingOrder(
+            in: userSessions(fromDataFixtures: [returning, survivor]),
+            preserving: userSessions(fromDataFixtures: previous),
             now: now
         )
 
-        XCTAssertEqual(result.map(\.id), ["survivor", "returning"])
+        XCTAssertEqual(result.map(\.displayRecord.data.id), ["survivor", "returning"])
     }
 
-    func testReconciledActiveOrderUsesStableConversationIdentityAcrossDesktopPIDChange() {
+    func testReconciledOrderUsesStableConversationIdentityAcrossDesktopPIDChange() {
         let now = Date(timeIntervalSince1970: 90_000)
         let terminal = TerminalInfo(program: "Claude", bundleId: HostAppBundleID.claudeDesktop)
         var desktop = SessionData.mock(
@@ -223,40 +265,46 @@ final class SessionDisplayPolicyTests: XCTestCase {
 
         desktop.pid = 200
         desktop.lastActivity = now
-        let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [other, desktop],
-            preserving: previous,
+        let result = SessionDisplayPolicy.reconcilingOrder(
+            in: [other, desktop].map {
+                userSession(identity: SessionIdentityPolicy.logicalIdentity(for: $0), display: $0, records: [$0])
+            },
+            preserving: previous.map {
+                userSession(identity: SessionIdentityPolicy.logicalIdentity(for: $0), display: $0, records: [$0])
+            },
             now: now
         )
 
-        XCTAssertEqual(result.map(\.id), ["200", "other"])
+        XCTAssertEqual(result.map(\.displayRecord.data.id), ["200", "other"])
         XCTAssertEqual(
             SessionIdentityPolicy.stableKey(for: previous[0]),
-            SessionIdentityPolicy.stableKey(for: result[0])
+            SessionIdentityPolicy.stableKey(for: result[0].displayRecord.data)
         )
     }
 
-    func testReconciledActiveOrderUsesPermanentIdentityAcrossRecordReplacementAndStatusMovement() {
+    func testReconciledOrderUsesPermanentIdentityAcrossRecordReplacementAndStatusMovement() {
         let now = Date(timeIntervalSince1970: 95_000)
         let sharedID = "11111111-1111-4111-8111-111111111111"
         var userSession = SessionData.mock(
-            id: "old-observation", cctopSessionId: sharedID,
+            id: "old-record", cctopSessionId: sharedID,
             status: .working, pid: 100, source: SessionData.opencodeSource
         )
         let workingPeer = SessionData.mock(id: "peer", status: .working, pid: 200, source: SessionData.opencodeSource)
         let previous = [userSession, workingPeer]
 
         userSession = SessionData.mock(
-            id: "new-observation", cctopSessionId: sharedID,
+            id: "new-record", cctopSessionId: sharedID,
             status: .waitingInput, pid: 300, source: SessionData.opencodeSource
         )
-        let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [workingPeer, userSession], preserving: previous, now: now
+        let result = SessionDisplayPolicy.reconcilingOrder(
+            in: userSessions(fromDataFixtures: [workingPeer, userSession]),
+            preserving: userSessions(fromDataFixtures: previous),
+            now: now
         )
 
-        XCTAssertEqual(result.map(\.pid), [300, 200])
+        XCTAssertEqual(result.map(\.displayRecord.data.pid), [300, 200])
         XCTAssertEqual(
-            result.map { SessionIdentityPolicy.logicalIdentity(for: $0) },
+            result.map(\.identity),
             [
                 SessionIdentityPolicy.logicalIdentity(for: userSession),
                 SessionIdentityPolicy.logicalIdentity(for: workingPeer),
@@ -264,27 +312,27 @@ final class SessionDisplayPolicyTests: XCTestCase {
         )
     }
 
-    func testReconciledActiveOrderDoesNotReplayDuplicatePreviousLogicalRows() {
-        let now = Date(timeIntervalSince1970: 96_000)
+    func testReconciledOrderKeepsLegacySlotAfterPermanentIDStamp() {
+        let now = Date(timeIntervalSince1970: 95_500)
         let sharedID = "11111111-1111-4111-8111-111111111111"
-        let previousFirst = SessionData.mock(
-            id: "old-first", cctopSessionId: sharedID,
-            status: .working, pid: 100, source: SessionData.opencodeSource
+        var legacy = SessionData.mock(
+            id: "same-record", status: .working, pid: 100, source: SessionData.opencodeSource
         )
-        let previousSecond = SessionData.mock(
-            id: "old-second", cctopSessionId: sharedID,
+        legacy.cctopSessionId = nil
+        var stamped = legacy
+        stamped.cctopSessionId = sharedID
+        let peer = SessionData.mock(
+            id: "peer", cctopSessionId: "22222222-2222-4222-8222-222222222222",
             status: .working, pid: 200, source: SessionData.opencodeSource
         )
-        let current = SessionData.mock(
-            id: "current", cctopSessionId: sharedID,
-            status: .working, pid: 300, source: SessionData.opencodeSource
+
+        let result = SessionDisplayPolicy.reconcilingOrder(
+            in: userSessions(fromDataFixtures: [peer, stamped]),
+            preserving: userSessions(fromDataFixtures: [legacy, peer]),
+            now: now
         )
 
-        let result = SessionDisplayPolicy.reconcilingActiveOrder(
-            in: [current], preserving: [previousFirst, previousSecond], now: now
-        )
-
-        XCTAssertEqual(result.map(\.pid), [300])
+        XCTAssertEqual(result.map(\.displayRecord.data.pid), [100, 200])
     }
 
     private func activeIdle(id: String, lastActivity: Date) -> SessionData {

--- a/menubar/CctopMenubarTests/SessionLifecycleTests.swift
+++ b/menubar/CctopMenubarTests/SessionLifecycleTests.swift
@@ -181,7 +181,7 @@ final class SessionLifecycleTests: XCTestCase {
             }
         )
 
-        XCTAssertEqual(manager.sessions.map(\.lifecycle), [.dormant])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.lifecycle), [.dormant])
         XCTAssertNotNil(try SessionData.fromFile(path: sessionPath).disconnectedAt)
     }
 
@@ -222,7 +222,7 @@ final class SessionLifecycleTests: XCTestCase {
             }
         )
 
-        XCTAssertEqual(manager.sessions.map(\.lifecycle), [.dormant])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.lifecycle), [.dormant])
         XCTAssertEqual(try SessionData.fromFile(path: sessionPath).disconnectedAt, disconnectedAt)
     }
 
@@ -254,7 +254,7 @@ final class SessionLifecycleTests: XCTestCase {
             }
         )
 
-        XCTAssertEqual(manager.sessions.count, 0)
+        XCTAssertEqual(manager.userSessions.count, 0)
         XCTAssertFalse(FileManager.default.fileExists(atPath: sessionPath))
     }
 
@@ -302,7 +302,7 @@ final class SessionLifecycleTests: XCTestCase {
             processAlive: { $0.pid == pid && $0.isAlive }
         )
 
-        XCTAssertEqual(manager.sessions.map(\.lifecycle), [.active])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.lifecycle), [.active])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
     }
 
@@ -1041,7 +1041,7 @@ final class SessionLifecycleTests: XCTestCase {
             startMonitoring: false
         )
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertEqual(manager.recentResumeTargets.map(\.title), ["Run plugin node:test suites in CI"])
         XCTAssertEqual(manager.recentResumeTargets.map(\.openActionLabel), ["Open Claude Desktop"])
     }

--- a/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
+++ b/menubar/CctopMenubarTests/SessionManagerVisibilityTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Darwin
 import XCTest
 @testable import CctopMenubar
@@ -49,23 +50,22 @@ final class SessionManagerVisibilityTests: XCTestCase {
             processAlive: { _ in true },
             manualSessionVisibility: visibility
         )
-        let originalOrder = manager.sessions.map { SessionIdentityPolicy.stableKey(for: $0) }
-        let hidden = try XCTUnwrap(manager.sessions.dropFirst().first)
-        let hiddenStableKey = SessionIdentityPolicy.stableKey(for: hidden)
-        let hiddenSessionID = try XCTUnwrap(hidden.cctopSessionId)
+        let originalOrder = manager.userSessions.map(\.identity)
+        let hiddenUserSession = try XCTUnwrap(manager.userSessions.dropFirst().first)
+        let hidden = hiddenUserSession.displayRecord.data
+        let hiddenSessionID = try XCTUnwrap(hiddenUserSession.identity.cctopSessionID)
 
-        manager.hideSession(hidden)
+        manager.hideSession(hiddenUserSession.identity)
 
-        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data), manager.sessions)
         XCTAssertFalse(manager.userSessions.contains { $0.identity.cctopSessionID == hiddenSessionID })
         XCTAssertEqual(
-            manager.sessions.map { SessionIdentityPolicy.stableKey(for: $0) },
-            originalOrder.filter { $0 != hiddenStableKey }
+            manager.userSessions.map(\.identity),
+            originalOrder.filter { $0 != hiddenUserSession.identity }
         )
-        XCTAssertEqual(StatusCounts(sessions: manager.sessions).total, 2)
+        XCTAssertEqual(StatusCounts(userSessions: manager.userSessions).total, 2)
         XCTAssertEqual(
             DisplayStateWriter.snapshot(
-                sessions: manager.sessions,
+                userSessions: manager.userSessions,
                 theme: .claude,
                 appRunning: true,
                 appIdentity: nil,
@@ -79,8 +79,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         manager.loadSessions()
         XCTAssertEqual(
-            manager.sessions.map { SessionIdentityPolicy.stableKey(for: $0) },
-            originalOrder.filter { $0 != hiddenStableKey }
+            manager.userSessions.map(\.identity),
+            originalOrder.filter { $0 != hiddenUserSession.identity }
         )
         XCTAssertTrue(manager.cleanupActiveProjectPaths.contains(hidden.projectPath))
 
@@ -90,7 +90,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             processAlive: { _ in true },
             manualSessionVisibility: visibility
         )
-        XCTAssertFalse(reloaded.sessions.contains { $0.cctopSessionId == hiddenSessionID })
+        XCTAssertFalse(reloaded.userSessions.contains { $0.identity.cctopSessionID == hiddenSessionID })
 
         try FileManager.default.removeItem(atPath: hiddenPath)
         reloaded.loadSessions()
@@ -142,24 +142,120 @@ final class SessionManagerVisibilityTests: XCTestCase {
             startMonitoring: false
         )
 
-        XCTAssertEqual(manager.sessions.count, 2)
-        XCTAssertEqual(manager.userSessions.map { $0.displayRecord.data }, manager.sessions)
+        XCTAssertEqual(manager.userSessions.count, 2)
         let shared = try XCTUnwrap(manager.userSessions.first { $0.identity.cctopSessionID == sharedID })
         XCTAssertEqual(shared.displayRecord.data.pid, 22_222)
         XCTAssertEqual(Set(shared.records.compactMap { $0.data.pid }), [11_111, 22_222])
 
-        previous.sessionName = "Updated non-winning observation"
+        previous.sessionName = "Updated non-winning record"
         try previous.writeToFile(path: previousURL.path)
         manager.loadSessions()
 
-        XCTAssertEqual(manager.userSessions.map { $0.displayRecord.data }, manager.sessions)
         let refreshed = try XCTUnwrap(manager.userSessions.first { $0.identity.cctopSessionID == sharedID })
         XCTAssertEqual(refreshed.displayRecord.data.pid, 22_222)
         XCTAssertTrue(refreshed.records.contains { $0.data.sessionName == previous.sessionName })
 
-        manager.hideSession(current)
-        XCTAssertEqual(manager.userSessions.map { $0.displayRecord.data }, manager.sessions)
+        manager.hideSession(refreshed.identity)
         XCTAssertFalse(manager.userSessions.contains { $0.identity.cctopSessionID == sharedID })
+    }
+
+    @MainActor
+    func testUpdateSessionProjectionPublishesRetainedRecordChangesWhenDisplayDataIsUnchanged() throws {
+        let sources = try isolatedSessionDataSources(prefix: "cctop-record-identity")
+        let historyDir = sources.sessionsDir.appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: historyDir, withIntermediateDirectories: true)
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: historyDir),
+            dataSources: sources,
+            startMonitoring: false
+        )
+        let displayData = SessionData.mock(
+            id: "display",
+            cctopSessionId: "22222222-2222-4222-8222-222222222222",
+            status: .working,
+            pid: 456,
+            source: SessionData.codexSource
+        )
+        var retainedData = displayData
+        retainedData.pid = 789
+        let displayRecord = SessionRecord(
+            data: displayData,
+            lifecycleRank: SessionLifecycle.active.rawValue,
+            mtime: Date(timeIntervalSince1970: 123_456),
+            path: sources.sessionsDir.appendingPathComponent("display.json").path
+        )
+        let retainedRecord = SessionRecord(
+            data: retainedData,
+            lifecycleRank: SessionLifecycle.dormant.rawValue,
+            mtime: Date(timeIntervalSince1970: 123_400),
+            path: sources.sessionsDir.appendingPathComponent("retained.json").path
+        )
+        let initial = UserSession(
+            identity: SessionIdentityPolicy.logicalIdentity(for: displayData),
+            records: [displayRecord],
+            displayRecord: displayRecord
+        )
+        manager.updateSessionProjection([initial])
+        var didPublish = false
+        let cancellable: AnyCancellable = manager.objectWillChange.sink { didPublish = true }
+        defer { cancellable.cancel() }
+
+        manager.updateSessionProjection([
+            UserSession(
+                identity: initial.identity,
+                records: [displayRecord, retainedRecord],
+                displayRecord: displayRecord
+            ),
+        ])
+
+        XCTAssertTrue(didPublish)
+        XCTAssertEqual(manager.userSessions.first?.records.count, 2)
+    }
+
+    @MainActor
+    func testIdentityAssignmentReturnsTheRecordWithEvidenceIntact() throws {
+        let sources = try isolatedSessionDataSources(prefix: "cctop-record-evidence")
+        let historyDir = sources.sessionsDir.appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: historyDir, withIntermediateDirectories: true)
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: historyDir),
+            dataSources: sources,
+            startMonitoring: false
+        )
+        let durableSessionID = "11111111-1111-4111-8111-111111111111"
+        let assignedCctopSessionID = "22222222-2222-4222-8222-222222222222"
+        var data = SessionData.mock(
+            id: durableSessionID,
+            status: .working,
+            pid: 456,
+            source: SessionData.codexSource
+        )
+        data.cctopSessionId = nil
+        data.harnessSessionId = durableSessionID
+        var knownData = data
+        knownData.cctopSessionId = assignedCctopSessionID
+        let recordURL = sources.sessionsDir.appendingPathComponent("record.json")
+        try data.writeToFile(path: recordURL.path)
+        let record = SessionRecord(
+            data: data,
+            lifecycleRank: SessionLifecycle.dormant.rawValue,
+            mtime: Date(timeIntervalSince1970: 123_456),
+            path: recordURL.path
+        )
+
+        let result = try XCTUnwrap(
+            manager.assigningCctopSessionIdentities(
+                to: [record],
+                knownRecords: [(url: sources.sessionsDir.appendingPathComponent("known.json"), session: knownData)]
+            ).first
+        )
+        waitForIdentityMigrationQueue(manager)
+
+        XCTAssertEqual(result.data.cctopSessionId, assignedCctopSessionID)
+        XCTAssertEqual(result.data.sessionId, data.sessionId)
+        XCTAssertEqual(result.lifecycleRank, record.lifecycleRank)
+        XCTAssertEqual(result.mtime, record.mtime)
+        XCTAssertEqual(result.path, record.path)
     }
 
     @MainActor
@@ -185,13 +281,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
             dataSources: sources,
             startMonitoring: false
         )
-        XCTAssertEqual(manager.sessions.count, 1)
         XCTAssertEqual(manager.userSessions.count, 1)
 
         try FileManager.default.removeItem(at: sessionsDir)
         manager.loadSessions()
 
-        XCTAssertTrue(manager.sessions.isEmpty)
         XCTAssertTrue(manager.userSessions.isEmpty)
     }
 
@@ -207,8 +301,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let identityBlockerPath = (root as NSString).appendingPathComponent("session-identities")
         try Data("not a directory".utf8).write(to: URL(fileURLWithPath: identityBlockerPath))
         let threadID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
-        let currentRecordID = "current-observation"
-        let conflictingRecordID = "conflicting-observation"
+        let currentRecordID = "current-record"
+        let conflictingRecordID = "conflicting-record"
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
         let conflictingCctopSessionID = "22222222-2222-4222-8222-222222222222"
         var session = SessionData(
@@ -269,7 +363,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let historyManager = HistoryManager(historyDir: URL(fileURLWithPath: historyDir))
         let manager = SessionManager(historyManager: historyManager, dataSources: sources, startMonitoring: false)
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(postedNotificationIDs.isEmpty)
         XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
         XCTAssertNil(try SessionData.fromFile(path: sessionPath).cctopSessionId)
@@ -281,7 +375,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try FileManager.default.removeItem(atPath: conflictingPath)
         manager.loadSessions()
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(postedNotificationIDs.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [cctopSessionID])
         XCTAssertNil(try SessionData.fromFile(path: sessionPath).cctopSessionId)
@@ -293,7 +387,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try FileManager.default.removeItem(atPath: identityBlockerPath)
         manager.loadSessions()
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [cctopSessionID])
         XCTAssertEqual(
             defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
@@ -305,10 +399,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
         manager.loadSessions()
         XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
         manager.loadSessions()
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
 
         let reloaded = SessionManager(historyManager: historyManager, dataSources: sources, startMonitoring: false)
-        XCTAssertTrue(reloaded.sessions.isEmpty)
+        XCTAssertTrue(reloaded.userSessions.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [cctopSessionID])
         XCTAssertTrue(postedNotificationIDs.isEmpty)
     }
@@ -374,7 +468,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             startMonitoring: false
         )
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(
             manager.cleanupSources.filter { $0.sessionId == threadID }.map(\.projectPath),
@@ -409,7 +503,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try FileManager.default.removeItem(atPath: brokenPath)
         manager.loadSessions()
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
         XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 1)
         XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == unrelatedThreadID }.count, 1)
@@ -449,7 +543,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             startMonitoring: false
         )
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.map(\.projectPath), [projectPath])
         XCTAssertEqual(
@@ -547,7 +641,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             startMonitoring: false
         )
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertTrue(manager.cleanupSources.contains { $0.projectPath == projectPath })
         XCTAssertEqual(
@@ -595,7 +689,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
             ["codex:\(threadID)"]
         )
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 0)
         XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
@@ -610,7 +704,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             defaults.stringArray(forKey: ManualSessionVisibilityStore.legacyDefaultsKey),
             ["codex:\(threadID)"]
         )
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 0)
         XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
@@ -625,7 +719,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertEqual(visibility.hiddenSessionIDs, migratedSessionIDs)
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(manager.cleanupSources.filter { $0.sessionId == threadID }.count, 0)
         XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
@@ -639,7 +733,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         manager.loadSessions()
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertTrue(visibility.hiddenSessionIDs.isEmpty)
         XCTAssertEqual(
@@ -659,7 +753,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         XCTAssertEqual(visibility.hiddenSessionIDs, [try XCTUnwrap(fastPeer.cctopSessionId)])
         XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.legacyDefaultsKey))
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertTrue(FileManager.default.fileExists(atPath: fastPeerPath))
         XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: historyDir), ["history.json"])
@@ -718,7 +812,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             startMonitoring: false
         )
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertFalse(FileManager.default.fileExists(atPath: finishedURL.path))
         XCTAssertEqual(try FileManager.default.contentsOfDirectory(at: historyURL, includingPropertiesForKeys: nil).count, 1)
@@ -766,7 +860,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         archived.cctopSessionId = nil
         archived.harnessSessionId = durableConversationID
-        archived.sessionName = "Archived desktop observation"
+        archived.sessionName = "Archived desktop record"
         archived.lastActivity = Date(timeIntervalSince1970: 2_000)
         try archived.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("archived-desktop.json"))
         try Data("not valid session json".utf8).write(
@@ -786,12 +880,14 @@ final class SessionManagerVisibilityTests: XCTestCase {
             dataSources: sources,
             startMonitoring: false
         )
-        let hidden = try XCTUnwrap(manager.sessions.first { $0.sessionId == live.sessionId })
+        let hiddenUserSession = try XCTUnwrap(manager.userSessions.first {
+            $0.displayRecord.data.sessionId == live.sessionId
+        })
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
 
-        manager.hideSession(hidden)
+        manager.hideSession(hiddenUserSession.identity)
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [sharedID])
 
@@ -800,7 +896,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [sharedID])
     }
@@ -817,7 +913,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let sharedID = "33333333-3333-4333-8333-333333333333"
         let durableConversationID = "59253133-4a65-48fb-af2b-844463d3b5bb"
         var live = SessionData(
-            sessionId: "live-terminal-observation",
+            sessionId: "live-terminal-record",
             projectPath: "/tmp/live-terminal",
             branch: "main",
             terminal: TerminalInfo(program: "zsh")
@@ -836,7 +932,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         archived.cctopSessionId = sharedID
         archived.harnessSessionId = durableConversationID
-        archived.sessionName = "Archived desktop observation"
+        archived.sessionName = "Archived desktop record"
         archived.lastActivity = Date(timeIntervalSince1970: 2_000)
         try archived.writeToFile(path: sessionsURL.appendingPathComponent("archived-desktop.json").path)
 
@@ -854,15 +950,15 @@ final class SessionManagerVisibilityTests: XCTestCase {
             startMonitoring: false
         )
 
-        XCTAssertEqual(manager.sessions.map(\.cctopSessionId), [sharedID])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.cctopSessionId), [sharedID])
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
 
         try FileManager.default.removeItem(at: liveURL)
         manager.loadSessions()
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertEqual(manager.recentResumeTargets.map(\.id), ["desktop:\(sharedID)"])
-        XCTAssertEqual(manager.recentResumeTargets.map(\.title), ["Archived desktop observation"])
+        XCTAssertEqual(manager.recentResumeTargets.map(\.title), ["Archived desktop record"])
     }
 
     @MainActor
@@ -889,10 +985,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         var hidden = claudeDesktopSession(sessionId: durableConversationID, projectPath: "/tmp/archived-only")
         hidden.cctopSessionId = sharedID
-        visibility.hide(hidden)
+        visibility.hide(cctopSessionID: try XCTUnwrap(hidden.cctopSessionId))
         hidden.cctopSessionId = nil
         hidden.harnessSessionId = durableConversationID
-        hidden.sessionName = "Archived-only observation"
+        hidden.sessionName = "Archived-only record"
         try hidden.writeToFile(path: sessionsURL.appendingPathComponent("archived-only.json").path)
 
         var sources = isolatedSessionDataSources(sessionsDir: sessionsURL, manualSessionVisibility: visibility)
@@ -908,7 +1004,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             startMonitoring: false
         )
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [sharedID])
 
@@ -934,8 +1030,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
         let durableSessionID = "59253133-4a65-48fb-af2b-844463d3b5bb"
-        let terminalRecordID = "busy-terminal-observation"
-        let bundlelessRecordID = "busy-desktop-observation"
+        let terminalRecordID = "busy-terminal-record"
+        let bundlelessRecordID = "busy-desktop-record"
         let projectPath = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -1005,14 +1101,14 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         waitForIdentityMigrationQueue(manager)
 
-        let hidden = try XCTUnwrap(manager.sessions.first)
-        let hiddenID = try XCTUnwrap(hidden.cctopSessionId)
-        XCTAssertEqual(manager.sessions.count, 1)
+        let hiddenUserSession = try XCTUnwrap(manager.userSessions.first)
+        let hiddenID = try XCTUnwrap(hiddenUserSession.identity.cctopSessionID)
+        XCTAssertEqual(manager.userSessions.count, 1)
         XCTAssertNil(try SessionData.fromFile(path: terminalURL.path).cctopSessionId)
         XCTAssertNil(try SessionData.fromFile(path: desktopURL.path).cctopSessionId)
 
-        manager.hideSession(hidden)
-        XCTAssertTrue(manager.sessions.isEmpty)
+        manager.hideSession(hiddenUserSession.identity)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [hiddenID])
 
         processAlive = false
@@ -1046,7 +1142,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         processAlive = true
         now = initialNow
         manager.loadSessions()
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [hiddenID])
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertTrue(postedNotificationIDs.isEmpty)
@@ -1083,7 +1179,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
         var hiddenSnapshot = session
         hiddenSnapshot.cctopSessionId = mappedID
-        visibility.hide(hiddenSnapshot)
+        visibility.hide(cctopSessionID: try XCTUnwrap(hiddenSnapshot.cctopSessionId))
 
         var missingSources = isolatedSessionDataSources(sessionsDir: sessionsURL, manualSessionVisibility: visibility)
         missingSources.codexThreads = StubCodexThreadState(existing: [], archived: [])
@@ -1097,7 +1193,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         waitForIdentityMigrationQueue(missingManager)
 
-        XCTAssertTrue(missingManager.sessions.isEmpty)
+        XCTAssertTrue(missingManager.userSessions.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [mappedID])
         XCTAssertEqual(try SessionData.fromFile(path: sessionURL.path).cctopSessionId, mappedID)
 
@@ -1109,7 +1205,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             startMonitoring: false
         )
 
-        XCTAssertTrue(restoredManager.sessions.isEmpty)
+        XCTAssertTrue(restoredManager.userSessions.isEmpty)
         XCTAssertEqual(visibility.hiddenSessionIDs, [mappedID])
     }
 
@@ -1155,14 +1251,14 @@ final class SessionManagerVisibilityTests: XCTestCase {
         finished.status = .working
         let finishedURL = sessionsURL.appendingPathComponent("hidden-finished.json")
         try finished.writeToFile(path: finishedURL.path)
-        visibility.hide(finished)
+        visibility.hide(cctopSessionID: try XCTUnwrap(finished.cctopSessionId))
         try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: historyURL.path)
 
         var sources = isolatedSessionDataSources(sessionsDir: sessionsURL, manualSessionVisibility: visibility)
         sources.processAlive = { _ in false }
         let manager = SessionManager(historyManager: historyManager, dataSources: sources, startMonitoring: false)
 
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
         XCTAssertTrue(FileManager.default.fileExists(atPath: finishedURL.path))
         XCTAssertEqual(visibility.hiddenSessionIDs, [hiddenID])
@@ -1184,7 +1280,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
         let hidden = SessionData.mock(id: "hidden-thread", source: SessionData.codexSource)
-        visibility.hide(hidden)
+        let hiddenID = try XCTUnwrap(hidden.cctopSessionId)
+        visibility.hide(cctopSessionID: hiddenID)
         try Data("not valid session json".utf8).write(
             to: URL(fileURLWithPath: (sessionsDir as NSString).appendingPathComponent("broken.json"))
         )
@@ -1195,10 +1292,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
             manualSessionVisibility: visibility
         )
 
-        XCTAssertTrue(visibility.isHidden(hidden))
+        XCTAssertTrue(visibility.isHidden(cctopSessionID: hiddenID))
         try FileManager.default.removeItem(atPath: (sessionsDir as NSString).appendingPathComponent("broken.json"))
         manager.loadSessions()
-        XCTAssertFalse(visibility.isHidden(hidden))
+        XCTAssertFalse(visibility.isHidden(cctopSessionID: hiddenID))
     }
 
     @MainActor
@@ -1237,7 +1334,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
-        visibility.hide(hidden)
+        let hiddenID = try XCTUnwrap(hidden.cctopSessionId)
+        visibility.hide(cctopSessionID: hiddenID)
 
         let manager = makeManager(
             sessionsDir: sessionsDir,
@@ -1270,7 +1368,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [projectPath, newActivePath])
         XCTAssertEqual(manager.cleanupSources.map(\.sessionId), cleanupSourceIDs)
         XCTAssertEqual(refreshedActivePaths, [projectPath, newActivePath])
-        XCTAssertTrue(visibility.isHidden(hidden))
+        XCTAssertTrue(visibility.isHidden(cctopSessionID: hiddenID))
 
         let snapshot = manager.cleanupSnapshotForRemoval()
         XCTAssertEqual(snapshot.activeProjectPaths, [projectPath, newActivePath])
@@ -1328,7 +1426,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
-        visibility.hide(hidden)
+        visibility.hide(cctopSessionID: try XCTUnwrap(hidden.cctopSessionId))
         let manager = makeManager(
             sessionsDir: sessionsDir,
             historyDir: historyDir,
@@ -1350,10 +1448,12 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try live.writeToFile(path: (sessionsDir as NSString).appendingPathComponent("4202.json"))
         manager.loadSessions()
 
-        let visible = try XCTUnwrap(manager.sessions.first { $0.cctopSessionId == live.cctopSessionId })
+        let visibleUserSession = try XCTUnwrap(manager.userSessions.first {
+            $0.identity.cctopSessionID == live.cctopSessionId
+        })
         XCTAssertEqual(Set(manager.recentResumeTargets.map(\.projectPath)), [targetProjectPath, unrelatedProjectPath])
 
-        manager.hideSession(visible)
+        manager.hideSession(visibleUserSession.identity)
 
         XCTAssertEqual(manager.recentResumeTargets.map(\.projectPath), [unrelatedProjectPath])
     }
@@ -1390,7 +1490,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let visibility = ManualSessionVisibilityStore(defaults: defaults)
-        visibility.hide(hidden)
+        let hiddenID = try XCTUnwrap(hidden.cctopSessionId)
+        visibility.hide(cctopSessionID: hiddenID)
 
         let manager = makeManager(
             sessionsDir: sessionsPath,
@@ -1400,7 +1501,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         XCTAssertTrue(manager.historyManager.recentProjects.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
-        XCTAssertTrue(visibility.isHidden(hidden))
+        XCTAssertTrue(visibility.isHidden(cctopSessionID: hiddenID))
 
         let threadID = "legacy-hidden-directory-session"
         let legacySuiteName = "cctop-legacy-hide-recent-directory-\(UUID().uuidString)"
@@ -1444,9 +1545,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
             manualSessionVisibility: visibility
         )
 
-        manager.hideSession(vanished)
+        let vanishedID = try XCTUnwrap(vanished.cctopSessionId)
+        let vanishedUUID = try XCTUnwrap(UUID(uuidString: vanishedID))
+        manager.hideSession(.permanent(vanishedUUID))
 
-        XCTAssertFalse(visibility.isHidden(vanished))
+        XCTAssertFalse(visibility.isHidden(cctopSessionID: vanishedID))
         XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.defaultsKey))
     }
 
@@ -1560,7 +1663,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions, [])
+        XCTAssertEqual(manager.userSessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: memoryPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: memoryPath + ".lock"))
         XCTAssertTrue(try SessionData.fromFile(path: memoryPath).hidden)
@@ -1589,7 +1692,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions, [])
+        XCTAssertEqual(manager.userSessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: titleHelperPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: titleHelperPath + ".lock"))
         XCTAssertTrue(try SessionData.fromFile(path: titleHelperPath).hidden)
@@ -1670,7 +1773,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions, [])
+        XCTAssertEqual(manager.userSessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: hiddenPath))
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
     }
@@ -1704,7 +1807,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions, [])
+        XCTAssertEqual(manager.userSessions, [])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [worktreePath])
     }
 
@@ -1734,7 +1837,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions, [])
+        XCTAssertEqual(manager.userSessions, [])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [worktreePath])
         XCTAssertTrue(try SessionData.fromFile(path: sessionPath).hidden)
     }
@@ -1905,7 +2008,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         let manager = makeManager(sessionsDir: sessionsDir, historyDir: historyDir)
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions, [])
+        XCTAssertEqual(manager.userSessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath + ".lock"))
         XCTAssertTrue(try SessionData.fromFile(path: sessionPath).hidden)
@@ -1952,7 +2055,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions, [])
+        XCTAssertEqual(manager.userSessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: cliPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: desktopPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: cliPath + ".lock"))
@@ -1995,7 +2098,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), ["delegated-visible"])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), ["delegated-visible"])
         let persisted = try SessionData.fromFile(path: sessionPath)
         XCTAssertFalse(persisted.hidden)
         XCTAssertFalse(persisted.isSubagentSession)
@@ -2046,7 +2149,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), ["delegated-sticky"])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), ["delegated-sticky"])
         let persisted = try SessionData.fromFile(path: sessionPath)
         XCTAssertFalse(persisted.hidden)
         XCTAssertFalse(persisted.isSubagentSession)
@@ -2095,7 +2198,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions, [])
+        XCTAssertEqual(manager.userSessions, [])
         let persisted = try SessionData.fromFile(path: sessionPath)
         XCTAssertTrue(persisted.hidden)
         XCTAssertTrue(persisted.isSubagentSession)
@@ -2138,7 +2241,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions, [])
+        XCTAssertEqual(manager.userSessions, [])
         let persisted = try SessionData.fromFile(path: sessionPath)
         XCTAssertTrue(persisted.hidden)
         XCTAssertTrue(persisted.isSubagentSession)
@@ -2179,7 +2282,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions, [])
+        XCTAssertEqual(manager.userSessions, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath + ".lock"))
         XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
@@ -2229,7 +2332,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), ["visible-thread"])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), ["visible-thread"])
         XCTAssertTrue(FileManager.default.fileExists(atPath: missingPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: missingPath + ".lock"))
         XCTAssertFalse(try SessionData.fromFile(path: missingPath).hidden)
@@ -2272,9 +2375,9 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), ["fresh-thread"])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), ["fresh-thread"])
         XCTAssertEqual(
-            SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.sessionId),
+            SessionDisplayPolicy.activeSessions(from: manager.userSessions, now: now).map(\.displayRecord.data.sessionId),
             ["fresh-thread"]
         )
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
@@ -2308,7 +2411,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
             processAlive: { _ in true },
             now: { now }
         )
-        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["101", "202"])
+        XCTAssertEqual(
+            SessionDisplayPolicy.activeSessions(from: manager.userSessions, now: now).map(\.displayRecord.data.id),
+            ["101", "202"]
+        )
 
         var gamma = SessionData.mock(id: "gamma", status: .waitingInput, pid: 303, source: SessionData.opencodeSource)
         gamma.lastActivity = now.addingTimeInterval(-30)
@@ -2317,7 +2423,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try gamma.writeToFile(path: gammaPath)
         try delta.writeToFile(path: deltaPath)
         manager.loadSessions()
-        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["303", "404", "101", "202"])
+        XCTAssertEqual(
+            SessionDisplayPolicy.activeSessions(from: manager.userSessions, now: now).map(\.displayRecord.data.id),
+            ["303", "404", "101", "202"]
+        )
 
         alpha.status = .waitingInput
         alpha.lastActivity = now
@@ -2330,10 +2439,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try beta.writeToFile(path: betaPath)
         manager.loadSessions()
 
-        let activeAfterUpdates = SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now)
-        XCTAssertEqual(activeAfterUpdates.map(\.id), ["303", "404", "101", "202"])
+        let activeAfterUpdates = SessionDisplayPolicy.activeSessions(from: manager.userSessions, now: now)
+        XCTAssertEqual(activeAfterUpdates.map(\.displayRecord.data.id), ["303", "404", "101", "202"])
         let snapshot = DisplayStateWriter.snapshot(
-            sessions: manager.sessions,
+            userSessions: manager.userSessions,
             theme: .claude,
             appRunning: true,
             appIdentity: DisplayState.ProcessIdentity(pid: 999, startTime: 1_234),
@@ -2341,20 +2450,26 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         XCTAssertEqual(
             snapshot.sessions.map(\.cctopSessionId),
-            activeAfterUpdates.map { $0.cctopSessionId ?? "" }
+            activeAfterUpdates.map { $0.identity.cctopSessionID ?? "" }
         )
         XCTAssertEqual(snapshot.sessions.count, activeAfterUpdates.count)
-        XCTAssertTrue(activeAfterUpdates.allSatisfy { CctopSessionID.isValid($0.cctopSessionId) })
+        XCTAssertTrue(activeAfterUpdates.allSatisfy { CctopSessionID.isValid($0.identity.cctopSessionID) })
 
         alpha.hidden = true
         try alpha.writeToFile(path: alphaPath)
         manager.loadSessions()
-        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["303", "404", "202"])
+        XCTAssertEqual(
+            SessionDisplayPolicy.activeSessions(from: manager.userSessions, now: now).map(\.displayRecord.data.id),
+            ["303", "404", "202"]
+        )
 
         beta.endedAt = now
         try beta.writeToFile(path: betaPath)
         manager.loadSessions()
-        XCTAssertEqual(SessionDisplayPolicy.activeSessions(from: manager.sessions, now: now).map(\.id), ["303", "404"])
+        XCTAssertEqual(
+            SessionDisplayPolicy.activeSessions(from: manager.userSessions, now: now).map(\.displayRecord.data.id),
+            ["303", "404"]
+        )
     }
 
     @MainActor
@@ -2384,7 +2499,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
             historyDir: historyDir,
             processAlive: { _ in true }
         )
-        XCTAssertNil(manager.sessions.first?.cctopSessionId)
+        XCTAssertNil(manager.userSessions.first?.displayRecord.data.cctopSessionId)
         waitForIdentityMigrationQueue(manager)
         XCTAssertNil(try SessionData.fromFile(path: sessionPath).cctopSessionId)
 
@@ -2406,7 +2521,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         waitForIdentityMigrationQueue(manager)
 
         XCTAssertEqual(try SessionData.fromFile(path: sessionPath).cctopSessionId, hookAssignedID)
-        XCTAssertEqual(manager.sessions.first?.cctopSessionId, hookAssignedID)
+        XCTAssertEqual(manager.userSessions.first?.displayRecord.data.cctopSessionId, hookAssignedID)
     }
 
     @MainActor
@@ -2431,8 +2546,8 @@ final class SessionManagerVisibilityTests: XCTestCase {
             historyDir: historyDir,
             processAlive: { _ in true }
         )
-        let publishedIDs = Set(manager.sessions.compactMap(\.cctopSessionId))
-        XCTAssertEqual(manager.sessions.count, 1)
+        let publishedIDs = Set(manager.userSessions.compactMap(\.displayRecord.data.cctopSessionId))
+        XCTAssertEqual(manager.userSessions.count, 1)
         XCTAssertEqual(publishedIDs.count, 1)
         XCTAssertTrue(publishedIDs.allSatisfy(CctopSessionID.isValid))
 
@@ -2470,7 +2585,10 @@ final class SessionManagerVisibilityTests: XCTestCase {
             processAlive: { _ in true }
         )
 
-        XCTAssertNil(manager.sessions.first(where: { $0.pid == 6003 })?.cctopSessionId)
+        XCTAssertNil(
+            manager.userSessions.first(where: { $0.displayRecord.data.pid == 6003 })?
+                .displayRecord.data.cctopSessionId
+        )
         XCTAssertNil(try SessionData.fromFile(
             path: (sessionsDir as NSString).appendingPathComponent("6003.json")
         ).cctopSessionId)
@@ -2510,7 +2628,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), ["codex-user-exec"])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), ["codex-user-exec"])
         XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
     }
 
@@ -2548,7 +2666,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), ["codex-exec-first-message"])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), ["codex-exec-first-message"])
         XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
     }
 
@@ -2586,7 +2704,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), ["parent-thread"])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), ["parent-thread"])
         XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
     }
 
@@ -2635,7 +2753,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: oldPath))
         XCTAssertTrue(FileManager.default.fileExists(atPath: desktopPath))
-        XCTAssertEqual(manager.sessions.map(\.sessionId), ["conv-a"])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), ["conv-a"])
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
     }
 
@@ -2667,7 +2785,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), [])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), [])
         XCTAssertEqual(manager.cleanupSources.map(\.sessionId), ["archived-thread"])
         XCTAssertEqual(manager.cleanupSources.map(\.projectPath), ["/tmp/p"])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
@@ -2678,7 +2796,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [], userExecThreads: ["archived-thread"])
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), ["archived-thread"])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), ["archived-thread"])
         XCTAssertEqual(manager.cleanupSources.map(\.sessionId), [])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, ["/tmp/p"])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
@@ -2715,11 +2833,11 @@ final class SessionManagerVisibilityTests: XCTestCase {
             processAlive: { _ in true }
         )
         manager.loadSessions()
-        XCTAssertEqual(manager.sessions.map(\.sessionId), [threadID])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), [threadID])
 
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [threadID])
         manager.loadSessions()
-        XCTAssertEqual(manager.sessions.map(\.sessionId), [])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), [])
         XCTAssertEqual(manager.cleanupSources.map(\.sessionId), [threadID])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
@@ -2727,7 +2845,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
 
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [], userExecThreads: [threadID])
         manager.loadSessions()
-        XCTAssertEqual(manager.sessions.map(\.sessionId), [threadID])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), [threadID])
         XCTAssertEqual(manager.cleanupSources.map(\.sessionId), [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
     }
@@ -2762,7 +2880,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), ["archived-without-source"])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), ["archived-without-source"])
         XCTAssertEqual(manager.cleanupSources.map(\.sessionId), [])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, ["/tmp/p"])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
@@ -2772,7 +2890,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         try writeCodexStateDatabase(path: stateDB, archivedThreads: [])
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), ["archived-without-source"])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), ["archived-without-source"])
         XCTAssertEqual(manager.cleanupSources.map(\.sessionId), [])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, ["/tmp/p"])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
@@ -2810,7 +2928,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), [])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), [])
         XCTAssertEqual(manager.cleanupSources.map(\.sessionId), ["archived-claude-session"])
         XCTAssertEqual(manager.cleanupSources.map(\.projectPath), ["/tmp/p"])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
@@ -2826,7 +2944,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), ["archived-claude-session"])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), ["archived-claude-session"])
         XCTAssertEqual(manager.cleanupSources.map(\.sessionId), [])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, ["/tmp/p"])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
@@ -2865,7 +2983,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), [])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), [])
         XCTAssertEqual(manager.cleanupSources.map(\.sessionId), ["archived-claude-without-source"])
         XCTAssertEqual(manager.cleanupSources.map(\.projectPath), ["/tmp/p"])
         XCTAssertEqual(manager.cleanupActiveProjectPaths, [])
@@ -2910,7 +3028,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         )
         manager.loadSessions()
 
-        XCTAssertEqual(manager.sessions.map(\.sessionId), [])
+        XCTAssertEqual(manager.userSessions.map(\.displayRecord.data.sessionId), [])
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         XCTAssertFalse(try SessionData.fromFile(path: sessionPath).hidden)
         XCTAssertTrue((try FileManager.default.contentsOfDirectory(atPath: historyDir)).isEmpty)
@@ -3109,7 +3227,7 @@ final class SessionManagerVisibilityTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: sessionPath))
         manager.loadSessions()
         XCTAssertEqual(visibility.hiddenSessionIDs, [cctopSessionID])
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertTrue(manager.recentResumeTargets.isEmpty)
 
         defaults.removeObject(forKey: ManualSessionVisibilityStore.defaultsKey)

--- a/menubar/CctopMenubarTests/SessionTestSupport.swift
+++ b/menubar/CctopMenubarTests/SessionTestSupport.swift
@@ -328,18 +328,14 @@ extension XCTestCase {
         return SessionRecord(data: s, lifecycleRank: lifecycleRank, mtime: mtime, path: path)
     }
 
-    @MainActor
-    func setSessionProjection(_ sessions: [SessionData], on manager: SessionManager) {
-        manager.updateSessionProjection(userSessionProjection(from: sessions))
-    }
-
-    func userSessionProjection(from sessions: [SessionData]) -> [UserSession] {
-        let records = sessions.enumerated().map { index, session in
+    /// Runs raw test fixtures forward through the same record and grouping stages as production.
+    func userSessions(fromDataFixtures dataFixtures: [SessionData]) -> [UserSession] {
+        let records = dataFixtures.enumerated().map { index, data in
             SessionRecord(
-                data: session,
-                lifecycleRank: session.lifecycle.rawValue,
+                data: data,
+                lifecycleRank: data.lifecycle.rawValue,
                 mtime: .distantPast,
-                path: "/test-projection-\(index).json"
+                path: "/test-source-record-\(index).json"
             )
         }
         return UserSession.grouping(
@@ -348,7 +344,11 @@ extension XCTestCase {
         )
     }
 
-    func userSession(display: SessionData, records: [SessionData]) -> UserSession {
+    func userSession(
+        identity: SessionIdentityPolicy.LogicalIdentity,
+        display: SessionData,
+        records: [SessionData]
+    ) -> UserSession {
         let sessionRecords = records.enumerated().map { index, data in
             SessionRecord(
                 data: data,
@@ -365,7 +365,7 @@ extension XCTestCase {
                 path: "/test-user-session-display.json"
             )
         return UserSession(
-            identity: SessionIdentityPolicy.logicalIdentity(for: display),
+            identity: identity,
             records: sessionRecords,
             displayRecord: displayRecord
         )

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -507,9 +507,18 @@ final class SessionTests: XCTestCase {
             id: "unrelated", cctopSessionId: "22222222-2222-4222-8222-222222222222",
             status: .waitingPermission, pid: 33_333, source: SessionData.opencodeSource
         )
-        let oldRequest = try XCTUnwrap(SessionManager.notificationRequest(for: oldRecord))
-        let currentRequest = try XCTUnwrap(SessionManager.notificationRequest(for: currentRecord))
-        let unrelatedRequest = try XCTUnwrap(SessionManager.notificationRequest(for: unrelated))
+        let oldRequest = try XCTUnwrap(SessionManager.notificationRequest(
+            forCctopSessionID: sharedID,
+            displayData: oldRecord
+        ))
+        let currentRequest = try XCTUnwrap(SessionManager.notificationRequest(
+            forCctopSessionID: sharedID,
+            displayData: currentRecord
+        ))
+        let unrelatedRequest = try XCTUnwrap(SessionManager.notificationRequest(
+            forCctopSessionID: "22222222-2222-4222-8222-222222222222",
+            displayData: unrelated
+        ))
         let preMigrationContent = UNMutableNotificationContent()
         preMigrationContent.userInfo = [
             SessionIdentityPolicy.notificationCctopSessionIDKey: sharedID,
@@ -552,7 +561,7 @@ final class SessionTests: XCTestCase {
 
         let resolvedID = SessionIdentityPolicy.notificationCctopSessionID(
             matchingNotificationUserInfo: userInfo,
-            in: userSessionProjection(from: [first, second])
+            in: userSessions(fromDataFixtures: [first, second])
         )
 
         XCTAssertEqual(resolvedID, secondID)
@@ -568,7 +577,7 @@ final class SessionTests: XCTestCase {
 
         let resolvedID = SessionIdentityPolicy.notificationCctopSessionID(
             matchingNotificationUserInfo: userInfo,
-            in: userSessionProjection(from: [session])
+            in: userSessions(fromDataFixtures: [session])
         )
 
         XCTAssertNil(resolvedID)
@@ -586,7 +595,7 @@ final class SessionTests: XCTestCase {
 
         let resolvedID = SessionIdentityPolicy.notificationCctopSessionID(
             matchingNotificationUserInfo: userInfo,
-            in: userSessionProjection(from: [currentRecord])
+            in: userSessions(fromDataFixtures: [currentRecord])
         )
 
         XCTAssertEqual(resolvedID, cctopSessionID)
@@ -607,7 +616,7 @@ final class SessionTests: XCTestCase {
         XCTAssertNil(
             SessionIdentityPolicy.notificationCctopSessionID(
                 matchingNotificationUserInfo: [SessionIdentityPolicy.notificationSessionIDKey: "codex-thread-1"],
-                in: userSessionProjection(from: [first, second])
+                in: userSessions(fromDataFixtures: [first, second])
             )
         )
     }
@@ -626,7 +635,11 @@ final class SessionTests: XCTestCase {
             matchingNotificationUserInfo: [
                 SessionIdentityPolicy.notificationSessionIDKey: "codex-thread-1",
             ],
-            in: [userSession(display: current, records: [stale, current])]
+            in: [userSession(
+                identity: SessionIdentityPolicy.logicalIdentity(for: current),
+                display: current,
+                records: [stale, current]
+            )]
         )
 
         XCTAssertEqual(resolvedID, current.cctopSessionId)
@@ -650,7 +663,7 @@ final class SessionTests: XCTestCase {
                 matchingNotificationUserInfo: [
                     SessionIdentityPolicy.notificationSessionIDKey: "shared-session",
                 ],
-                in: userSessionProjection(from: [unstampedCodex, stampedDesktop])
+                in: userSessions(fromDataFixtures: [unstampedCodex, stampedDesktop])
             )
         )
     }
@@ -668,7 +681,7 @@ final class SessionTests: XCTestCase {
         XCTAssertNil(
             SessionIdentityPolicy.notificationCctopSessionID(
                 matchingNotificationUserInfo: userInfo,
-                in: userSessionProjection(from: [session])
+                in: userSessions(fromDataFixtures: [session])
             )
         )
     }
@@ -685,7 +698,7 @@ final class SessionTests: XCTestCase {
         XCTAssertNil(
             SessionIdentityPolicy.notificationCctopSessionID(
                 matchingNotificationUserInfo: userInfo,
-                in: userSessionProjection(from: [session])
+                in: userSessions(fromDataFixtures: [session])
             )
         )
     }
@@ -702,7 +715,7 @@ final class SessionTests: XCTestCase {
         XCTAssertNil(
             SessionIdentityPolicy.notificationCctopSessionID(
                 matchingNotificationUserInfo: userInfo,
-                in: userSessionProjection(from: [session])
+                in: userSessions(fromDataFixtures: [session])
             )
         )
     }
@@ -737,8 +750,8 @@ final class SessionTests: XCTestCase {
             source: SessionData.codexSource
         )
 
-        store.hide(terminal)
-        store.hide(codex)
+        store.hide(cctopSessionID: try XCTUnwrap(terminal.cctopSessionId))
+        store.hide(cctopSessionID: try XCTUnwrap(codex.cctopSessionId))
 
         let stored = try XCTUnwrap(defaults.stringArray(forKey: ManualSessionVisibilityStore.defaultsKey))
         XCTAssertEqual(stored, [
@@ -757,14 +770,11 @@ final class SessionTests: XCTestCase {
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = ManualSessionVisibilityStore(defaults: defaults)
-        let first = SessionData.mock(
-            id: "first", cctopSessionId: "11111111-1111-4111-8111-111111111111"
-        )
+        let firstID = "11111111-1111-4111-8111-111111111111"
         let secondID = "22222222-2222-4222-8222-222222222222"
-        let second = SessionData.mock(id: "second", cctopSessionId: secondID)
 
-        store.hide(first)
-        store.hide(second)
+        store.hide(cctopSessionID: firstID)
+        store.hide(cctopSessionID: secondID)
         store.prune(retaining: [secondID])
 
         XCTAssertEqual(store.hiddenSessionIDs, [secondID])
@@ -874,13 +884,13 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(store.unresolvedDurableLegacyKeys, [legacyKey])
 
         let first = SessionData.mock(
-            id: "first-observation",
+            id: "first-record",
             cctopSessionId: firstID,
             harnessSessionId: threadID,
             source: SessionData.codexSource
         )
         let second = SessionData.mock(
-            id: "second-observation",
+            id: "second-record",
             cctopSessionId: secondID,
             harnessSessionId: threadID,
             source: SessionData.codexSource
@@ -904,11 +914,14 @@ final class SessionTests: XCTestCase {
         var legacy = SessionData.mock(id: "legacy")
         legacy.cctopSessionId = nil
 
-        store.hide(legacy)
+        store.hide(cctopSessionID: "not-a-uuid")
 
-        XCTAssertFalse(store.isHidden(legacy))
+        XCTAssertFalse(store.isHidden(cctopSessionID: "not-a-uuid"))
         XCTAssertNil(defaults.object(forKey: ManualSessionVisibilityStore.defaultsKey))
-        XCTAssertNil(ManualSessionHideConfirmation(session: legacy))
+        XCTAssertNil(ManualSessionHideConfirmation(
+            identity: SessionIdentityPolicy.logicalIdentity(for: legacy),
+            displayName: legacy.displayName
+        ))
     }
 
     func testManualSessionHideConfirmationDescribesIrreversibleVisibleEffect() throws {
@@ -920,7 +933,11 @@ final class SessionTests: XCTestCase {
             source: SessionData.codexSource
         )
 
-        let confirmation = try XCTUnwrap(ManualSessionHideConfirmation(session: session))
+        let identity = SessionIdentityPolicy.logicalIdentity(for: session)
+        let confirmation = try XCTUnwrap(ManualSessionHideConfirmation(
+            identity: identity,
+            displayName: session.displayName
+        ))
 
         XCTAssertEqual(confirmation.id, "hide:11111111-1111-4111-8111-111111111111")
         XCTAssertEqual(confirmation.title, "Hide “Investigate lifecycle” from cctop?")
@@ -931,7 +948,8 @@ final class SessionTests: XCTestCase {
                 + "This does not stop or delete the underlying session; cctop will keep it available for lifecycle and Cleanup. "
                 + "You cannot show it again while its local session record exists."
         )
-        XCTAssertEqual(confirmation.session, session)
+        XCTAssertEqual(confirmation.identity, identity)
+        XCTAssertEqual(confirmation.displayName, session.displayName)
     }
 
     func testPopupConfirmationRoutesCleanupAndSessionHideWithDistinctIdentity() throws {
@@ -939,11 +957,8 @@ final class SessionTests: XCTestCase {
             .normalRemove(.mock(state: .review(["Worktree has untracked files"])))
         )
         let sessionConfirmation = try XCTUnwrap(ManualSessionHideConfirmation(
-            session: .mock(
-                id: "private-session",
-                cctopSessionId: "11111111-1111-4111-8111-111111111111",
-                source: SessionData.codexSource
-            )
+            identity: .permanent(try XCTUnwrap(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))),
+            displayName: "Private session"
         ))
         let cleanupRoute = PopupConfirmation.cleanup(cleanupConfirmation)
         let sessionRoute = PopupConfirmation.sessionHide(sessionConfirmation)
@@ -963,7 +978,7 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testNotificationRequestDoesNotUseVisibleThreadGrouping() throws {
+    func testNotificationRequestUsesExplicitUserSessionIdentity() throws {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
         let session = SessionData.mock(
             id: "claude-desktop-thread-1",
@@ -973,20 +988,22 @@ final class SessionTests: XCTestCase {
             source: "cc"
         )
 
-        let request = try XCTUnwrap(SessionManager.notificationRequest(for: session))
+        let request = try XCTUnwrap(SessionManager.notificationRequest(
+            forCctopSessionID: cctopSessionID,
+            displayData: session
+        ))
 
         XCTAssertEqual(request.identifier, "session-\(cctopSessionID)")
         XCTAssertEqual(request.content.threadIdentifier, "")
     }
 
-    func testNotificationRequestFailsClosedWithoutPermanentIdentity() {
-        var missing = SessionData.mock(id: "legacy", status: .waitingInput)
-        missing.cctopSessionId = nil
-        var malformed = missing
-        malformed.cctopSessionId = "not-a-uuid"
+    func testNotificationRequestRejectsInvalidExplicitIdentity() {
+        let displayData = SessionData.mock(id: "legacy", status: .waitingInput)
 
-        XCTAssertNil(SessionManager.notificationRequest(for: missing))
-        XCTAssertNil(SessionManager.notificationRequest(for: malformed))
+        XCTAssertNil(SessionManager.notificationRequest(
+            forCctopSessionID: "not-a-uuid",
+            displayData: displayData
+        ))
     }
 
     @MainActor
@@ -1023,9 +1040,9 @@ final class SessionTests: XCTestCase {
             dataSources: sources,
             startMonitoring: false
         )
-        setSessionProjection([session], on: manager)
+        manager.updateSessionProjection(userSessions(fromDataFixtures: [session]))
 
-        manager.postNotification(for: session)
+        manager.postNotification(forCctopSessionID: cctopSessionID)
 
         XCTAssertEqual(
             recorder.events,
@@ -1077,16 +1094,16 @@ final class SessionTests: XCTestCase {
         )
         var noLongerNeedsAttention = session
         noLongerNeedsAttention.status = .working
-        setSessionProjection([noLongerNeedsAttention], on: manager)
-        manager.postNotification(for: session)
+        manager.updateSessionProjection(userSessions(fromDataFixtures: [noLongerNeedsAttention]))
+        manager.postNotification(forCctopSessionID: try XCTUnwrap(session.cctopSessionId))
 
-        setSessionProjection([session], on: manager)
-        store.hide(session)
+        manager.updateSessionProjection(userSessions(fromDataFixtures: [session]))
+        store.hide(cctopSessionID: try XCTUnwrap(session.cctopSessionId))
 
-        manager.postNotification(for: session)
+        manager.postNotification(forCctopSessionID: try XCTUnwrap(session.cctopSessionId))
         store.prune(retaining: [])
-        setSessionProjection([], on: manager)
-        manager.postNotification(for: session)
+        manager.updateSessionProjection([])
+        manager.postNotification(forCctopSessionID: try XCTUnwrap(session.cctopSessionId))
 
         XCTAssertEqual(recorder.events, [])
     }
@@ -1120,15 +1137,15 @@ final class SessionTests: XCTestCase {
             dataSources: sources,
             startMonitoring: false
         )
-        setSessionProjection([replacement], on: manager)
+        manager.updateSessionProjection(userSessions(fromDataFixtures: [replacement]))
 
-        manager.postNotification(for: original)
+        manager.postNotification(forCctopSessionID: try XCTUnwrap(original.cctopSessionId))
 
         XCTAssertTrue(recorder.events.isEmpty)
     }
 
     @MainActor
-    func testPostNotificationFailsClosedWithoutPermanentIdentity() throws {
+    func testPostNotificationFailsClosedForInvalidExplicitIdentity() throws {
         final class Recorder {
             var events: [String] = []
         }
@@ -1155,9 +1172,9 @@ final class SessionTests: XCTestCase {
             dataSources: sources,
             startMonitoring: false
         )
-        setSessionProjection([missingIdentity], on: manager)
+        manager.updateSessionProjection(userSessions(fromDataFixtures: [missingIdentity]))
 
-        manager.postNotification(for: missingIdentity)
+        manager.postNotification(forCctopSessionID: "not-a-uuid")
 
         XCTAssertTrue(recorder.events.isEmpty)
     }
@@ -1197,14 +1214,14 @@ final class SessionTests: XCTestCase {
         )
         var staleWaitingSnapshot = working
         staleWaitingSnapshot.status = .waitingPermission
-        staleWaitingSnapshot.notificationMessage = "Stale observation"
-        waiting.notificationMessage = "Current observation"
-        setSessionProjection([waiting], on: manager)
+        staleWaitingSnapshot.notificationMessage = "Stale record"
+        waiting.notificationMessage = "Current record"
+        manager.updateSessionProjection(userSessions(fromDataFixtures: [waiting]))
 
-        manager.postNotification(for: staleWaitingSnapshot)
+        manager.postNotification(forCctopSessionID: sharedID)
 
         let request = try XCTUnwrap(recorder.requests.first)
-        XCTAssertEqual(request.content.body, "Current observation")
+        XCTAssertEqual(request.content.body, "Current record")
         XCTAssertEqual(request.identifier, "session-\(sharedID)")
         XCTAssertEqual(recorder.removals, [
             "pending:session-\(sharedID)",
@@ -1213,8 +1230,8 @@ final class SessionTests: XCTestCase {
 
         recorder.requests.removeAll()
         recorder.removals.removeAll()
-        setSessionProjection([working], on: manager)
-        manager.postNotification(for: staleWaitingSnapshot)
+        manager.updateSessionProjection(userSessions(fromDataFixtures: [working]))
+        manager.postNotification(forCctopSessionID: sharedID)
         XCTAssertTrue(recorder.requests.isEmpty)
         XCTAssertTrue(recorder.removals.isEmpty)
     }
@@ -1256,17 +1273,21 @@ final class SessionTests: XCTestCase {
             startMonitoring: false
         )
         manager.updateSessionProjection([
-            userSession(display: first, records: [unstamped, first]),
+            userSession(
+                identity: SessionIdentityPolicy.logicalIdentity(for: first),
+                display: first,
+                records: [unstamped, first]
+            ),
         ])
 
-        manager.hideSession(first)
+        manager.hideSession(try XCTUnwrap(manager.userSessions.first?.identity))
 
         let expectedIdentifiers = [
             "session-\(sharedID)",
             "session-codex:current-codex-thread",
             "session-codex:legacy-codex-thread",
         ]
-        XCTAssertTrue(manager.sessions.isEmpty)
+        XCTAssertTrue(manager.userSessions.isEmpty)
         XCTAssertEqual(recorder.pending, [expectedIdentifiers])
         XCTAssertEqual(recorder.delivered, [expectedIdentifiers])
         XCTAssertNil(SessionIdentityPolicy.legacyNotificationRequestIdentifier(for: processScoped))
@@ -1316,11 +1337,11 @@ final class SessionTests: XCTestCase {
             status: .waitingInput, source: SessionData.codexSource
         )
         attention.lifecycle = .active
-        setSessionProjection([attention], on: manager)
+        manager.updateSessionProjection(userSessions(fromDataFixtures: [attention]))
 
-        manager.hideSession(attention)
+        manager.hideSession(try XCTUnwrap(manager.userSessions.first?.identity))
 
-        XCTAssertEqual(manager.sessions, [])
+        XCTAssertEqual(manager.userSessions, [])
         XCTAssertEqual(recorder.events, [
             "pending:session-\(cctopSessionID),session-codex:attention",
             "delivered:session-\(cctopSessionID),session-codex:attention",
@@ -1330,21 +1351,21 @@ final class SessionTests: XCTestCase {
     func testNotificationActionsRemoveResolvedAttentionSession() {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
         let oldSession = SessionData.mock(
-            id: "old-observation", cctopSessionId: cctopSessionID,
+            id: "old-record", cctopSessionId: cctopSessionID,
             status: .waitingInput,
             lastPrompt: "Waiting",
             pid: 11_111, source: SessionData.opencodeSource
         )
         let resolvedSession = SessionData.mock(
-            id: "new-observation", cctopSessionId: cctopSessionID,
+            id: "new-record", cctopSessionId: cctopSessionID,
             status: .working,
             pid: 22_222, source: SessionData.opencodeSource
         )
 
         XCTAssertEqual(
             SessionManager.notificationActions(
-                newSessions: [resolvedSession],
-                oldSessions: [oldSession],
+                newUserSessions: userSessions(fromDataFixtures: [resolvedSession]),
+                oldUserSessions: userSessions(fromDataFixtures: [oldSession]),
                 notificationsEnabled: true
             ),
             [.remove(cctopSessionID: cctopSessionID)]
@@ -1362,8 +1383,8 @@ final class SessionTests: XCTestCase {
 
         XCTAssertEqual(
             SessionManager.notificationActions(
-                newSessions: [],
-                oldSessions: [oldSession],
+                newUserSessions: [],
+                oldUserSessions: userSessions(fromDataFixtures: [oldSession]),
                 notificationsEnabled: true
             ),
             [.remove(cctopSessionID: cctopSessionID)]
@@ -1396,12 +1417,15 @@ final class SessionTests: XCTestCase {
             id: "codex-thread-1", cctopSessionId: cctopSessionID,
             status: .waitingPermission, pid: 11_111, source: SessionData.codexSource
         )
-        let currentSession = SessionData.mock(
+        let currentData = SessionData.mock(
             id: "codex-thread-1", cctopSessionId: cctopSessionID,
             status: .working, pid: 22_222, source: SessionData.codexSource
         )
 
-        manager.syncTransitionNotifications(for: [currentSession], oldSessions: [oldSession])
+        manager.syncTransitionNotifications(
+            for: userSessions(fromDataFixtures: [currentData]),
+            oldUserSessions: userSessions(fromDataFixtures: [oldSession])
+        )
 
         let identifiers = ["session-\(cctopSessionID)", "session-codex:codex-thread-1"]
         XCTAssertEqual(recorder.pending, [identifiers])
@@ -1409,14 +1433,70 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(recorder.cctopSessionIDs, [cctopSessionID])
     }
 
+    @MainActor
+    func testResolvedTransitionRemovesNotificationIdentifiersFromAllRetainedRecords() throws {
+        final class Recorder {
+            var pending: [[String]] = []
+            var delivered: [[String]] = []
+        }
+
+        let recorder = Recorder()
+        var sources = try isolatedSessionDataSources(prefix: "cctop-retained-notification-removal")
+        sources.notificationClient = SessionNotificationClient(
+            add: { _, completion in completion(nil) },
+            removePending: { recorder.pending.append($0) },
+            removeDelivered: { recorder.delivered.append($0) }
+        )
+        let manager = SessionManager(
+            historyManager: HistoryManager(historyDir: FileManager.default.temporaryDirectory),
+            dataSources: sources,
+            startMonitoring: false
+        )
+        let cctopSessionID = "11111111-1111-4111-8111-111111111111"
+        let oldDisplay = SessionData.mock(
+            id: "current-thread", cctopSessionId: cctopSessionID,
+            status: .waitingPermission, pid: 11_111, source: SessionData.codexSource
+        )
+        var retainedLegacy = SessionData.mock(
+            id: "legacy-thread", status: .waitingPermission,
+            pid: 22_222, source: SessionData.codexSource
+        )
+        retainedLegacy.cctopSessionId = nil
+        let currentDisplay = SessionData.mock(
+            id: "current-thread", cctopSessionId: cctopSessionID,
+            status: .working, pid: 33_333, source: SessionData.codexSource
+        )
+
+        manager.syncTransitionNotifications(
+            for: [userSession(
+                identity: SessionIdentityPolicy.logicalIdentity(for: currentDisplay),
+                display: currentDisplay,
+                records: [currentDisplay]
+            )],
+            oldUserSessions: [userSession(
+                identity: SessionIdentityPolicy.logicalIdentity(for: oldDisplay),
+                display: oldDisplay,
+                records: [oldDisplay, retainedLegacy]
+            )]
+        )
+
+        let identifiers = [
+            "session-\(cctopSessionID)",
+            "session-codex:current-thread",
+            "session-codex:legacy-thread",
+        ]
+        XCTAssertEqual(recorder.pending, [identifiers])
+        XCTAssertEqual(recorder.delivered, [identifiers])
+    }
+
     func testNotificationActionsPostOneTransitionAcrossReplacementRecord() {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
         let oldSession = SessionData.mock(
-            id: "old-observation", cctopSessionId: cctopSessionID,
+            id: "old-record", cctopSessionId: cctopSessionID,
             status: .working, pid: 11_111, source: SessionData.opencodeSource
         )
         let waitingSession = SessionData.mock(
-            id: "new-observation", cctopSessionId: cctopSessionID,
+            id: "new-record", cctopSessionId: cctopSessionID,
             status: .waitingInput,
             lastPrompt: "Waiting",
             pid: 22_222, source: SessionData.opencodeSource
@@ -1424,28 +1504,30 @@ final class SessionTests: XCTestCase {
 
         XCTAssertEqual(
             SessionManager.notificationActions(
-                newSessions: [waitingSession],
-                oldSessions: [oldSession],
+                newUserSessions: userSessions(fromDataFixtures: [waitingSession]),
+                oldUserSessions: userSessions(fromDataFixtures: [oldSession]),
                 notificationsEnabled: true
             ),
-            [.post(session: waitingSession)]
+            [.post(cctopSessionID: cctopSessionID)]
         )
     }
 
     func testNotificationActionsDoNotRepostWaitingTransitionAcrossReplacementRecord() {
         let cctopSessionID = "11111111-1111-4111-8111-111111111111"
         let oldSession = SessionData.mock(
-            id: "old-observation", cctopSessionId: cctopSessionID,
+            id: "old-record", cctopSessionId: cctopSessionID,
             status: .waitingPermission, pid: 11_111, source: SessionData.opencodeSource
         )
         let replacement = SessionData.mock(
-            id: "new-observation", cctopSessionId: cctopSessionID,
+            id: "new-record", cctopSessionId: cctopSessionID,
             status: .waitingPermission, pid: 22_222, source: SessionData.opencodeSource
         )
 
         XCTAssertEqual(
             SessionManager.notificationActions(
-                newSessions: [replacement], oldSessions: [oldSession], notificationsEnabled: true
+                newUserSessions: userSessions(fromDataFixtures: [replacement]),
+                oldUserSessions: userSessions(fromDataFixtures: [oldSession]),
+                notificationsEnabled: true
             ),
             []
         )
@@ -1461,7 +1543,9 @@ final class SessionTests: XCTestCase {
 
         XCTAssertEqual(
             SessionManager.notificationActions(
-                newSessions: [waitingSession], oldSessions: [oldSession], notificationsEnabled: true
+                newUserSessions: userSessions(fromDataFixtures: [waitingSession]),
+                oldUserSessions: userSessions(fromDataFixtures: [oldSession]),
+                notificationsEnabled: true
             ),
             []
         )
@@ -1474,8 +1558,8 @@ final class SessionTests: XCTestCase {
     ) -> [SessionNotificationAction] {
         XCTAssertEqual(newSession.cctopSessionId, oldSession.cctopSessionId)
         return SessionManager.notificationActions(
-            newSessions: [newSession],
-            oldSessions: [oldSession],
+            newUserSessions: userSessions(fromDataFixtures: [newSession]),
+            oldUserSessions: userSessions(fromDataFixtures: [oldSession]),
             notificationsEnabled: notificationsEnabled
         )
     }
@@ -1597,7 +1681,7 @@ final class SessionTests: XCTestCase {
 
         XCTAssertEqual(
             notificationActions(newSession: waitingSession, oldSession: oldSession),
-            [.post(session: waitingSession)]
+            [.post(cctopSessionID: notificationTestCctopSessionID)]
         )
     }
 
@@ -1653,19 +1737,19 @@ final class SessionTests: XCTestCase {
 
         XCTAssertEqual(
             notificationActions(newSession: explicitMessageSession, oldSession: oldSession),
-            [.post(session: explicitMessageSession)]
+            [.post(cctopSessionID: notificationTestCctopSessionID)]
         )
         XCTAssertEqual(
             notificationActions(newSession: scaffoldWithRequestSession, oldSession: oldSession),
-            [.post(session: scaffoldWithRequestSession)]
+            [.post(cctopSessionID: notificationTestCctopSessionID)]
         )
         XCTAssertEqual(
             notificationActions(newSession: promptStartingWithScaffoldHeading, oldSession: oldSession),
-            [.post(session: promptStartingWithScaffoldHeading)]
+            [.post(cctopSessionID: notificationTestCctopSessionID)]
         )
         XCTAssertEqual(
             notificationActions(newSession: multilinePromptStartingWithScaffoldHeading, oldSession: oldSession),
-            [.post(session: multilinePromptStartingWithScaffoldHeading)]
+            [.post(cctopSessionID: notificationTestCctopSessionID)]
         )
     }
 
@@ -1695,11 +1779,11 @@ final class SessionTests: XCTestCase {
 
         XCTAssertEqual(
             notificationActions(newSession: permissionSession, oldSession: oldSession),
-            [.post(session: permissionSession)]
+            [.post(cctopSessionID: notificationTestCctopSessionID)]
         )
         XCTAssertEqual(
             notificationActions(newSession: errorSession, oldSession: oldSession),
-            [.post(session: errorSession)]
+            [.post(cctopSessionID: notificationTestCctopSessionID)]
         )
     }
 
@@ -1721,7 +1805,7 @@ final class SessionTests: XCTestCase {
 
         XCTAssertEqual(
             notificationActions(newSession: userFacingSession, oldSession: oldMachineOnlySession),
-            [.post(session: userFacingSession)]
+            [.post(cctopSessionID: notificationTestCctopSessionID)]
         )
     }
 
@@ -1766,8 +1850,8 @@ final class SessionTests: XCTestCase {
 
         XCTAssertEqual(
             SessionManager.notificationActions(
-                newSessions: [waitingSession],
-                oldSessions: [oldSession],
+                newUserSessions: userSessions(fromDataFixtures: [waitingSession]),
+                oldUserSessions: userSessions(fromDataFixtures: [oldSession]),
                 notificationsEnabled: false
             ),
             []
@@ -2417,27 +2501,27 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(rotated.terminal, newTerminal)
     }
 
-    func testPermanentIDFocusResolverReturnsCurrentRecord() throws {
+    func testPermanentIDFocusResolverReturnsCurrentUserSession() throws {
         let targetID = "11111111-2222-4333-8444-555555555555"
         let target = SessionData.mock(id: "abc", cctopSessionId: targetID, harnessSessionId: "abc", pid: 111)
         let other = SessionData.mock(id: "def", harnessSessionId: "def", pid: 222)
 
         let resolved = try XCTUnwrap(
-            FocusTargetResolver.currentSession(
+            FocusTargetResolver.currentUserSession(
                 forCctopSessionID: targetID,
-                in: userSessionProjection(from: [other, target])
+                in: userSessions(fromDataFixtures: [other, target])
             )
         )
-        XCTAssertEqual(resolved.sessionId, "abc")
+        XCTAssertEqual(resolved.focusTarget.sessionId, "abc")
     }
 
     func testPermanentIDFocusResolverRejectsInvalidIdentity() {
         let currentID = "11111111-2222-4333-8444-555555555555"
         let current = SessionData.mock(id: "current", cctopSessionId: currentID)
 
-        XCTAssertNil(FocusTargetResolver.currentSession(
+        XCTAssertNil(FocusTargetResolver.currentUserSession(
             forCctopSessionID: "111",
-            in: userSessionProjection(from: [current])
+            in: userSessions(fromDataFixtures: [current])
         ))
     }
 
@@ -2446,9 +2530,9 @@ final class SessionTests: XCTestCase {
         let missingID = "22222222-3333-4444-8555-666666666666"
         let current = SessionData.mock(id: "current", cctopSessionId: currentID)
 
-        let userSessions = userSessionProjection(from: [current])
-        XCTAssertNil(FocusTargetResolver.currentSession(forCctopSessionID: missingID, in: userSessions))
-        XCTAssertNil(FocusTargetResolver.currentSession(forCctopSessionID: currentID, in: []))
+        let userSessions = userSessions(fromDataFixtures: [current])
+        XCTAssertNil(FocusTargetResolver.currentUserSession(forCctopSessionID: missingID, in: userSessions))
+        XCTAssertNil(FocusTargetResolver.currentUserSession(forCctopSessionID: currentID, in: []))
     }
 
     func testLogicalFocusResolverUsesUserSessionDisplayRecord() {
@@ -2456,26 +2540,33 @@ final class SessionTests: XCTestCase {
         let first = SessionData.mock(id: "first", cctopSessionId: cctopSessionID, pid: 111)
         let second = SessionData.mock(id: "second", cctopSessionId: cctopSessionID, pid: 222)
         let identity = SessionIdentityPolicy.logicalIdentity(for: first)
-        let current = userSession(display: second, records: [first, second])
+        let current = userSession(identity: identity, display: second, records: [first, second])
 
-        XCTAssertEqual(FocusTargetResolver.currentSession(for: identity, in: [current])?.pid, 222)
+        XCTAssertEqual(FocusTargetResolver.currentUserSession(for: identity, in: [current])?.focusTarget.pid, 222)
     }
 
     func testLogicalFocusResolverKeepsLegacyFallbackUniqueAndFailsClosedWhenAmbiguous() {
         var first = SessionData.mock(id: "first", pid: 111, source: SessionData.opencodeSource)
         first.cctopSessionId = nil
         let identity = SessionIdentityPolicy.logicalIdentity(for: first)
-        let current = userSession(display: first, records: [first])
+        let current = userSession(identity: identity, display: first, records: [first])
         var conflicting = first
         conflicting.cctopSessionId = "22222222-3333-4444-8555-666666666666"
-        let conflictingUserSession = userSession(display: conflicting, records: [conflicting])
+        let conflictingUserSession = userSession(
+            identity: SessionIdentityPolicy.logicalIdentity(for: conflicting),
+            display: conflicting,
+            records: [conflicting]
+        )
 
-        XCTAssertEqual(FocusTargetResolver.currentSession(for: identity, in: [current])?.sessionId, "first")
-        XCTAssertNil(FocusTargetResolver.currentSession(for: identity, in: [current, conflictingUserSession]))
-        XCTAssertNil(FocusTargetResolver.currentSession(for: identity, in: []))
+        XCTAssertEqual(
+            FocusTargetResolver.currentUserSession(for: identity, in: [current])?.focusTarget.sessionId,
+            "first"
+        )
+        XCTAssertNil(FocusTargetResolver.currentUserSession(for: identity, in: [current, conflictingUserSession]))
+        XCTAssertNil(FocusTargetResolver.currentUserSession(for: identity, in: []))
     }
 
-    func testRepeatedCctopSessionIDKeepsRows() {
+    func testRepeatedCctopSessionIDFormsOneDisplayStateUserSession() {
         let now = Date()
         let cctopSessionID = "11111111-2222-4333-8444-555555555555"
         var working = SessionData.mock(
@@ -2489,18 +2580,17 @@ final class SessionTests: XCTestCase {
         )
         idle.lastActivity = now.addingTimeInterval(-5)
 
+        let userSessions = userSessions(fromDataFixtures: [idle, working])
         let snapshot = DisplayStateWriter.snapshot(
-            sessions: [idle, working],
+            userSessions: userSessions,
             theme: .claude,
             appRunning: true,
             appIdentity: nil,
             now: now
         )
-        XCTAssertEqual(snapshot.sessions.count, 2)
-
-        let ordered = SessionDisplayPolicy.activeSessions(from: [idle, working], now: now)
-        XCTAssertEqual(ordered.count, 2)
-        XCTAssertEqual(snapshot.sessions.map(\.cctopSessionId), [cctopSessionID, cctopSessionID])
+        XCTAssertEqual(userSessions.count, 1)
+        XCTAssertEqual(snapshot.sessions.count, 1)
+        XCTAssertEqual(snapshot.sessions.map(\.cctopSessionId), [cctopSessionID])
     }
 
     // MARK: - Cctop session identity

--- a/menubar/CctopMenubarTests/SnapshotTests.swift
+++ b/menubar/CctopMenubarTests/SnapshotTests.swift
@@ -127,8 +127,7 @@ final class SnapshotTests: XCTestCase {
     ///   make snapshots
     func testGenerateMenubarScreenshot() throws {
         let view = PopupView(
-            sessions: SessionData.qaShowcase,
-            userSessions: userSessionProjection(from: SessionData.qaShowcase),
+            userSessions: userSessions(fromDataFixtures: SessionData.qaShowcase),
             updater: DisabledUpdater(),
             pluginManager: inertPluginManager()
         )
@@ -140,8 +139,7 @@ final class SnapshotTests: XCTestCase {
         let rc = NavigateController()
         rc.isActive = true
         let view = PopupView(
-            sessions: Array(SessionData.qaShowcase.prefix(4)),
-            userSessions: userSessionProjection(from: Array(SessionData.qaShowcase.prefix(4))),
+            userSessions: userSessions(fromDataFixtures: Array(SessionData.qaShowcase.prefix(4))),
             updater: DisabledUpdater(),
             pluginManager: inertPluginManager(), navigate: rc
         )
@@ -190,8 +188,7 @@ final class SnapshotTests: XCTestCase {
 
     func testGenerateRecentProjectsScreenshot() throws {
         let view = PopupView(
-            sessions: SessionData.qaShowcase,
-            userSessions: userSessionProjection(from: SessionData.qaShowcase),
+            userSessions: userSessions(fromDataFixtures: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             updater: DisabledUpdater(), pluginManager: inertPluginManager(), initialTab: .recent
         )
@@ -302,7 +299,6 @@ final class SnapshotTests: XCTestCase {
         XCTAssertEqual(recentProjects[2].metadataEvidenceText, "Codex \u{00B7} 1 session")
 
         let view = PopupView(
-            sessions: [],
             userSessions: [],
             recentProjects: recentProjects,
             updater: DisabledUpdater(),
@@ -344,7 +340,6 @@ final class SnapshotTests: XCTestCase {
         XCTAssertTrue(recentProjects.isEmpty)
 
         let view = PopupView(
-            sessions: [],
             userSessions: [],
             recentProjects: recentProjects,
             updater: DisabledUpdater(),
@@ -411,7 +406,6 @@ final class SnapshotTests: XCTestCase {
         XCTAssertFalse(targets.contains { $0.openActionLabel.contains("Thread") || ($0.inlineActionLabel?.contains("Thread") ?? false) })
 
         let view = PopupView(
-            sessions: [],
             userSessions: [],
             recentResumeTargets: targets,
             updater: DisabledUpdater(),
@@ -429,8 +423,7 @@ final class SnapshotTests: XCTestCase {
 
     func testGenerateCleanupScreenshot() throws {
         let view = PopupView(
-            sessions: SessionData.qaShowcase,
-            userSessions: userSessionProjection(from: SessionData.qaShowcase),
+            userSessions: userSessions(fromDataFixtures: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: WorktreeCleanupCandidate.mockCandidates.filter(\.state.isActionable),
             updater: DisabledUpdater(),
@@ -444,8 +437,7 @@ final class SnapshotTests: XCTestCase {
         let candidates = WorktreeCleanupCandidate.mockCandidates.filter(\.state.isActionable)
         let directoryName = "cctop-cleanup-discoverability-proof-\(Int(Date().timeIntervalSince1970))"
         let normalView = PopupView(
-            sessions: SessionData.qaShowcase,
-            userSessions: userSessionProjection(from: SessionData.qaShowcase),
+            userSessions: userSessions(fromDataFixtures: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: candidates,
             updater: DisabledUpdater(),
@@ -453,8 +445,7 @@ final class SnapshotTests: XCTestCase {
             initialTab: .cleanup
         )
         let scanningView = PopupView(
-            sessions: SessionData.qaShowcase,
-            userSessions: userSessionProjection(from: SessionData.qaShowcase),
+            userSessions: userSessions(fromDataFixtures: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: candidates,
             cleanupIsScanning: true,
@@ -463,8 +454,7 @@ final class SnapshotTests: XCTestCase {
             initialTab: .cleanup
         )
         let nudgedView = PopupView(
-            sessions: SessionData.qaShowcase,
-            userSessions: userSessionProjection(from: SessionData.qaShowcase),
+            userSessions: userSessions(fromDataFixtures: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: candidates,
             cleanupHasUnseenCandidates: true,
@@ -508,8 +498,7 @@ final class SnapshotTests: XCTestCase {
         let candidates = [clean, review]
 
         let cleanView = PopupView(
-            sessions: SessionData.qaShowcase,
-            userSessions: userSessionProjection(from: SessionData.qaShowcase),
+            userSessions: userSessions(fromDataFixtures: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: candidates,
             updater: DisabledUpdater(),
@@ -518,8 +507,7 @@ final class SnapshotTests: XCTestCase {
             initialCleanupCandidate: clean
         )
         let reviewView = PopupView(
-            sessions: SessionData.qaShowcase,
-            userSessions: userSessionProjection(from: SessionData.qaShowcase),
+            userSessions: userSessions(fromDataFixtures: SessionData.qaShowcase),
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: candidates,
             updater: DisabledUpdater(),
@@ -549,8 +537,7 @@ final class SnapshotTests: XCTestCase {
         for theme in AppTheme.allCases {
             ThemeManager.shared.setTheme(theme)
             let view = PopupView(
-                sessions: SessionData.qaShowcase,
-                userSessions: userSessionProjection(from: SessionData.qaShowcase),
+                userSessions: userSessions(fromDataFixtures: SessionData.qaShowcase),
                 updater: DisabledUpdater(),
                 pluginManager: inertPluginManager()
             )

--- a/menubar/CctopMenubarTests/StatusCountsUserSessionInitTests.swift
+++ b/menubar/CctopMenubarTests/StatusCountsUserSessionInitTests.swift
@@ -1,15 +1,15 @@
 import XCTest
 @testable import CctopMenubar
 
-final class StatusCountsSessionInitTests: XCTestCase {
+final class StatusCountsUserSessionInitTests: XCTestCase {
     func testEmptyArray_returnsZero() {
-        let counts = StatusCounts(sessions: [])
+        let counts = StatusCounts(userSessions: [])
         XCTAssertEqual(counts.total, 0)
     }
 
     func testIdle_countsAsIdle() {
-        let sessions = [SessionData.mock(status: .idle)]
-        let counts = StatusCounts(sessions: sessions)
+        let userSessions = userSessions(fromDataFixtures: [.mock(status: .idle)])
+        let counts = StatusCounts(userSessions: userSessions)
         XCTAssertEqual(counts.idle, 1)
         XCTAssertEqual(counts.working, 0)
     }
@@ -20,7 +20,10 @@ final class StatusCountsSessionInitTests: XCTestCase {
         session.lifecycle = .active
         session.lastActivity = now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval + 60)
 
-        let counts = StatusCounts(sessions: [session], now: now)
+        let counts = StatusCounts(
+            userSessions: userSessions(fromDataFixtures: [session]),
+            now: now
+        )
 
         XCTAssertEqual(counts.idle, 1)
         XCTAssertEqual(counts.total, 1)
@@ -32,7 +35,10 @@ final class StatusCountsSessionInitTests: XCTestCase {
         session.lifecycle = .active
         session.lastActivity = now.addingTimeInterval(-SessionDisplayPolicy.staleIdleInterval - 60)
 
-        let counts = StatusCounts(sessions: [session], now: now)
+        let counts = StatusCounts(
+            userSessions: userSessions(fromDataFixtures: [session]),
+            now: now
+        )
 
         XCTAssertEqual(counts.idle, 0)
         XCTAssertEqual(counts.total, 0)
@@ -42,44 +48,44 @@ final class StatusCountsSessionInitTests: XCTestCase {
         var session = SessionData.mock(status: .waitingPermission)
         session.lifecycle = .dormant
 
-        let counts = StatusCounts(sessions: [session])
+        let counts = StatusCounts(userSessions: userSessions(fromDataFixtures: [session]))
 
         XCTAssertEqual(counts.permission, 0)
         XCTAssertEqual(counts.total, 0)
     }
 
     func testWorking_countsAsWorking() {
-        let sessions = [SessionData.mock(status: .working)]
-        let counts = StatusCounts(sessions: sessions)
+        let userSessions = userSessions(fromDataFixtures: [.mock(status: .working)])
+        let counts = StatusCounts(userSessions: userSessions)
         XCTAssertEqual(counts.working, 1)
     }
 
     func testCompacting_countsAsWorking() {
-        let sessions = [SessionData.mock(status: .compacting)]
-        let counts = StatusCounts(sessions: sessions)
+        let userSessions = userSessions(fromDataFixtures: [.mock(status: .compacting)])
+        let counts = StatusCounts(userSessions: userSessions)
         XCTAssertEqual(counts.working, 1)
     }
 
     func testWaitingPermission_countsAsPermission() {
-        let sessions = [SessionData.mock(status: .waitingPermission)]
-        let counts = StatusCounts(sessions: sessions)
+        let userSessions = userSessions(fromDataFixtures: [.mock(status: .waitingPermission)])
+        let counts = StatusCounts(userSessions: userSessions)
         XCTAssertEqual(counts.permission, 1)
     }
 
     func testWaitingInput_countsAsAttention() {
-        let sessions = [SessionData.mock(status: .waitingInput)]
-        let counts = StatusCounts(sessions: sessions)
+        let userSessions = userSessions(fromDataFixtures: [.mock(status: .waitingInput)])
+        let counts = StatusCounts(userSessions: userSessions)
         XCTAssertEqual(counts.attention, 1)
     }
 
     func testNeedsAttention_countsAsAttention() {
-        let sessions = [SessionData.mock(status: .needsAttention)]
-        let counts = StatusCounts(sessions: sessions)
+        let userSessions = userSessions(fromDataFixtures: [.mock(status: .needsAttention)])
+        let counts = StatusCounts(userSessions: userSessions)
         XCTAssertEqual(counts.attention, 1)
     }
 
     func testMixedStatuses_aggregatesCorrectly() {
-        let sessions = [
+        let userSessions = userSessions(fromDataFixtures: [
             SessionData.mock(id: "1", status: .idle),
             SessionData.mock(id: "2", status: .idle),
             SessionData.mock(id: "3", status: .working),
@@ -87,13 +93,29 @@ final class StatusCountsSessionInitTests: XCTestCase {
             SessionData.mock(id: "5", status: .waitingPermission),
             SessionData.mock(id: "6", status: .waitingInput),
             SessionData.mock(id: "7", status: .needsAttention),
-        ]
-        let counts = StatusCounts(sessions: sessions)
+        ])
+        let counts = StatusCounts(userSessions: userSessions)
         XCTAssertEqual(counts.idle, 2)
         XCTAssertEqual(counts.working, 2)  // working + compacting
         XCTAssertEqual(counts.permission, 1)
         XCTAssertEqual(counts.attention, 2)  // waitingInput + needsAttention
         XCTAssertEqual(counts.total, 7)
         XCTAssertEqual(counts.needsAction, 3)  // permission + attention
+    }
+
+    func testRetainedRecords_countSelectedUserSessionOnce() {
+        let selectedData = SessionData.mock(id: "selected", status: .working)
+        let retainedData = SessionData.mock(id: "retained", status: .waitingPermission)
+        let session = userSession(
+            identity: .permanent(UUID()),
+            display: selectedData,
+            records: [selectedData, retainedData]
+        )
+
+        let counts = StatusCounts(userSessions: [session])
+
+        XCTAssertEqual(counts.working, 1)
+        XCTAssertEqual(counts.permission, 0)
+        XCTAssertEqual(counts.total, 1)
     }
 }

--- a/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupSnapshotTests.swift
@@ -314,8 +314,7 @@ final class WorktreeCleanupScenarioSnapshotTests: XCTestCase {
         isScanning: Bool = false
     ) -> PopupView {
         PopupView(
-            sessions: sessions,
-            userSessions: userSessionProjection(from: sessions),
+            userSessions: userSessions(fromDataFixtures: sessions),
             recentProjects: RecentProject.mockRecents,
             cleanupCandidates: candidates,
             cleanupIsScanning: isScanning,

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -5275,7 +5275,6 @@ final class WorktreeCleanupTests: XCTestCase {
         onLayoutChanged: @escaping () -> Void = {}
     ) -> PopupView {
         PopupView(
-            sessions: [],
             userSessions: [],
             cleanupCandidates: cleanupCandidates,
             updater: DisabledUpdater(),


### PR DESCRIPTION
Moves the app to one forward session pipeline: decoded SessionData becomes SessionRecord evidence, related records become UserSession, and presentation derives from UserSession.displayRecord.

- Makes UserSession the sole identity and ordering authority for navigation, hiding, notifications, status counts, and Stream Deck display state.
- Preserves record evidence and row position through file replacement and permanent-ID stamping.
- Keeps direct row actions on the exact rendered SessionData while indirect actions resolve the current UserSession and fail closed on missing or ambiguous evidence.
- Removes raw-session reconstruction and compatibility paths.