### PR TITLE
Prefer Codex Desktop over inherited cmux targets

### DIFF
--- a/menubar/CctopMenubar/Services/CodexDesktopRuntimeProbe.swift
+++ b/menubar/CctopMenubar/Services/CodexDesktopRuntimeProbe.swift
@@ -48,6 +48,10 @@ struct CodexDesktopRuntimeProbe {
         return environment(server.pid)["CODEX_SQLITE_HOME"].flatMap(Config.nonEmpty)
     }
 
+    func isCurrentDesktopAppServer(pid: pid_t) -> Bool {
+        currentDesktopAppServer()?.pid == pid
+    }
+
     private func currentDesktopAppServer() -> ProcessSnapshot? {
         let apps = runningApps().filter { $0.bundleIdentifier == HostAppBundleID.codexDesktop }
         guard apps.count == 1, let app = apps.first else { return nil }

--- a/menubar/CctopMenubar/Services/CodexDesktopRuntimeProbe.swift
+++ b/menubar/CctopMenubar/Services/CodexDesktopRuntimeProbe.swift
@@ -48,8 +48,12 @@ struct CodexDesktopRuntimeProbe {
         return environment(server.pid)["CODEX_SQLITE_HOME"].flatMap(Config.nonEmpty)
     }
 
-    func isCurrentDesktopAppServer(pid: pid_t) -> Bool {
-        currentDesktopAppServer()?.pid == pid
+    func isCurrentDesktopAppServer(for session: SessionData) -> Bool {
+        guard session.isCodex,
+              session.pidStartTime != nil,
+              session.isAlive,
+              let pid = session.pid.flatMap(pid_t.init(exactly:)) else { return false }
+        return currentDesktopAppServer()?.pid == pid
     }
 
     private func currentDesktopAppServer() -> ProcessSnapshot? {

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -43,18 +43,19 @@ func resolveFocusStrategy(session: SessionData) -> FocusStrategy {
 /// Pure function — no AppKit side effects, fully testable.
 func resolveFocusStrategy(
     session: SessionData,
-    multiplexerOverride: MultiplexerInfo?
+    multiplexerOverride: MultiplexerInfo?,
+    isCodexDesktopAppServerTarget: Bool = false
 ) -> FocusStrategy {
     let terminal = session.terminal
     let multiplexer = multiplexerOverride ?? terminal?.multiplexer
 
-    // Direct terminal/editor metadata wins. A Codex session without it uses its exact
-    // thread deep link. Persisted `com.openai.codex` metadata is ignored.
+    // Positive live Codex Desktop app-server evidence wins over inherited terminal metadata.
+    // Otherwise direct terminal/editor metadata wins. Persisted `com.openai.codex` metadata is ignored.
     let program = terminal?.program
     let directHost = multiplexer?.isCmux == true ? HostApp.cmux : HostApp.from(editorName: program)
     let hasProgramEvidence = program?.isEmpty == false && program?.lowercased() != "codex"
     let hasDirectHostEvidence = hasProgramEvidence || terminal?.tty?.isEmpty == false || multiplexer != nil
-    let hostApp = session.trustedHostApp
+    let hostApp = (session.isCodex && isCodexDesktopAppServerTarget ? HostApp.codexDesktop : nil) ?? session.trustedHostApp
         ?? (hasDirectHostEvidence ? directHost : nil)
         ?? (session.isCodex ? HostApp.codexDesktop : nil)
         ?? .unknown
@@ -128,7 +129,14 @@ private let focusQueue = DispatchQueue(label: "cctop.focus-terminal", qos: .user
 func focusTerminal(session: SessionData) {
     focusQueue.async {
         let multiplexerOverride = resolveCmuxLiveMultiplexer(session: session)
-        let strategy = resolveFocusStrategy(session: session, multiplexerOverride: multiplexerOverride)
+        let isCodexDesktopAppServerTarget = session.isCodex && session.pid.flatMap(pid_t.init(exactly:)).map {
+            CodexDesktopRuntimeProbe().isCurrentDesktopAppServer(pid: $0)
+        } == true
+        let strategy = resolveFocusStrategy(
+            session: session,
+            multiplexerOverride: multiplexerOverride,
+            isCodexDesktopAppServerTarget: isCodexDesktopAppServerTarget
+        )
         let muxStrategy = resolveMultiplexerFocus(session: session, multiplexerOverride: multiplexerOverride,
                                                   primaryStrategy: strategy)
         let shouldDeactivate = executeFocusStrategy(strategy)

--- a/menubar/CctopMenubar/Services/FocusTerminal.swift
+++ b/menubar/CctopMenubar/Services/FocusTerminal.swift
@@ -129,9 +129,7 @@ private let focusQueue = DispatchQueue(label: "cctop.focus-terminal", qos: .user
 func focusTerminal(session: SessionData) {
     focusQueue.async {
         let multiplexerOverride = resolveCmuxLiveMultiplexer(session: session)
-        let isCodexDesktopAppServerTarget = session.isCodex && session.pid.flatMap(pid_t.init(exactly:)).map {
-            CodexDesktopRuntimeProbe().isCurrentDesktopAppServer(pid: $0)
-        } == true
+        let isCodexDesktopAppServerTarget = CodexDesktopRuntimeProbe().isCurrentDesktopAppServer(for: session)
         let strategy = resolveFocusStrategy(
             session: session,
             multiplexerOverride: multiplexerOverride,

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -25,6 +25,29 @@ final class FocusStrategyTests: XCTestCase {
         )
     }
 
+    private func makeCodexDesktopProbe(
+        apps: [CodexDesktopRuntimeProbe.RunningApp],
+        servers: [CodexDesktopRuntimeProbe.ProcessSnapshot]
+    ) -> CodexDesktopRuntimeProbe {
+        CodexDesktopRuntimeProbe(
+            runningApps: { apps },
+            childProcesses: { _ in servers },
+            environment: { _ in [:] }
+        )
+    }
+
+    private func spawnLiveProcess() throws -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["30"]
+        try process.run()
+        addTeardownBlock {
+            if process.isRunning { process.terminate() }
+            process.waitUntilExit()
+        }
+        return process
+    }
+
     func testActionTitleDescribesResolvedFocusBehavior() throws {
         let codexURL = try XCTUnwrap(URL(string: "codex://threads/019e1eff-3374-74b0-8d3d-6fba94e7d75f"))
 
@@ -463,7 +486,8 @@ final class FocusStrategyTests: XCTestCase {
 
     func testCodexDesktopAppServerOverridesInheritedCmux() throws {
         let threadID = "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
-        let appServerPID: pid_t = 61_871
+        let appServerPID = pid_t(try spawnLiveProcess().processIdentifier)
+        let appServerStartTime = try XCTUnwrap(SessionData.processStartTime(pid: UInt32(appServerPID)))
         let multiplexer = MultiplexerInfo.cmux(
             socket: "/tmp/cmux.sock",
             workspaceId: "b48dbe7e-b98f-48e7-9914-17d7f119beaa",
@@ -475,6 +499,7 @@ final class FocusStrategyTests: XCTestCase {
             id: threadID,
             project: "myapp",
             pid: UInt32(appServerPID),
+            pidStartTime: appServerStartTime,
             terminal: TerminalInfo(program: "", multiplexer: multiplexer),
             source: SessionData.codexSource
         )
@@ -488,16 +513,8 @@ final class FocusStrategyTests: XCTestCase {
             executablePath: "/Applications/ChatGPT.app/Contents/Resources/codex",
             arguments: ["codex", "app-server", "--analytics-default-enabled"]
         )
-        let makeProbe = {
-            (apps: [CodexDesktopRuntimeProbe.RunningApp], servers: [CodexDesktopRuntimeProbe.ProcessSnapshot]) in
-            CodexDesktopRuntimeProbe(
-                runningApps: { apps },
-                childProcesses: { _ in servers },
-                environment: { _ in [:] }
-            )
-        }
-        let probe = makeProbe([app], [appServer])
-        let isDesktopTarget = probe.isCurrentDesktopAppServer(pid: appServerPID)
+        let probe = makeCodexDesktopProbe(apps: [app], servers: [appServer])
+        let isDesktopTarget = probe.isCurrentDesktopAppServer(for: session)
 
         let strategy = resolveFocusStrategy(
             session: session,
@@ -514,9 +531,21 @@ final class FocusStrategyTests: XCTestCase {
         XCTAssertNotEqual(strategy, .openURL(try XCTUnwrap(cmuxNavigationURL(multiplexer: multiplexer))))
         XCTAssertNotEqual(strategy, .openInFinder(session.projectPath))
         XCTAssertNil(resolveMultiplexerFocus(session: session, primaryStrategy: strategy))
-        XCTAssertFalse(probe.isCurrentDesktopAppServer(pid: appServerPID + 1))
-        XCTAssertFalse(makeProbe([app, app], [appServer]).isCurrentDesktopAppServer(pid: appServerPID))
-        XCTAssertFalse(makeProbe([app], [appServer, appServer]).isCurrentDesktopAppServer(pid: appServerPID))
+
+        var staleGeneration = session
+        staleGeneration.pidStartTime = appServerStartTime - 10
+        var missingGeneration = session
+        missingGeneration.pidStartTime = nil
+        var otherProcess = session
+        otherProcess.pid = UInt32(appServerPID) + 1
+
+        XCTAssertFalse(probe.isCurrentDesktopAppServer(for: staleGeneration))
+        XCTAssertFalse(probe.isCurrentDesktopAppServer(for: missingGeneration))
+        XCTAssertFalse(probe.isCurrentDesktopAppServer(for: otherProcess))
+        XCTAssertFalse(makeCodexDesktopProbe(apps: [app, app], servers: [appServer])
+            .isCurrentDesktopAppServer(for: session))
+        XCTAssertFalse(makeCodexDesktopProbe(apps: [app], servers: [appServer, appServer])
+            .isCurrentDesktopAppServer(for: session))
     }
 
     func testCodexCLICmuxStillUsesCmuxRoute() throws {

--- a/menubar/CctopMenubarTests/FocusStrategyTests.swift
+++ b/menubar/CctopMenubarTests/FocusStrategyTests.swift
@@ -461,6 +461,89 @@ final class FocusStrategyTests: XCTestCase {
         )
     }
 
+    func testCodexDesktopAppServerOverridesInheritedCmux() throws {
+        let threadID = "019e1eff-3374-74b0-8d3d-6fba94e7d75f"
+        let appServerPID: pid_t = 61_871
+        let multiplexer = MultiplexerInfo.cmux(
+            socket: "/tmp/cmux.sock",
+            workspaceId: "b48dbe7e-b98f-48e7-9914-17d7f119beaa",
+            surfaceId: "0beee68a-a07d-4225-acf6-8c973615aa91",
+            paneId: nil,
+            binaryPath: "/Applications/cmux.app/Contents/Resources/bin/cmux"
+        )
+        let session = SessionData.mock(
+            id: threadID,
+            project: "myapp",
+            pid: UInt32(appServerPID),
+            terminal: TerminalInfo(program: "", multiplexer: multiplexer),
+            source: SessionData.codexSource
+        )
+        let app = CodexDesktopRuntimeProbe.RunningApp(
+            pid: 61_700,
+            bundleIdentifier: HostAppBundleID.codexDesktop,
+            bundleURLPath: "/Applications/ChatGPT.app"
+        )
+        let appServer = CodexDesktopRuntimeProbe.ProcessSnapshot(
+            pid: appServerPID,
+            executablePath: "/Applications/ChatGPT.app/Contents/Resources/codex",
+            arguments: ["codex", "app-server", "--analytics-default-enabled"]
+        )
+        let makeProbe = {
+            (apps: [CodexDesktopRuntimeProbe.RunningApp], servers: [CodexDesktopRuntimeProbe.ProcessSnapshot]) in
+            CodexDesktopRuntimeProbe(
+                runningApps: { apps },
+                childProcesses: { _ in servers },
+                environment: { _ in [:] }
+            )
+        }
+        let probe = makeProbe([app], [appServer])
+        let isDesktopTarget = probe.isCurrentDesktopAppServer(pid: appServerPID)
+
+        let strategy = resolveFocusStrategy(
+            session: session,
+            multiplexerOverride: nil,
+            isCodexDesktopAppServerTarget: isDesktopTarget
+        )
+        let intended = FocusStrategy.openURL(
+            try XCTUnwrap(URL(string: "codex://threads/\(threadID)")),
+            restoreBundleID: HostAppBundleID.codexDesktop
+        )
+
+        XCTAssertTrue(isDesktopTarget)
+        XCTAssertEqual(strategy, intended)
+        XCTAssertNotEqual(strategy, .openURL(try XCTUnwrap(cmuxNavigationURL(multiplexer: multiplexer))))
+        XCTAssertNotEqual(strategy, .openInFinder(session.projectPath))
+        XCTAssertNil(resolveMultiplexerFocus(session: session, primaryStrategy: strategy))
+        XCTAssertFalse(probe.isCurrentDesktopAppServer(pid: appServerPID + 1))
+        XCTAssertFalse(makeProbe([app, app], [appServer]).isCurrentDesktopAppServer(pid: appServerPID))
+        XCTAssertFalse(makeProbe([app], [appServer, appServer]).isCurrentDesktopAppServer(pid: appServerPID))
+    }
+
+    func testCodexCLICmuxStillUsesCmuxRoute() throws {
+        let multiplexer = MultiplexerInfo.cmux(
+            socket: "/tmp/cmux.sock",
+            workspaceId: "b48dbe7e-b98f-48e7-9914-17d7f119beaa",
+            surfaceId: "0beee68a-a07d-4225-acf6-8c973615aa91",
+            paneId: nil,
+            binaryPath: "/Applications/cmux.app/Contents/Resources/bin/cmux"
+        )
+        let session = SessionData.mock(
+            id: "019e1eff-3374-74b0-8d3d-6fba94e7d75f",
+            project: "myapp",
+            pid: 61_872,
+            terminal: TerminalInfo(program: "cmux", multiplexer: multiplexer),
+            source: SessionData.codexSource
+        )
+
+        let strategy = resolveFocusStrategy(
+            session: session,
+            multiplexerOverride: nil,
+            isCodexDesktopAppServerTarget: false
+        )
+
+        XCTAssertEqual(strategy, .openURL(try XCTUnwrap(cmuxNavigationURL(multiplexer: multiplexer))))
+    }
+
     func testCurrentPermanentIDCodexRouteUsesThreadDeepLinkDespiteStalePID() throws {
         let threadID = "019faecb-6e9b-7f41-a51f-bb998875ca77"
         let cctopSessionID = "82498aba-410e-4b6b-b48d-62f7c6a81eae"


### PR DESCRIPTION
## Summary

- Prefer an exact live Codex Desktop app-server match before inherited terminal or multiplexer metadata.
- Preserve existing Codex CLI cmux routing when Desktop evidence is absent.
- Fail closed for stale, non-matching, or ambiguous app-server evidence.

Fixes #254.