### PR TITLE
Add reversible session acknowledgement and temporary drop

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -251,7 +251,7 @@ body type, and never used in the app.
 | 10.5 · semibold   | Status label ("Working" / "Waiting" / "Permission")                  |
 | 10.5 mono         | Command stripe (working session row 3)                               |
 | 10                | Subagent badge, branch (mono), timestamp                             |
-| 11 · medium       | Main Active / Idle / Recent / Cleanup tab labels and counts          |
+| 10 · medium       | Primary Active / Idle / Ack / Dropped selector labels and counts |
 | 9.5 · semibold    | Uppercase Settings section labels                                    |
 | 9.5 · medium      | Settings segmented picker labels and source badges                   |
 
@@ -318,7 +318,8 @@ when you glance at it from peripheral vision.
 | **Row 3 — waiting**       | 10.5 px `textSecondary` note: `notificationMessage ?? contextLine ?? "Waiting for input"`. Permission notes are 10.5 px italic `statusAttention`. |
 | Selected / hover          | `cardSelectionStyle` uses a theme-ink 7–7.5% fill, radius 10, and an 8 px horizontal inset. It has no stroke, divider, or left accent bar. |
 | Source badge visibility   | Shown only when `Set(sessions.map(\.agentBadge)).count > 1` (keyed on `agentBadge`, not `sourceLabel`, so CC + Claude Desktop counts as multiple sources) |
-| Hide interaction          | A native context-menu item and named accessibility action open the same destructive confirmation. Left-click remains jump-to-session. |
+| Acknowledge interaction   | Attention rows expose a native context-menu item and named accessibility action. Acknowledgement maps only the current event to the existing neutral idle presentation; it does not end or hide the session. |
+| Hide interaction          | A separate native context-menu item and named accessibility action open the same destructive confirmation. Left-click remains jump-to-session. |
 
 #### Source badge (`SourceBadgeView.swift`) — six variants
 
@@ -388,6 +389,11 @@ Deck's action picker. The bundled Claude Code,
 Codex, opencode, and pi integrations do not expose logo fields in their current
 direct hook/extension formats; do not invent unsupported manifest metadata.
 
+A Stream Deck Session key focuses its exact rendered permanent session ID on a
+single press. A second press on that same physical key and session ID within
+350 ms sends Acknowledge for the same target. The first focus still occurs, and
+presses on different key contexts never combine into a double press.
+
 The menubar status item is 36×18 with a centered 36×6 live hairline. It
 resolves semantic colors against the status button's effective light/dark
 appearance. It contains no separate glyph.
@@ -430,19 +436,22 @@ Always black, regardless of theme — it's OS chrome that meets the camera notch
 | Border        | None                                                  |
 | Radius        | 5 px                                                  |
 
-### Tab button (Active / Idle / Recent / Cleanup)
+### Selector bar (Active / Idle / Ack / Dropped, with overflow)
 
-The four equal-width 22 px segments live in one track with 2 px inset and
-8 px outer / 6 px inner radii. The selected tab uses a native-style thumb
+Four equal-width 22 px primary segments and one fixed 28 px overflow control
+live in one compact track with 2 px inset and 8 px outer / 6 px inner radii.
+The overflow menu exposes Recent and Cleanup with their counts. The selected tab uses a native-style thumb
 and subtle shadow, never an accent stroke. Hover is fill-only. Labels and
-tabular counts are 11 px; zero counts mute, while scanning and unseen Cleanup
-states keep their existing progress/attention cues.
+tabular counts are 10 px with tight 2 px internal spacing and 1 px between segments; zero counts remain visible, while scanning and unseen Cleanup
+states keep their existing progress/attention cues. Ack mirrors acknowledged
+rows that remain in Active or Idle. Dropped is the only selector that exposes
+temporarily dropped rows and their Restore Session action.
 
 ### Settings grouped list
 
-Settings uses a native grouped-list structure. Active, Idle, and Recent all use
-the same flat, dense panel list renderer so tab changes do not change the
-component vocabulary.
+Settings uses a native grouped-list structure. Active, Idle, Ack, Dropped, and
+Recent all use the same flat, dense panel list renderer so selector changes do
+not change the component vocabulary.
 
 | Property            | Value                                                  |
 |---------------------|--------------------------------------------------------|
@@ -521,12 +530,12 @@ site-only and reserved for sections, not components.
 | Width                     | Fixed 320 px                                   |
 | Outer surface             | Continuous `panelBackground`, radius 16, one subtle inner rim; no tinted header/tab/footer bands |
 | Header padding            | 16 / 14 / 14 / 10 (l / t / r / b)             |
-| Tab bar                   | 16 px horizontal margin · 8 px bottom margin · four equal 22 px segments |
+| Tab bar                   | 16 px horizontal margin · 8 px bottom margin · four equal 22 px segments + 28 px overflow |
 | Card padding              | 9 px inner horizontal + 8 px selection inset · 8 px vertical |
 | Footer padding            | 16 / 12 / 6 / 10 (l / r / t / b)              |
 | Footer content            | 10.5 px Quit · version · shortcut, separated by muted middle dots; 20 px neutral Settings glyph/fill with a 28 px hit target |
 | Scroll area max height    | 290 px (then scrolls)                          |
-| Active/Idle/Recent spacing| 2 px row gap, 0 px top and 4 px bottom; no dividers |
+| Session/Recent spacing    | 2 px row gap, 0 px top and 4 px bottom; no dividers |
 | Settings content padding  | 8 px horizontal · 0 px top · 6 px bottom around the sunk well |
 
 The panel reflows in **height only**; width is fixed to keep card layout

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -80,6 +80,29 @@ again while its local record exists. Persist the preference by cctop's permanent
 while continuing lifecycle classification and Cleanup protection from the full
 local session inventory.
 
+### Acknowledgement is not lifecycle
+
+Users may acknowledge an attention state they have already reviewed. This
+quietly maps that exact event to cctop's existing neutral idle presentation
+without hiding, ending, or editing the underlying session. The acknowledgement
+expires when the same session reports a newer attention event, so cctop earns
+the right to become conspicuous again. Acknowledged sessions remain grey in
+Active or Idle and are also collected in the Ack selector so the user can find
+them directly. A Stream Deck session key focuses on the first press and
+acknowledges that same permanent session when pressed again within the
+double-press window. Presses on separate keys never combine.
+
+### Temporary drop is not hiding
+
+Users may drop a session they no longer need to see right now. Drop removes the
+exact current session revision from operational surfaces without stopping,
+archiving, ending, or editing the underlying session. The Dropped selector
+keeps it reachable for explicit restoration. A drop survives a cctop restart so
+the session does not immediately return to Active or Idle, but either Restore
+Session or the next genuine hook event restores it. Keep this action distinct
+from durable **Hide Session**, and do not require destructive-action confirmation
+for it.
+
 ### Show decision evidence inline
 
 When cctop asks users to decide, the evidence needed for that decision should be
@@ -224,6 +247,10 @@ When cctop cannot prove something, it should say so plainly:
 - **Active**: a visible session with live work or recent state.
 - **Idle**: a session that is connected but not currently asking for action.
 - **Waiting**: a session that needs user input or permission.
+- **Ack**: acknowledged sessions, mirrored from Active or Idle in a neutral grey
+  presentation until newer attention arrives.
+- **Dropped**: temporarily suppressed sessions, excluded from operational
+  surfaces but reachable for restoration.
 - **Recent**: a remembered project or session target that is no longer active.
 - **Clean**: a cleanup candidate whose fresh checks support direct removal.
 - **Review**: a cleanup candidate that needs user inspection before removal.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ project with a keystroke.
 ## Why cctop
 
 - See at a glance which coding sessions are working, idle, or waiting on you.
+- Acknowledge an attention state you already reviewed without closing the
+  session. It stays neutral until a newer attention event arrives.
+- Temporarily drop a session from operational status until its next activity,
+  or restore it directly from the Dropped selector.
 - Right-click to hide a session from cctop without stopping it or deleting its data.
   cctop asks first because you cannot show it again while its local session record exists.
 - Jump directly to the right editor window, terminal pane, desktop thread, or project.
@@ -185,7 +189,9 @@ Open **Settings**. cctop shows setup actions for detected coding clients under
   column 1 without switching away from your current profile. If you skip that
   prompt, use **Import default profile** later or place the Session and Toggle
   Panel actions manually on any supported model. To show more sessions, add
-  Session actions and set their slots to 6, 7, and so on.
+  Session actions and set their slots to 6, 7, and so on. Press a session key
+  once to focus it; press the same key again within 350 ms to acknowledge its
+  current attention event.
 - Codex CLI / Codex Desktop: click **Install Hooks**, then start a new Codex CLI
   session and choose **Trust all and continue** when Codex reviews the hooks.
   Codex Desktop shares that trust state.

--- a/docs/session-files.md
+++ b/docs/session-files.md
@@ -281,6 +281,24 @@ records remain available to Cleanup without entering Recent Projects. Unreadable
 pre-PID files survive while stored manual-hide evidence prevents proving them
 unrelated.
 
+### Temporary dropping
+
+The app's **Drop Until Next Activity** action is a reversible presentation
+preference, separate from manual hiding and from the hook-owned `hidden` field.
+cctop stores the permanent `cctop_session_id` with the latest `last_activity`
+represented by the full grouped `UserSession`. It does not rewrite the source
+JSON, stop the process, archive the conversation, or change lifecycle.
+
+An exact matching revision is omitted from Active, Idle, status counts, Navigate
+mode, notifications, the notch or menu bar indicator, and Stream Deck display
+state. It remains available in the Dropped selector, where **Restore Session**
+removes the presentation preference without editing source JSON. The drop
+survives an app restart. Any grouped record with a newer `last_activity` changes
+the activity revision, prunes the stored drop, and republishes the session to
+normal surfaces. Partial inventories retain unobserved drop evidence; a complete
+inventory prunes missing sessions. **Hide Session** also clears any temporary
+drop for the same permanent ID so only the durable visibility decision remains.
+
 ### `is_subagent`
 
 Type: `boolean`

--- a/menubar/CctopMenubar.xcodeproj/project.pbxproj
+++ b/menubar/CctopMenubar.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		WCT000010000000000000001 /* WorktreeCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = WCT000020000000000000001 /* WorktreeCleanupTests.swift */; };
 		SLP000010000000000000001 /* SessionLifecyclePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = SLP000020000000000000001 /* SessionLifecyclePolicy.swift */; };
 		SIP000010000000000000001 /* SessionIdentityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = SIP000020000000000000001 /* SessionIdentityPolicy.swift */; };
+		STD000010000000000000001 /* SessionTemporaryDropStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = STD000020000000000000001 /* SessionTemporaryDropStore.swift */; };
 		LGS000010000000000000001 /* UserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = LGS000020000000000000001 /* UserSession.swift */; };
 		CSI000010000000000000001 /* CctopSessionIdentityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CSI000030000000000000001 /* CctopSessionIdentityStore.swift */; };
 		CSI000020000000000000001 /* CctopSessionIdentityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CSI000030000000000000001 /* CctopSessionIdentityStore.swift */; };
@@ -195,6 +196,7 @@
 		C10000020000000000000001 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		SLP000020000000000000001 /* SessionLifecyclePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLifecyclePolicy.swift; sourceTree = "<group>"; };
 		SIP000020000000000000001 /* SessionIdentityPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIdentityPolicy.swift; sourceTree = "<group>"; };
+		STD000020000000000000001 /* SessionTemporaryDropStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTemporaryDropStore.swift; sourceTree = "<group>"; };
 		LGS000020000000000000001 /* UserSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSession.swift; sourceTree = "<group>"; };
 		CSI000030000000000000001 /* CctopSessionIdentityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CctopSessionIdentityStore.swift; sourceTree = "<group>"; };
 		DCL000020000000000000001 /* DesktopAppConnectionLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopAppConnectionLookup.swift; sourceTree = "<group>"; };
@@ -378,6 +380,7 @@
 				C10000020000000000000001 /* SessionManager.swift */,
 				SLP000020000000000000001 /* SessionLifecyclePolicy.swift */,
 				SIP000020000000000000001 /* SessionIdentityPolicy.swift */,
+				STD000020000000000000001 /* SessionTemporaryDropStore.swift */,
 				LGS000020000000000000001 /* UserSession.swift */,
 				CSI000030000000000000001 /* CctopSessionIdentityStore.swift */,
 				DCL000020000000000000001 /* DesktopAppConnectionLookup.swift */,
@@ -711,6 +714,7 @@
 				C10000010000000000000001 /* SessionManager.swift in Sources */,
 				SLP000010000000000000001 /* SessionLifecyclePolicy.swift in Sources */,
 				SIP000010000000000000001 /* SessionIdentityPolicy.swift in Sources */,
+				STD000010000000000000001 /* SessionTemporaryDropStore.swift in Sources */,
 				LGS000010000000000000001 /* UserSession.swift in Sources */,
 				CSI000010000000000000001 /* CctopSessionIdentityStore.swift in Sources */,
 				DCL000010000000000000001 /* DesktopAppConnectionLookup.swift in Sources */,

--- a/menubar/CctopMenubar/AppDelegate.swift
+++ b/menubar/CctopMenubar/AppDelegate.swift
@@ -784,7 +784,7 @@ extension AppDelegate {
         case "toggle":
             togglePanel()
         case "focus":
-            guard let cctopSessionID = Self.focusSessionID(from: url),
+            guard let cctopSessionID = Self.sessionID(from: url),
                   CctopSessionID.isValid(cctopSessionID) else {
                 Self.urlLogger.notice("Ignored malformed cctop focus command")
                 return
@@ -824,9 +824,26 @@ extension AppDelegate {
             )
             guard let resolvedUserSession else { return }
             focusTerminal(session: resolvedUserSession.focusTarget)
+        case "acknowledge":
+            handleAcknowledgeCommand(url)
         default:
             break
         }
+    }
+
+    @MainActor private func handleAcknowledgeCommand(_ url: URL) {
+        guard let cctopSessionID = Self.sessionID(from: url),
+              CctopSessionID.isValid(cctopSessionID) else {
+            Self.urlLogger.notice("Ignored malformed cctop acknowledge command")
+            return
+        }
+        sessionManager.loadSessions()
+        let activeUserSessions = SessionDisplayPolicy.activeSessions(from: sessionManager.userSessions)
+        guard let userSession = FocusTargetResolver.currentUserSession(
+            forCctopSessionID: cctopSessionID,
+            in: activeUserSessions
+        ) else { return }
+        sessionManager.acknowledgeSession(userSession.identity)
     }
 
     nonisolated static func urlCommand(from url: URL) -> String {
@@ -836,7 +853,7 @@ extension AppDelegate {
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
     }
 
-    nonisolated static func focusSessionID(from url: URL) -> String? {
+    nonisolated static func sessionID(from url: URL) -> String? {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let value = components.queryItems?.first(where: { $0.name == "sid" })?.value,
               !value.isEmpty else { return nil }

--- a/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
+++ b/menubar/CctopMenubar/Services/SessionIdentityPolicy.swift
@@ -369,3 +369,88 @@ struct ManualSessionVisibilityStore {
         }
     }
 }
+
+/// Identifies one attention event without changing the hook-owned session record.
+/// A later hook event changes `lastActivity`, so an acknowledgement never suppresses
+/// a newer request for the user's attention.
+struct SessionAttentionRevision: Codable, Equatable {
+    let status: SessionStatus
+    let lastActivity: Date
+
+    init?(session: SessionData) {
+        guard session.status.needsAttention else { return nil }
+        status = session.status
+        lastActivity = session.lastActivity
+    }
+}
+
+/// Persists which exact attention event the user has already reviewed. This is a
+/// presentation preference only: it never hides, ends, or edits the session file.
+struct SessionAttentionAcknowledgementStore {
+    static let defaultsKey = "acknowledgedSessionAttentionRevisions"
+    static let live = SessionAttentionAcknowledgementStore(defaults: .standard)
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    var acknowledgedRevisions: [String: SessionAttentionRevision] {
+        guard let data = defaults.data(forKey: Self.defaultsKey),
+              let decoded = try? JSONDecoder.sessionDecoder.decode(
+                  [String: SessionAttentionRevision].self,
+                  from: data
+              ) else { return [:] }
+        return decoded.filter { CctopSessionID.isValid($0.key) }
+    }
+
+    func isAcknowledged(cctopSessionID: String, session: SessionData) -> Bool {
+        guard CctopSessionID.isValid(cctopSessionID),
+              let revision = SessionAttentionRevision(session: session) else { return false }
+        return acknowledgedRevisions[cctopSessionID] == revision
+    }
+
+    func acknowledge(cctopSessionID: String, session: SessionData) {
+        guard CctopSessionID.isValid(cctopSessionID),
+              let revision = SessionAttentionRevision(session: session) else { return }
+        var revisions = acknowledgedRevisions
+        revisions[cctopSessionID] = revision
+        save(revisions)
+    }
+
+    func remove(cctopSessionID: String) {
+        var revisions = acknowledgedRevisions
+        guard revisions.removeValue(forKey: cctopSessionID) != nil else { return }
+        save(revisions)
+    }
+
+    /// Remove stale revisions when the complete inventory disproves them. During a
+    /// partial inventory, an older decoded peer cannot disprove the stored latest
+    /// revision; only affirmative newer activity expires the acknowledgement.
+    func reconcile(
+        currentAttentionRevisions: [String: SessionAttentionRevision],
+        currentLastActivities: [String: Date],
+        inventoryComplete: Bool
+    ) {
+        let current = acknowledgedRevisions
+        let retained = current.filter { cctopSessionID, acknowledgedRevision in
+            if inventoryComplete {
+                return currentAttentionRevisions[cctopSessionID] == acknowledgedRevision
+            }
+            guard let currentLastActivity = currentLastActivities[cctopSessionID] else { return true }
+            return currentLastActivity <= acknowledgedRevision.lastActivity
+        }
+        guard retained != current else { return }
+        save(retained)
+    }
+
+    private func save(_ revisions: [String: SessionAttentionRevision]) {
+        guard !revisions.isEmpty else {
+            defaults.removeObject(forKey: Self.defaultsKey)
+            return
+        }
+        guard let data = try? JSONEncoder.sessionEncoder.encode(revisions) else { return }
+        defaults.set(data, forKey: Self.defaultsKey)
+    }
+}

--- a/menubar/CctopMenubar/Services/SessionManager+Archive.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Archive.swift
@@ -16,6 +16,8 @@ struct SessionDataSources {
     var notificationsEnabled: () -> Bool
     var notificationClient: SessionNotificationClient = .live
     var manualSessionVisibility: ManualSessionVisibilityStore = .live
+    var attentionAcknowledgements: SessionAttentionAcknowledgementStore = .live
+    var temporaryDrops: SessionTemporaryDropStore = .live
     var now: () -> Date
 
     /// A function rather than a stored constant so `Config.sessionsDir()` is resolved

--- a/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
+++ b/menubar/CctopMenubar/Services/SessionManager+Notifications.swift
@@ -70,23 +70,205 @@ enum SessionNotificationAction: Equatable {
     case post(cctopSessionID: String)
 }
 
+struct SessionAttentionProjection {
+    let userSessions: [UserSession]
+    let acknowledgedSessionIDs: Set<String>
+}
+
+struct SessionTemporaryDropProjection {
+    let visible: [UserSession]
+    let dropped: [UserSession]
+}
+
 @MainActor
 extension SessionManager {
+    func publishRecentResumeTargets(_ targets: [RecentResumeTarget]) {
+        if targets != recentResumeTargets {
+            recentResumeTargets = targets
+        }
+    }
+
+    func updateAuxiliarySessionProjections(
+        dropped: [UserSession],
+        acknowledgedSessionIDs: Set<String>
+    ) {
+        if dropped != droppedUserSessions {
+            droppedUserSessions = dropped
+        }
+        if acknowledgedSessionIDs != self.acknowledgedSessionIDs {
+            self.acknowledgedSessionIDs = acknowledgedSessionIDs
+        }
+    }
+
+    func acknowledgeSession(_ identity: SessionIdentityPolicy.LogicalIdentity) {
+        guard let cctopSessionID = identity.cctopSessionID,
+              let current = userSessions.first(where: { $0.identity == identity }),
+              current.status.needsAttention else { return }
+
+        let oldUserSessions = userSessions
+        dataSources.attentionAcknowledgements.acknowledge(
+            cctopSessionID: cctopSessionID,
+            session: current.displayRecord.data
+        )
+        let acknowledged = userSessions.map { userSession -> UserSession in
+            guard userSession.identity == identity else { return userSession }
+            var displayData = userSession.displayRecord.data
+            displayData.status = .idle
+            return userSession.replacingDisplayData(displayData)
+        }
+        let now = dataSources.now()
+        let reordered = SessionDisplayPolicy.reconcilingOrder(
+            in: acknowledged,
+            preserving: oldUserSessions,
+            now: now
+        )
+        var nextAcknowledgedSessionIDs = acknowledgedSessionIDs
+        nextAcknowledgedSessionIDs.insert(cctopSessionID)
+        updateAuxiliarySessionProjections(
+            dropped: droppedUserSessions,
+            acknowledgedSessionIDs: nextAcknowledgedSessionIDs
+        )
+        updateSessionProjection(
+            reordered,
+            displaySignature: SessionDisplayPolicy.signature(for: reordered, now: now),
+            syncNotificationsFrom: oldUserSessions
+        )
+    }
+
+    /// Apply user acknowledgement against hook-owned status before display-only
+    /// lifecycle and timeout adjustments. This preserves the exact acknowledgement
+    /// until a newer hook event while regular surfaces use a neutral idle presentation.
+    func applyingAttentionAcknowledgements(
+        to userSessions: [UserSession],
+        inventoryComplete: Bool
+    ) -> SessionAttentionProjection {
+        var revisions: [String: SessionAttentionRevision] = [:]
+        var lastActivities: [String: Date] = [:]
+        for userSession in userSessions {
+            guard let cctopSessionID = userSession.identity.cctopSessionID else { continue }
+            lastActivities[cctopSessionID] = userSession.records.map(\.data.lastActivity).max()
+                ?? userSession.displayRecord.data.lastActivity
+            if let revision = SessionAttentionRevision(session: userSession.displayRecord.data) {
+                revisions[cctopSessionID] = revision
+            }
+        }
+        dataSources.attentionAcknowledgements.reconcile(
+            currentAttentionRevisions: revisions,
+            currentLastActivities: lastActivities,
+            inventoryComplete: inventoryComplete
+        )
+        let acknowledgedRevisions = dataSources.attentionAcknowledgements.acknowledgedRevisions
+        var acknowledgedSessionIDs: Set<String> = []
+        let projectedUserSessions = userSessions.map { userSession in
+            guard let cctopSessionID = userSession.identity.cctopSessionID,
+                  let currentRevision = revisions[cctopSessionID],
+                  let acknowledgedRevision = acknowledgedRevisions[cctopSessionID] else {
+                return userSession
+            }
+            let coversCurrentRevision = acknowledgedRevision == currentRevision
+                || (!inventoryComplete
+                    && acknowledgedRevision.lastActivity >= currentRevision.lastActivity)
+            guard coversCurrentRevision else { return userSession }
+            acknowledgedSessionIDs.insert(cctopSessionID)
+            var displayData = userSession.displayRecord.data
+            displayData.status = .idle
+            return userSession.replacingDisplayData(displayData)
+        }
+        return SessionAttentionProjection(
+            userSessions: projectedUserSessions,
+            acknowledgedSessionIDs: acknowledgedSessionIDs
+        )
+    }
+
+    /// Separate exact, unchanged activity revisions from operational surfaces.
+    /// The Dropped selector retains reachability; a later hook event advances
+    /// `lastActivity`, expires the drop, and returns the session to normal tabs.
+    func partitioningTemporaryDrops(
+        to userSessions: [UserSession],
+        inventoryComplete: Bool
+    ) -> SessionTemporaryDropProjection {
+        var revisions: [String: SessionActivityRevision] = [:]
+        for userSession in userSessions {
+            guard let cctopSessionID = userSession.identity.cctopSessionID else { continue }
+            revisions[cctopSessionID] = SessionActivityRevision(userSession: userSession)
+        }
+        dataSources.temporaryDrops.reconcile(
+            currentRevisions: revisions,
+            inventoryComplete: inventoryComplete
+        )
+        let droppedRevisions = dataSources.temporaryDrops.droppedRevisions
+        var visible: [UserSession] = []
+        var dropped: [UserSession] = []
+        for userSession in userSessions {
+            guard let cctopSessionID = userSession.identity.cctopSessionID,
+                  let droppedRevision = droppedRevisions[cctopSessionID],
+                  let currentRevision = revisions[cctopSessionID] else {
+                visible.append(userSession)
+                continue
+            }
+            let coversCurrentRevision = droppedRevision == currentRevision
+                || (!inventoryComplete
+                    && droppedRevision.lastActivity >= currentRevision.lastActivity)
+            guard coversCurrentRevision else {
+                visible.append(userSession)
+                continue
+            }
+            dropped.append(userSession)
+        }
+        return SessionTemporaryDropProjection(visible: visible, dropped: dropped)
+    }
+
+    func dropSession(_ identity: SessionIdentityPolicy.LogicalIdentity) {
+        guard let cctopSessionID = identity.cctopSessionID,
+              let droppedUserSession = userSessions.first(where: { $0.identity == identity }) else { return }
+
+        dataSources.temporaryDrops.drop(
+            cctopSessionID: cctopSessionID,
+            userSession: droppedUserSession
+        )
+        dataSources.attentionAcknowledgements.remove(cctopSessionID: cctopSessionID)
+        removeNotification(cctopSessionID: cctopSessionID, matching: droppedUserSession.records)
+        let nextDroppedUserSessions = SessionDisplayPolicy.reconcilingOrder(
+            in: droppedUserSessions + [droppedUserSession],
+            preserving: droppedUserSessions,
+            now: dataSources.now()
+        )
+        updateAuxiliarySessionProjections(
+            dropped: nextDroppedUserSessions,
+            acknowledgedSessionIDs: acknowledgedSessionIDs.subtracting([cctopSessionID])
+        )
+        updateSessionProjection(userSessions.filter { $0.identity != identity })
+    }
+
+    func restoreDroppedSession(_ identity: SessionIdentityPolicy.LogicalIdentity) {
+        guard let cctopSessionID = identity.cctopSessionID,
+              droppedUserSessions.contains(where: { $0.identity == identity }) else { return }
+        dataSources.temporaryDrops.remove(cctopSessionID: cctopSessionID)
+        loadSessions()
+    }
+
     func hideSession(_ identity: SessionIdentityPolicy.LogicalIdentity) {
         guard let cctopSessionID = identity.cctopSessionID,
-              let hiddenUserSession = userSessions.first(where: { $0.identity == identity }) else { return }
+              let hiddenUserSession = (userSessions + droppedUserSessions)
+                .first(where: { $0.identity == identity }) else { return }
 
         let hiddenRecords = hiddenUserSession.records
         let hiddenProjectPaths = Set(hiddenRecords.map {
             HistoryManager.canonicalRecentProjectPath($0.data.projectPath)
         })
         dataSources.manualSessionVisibility.hide(cctopSessionID: cctopSessionID)
+        dataSources.attentionAcknowledgements.remove(cctopSessionID: cctopSessionID)
+        dataSources.temporaryDrops.remove(cctopSessionID: cctopSessionID)
         recentResumeTargets.removeAll { target in
             if target.cctopSessionId == cctopSessionID { return true }
             guard case .project = target else { return false }
             return hiddenProjectPaths.contains(HistoryManager.canonicalRecentProjectPath(target.projectPath))
         }
         removeNotification(cctopSessionID: cctopSessionID, matching: hiddenRecords)
+        updateAuxiliarySessionProjections(
+            dropped: droppedUserSessions.filter { $0.identity != identity },
+            acknowledgedSessionIDs: acknowledgedSessionIDs.subtracting([cctopSessionID])
+        )
         updateSessionProjection(userSessions.filter { $0.identity != identity })
     }
 

--- a/menubar/CctopMenubar/Services/SessionManager.swift
+++ b/menubar/CctopMenubar/Services/SessionManager.swift
@@ -3,18 +3,17 @@ import Darwin.libproc
 import Foundation
 @preconcurrency import UserNotifications
 import os.log
-
 let sessionManagerLogger = Logger(subsystem: "com.st0012.CctopMenubar", category: "SessionManager")
-
 struct WorktreeCleanupSessionSnapshot {
     let cleanupSources: [SessionDataCleanupSource]
     let activeProjectPaths: Set<String>
 }
-
 @MainActor
 // swiftlint:disable:next type_body_length
 class SessionManager: ObservableObject {
     @Published private(set) var userSessions: [UserSession] = []
+    @Published var droppedUserSessions: [UserSession] = []
+    @Published var acknowledgedSessionIDs: Set<String> = []
     @Published var recentResumeTargets: [RecentResumeTarget] = []
 
     let historyManager: HistoryManager
@@ -73,6 +72,7 @@ class SessionManager: ObservableObject {
             lastDisplaySignature = .empty
             lastLoadLogSignature = nil
             sessionFileCache.removeAll()
+            updateAuxiliarySessionProjections(dropped: [], acknowledgedSessionIDs: [])
             updateSessionProjection([])
             if !hasStoredHideEvidence {
                 publishRecentResumeTargets(historyManager.recentProjects.map(RecentResumeTarget.project))
@@ -119,15 +119,32 @@ class SessionManager: ObservableObject {
             winners: visibleCandidates,
             records: visibleRecords
         )
-        let loadedUserSessions = groupedUserSessions.map {
+        let dropProjection = partitioningTemporaryDrops(
+            to: groupedUserSessions,
+            inventoryComplete: inventoryComplete
+        )
+        let acknowledgementProjection = applyingAttentionAcknowledgements(
+            to: dropProjection.visible,
+            inventoryComplete: inventoryComplete
+        )
+        let adjustedUserSessions = acknowledgementProjection.userSessions.map {
             $0.replacingDisplayData(adjustDisplayStatus($0.displayRecord.data))
         }
         let newUserSessions = SessionDisplayPolicy.reconcilingOrder(
-            in: loadedUserSessions,
+            in: adjustedUserSessions,
             preserving: oldUserSessions,
             now: now
         )
+        let newDroppedUserSessions = SessionDisplayPolicy.reconcilingOrder(
+            in: dropProjection.dropped,
+            preserving: droppedUserSessions,
+            now: now
+        )
         let displaySignature = SessionDisplayPolicy.signature(for: newUserSessions, now: now)
+        updateAuxiliarySessionProjections(
+            dropped: newDroppedUserSessions,
+            acknowledgedSessionIDs: acknowledgementProjection.acknowledgedSessionIDs
+        )
         updateSessionProjection(
             newUserSessions,
             displaySignature: displaySignature,
@@ -148,7 +165,9 @@ class SessionManager: ObservableObject {
         )
         let activeProjectPaths = classification.protectedProjectPathsForCleanup
         let recentExcludedPaths = activeProjectPaths.union(classification.manualHiddenProjectPaths(hiddenSessionIDs))
-        let publishedSessionIDs = Set(newUserSessions.compactMap { $0.identity.cctopSessionID })
+        let publishedSessionIDs = Set(
+            (newUserSessions + newDroppedUserSessions).compactMap { $0.identity.cctopSessionID }
+        )
         let shouldFreezeVisibilityProjections = manualHides.hasUnresolvedLegacyKeys
             || (!inventoryComplete && !hiddenSessionIDs.isEmpty)
         if !shouldFreezeVisibilityProjections {
@@ -175,12 +194,6 @@ class SessionManager: ObservableObject {
         if inventoryComplete {
             let validSessionIDs = Set(identifiedInventory.compactMap(\.cctopSessionId).filter(CctopSessionID.isValid))
             dataSources.manualSessionVisibility.prune(retaining: validSessionIDs)
-        }
-    }
-
-    private func publishRecentResumeTargets(_ targets: [RecentResumeTarget]) {
-        if targets != recentResumeTargets {
-            recentResumeTargets = targets
         }
     }
 

--- a/menubar/CctopMenubar/Services/SessionTemporaryDropStore.swift
+++ b/menubar/CctopMenubar/Services/SessionTemporaryDropStore.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Identifies the latest hook-owned activity represented by one grouped session.
+/// Any later event advances this value and therefore expires a temporary drop.
+struct SessionActivityRevision: Codable, Equatable {
+    let lastActivity: Date
+
+    init(lastActivity: Date) {
+        self.lastActivity = lastActivity
+    }
+
+    init(userSession: UserSession) {
+        self.init(
+            lastActivity: userSession.records.map(\.data.lastActivity).max()
+                ?? userSession.displayRecord.data.lastActivity
+        )
+    }
+}
+
+/// Persists sessions removed from cctop only until their next activity event.
+/// This is presentation state: it never edits, ends, archives, or permanently
+/// hides the hook-owned session record.
+struct SessionTemporaryDropStore {
+    static let defaultsKey = "temporarilyDroppedSessionActivityRevisions"
+    static let live = SessionTemporaryDropStore(defaults: .standard)
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    var droppedRevisions: [String: SessionActivityRevision] {
+        guard let data = defaults.data(forKey: Self.defaultsKey),
+              let decoded = try? JSONDecoder.sessionDecoder.decode(
+                  [String: SessionActivityRevision].self,
+                  from: data
+              ) else { return [:] }
+        return decoded.filter { CctopSessionID.isValid($0.key) }
+    }
+
+    func drop(cctopSessionID: String, userSession: UserSession) {
+        guard CctopSessionID.isValid(cctopSessionID) else { return }
+        var revisions = droppedRevisions
+        revisions[cctopSessionID] = SessionActivityRevision(userSession: userSession)
+        save(revisions)
+    }
+
+    func remove(cctopSessionID: String) {
+        var revisions = droppedRevisions
+        guard revisions.removeValue(forKey: cctopSessionID) != nil else { return }
+        save(revisions)
+    }
+
+    /// Keep an exact drop while its activity revision is unchanged. During a
+    /// partial inventory, an older decoded peer cannot disprove the stored latest
+    /// revision; only affirmative newer activity expires the drop.
+    func reconcile(
+        currentRevisions: [String: SessionActivityRevision],
+        inventoryComplete: Bool
+    ) {
+        let current = droppedRevisions
+        let retained = current.filter { cctopSessionID, droppedRevision in
+            if inventoryComplete {
+                return currentRevisions[cctopSessionID] == droppedRevision
+            }
+            guard let currentRevision = currentRevisions[cctopSessionID] else { return true }
+            return currentRevision.lastActivity <= droppedRevision.lastActivity
+        }
+        guard retained != current else { return }
+        save(retained)
+    }
+
+    private func save(_ revisions: [String: SessionActivityRevision]) {
+        guard !revisions.isEmpty else {
+            defaults.removeObject(forKey: Self.defaultsKey)
+            return
+        }
+        guard let data = try? JSONEncoder.sessionEncoder.encode(revisions) else { return }
+        defaults.set(data, forKey: Self.defaultsKey)
+    }
+}

--- a/menubar/CctopMenubar/Views/PopupNavigation.swift
+++ b/menubar/CctopMenubar/Views/PopupNavigation.swift
@@ -1,12 +1,18 @@
 import Foundation
+import SwiftUI
 
 enum PopupTab: CaseIterable, Hashable {
-    case active, idle, recent, cleanup
+    case active, idle, acknowledged, dropped, recent, cleanup
+
+    static let primaryCases: [PopupTab] = [.active, .idle, .acknowledged, .dropped]
+    static let secondaryCases: [PopupTab] = [.recent, .cleanup]
 
     var label: String {
         switch self {
         case .active: return "Active"
         case .idle: return "Idle"
+        case .acknowledged: return "Ack"
+        case .dropped: return "Dropped"
         case .recent: return "Recent"
         case .cleanup: return "Cleanup"
         }
@@ -19,6 +25,10 @@ enum PopupTab: CaseIterable, Hashable {
             return "Current sessions; idle moves after \(staleIdleDuration)."
         case .idle:
             return "Dormant sessions and idle sessions over \(staleIdleDuration)."
+        case .acknowledged:
+            return "Acknowledged sessions; newer attention clears the acknowledgement."
+        case .dropped:
+            return "Sessions removed from normal surfaces until restored or newer activity."
         case .recent:
             return "Finished work and archived desktop sessions. Rows open the project or app when possible."
         case .cleanup:
@@ -32,6 +42,10 @@ enum PopupTab: CaseIterable, Hashable {
             return "Current and recently idle sessions appear here."
         case .idle:
             return "Dormant and long-idle sessions appear here."
+        case .acknowledged:
+            return "Acknowledged sessions appear here until they report newer attention."
+        case .dropped:
+            return "Dropped sessions appear here until restored or they report newer activity."
         case .recent:
             return "Finished work and archived desktop sessions appear here."
         case .cleanup:
@@ -64,6 +78,70 @@ enum PopupTab: CaseIterable, Hashable {
     private static var staleIdleDurationText: String {
         let hours = Int(SessionDisplayPolicy.staleIdleInterval / 3_600)
         return "\(hours) hours"
+    }
+}
+
+struct SecondaryTabMenuView: View {
+    let selectedTab: PopupTab
+    let cleanupIsScanning: Bool
+    let cleanupHasAttention: Bool
+    let count: (PopupTab) -> Int
+    let onSelect: (PopupTab) -> Void
+
+    private var isSelected: Bool {
+        PopupTab.secondaryCases.contains(selectedTab)
+    }
+
+    var body: some View {
+        Menu {
+            ForEach(PopupTab.secondaryCases, id: \.self) { tab in
+                Button {
+                    onSelect(tab)
+                } label: {
+                    Text(menuLabel(for: tab))
+                }
+            }
+        } label: {
+            ZStack(alignment: .topTrailing) {
+                if cleanupIsScanning {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .tint(isSelected ? Color.textPrimary : Color.textSecondary)
+                        .frame(width: 10, height: 10)
+                } else {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 10, weight: .semibold))
+                }
+                if cleanupHasAttention && selectedTab != .cleanup {
+                    Circle()
+                        .fill(Color.statusAttention)
+                        .frame(width: 5, height: 5)
+                        .offset(x: 5, y: -3)
+                }
+            }
+            .foregroundStyle(isSelected ? Color.textPrimary : Color.textSecondary)
+            .frame(width: 28, height: 22)
+            .background {
+                if isSelected {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color.segmentThumbBackground)
+                }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        }
+        .menuIndicator(.hidden)
+        .menuStyle(.borderlessButton)
+        .fixedSize(horizontal: true, vertical: false)
+        .help("Recent and Cleanup")
+        .accessibilityLabel("More views")
+        .accessibilityValue(isSelected ? selectedTab.label : "")
+    }
+
+    private func menuLabel(for tab: PopupTab) -> String {
+        if tab == .cleanup && cleanupIsScanning {
+            return "Cleanup checking"
+        }
+        return "\(tab.label) \(count(tab))"
     }
 }
 
@@ -100,7 +178,7 @@ enum PopupSelectionTarget: Equatable {
         in context: PopupSelectionContext
     ) -> PopupSelectionTarget? {
         switch tab {
-        case .active, .idle:
+        case .active, .idle, .acknowledged, .dropped:
             return nil
         case .recent:
             guard index < context.recentTargets.count else { return nil }

--- a/menubar/CctopMenubar/Views/PopupView+EmptyState.swift
+++ b/menubar/CctopMenubar/Views/PopupView+EmptyState.swift
@@ -36,6 +36,22 @@ extension PopupView {
         )
     }
 
+    var noAcknowledgedSessionsContent: some View {
+        emptyPlaceholder(
+            systemImage: "checkmark.circle",
+            title: "No acknowledged sessions",
+            detail: PopupTab.acknowledged.emptyStateDetail
+        )
+    }
+
+    var noDroppedSessionsContent: some View {
+        emptyPlaceholder(
+            systemImage: "arrow.uturn.backward.circle",
+            title: "No dropped sessions",
+            detail: PopupTab.dropped.emptyStateDetail
+        )
+    }
+
     func emptyPlaceholder(systemImage: String, title: String, detail: String? = nil) -> some View {
         VStack(spacing: 8) {
             Image(systemName: systemImage)

--- a/menubar/CctopMenubar/Views/PopupView+Sessions.swift
+++ b/menubar/CctopMenubar/Views/PopupView+Sessions.swift
@@ -45,14 +45,31 @@ struct PanelSessionRow: Identifiable {
     let slot: Int
     let userSession: UserSession
     let id: SessionIdentityPolicy.LogicalIdentity
+    var presentation: PanelSessionPresentation = .standard
 
     /// Direct actions use the exact data selected for this rendered row.
     var session: SessionData { userSession.displayRecord.data }
 }
 
+enum PanelSessionPresentation: Equatable {
+    case standard
+    case acknowledged
+    case dropped
+
+    var statusLabel: String? {
+        switch self {
+        case .standard: nil
+        case .acknowledged: "Acknowledged"
+        case .dropped: "Dropped"
+        }
+    }
+}
+
 extension PopupView {
     var isNavigateActive: Bool { navigate?.isActive ?? false }
-    var hasMultipleSources: Bool { Set(userSessions.map(\.agentBadge)).count > 1 }
+    var hasMultipleSources: Bool {
+        Set((userSessions + droppedUserSessions).map(\.agentBadge)).count > 1
+    }
 
     var currentActiveUserSessions: [UserSession] {
         SessionDisplayPolicy.activeSessions(from: userSessions)
@@ -92,6 +109,53 @@ extension PopupView {
         }
     }
 
+    var currentAcknowledgedUserSessions: [UserSession] {
+        userSessions.filter { userSession in
+            guard let cctopSessionID = userSession.identity.cctopSessionID else { return false }
+            return acknowledgedSessionIDs.contains(cctopSessionID)
+        }
+    }
+
+    var acknowledgedSessionRows: [PanelSessionRow] {
+        currentAcknowledgedUserSessions.enumerated().map { index, userSession in
+            PanelSessionRow(
+                slot: index,
+                userSession: userSession,
+                id: userSession.identity,
+                presentation: .acknowledged
+            )
+        }
+    }
+
+    var droppedSessionRows: [PanelSessionRow] {
+        droppedUserSessions.enumerated().map { index, userSession in
+            PanelSessionRow(
+                slot: index,
+                userSession: userSession,
+                id: userSession.identity,
+                presentation: .dropped
+            )
+        }
+    }
+
+    @ViewBuilder
+    var acknowledgedContent: some View {
+        if acknowledgedSessionRows.isEmpty {
+            noAcknowledgedSessionsContent
+        } else {
+            sessionList(acknowledgedSessionRows, tab: .acknowledged)
+        }
+    }
+
+    @ViewBuilder
+    var droppedContent: some View {
+        if droppedSessionRows.isEmpty {
+            noDroppedSessionsContent
+        } else {
+            sessionList(droppedSessionRows, tab: .dropped)
+        }
+    }
+
     func sessionList(
         _ rows: [PanelSessionRow],
         tab: PopupTab,
@@ -116,6 +180,7 @@ extension PopupView {
         }
     }
 
+    // swiftlint:disable:next function_body_length
     private func sessionRow(_ row: PanelSessionRow, showNavigateNumbers: Bool) -> some View {
         let focusStrategy = resolveFocusStrategy(session: row.session)
         let focusActionTitle = focusStrategy.actionTitle
@@ -124,7 +189,8 @@ extension PopupView {
             navigateIndex: showNavigateNumbers && isNavigateActive ? row.slot + 1 : nil,
             showSourceBadge: hasMultipleSources,
             isSelected: selectedSessionIdentity == row.id,
-            relativeTimeNow: relativeTimeNow
+            relativeTimeNow: relativeTimeNow,
+            presentationStatusLabel: row.presentation.statusLabel
         )
         .id(row.id)
         .onTapGesture { focusSession(row.session) }
@@ -143,6 +209,26 @@ extension PopupView {
             Button { copyPath(row.session.projectPath) } label: {
                 Label("Copy Project Path", systemImage: "doc.on.doc")
             }
+            if row.presentation == .dropped {
+                Divider()
+                Button { restoreDroppedSession(row) } label: {
+                    Label("Restore Session", systemImage: "arrow.uturn.backward.circle")
+                }
+                .disabled(row.userSession.identity.cctopSessionID == nil)
+            } else {
+                if row.session.status.needsAttention {
+                    Divider()
+                    Button { acknowledgeSession(row) } label: {
+                        Label("Acknowledge", systemImage: "checkmark.circle")
+                    }
+                    .disabled(row.userSession.identity.cctopSessionID == nil)
+                }
+                Divider()
+                Button { dropSession(row) } label: {
+                    Label("Drop Until Next Activity", systemImage: "xmark.circle")
+                }
+                .disabled(row.userSession.identity.cctopSessionID == nil)
+            }
             Divider()
             Button { requestHideSession(row) } label: {
                 Label("Hide Session", systemImage: "eye.slash")
@@ -151,9 +237,41 @@ extension PopupView {
         }
         .help(focusActionTitle)
         .accessibilityActions {
+            if row.presentation == .dropped {
+                Button("Restore Session") { restoreDroppedSession(row) }
+                    .disabled(row.userSession.identity.cctopSessionID == nil)
+            } else {
+                if row.session.status.needsAttention {
+                    Button("Acknowledge") { acknowledgeSession(row) }
+                        .disabled(row.userSession.identity.cctopSessionID == nil)
+                }
+                Button("Drop Until Next Activity") { dropSession(row) }
+                    .disabled(row.userSession.identity.cctopSessionID == nil)
+            }
             Button("Hide Session") { requestHideSession(row) }
                 .disabled(row.userSession.identity.cctopSessionID == nil)
         }
+    }
+
+    func acknowledgeSession(_ row: PanelSessionRow) {
+        guard row.session.status.needsAttention,
+              row.userSession.identity.cctopSessionID != nil else { return }
+        onAcknowledgeSession(row.userSession.identity)
+    }
+
+    func dropSession(_ row: PanelSessionRow) {
+        guard row.userSession.identity.cctopSessionID != nil else { return }
+        onDropSession(row.userSession.identity)
+        selectedIndex = nil
+        selectedSessionIdentity = nil
+    }
+
+    func restoreDroppedSession(_ row: PanelSessionRow) {
+        guard row.presentation == .dropped,
+              row.userSession.identity.cctopSessionID != nil else { return }
+        onRestoreDroppedSession(row.userSession.identity)
+        selectedIndex = nil
+        selectedSessionIdentity = nil
     }
 
     func moveSessionSelection(by delta: Int, in rows: [PanelSessionRow]) {
@@ -184,6 +302,10 @@ extension PopupView {
             candidates = SessionDisplayPolicy.activeSessions(from: userSessions)
         case .idle:
             candidates = SessionDisplayPolicy.idleSessions(from: userSessions)
+        case .acknowledged:
+            candidates = currentAcknowledgedUserSessions
+        case .dropped:
+            candidates = droppedUserSessions
         case .recent, .cleanup:
             return nil
         }

--- a/menubar/CctopMenubar/Views/PopupView.swift
+++ b/menubar/CctopMenubar/Views/PopupView.swift
@@ -7,6 +7,8 @@ private let relativeTimeRefresh = Timer.publish(every: 10, on: .main, in: .commo
 
 struct PopupView: View {
     let userSessions: [UserSession]
+    var acknowledgedSessionIDs: Set<String> = []
+    var droppedUserSessions: [UserSession] = []
     var recentProjects: [RecentProject] = []
     var recentResumeTargets: [RecentResumeTarget]?
     var cleanupCandidates: [WorktreeCleanupCandidate] = []
@@ -19,6 +21,9 @@ struct PopupView: View {
     var initialTab: PopupTab = .active
     var initialCleanupCandidate: WorktreeCleanupCandidate?
     var onOpenUpdater: (() -> Void)?
+    var onAcknowledgeSession: (SessionIdentityPolicy.LogicalIdentity) -> Void = { _ in }
+    var onDropSession: (SessionIdentityPolicy.LogicalIdentity) -> Void = { _ in }
+    var onRestoreDroppedSession: (SessionIdentityPolicy.LogicalIdentity) -> Void = { _ in }
     var onHideSession: (SessionIdentityPolicy.LogicalIdentity) -> Void = { _ in }
     var onSelectCleanupRemovalAction: ((WorktreeCleanupCandidate) async -> WorktreeRemovalService.RemovalAction)?
     var onExecuteCleanupRemovalAction: ((WorktreeRemovalService.RemovalAction) async -> WorktreeRemovalService.RemovalResult)?
@@ -64,6 +69,8 @@ struct PopupView: View {
                     switch selectedTab {
                     case .active: activeContent
                     case .idle: idleContent
+                    case .acknowledged: acknowledgedContent
+                    case .dropped: droppedContent
                     case .recent: recentContent
                     case .cleanup: cleanupContent
                     }
@@ -128,8 +135,8 @@ struct PopupView: View {
     // MARK: - Tab picker
 
     private var tabPicker: some View {
-        HStack(spacing: 0) {
-            ForEach(availableTabs, id: \.self) { tab in
+        HStack(spacing: 1) {
+            ForEach(PopupTab.primaryCases, id: \.self) { tab in
                 tabButton(
                     tab.label,
                     count: count(for: tab),
@@ -138,6 +145,13 @@ struct PopupView: View {
                     hasAttention: tab == .cleanup && cleanupHasUnseenCandidates
                 )
             }
+            SecondaryTabMenuView(
+                selectedTab: selectedTab,
+                cleanupIsScanning: cleanupIsScanning,
+                cleanupHasAttention: cleanupHasUnseenCandidates,
+                count: count(for:),
+                onSelect: selectTab
+            )
         }
         .padding(2)
         .background(Color.segmentBackground)
@@ -150,6 +164,8 @@ struct PopupView: View {
         switch tab {
         case .active: return activeSessionRows.count
         case .idle: return idleSessionRows.count
+        case .acknowledged: return acknowledgedSessionRows.count
+        case .dropped: return droppedSessionRows.count
         case .recent: return recentTargets.count
         case .cleanup: return actionableCleanupCandidates.count
         }
@@ -169,16 +185,20 @@ struct PopupView: View {
             hasAttention: hasAttention && selectedTab != tab,
             isSelected: selectedTab == tab
         ) {
-            if overlayController.active != nil { closeOverlay(animated: false) }
-            withAnimation(.easeInOut(duration: 0.15)) { selectedTab = tab }
-            notifyLayoutChanged()
+            selectTab(tab)
         }
         .help(tab.helpText)
+    }
+
+    private func selectTab(_ tab: PopupTab) {
+        if overlayController.active != nil { closeOverlay(animated: false) }
+        withAnimation(.easeInOut(duration: 0.15)) { selectedTab = tab }
+        notifyLayoutChanged()
     }
     // MARK: - Active tab
     private var activeContent: some View {
         Group {
-            if userSessions.isEmpty {
+            if userSessions.isEmpty && droppedUserSessions.isEmpty {
                 EmptyStateView(pluginManager: pluginManager)
             } else if activeSessionRows.isEmpty {
                 noActiveSessionsContent
@@ -210,6 +230,7 @@ struct PopupView: View {
             sessionList(idleSessionRows, tab: .idle)
         }
     }
+
     func panelList<Item: Identifiable, Row: View>(
         _ list: [Item],
         tab: PopupTab,
@@ -397,6 +418,12 @@ extension PopupView {
         case .idle:
             moveSessionSelection(by: delta, in: idleSessionRows)
             return
+        case .acknowledged:
+            moveSessionSelection(by: delta, in: acknowledgedSessionRows)
+            return
+        case .dropped:
+            moveSessionSelection(by: delta, in: droppedSessionRows)
+            return
         case .recent:
             moveIndexedSelection(by: delta, count: recentTargets.count)
         case .cleanup:
@@ -410,7 +437,7 @@ extension PopupView {
     }
 
     private func confirmSelection() {
-        if selectedTab == .active || selectedTab == .idle {
+        if [.active, .idle, .acknowledged, .dropped].contains(selectedTab) {
             confirmSessionSelection()
             return
         }

--- a/menubar/CctopMenubar/Views/PopupViewHelpers.swift
+++ b/menubar/CctopMenubar/Views/PopupViewHelpers.swift
@@ -153,7 +153,7 @@ struct TabButtonView: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 4) {
+            HStack(spacing: 2) {
                 Text(label)
                     .foregroundStyle(labelForegroundColor)
                 if isScanning {
@@ -174,9 +174,9 @@ struct TabButtonView: View {
                     }
                 }
             }
-            .font(.system(size: 11, weight: isSelected ? .semibold : .medium))
+            .font(.system(size: 10, weight: isSelected ? .semibold : .medium))
             .lineLimit(1)
-            .minimumScaleFactor(0.85)
+            .minimumScaleFactor(0.9)
             .allowsTightening(true)
             .frame(maxWidth: .infinity, minHeight: 22, maxHeight: 22)
             .background {
@@ -300,7 +300,7 @@ extension PopupView {
 
     func hideSession(_ identity: SessionIdentityPolicy.LogicalIdentity) {
         guard identity.cctopSessionID != nil,
-              userSessions.contains(where: { $0.identity == identity }) else { return }
+              (userSessions + droppedUserSessions).contains(where: { $0.identity == identity }) else { return }
         onHideSession(identity)
         selectedIndex = nil
         selectedSessionIdentity = nil
@@ -330,6 +330,8 @@ struct PanelContentView: View {
     var body: some View {
         PopupView(
             userSessions: sessionManager.userSessions,
+            acknowledgedSessionIDs: sessionManager.acknowledgedSessionIDs,
+            droppedUserSessions: sessionManager.droppedUserSessions,
             recentProjects: historyManager.recentProjects,
             recentResumeTargets: sessionManager.recentResumeTargets,
             cleanupCandidates: cleanupManager.candidates,
@@ -340,6 +342,9 @@ struct PanelContentView: View {
             navigate: navigate,
             overlayController: overlayController,
             onOpenUpdater: onOpenUpdater,
+            onAcknowledgeSession: { sessionManager.acknowledgeSession($0) },
+            onDropSession: { sessionManager.dropSession($0) },
+            onRestoreDroppedSession: { sessionManager.restoreDroppedSession($0) },
             onHideSession: { sessionManager.hideSession($0) },
             onSelectCleanupRemovalAction: onSelectCleanupRemovalAction,
             onExecuteCleanupRemovalAction: onExecuteCleanupRemovalAction,

--- a/menubar/CctopMenubar/Views/SessionCardView.swift
+++ b/menubar/CctopMenubar/Views/SessionCardView.swift
@@ -7,6 +7,7 @@ struct SessionCardView: View {
     var showSourceBadge = false
     var isSelected = false
     var relativeTimeNow = Date()
+    var presentationStatusLabel: String?
 
     @State private var isHovered = false
     @Environment(\.colorScheme) private var colorScheme
@@ -144,7 +145,9 @@ struct SessionCardView: View {
 
     @ViewBuilder
     private var statusLabel: some View {
-        if session.lifecycle == .dormant {
+        if let presentationStatusLabel {
+            statusText(presentationStatusLabel, color: Color.textMuted)
+        } else if session.lifecycle == .dormant {
             statusText("Dormant", color: Color.textMuted)
         } else {
             switch session.status {

--- a/menubar/CctopMenubarTests/PanelToggleTests.swift
+++ b/menubar/CctopMenubarTests/PanelToggleTests.swift
@@ -33,12 +33,17 @@ final class PanelToggleTests: XCTestCase {
         )
     }
 
-    func testFocusTargetDecodesCctopSessionIdentity() throws {
+    func testSessionCommandsDecodeCctopSessionIdentity() throws {
         let url = try XCTUnwrap(URL(string: "cctop://focus?sid=codex%3Aabc%2Fdef%3Fghi"))
         XCTAssertEqual(AppDelegate.urlCommand(from: url), "focus")
-        XCTAssertEqual(AppDelegate.focusSessionID(from: url), "codex:abc/def?ghi")
-        XCTAssertNil(AppDelegate.focusSessionID(from: try XCTUnwrap(URL(string: "cctop://focus"))))
-        XCTAssertNil(AppDelegate.focusSessionID(from: try XCTUnwrap(URL(string: "cctop://focus?sid="))))
+        XCTAssertEqual(AppDelegate.sessionID(from: url), "codex:abc/def?ghi")
+
+        let acknowledgeURL = try XCTUnwrap(URL(string: "cctop://acknowledge?sid=codex%3Aabc%2Fdef%3Fghi"))
+        XCTAssertEqual(AppDelegate.urlCommand(from: acknowledgeURL), "acknowledge")
+        XCTAssertEqual(AppDelegate.sessionID(from: acknowledgeURL), "codex:abc/def?ghi")
+
+        XCTAssertNil(AppDelegate.sessionID(from: try XCTUnwrap(URL(string: "cctop://focus"))))
+        XCTAssertNil(AppDelegate.sessionID(from: try XCTUnwrap(URL(string: "cctop://focus?sid="))))
     }
 
     func testNotificationActivationResolvesPermanentIDToCurrentCanonicalRecord() {

--- a/menubar/CctopMenubarTests/QASnapshotTests.swift
+++ b/menubar/CctopMenubarTests/QASnapshotTests.swift
@@ -132,6 +132,66 @@ final class QASnapshotTests: XCTestCase {
         )
     }
 
+    func testAttentionAcknowledgementPreview() throws {
+        var attention = SessionData.mock(
+            id: "attention-preview",
+            cctopSessionId: "11111111-1111-4111-8111-111111111111",
+            status: .waitingPermission,
+            notificationMessage: "Review completed; session remains open"
+        )
+        attention.lifecycle = .active
+        let before = userSessions(fromDataFixtures: [attention])
+        var acknowledgedData = before[0].displayRecord.data
+        acknowledgedData.status = .idle
+        let after = [before[0].replacingDisplayData(acknowledgedData)]
+
+        try renderFixedSnapshot(
+            AttentionAcknowledgementPreviewScene(
+                before: before,
+                after: after,
+                beforePluginManager: inertPluginManager(),
+                afterPluginManager: inertPluginManager()
+            ),
+            name: "18-attention-acknowledgement",
+            size: NSSize(width: 720, height: 390),
+            colorScheme: .dark
+        )
+    }
+
+    func testAckAndDroppedSelectorsPreview() throws {
+        let acknowledgedID = "22222222-2222-4222-8222-222222222222"
+        var acknowledged = SessionData.mock(
+            id: "ack-selector-preview",
+            cctopSessionId: acknowledgedID,
+            status: .idle,
+            notificationMessage: "Reviewed; this session remains open"
+        )
+        acknowledged.lifecycle = .active
+        let dropped = SessionData.mock(
+            id: "drop-selector-preview",
+            cctopSessionId: "33333333-3333-4333-8333-333333333333",
+            status: .working,
+            notificationMessage: "Hidden from operational status until activity"
+        )
+        let acknowledgedSessions = userSessions(fromDataFixtures: [acknowledged])
+        let droppedSessions = userSessions(fromDataFixtures: [dropped])
+
+        try renderSelectorSnapshot(
+            userSessions: acknowledgedSessions,
+            acknowledgedSessionIDs: [acknowledgedID],
+            droppedUserSessions: droppedSessions,
+            initialTab: .acknowledged,
+            name: "19a-ack-selector-dark"
+        )
+        try renderSelectorSnapshot(
+            userSessions: acknowledgedSessions,
+            acknowledgedSessionIDs: [acknowledgedID],
+            droppedUserSessions: droppedSessions,
+            initialTab: .dropped,
+            name: "19b-dropped-selector-dark"
+        )
+    }
+
     // MARK: - Polish review matrix
 
     func testPolishReviewMatrix() throws {
@@ -313,6 +373,41 @@ final class QASnapshotTests: XCTestCase {
         try captureToFile(hostingView: hostingView, path: "/tmp/cctop-qa/\(name).png")
     }
 
+    private func renderSelectorSnapshot(
+        userSessions: [UserSession],
+        acknowledgedSessionIDs: Set<String>,
+        droppedUserSessions: [UserSession],
+        initialTab: PopupTab,
+        name: String
+    ) throws {
+        let view = PopupView(
+            userSessions: userSessions,
+            acknowledgedSessionIDs: acknowledgedSessionIDs,
+            droppedUserSessions: droppedUserSessions,
+            updater: DisabledUpdater(),
+            pluginManager: inertPluginManager(),
+            initialTab: initialTab
+        )
+        .frame(width: 320)
+        .panelSnapshotChrome()
+        .environment(\.colorScheme, .dark)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 800),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.appearance = NSAppearance(named: .darkAqua)
+        let hostingView = NSHostingView(rootView: view)
+        window.contentView = hostingView
+        let fittingSize = hostingView.fittingSize
+        window.setContentSize(fittingSize)
+        hostingView.frame = NSRect(origin: .zero, size: fittingSize)
+        hostingView.layoutSubtreeIfNeeded()
+        try captureToFile(hostingView: hostingView, path: "/tmp/cctop-qa/\(name).png")
+    }
+
     private func renderSettingsSnapshot(
         updater: UpdaterBase,
         name: String,
@@ -383,6 +478,30 @@ final class QASnapshotTests: XCTestCase {
         try captureToFile(hostingView: hostingView, path: "/tmp/cctop-qa/\(name).png")
     }
 
+    private func renderFixedSnapshot<Content: View>(
+        _ content: Content,
+        name: String,
+        size: NSSize,
+        colorScheme: ColorScheme
+    ) throws {
+        let appearance: NSAppearance.Name = colorScheme == .dark ? .darkAqua : .aqua
+        let view = content
+            .frame(width: size.width, height: size.height)
+            .environment(\.colorScheme, colorScheme)
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.appearance = NSAppearance(named: appearance)
+        let hostingView = NSHostingView(rootView: view)
+        window.contentView = hostingView
+        hostingView.frame = NSRect(origin: .zero, size: size)
+        hostingView.layoutSubtreeIfNeeded()
+        try captureToFile(hostingView: hostingView, path: "/tmp/cctop-qa/\(name).png")
+    }
+
     private func scrollFirstScrollViewToBottom(in view: NSView) {
         guard
             let scrollView = firstSubview(ofType: NSScrollView.self, in: view),
@@ -416,6 +535,50 @@ final class QASnapshotTests: XCTestCase {
 
         try pngData.write(to: URL(fileURLWithPath: path))
         print("QA snapshot saved: \(path)")
+    }
+}
+
+private struct AttentionAcknowledgementPreviewScene: View {
+    let before: [UserSession]
+    let after: [UserSession]
+    let beforePluginManager: PluginManager
+    let afterPluginManager: PluginManager
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 24) {
+            panel(title: "Before", detail: "Needs attention", sessions: before, pluginManager: beforePluginManager)
+            panel(
+                title: "After Acknowledge",
+                detail: "Still one active session",
+                sessions: after,
+                pluginManager: afterPluginManager
+            )
+        }
+        .padding(24)
+        .background(Color(red: 0.07, green: 0.075, blue: 0.09))
+    }
+
+    private func panel(
+        title: String,
+        detail: String,
+        sessions: [UserSession],
+        pluginManager: PluginManager
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Color.white)
+            Text(detail)
+                .font(.system(size: 11))
+                .foregroundStyle(Color.white.opacity(0.62))
+            PopupView(
+                userSessions: sessions,
+                updater: DisabledUpdater(),
+                pluginManager: pluginManager
+            )
+            .frame(width: 320)
+            .panelSnapshotChrome()
+        }
     }
 }
 

--- a/menubar/CctopMenubarTests/SessionTestSupport.swift
+++ b/menubar/CctopMenubarTests/SessionTestSupport.swift
@@ -11,6 +11,26 @@ extension XCTestCase {
         return ManualSessionVisibilityStore(defaults: defaults)
     }
 
+    func isolatedAttentionAcknowledgements(
+        prefix: String
+    ) -> SessionAttentionAcknowledgementStore {
+        let suiteName = "\(prefix)-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Could not create isolated user defaults")
+        }
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+        return SessionAttentionAcknowledgementStore(defaults: defaults)
+    }
+
+    func isolatedTemporaryDrops(prefix: String) -> SessionTemporaryDropStore {
+        let suiteName = "\(prefix)-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Could not create isolated user defaults")
+        }
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+        return SessionTemporaryDropStore(defaults: defaults)
+    }
+
     func isolatedSessionDataSources(
         prefix: String
     ) throws -> SessionDataSources {
@@ -57,6 +77,10 @@ extension XCTestCase {
                 removeDelivered: { _ in }
             ),
             manualSessionVisibility: manualSessionVisibility,
+            attentionAcknowledgements: isolatedAttentionAcknowledgements(
+                prefix: "cctop-attention-ack"
+            ),
+            temporaryDrops: isolatedTemporaryDrops(prefix: "cctop-temporary-drop"),
             now: Date.init
         )
     }
@@ -280,6 +304,8 @@ extension XCTestCase {
         desktopAppConnection: DesktopAppConnectionLookup? = nil,
         processAlive: ((SessionData) -> Bool)? = nil,
         manualSessionVisibility: ManualSessionVisibilityStore? = nil,
+        attentionAcknowledgements: SessionAttentionAcknowledgementStore? = nil,
+        temporaryDrops: SessionTemporaryDropStore? = nil,
         now: (() -> Date)? = nil
     ) -> SessionManager {
         let visibility = manualSessionVisibility
@@ -299,6 +325,12 @@ extension XCTestCase {
         }
         if let processAlive {
             sources.processAlive = processAlive
+        }
+        if let attentionAcknowledgements {
+            sources.attentionAcknowledgements = attentionAcknowledgements
+        }
+        if let temporaryDrops {
+            sources.temporaryDrops = temporaryDrops
         }
         if let now {
             sources.now = now

--- a/menubar/CctopMenubarTests/SessionTests.swift
+++ b/menubar/CctopMenubarTests/SessionTests.swift
@@ -2618,6 +2618,387 @@ final class SessionTests: XCTestCase {
     }
 }
 
+@MainActor
+final class SessionAttentionAcknowledgementTests: XCTestCase {
+    private let firstID = "11111111-1111-4111-8111-111111111111"
+    private let secondID = "22222222-2222-4222-8222-222222222222"
+
+    func testAcknowledgementMatchesOnlyExactAttentionRevision() {
+        let store = isolatedAttentionAcknowledgements(prefix: "cctop-attention-revision")
+        var attention = SessionData.mock(
+            id: "attention",
+            cctopSessionId: firstID,
+            status: .waitingPermission
+        )
+        attention.lastActivity = Date(timeIntervalSince1970: 1_000)
+
+        store.acknowledge(cctopSessionID: firstID, session: attention)
+
+        XCTAssertTrue(store.isAcknowledged(cctopSessionID: firstID, session: attention))
+        var newerEvent = attention
+        newerEvent.lastActivity = Date(timeIntervalSince1970: 1_001)
+        XCTAssertFalse(store.isAcknowledged(cctopSessionID: firstID, session: newerEvent))
+        var differentAttentionState = attention
+        differentAttentionState.status = .waitingInput
+        XCTAssertFalse(store.isAcknowledged(cctopSessionID: firstID, session: differentAttentionState))
+        var working = attention
+        working.status = .working
+        XCTAssertFalse(store.isAcknowledged(cctopSessionID: firstID, session: working))
+    }
+
+    func testReconcileRetainsPartialOlderEvidenceAndOnlyNewerActivityExpiresIt() {
+        let store = isolatedAttentionAcknowledgements(prefix: "cctop-attention-reconcile")
+        var first = SessionData.mock(id: "first", cctopSessionId: firstID, status: .waitingInput)
+        first.lastActivity = Date(timeIntervalSince1970: 1_000)
+        var second = SessionData.mock(id: "second", cctopSessionId: secondID, status: .waitingInput)
+        second.lastActivity = Date(timeIntervalSince1970: 2_000)
+        store.acknowledge(cctopSessionID: firstID, session: first)
+        store.acknowledge(cctopSessionID: secondID, session: second)
+        let firstRevision = SessionAttentionRevision(session: first)!
+
+        store.reconcile(
+            currentAttentionRevisions: [firstID: firstRevision],
+            currentLastActivities: [firstID: first.lastActivity],
+            inventoryComplete: false
+        )
+        XCTAssertEqual(Set(store.acknowledgedRevisions.keys), [firstID, secondID])
+
+        var olderFirst = first
+        olderFirst.lastActivity = first.lastActivity.addingTimeInterval(-1)
+        store.reconcile(
+            currentAttentionRevisions: [firstID: SessionAttentionRevision(session: olderFirst)!],
+            currentLastActivities: [firstID: olderFirst.lastActivity],
+            inventoryComplete: false
+        )
+        XCTAssertEqual(Set(store.acknowledgedRevisions.keys), [firstID, secondID])
+
+        store.reconcile(
+            currentAttentionRevisions: [:],
+            currentLastActivities: [firstID: first.lastActivity.addingTimeInterval(1)],
+            inventoryComplete: false
+        )
+        XCTAssertEqual(Set(store.acknowledgedRevisions.keys), [secondID])
+
+        store.reconcile(
+            currentAttentionRevisions: [:],
+            currentLastActivities: [:],
+            inventoryComplete: true
+        )
+        XCTAssertTrue(store.acknowledgedRevisions.isEmpty)
+    }
+
+    func testPartialUnreadableLatestPeerDoesNotRepublishAcknowledgedAttention() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-attention-partial-peer-\(UUID().uuidString)", isDirectory: true)
+        let sessionsDir = root.appendingPathComponent("sessions", isDirectory: true)
+        let historyDir = root.appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        let store = isolatedAttentionAcknowledgements(prefix: "cctop-attention-partial-peer-store")
+        let olderActivity = Date(timeIntervalSince1970: 4_000)
+        var olderPeer = SessionData.mock(
+            id: "older-peer",
+            cctopSessionId: firstID,
+            status: .waitingPermission,
+            pid: UInt32(ProcessInfo.processInfo.processIdentifier),
+            source: SessionData.opencodeSource
+        )
+        olderPeer.lastActivity = olderActivity
+        var latestPeer = SessionData.mock(
+            id: "latest-peer",
+            cctopSessionId: firstID,
+            status: .waitingInput,
+            pid: UInt32(ProcessInfo.processInfo.processIdentifier),
+            source: SessionData.opencodeSource
+        )
+        latestPeer.lastActivity = olderActivity.addingTimeInterval(1)
+        let olderURL = sessionsDir.appendingPathComponent("older-peer.json")
+        let latestURL = sessionsDir.appendingPathComponent("latest-peer.json")
+        try olderPeer.writeToFile(path: olderURL.path)
+        try latestPeer.writeToFile(path: latestURL.path)
+        let manager = makeManager(
+            sessionsDir: sessionsDir.path,
+            historyDir: historyDir.path,
+            processAlive: { _ in true },
+            attentionAcknowledgements: store,
+            now: { latestPeer.lastActivity }
+        )
+        let identity = try XCTUnwrap(manager.userSessions.first?.identity)
+        manager.acknowledgeSession(identity)
+
+        try Data("{".utf8).write(to: latestURL)
+        manager.loadSessions()
+
+        XCTAssertEqual(manager.userSessions.first?.status, .idle)
+        XCTAssertEqual(manager.acknowledgedSessionIDs, [firstID])
+        XCTAssertEqual(store.acknowledgedRevisions[firstID]?.lastActivity, latestPeer.lastActivity)
+
+        try latestPeer.writeToFile(path: latestURL.path)
+        manager.loadSessions()
+        XCTAssertEqual(manager.userSessions.first?.status, .idle)
+        XCTAssertEqual(manager.acknowledgedSessionIDs, [firstID])
+    }
+
+    func testAcknowledgementTurnsCurrentEventIdleWithoutEndingAndNewEventRestoresAttention() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-attention-manager-\(UUID().uuidString)", isDirectory: true)
+        let sessionsDir = root.appendingPathComponent("sessions", isDirectory: true)
+        let historyDir = root.appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        let store = isolatedAttentionAcknowledgements(prefix: "cctop-attention-manager-store")
+        let now = Date(timeIntervalSince1970: 10_000)
+        var attention = SessionData.mock(
+            id: "attention",
+            cctopSessionId: firstID,
+            status: .waitingInput,
+            pid: UInt32(ProcessInfo.processInfo.processIdentifier),
+            source: SessionData.opencodeSource
+        )
+        attention.lastActivity = now
+        let sessionPath = sessionsDir.appendingPathComponent("attention.json").path
+        try attention.writeToFile(path: sessionPath)
+        let manager = makeManager(
+            sessionsDir: sessionsDir.path,
+            historyDir: historyDir.path,
+            processAlive: { _ in true },
+            attentionAcknowledgements: store,
+            now: { now }
+        )
+        let identity = try XCTUnwrap(manager.userSessions.first?.identity)
+
+        manager.acknowledgeSession(identity)
+
+        let acknowledged = try XCTUnwrap(manager.userSessions.first)
+        XCTAssertEqual(acknowledged.status, .idle)
+        XCTAssertEqual(acknowledged.displayRecord.data.lifecycle, .active)
+        XCTAssertEqual(acknowledged.records.first?.data.status, .waitingInput)
+        XCTAssertEqual(StatusCounts(userSessions: manager.userSessions, now: now).idle, 1)
+        XCTAssertTrue(store.isAcknowledged(cctopSessionID: firstID, session: attention))
+        XCTAssertEqual(manager.acknowledgedSessionIDs, [firstID])
+
+        attention.lastActivity = now.addingTimeInterval(1)
+        try attention.writeToFile(path: sessionPath)
+        manager.loadSessions()
+
+        XCTAssertEqual(manager.userSessions.first?.status, .waitingInput)
+        XCTAssertFalse(store.isAcknowledged(cctopSessionID: firstID, session: attention))
+        XCTAssertTrue(manager.acknowledgedSessionIDs.isEmpty)
+    }
+
+    func testAcknowledgementRemainsSelectableAcrossDisplayOnlyDormancy() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-attention-dormant-\(UUID().uuidString)", isDirectory: true)
+        let sessionsDir = root.appendingPathComponent("sessions", isDirectory: true)
+        let historyDir = root.appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        let store = isolatedAttentionAcknowledgements(prefix: "cctop-attention-dormant-store")
+        let lastActivity = Date(timeIntervalSince1970: 15_000)
+        var attention = SessionData.mock(
+            id: "attention-dormant",
+            cctopSessionId: firstID,
+            status: .waitingInput,
+            pid: 999_999,
+            source: SessionData.codexSource
+        )
+        attention.lastActivity = lastActivity
+        store.acknowledge(cctopSessionID: firstID, session: attention)
+        try attention.writeToFile(path: sessionsDir.appendingPathComponent("attention-dormant.json").path)
+
+        let manager = makeManager(
+            sessionsDir: sessionsDir.path,
+            historyDir: historyDir.path,
+            processAlive: { _ in false },
+            attentionAcknowledgements: store,
+            now: { lastActivity.addingTimeInterval(700) }
+        )
+
+        XCTAssertEqual(manager.userSessions.first?.displayRecord.data.lifecycle, .dormant)
+        XCTAssertEqual(manager.userSessions.first?.status, .idle)
+        XCTAssertEqual(manager.acknowledgedSessionIDs, [firstID])
+        XCTAssertTrue(store.isAcknowledged(cctopSessionID: firstID, session: attention))
+    }
+}
+
+@MainActor
+final class SessionTemporaryDropTests: XCTestCase {
+    private let sessionID = "33333333-3333-4333-8333-333333333333"
+
+    func testDropSurvivesReloadAndNewActivityRestoresSession() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-temporary-drop-manager-\(UUID().uuidString)", isDirectory: true)
+        let sessionsDir = root.appendingPathComponent("sessions", isDirectory: true)
+        let historyDir = root.appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        let store = isolatedTemporaryDrops(prefix: "cctop-temporary-drop-manager-store")
+        let now = Date(timeIntervalSince1970: 20_000)
+        var session = SessionData.mock(
+            id: "drop-me",
+            cctopSessionId: sessionID,
+            status: .waitingInput,
+            pid: UInt32(ProcessInfo.processInfo.processIdentifier),
+            source: SessionData.opencodeSource
+        )
+        session.lastActivity = now
+        let sessionPath = sessionsDir.appendingPathComponent("drop-me.json").path
+        try session.writeToFile(path: sessionPath)
+        let manager = makeManager(
+            sessionsDir: sessionsDir.path,
+            historyDir: historyDir.path,
+            processAlive: { _ in true },
+            temporaryDrops: store,
+            now: { now }
+        )
+        let identity = try XCTUnwrap(manager.userSessions.first?.identity)
+
+        manager.dropSession(identity)
+
+        XCTAssertTrue(manager.userSessions.isEmpty)
+        XCTAssertEqual(manager.droppedUserSessions.map(\.identity.cctopSessionID), [sessionID])
+        XCTAssertEqual(store.droppedRevisions[sessionID]?.lastActivity, now)
+        XCTAssertEqual(try SessionData.fromFile(path: sessionPath).lastActivity, now)
+
+        let reloaded = makeManager(
+            sessionsDir: sessionsDir.path,
+            historyDir: historyDir.path,
+            processAlive: { _ in true },
+            temporaryDrops: store,
+            now: { now }
+        )
+        XCTAssertTrue(reloaded.userSessions.isEmpty, "Drop should survive a cctop restart")
+        XCTAssertEqual(reloaded.droppedUserSessions.map(\.identity.cctopSessionID), [sessionID])
+
+        session.lastActivity = now.addingTimeInterval(1)
+        try session.writeToFile(path: sessionPath)
+        reloaded.loadSessions()
+
+        XCTAssertEqual(reloaded.userSessions.count, 1)
+        XCTAssertTrue(reloaded.droppedUserSessions.isEmpty)
+        XCTAssertEqual(reloaded.userSessions.first?.identity.cctopSessionID, sessionID)
+        XCTAssertTrue(store.droppedRevisions.isEmpty)
+    }
+
+    func testRestoreDroppedSessionReturnsItImmediatelyWithoutEditingSource() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-temporary-drop-restore-\(UUID().uuidString)", isDirectory: true)
+        let sessionsDir = root.appendingPathComponent("sessions", isDirectory: true)
+        let historyDir = root.appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        let store = isolatedTemporaryDrops(prefix: "cctop-temporary-drop-restore-store")
+        let now = Date(timeIntervalSince1970: 25_000)
+        var session = SessionData.mock(
+            id: "restore-me",
+            cctopSessionId: sessionID,
+            status: .working,
+            pid: UInt32(ProcessInfo.processInfo.processIdentifier),
+            source: SessionData.opencodeSource
+        )
+        session.lastActivity = now
+        let sessionPath = sessionsDir.appendingPathComponent("restore-me.json").path
+        try session.writeToFile(path: sessionPath)
+        let manager = makeManager(
+            sessionsDir: sessionsDir.path,
+            historyDir: historyDir.path,
+            processAlive: { _ in true },
+            temporaryDrops: store,
+            now: { now }
+        )
+        let identity = try XCTUnwrap(manager.userSessions.first?.identity)
+        manager.dropSession(identity)
+
+        manager.restoreDroppedSession(identity)
+
+        XCTAssertEqual(manager.userSessions.map(\.identity.cctopSessionID), [sessionID])
+        XCTAssertTrue(manager.droppedUserSessions.isEmpty)
+        XCTAssertTrue(store.droppedRevisions.isEmpty)
+        XCTAssertEqual(try SessionData.fromFile(path: sessionPath).lastActivity, now)
+    }
+
+    func testDropReconcileRetainsPartialOlderRevisionAndOnlyNewerActivityExpiresIt() {
+        let store = isolatedTemporaryDrops(prefix: "cctop-temporary-drop-reconcile")
+        var session = SessionData.mock(id: "drop", cctopSessionId: sessionID)
+        session.lastActivity = Date(timeIntervalSince1970: 30_000)
+        let userSession = userSessions(fromDataFixtures: [session])[0]
+        store.drop(cctopSessionID: sessionID, userSession: userSession)
+
+        store.reconcile(currentRevisions: [:], inventoryComplete: false)
+        XCTAssertNotNil(store.droppedRevisions[sessionID])
+
+        let olderRevision = SessionActivityRevision(lastActivity: session.lastActivity.addingTimeInterval(-1))
+        store.reconcile(currentRevisions: [sessionID: olderRevision], inventoryComplete: false)
+        XCTAssertNotNil(store.droppedRevisions[sessionID])
+
+        let newerRevision = SessionActivityRevision(lastActivity: session.lastActivity.addingTimeInterval(1))
+        store.reconcile(currentRevisions: [sessionID: newerRevision], inventoryComplete: false)
+        XCTAssertTrue(store.droppedRevisions.isEmpty)
+
+        store.drop(cctopSessionID: sessionID, userSession: userSession)
+        store.reconcile(currentRevisions: [:], inventoryComplete: true)
+        XCTAssertTrue(store.droppedRevisions.isEmpty)
+    }
+
+    func testPartialUnreadableLatestPeerDoesNotRepublishDroppedSession() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cctop-drop-partial-peer-\(UUID().uuidString)", isDirectory: true)
+        let sessionsDir = root.appendingPathComponent("sessions", isDirectory: true)
+        let historyDir = root.appendingPathComponent("history", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        let store = isolatedTemporaryDrops(prefix: "cctop-drop-partial-peer-store")
+        let olderActivity = Date(timeIntervalSince1970: 35_000)
+        var olderPeer = SessionData.mock(
+            id: "older-peer",
+            cctopSessionId: sessionID,
+            status: .working,
+            pid: UInt32(ProcessInfo.processInfo.processIdentifier),
+            source: SessionData.opencodeSource
+        )
+        olderPeer.lastActivity = olderActivity
+        var latestPeer = SessionData.mock(
+            id: "latest-peer",
+            cctopSessionId: sessionID,
+            status: .waitingInput,
+            pid: UInt32(ProcessInfo.processInfo.processIdentifier),
+            source: SessionData.opencodeSource
+        )
+        latestPeer.lastActivity = olderActivity.addingTimeInterval(1)
+        let olderURL = sessionsDir.appendingPathComponent("older-peer.json")
+        let latestURL = sessionsDir.appendingPathComponent("latest-peer.json")
+        try olderPeer.writeToFile(path: olderURL.path)
+        try latestPeer.writeToFile(path: latestURL.path)
+        let manager = makeManager(
+            sessionsDir: sessionsDir.path,
+            historyDir: historyDir.path,
+            processAlive: { _ in true },
+            temporaryDrops: store,
+            now: { latestPeer.lastActivity }
+        )
+        let identity = try XCTUnwrap(manager.userSessions.first?.identity)
+        manager.dropSession(identity)
+
+        try Data("{".utf8).write(to: latestURL)
+        manager.loadSessions()
+
+        XCTAssertTrue(manager.userSessions.isEmpty)
+        XCTAssertEqual(manager.droppedUserSessions.map(\.identity.cctopSessionID), [sessionID])
+        XCTAssertEqual(store.droppedRevisions[sessionID]?.lastActivity, latestPeer.lastActivity)
+
+        try latestPeer.writeToFile(path: latestURL.path)
+        manager.loadSessions()
+        XCTAssertTrue(manager.userSessions.isEmpty)
+        XCTAssertEqual(manager.droppedUserSessions.map(\.identity.cctopSessionID), [sessionID])
+    }
+}
+
 final class CctopSessionIdentityStoreTests: XCTestCase {
     private var rootURL: URL!
     private var sessionsURL: URL!

--- a/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
+++ b/menubar/CctopMenubarTests/WorktreeCleanupTests.swift
@@ -1377,8 +1377,42 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertFalse(WorktreeCleanupCandidate.State.ignored(["main checkout"]).isActionable)
     }
 
-    func testPopupTabAvailabilityAlwaysIncludesAllFourProductSurfaces() {
-        XCTAssertEqual(PopupTab.allCases, [.active, .idle, .recent, .cleanup])
+    func testPopupTabAvailabilityIncludesSessionStateSelectorsAndProductSurfaces() {
+        XCTAssertEqual(
+            PopupTab.allCases,
+            [.active, .idle, .acknowledged, .dropped, .recent, .cleanup]
+        )
+        XCTAssertEqual(PopupTab.primaryCases, [.active, .idle, .acknowledged, .dropped])
+        XCTAssertEqual(PopupTab.secondaryCases, [.recent, .cleanup])
+    }
+
+    @MainActor
+    func testAckAndDroppedSelectorsUseTheirDedicatedSessionCollections() {
+        let acknowledgedID = "44444444-4444-4444-8444-444444444444"
+        let droppedID = "55555555-5555-4555-8555-555555555555"
+        let acknowledged = SessionData.mock(
+            id: "acknowledged",
+            cctopSessionId: acknowledgedID,
+            status: .idle
+        )
+        let dropped = SessionData.mock(
+            id: "dropped",
+            cctopSessionId: droppedID,
+            status: .working
+        )
+        let view = PopupView(
+            userSessions: userSessions(fromDataFixtures: [acknowledged]),
+            acknowledgedSessionIDs: [acknowledgedID],
+            droppedUserSessions: userSessions(fromDataFixtures: [dropped]),
+            updater: DisabledUpdater(),
+            pluginManager: inertPluginManager()
+        )
+
+        XCTAssertEqual(view.acknowledgedSessionRows.map(\.id.cctopSessionID), [acknowledgedID])
+        XCTAssertEqual(view.acknowledgedSessionRows.map(\.presentation), [.acknowledged])
+        XCTAssertEqual(view.droppedSessionRows.map(\.id.cctopSessionID), [droppedID])
+        XCTAssertEqual(view.droppedSessionRows.map(\.presentation), [.dropped])
+        XCTAssertEqual(StatusCounts(userSessions: view.userSessions).total, 1)
     }
 
     func testPopupTabHelpTextDescribesCurrentBuckets() {
@@ -1391,6 +1425,14 @@ final class WorktreeCleanupTests: XCTestCase {
         XCTAssertEqual(
             PopupTab.idle.helpText,
             "Dormant sessions and idle sessions over \(staleIdleHours) hours."
+        )
+        XCTAssertEqual(
+            PopupTab.acknowledged.helpText,
+            "Acknowledged sessions; newer attention clears the acknowledgement."
+        )
+        XCTAssertEqual(
+            PopupTab.dropped.helpText,
+            "Sessions removed from normal surfaces until restored or newer activity."
         )
         let recentHelpText = PopupTab.recent.helpText
         XCTAssertTrue(recentHelpText.contains("Finished work"))
@@ -1414,6 +1456,14 @@ final class WorktreeCleanupTests: XCTestCase {
             PopupTab.idle.emptyStateDetail,
             "Dormant and long-idle sessions appear here."
         )
+        XCTAssertEqual(
+            PopupTab.acknowledged.emptyStateDetail,
+            "Acknowledged sessions appear here until they report newer attention."
+        )
+        XCTAssertEqual(
+            PopupTab.dropped.emptyStateDetail,
+            "Dropped sessions appear here until restored or they report newer activity."
+        )
         let recentEmptyStateDetail = PopupTab.recent.emptyStateDetail
         XCTAssertTrue(recentEmptyStateDetail.contains("Finished work"))
         XCTAssertTrue(recentEmptyStateDetail.contains("archived desktop sessions"))
@@ -1429,13 +1479,16 @@ final class WorktreeCleanupTests: XCTestCase {
         )
     }
 
-    func testKeyboardTabSwitchingIncludesCleanup() {
+    func testKeyboardTabSwitchingIncludesSessionStateSelectorsAndCleanup() {
         let tabs = PopupTab.allCases
 
         XCTAssertEqual(PopupTab.switched(from: .recent, action: .nextTab, availableTabs: tabs), .cleanup)
         XCTAssertEqual(PopupTab.switched(from: .cleanup, action: .nextTab, availableTabs: tabs), .active)
         XCTAssertEqual(PopupTab.switched(from: .active, action: .previousTab, availableTabs: tabs), .cleanup)
         XCTAssertEqual(PopupTab.switched(from: .active, action: .nextTab, availableTabs: tabs), .idle)
+        XCTAssertEqual(PopupTab.switched(from: .idle, action: .nextTab, availableTabs: tabs), .acknowledged)
+        XCTAssertEqual(PopupTab.switched(from: .acknowledged, action: .nextTab, availableTabs: tabs), .dropped)
+        XCTAssertEqual(PopupTab.switched(from: .dropped, action: .nextTab, availableTabs: tabs), .recent)
     }
 
     func testConfirmingCleanupSelectionTargetsCleanupDetail() {

--- a/plugins/streamdeck/com.st0012.cctop.sdPlugin/lib/controller.mjs
+++ b/plugins/streamdeck/com.st0012.cctop.sdPlugin/lib/controller.mjs
@@ -1,4 +1,9 @@
-import { focusURL, openCctopURL, TOGGLE_URL } from "./launcher.mjs";
+import {
+  acknowledgeURL,
+  focusURL,
+  openCctopURL,
+  TOGGLE_URL,
+} from "./launcher.mjs";
 import { keyImageFor } from "./render.mjs";
 import {
   commandSessionForSlot,
@@ -8,6 +13,7 @@ import {
 
 export const SESSION_ACTION = "com.st0012.cctop.session";
 export const TOGGLE_ACTION = "com.st0012.cctop.toggle-panel";
+export const SESSION_DOUBLE_PRESS_WINDOW_MS = 350;
 const CCTOP_APP_BUNDLE_ID = "com.st0012.CctopMenubar";
 
 export function parseArgs(argv) {
@@ -51,6 +57,7 @@ export class StreamDeckController {
     this.registerEvent = registerEvent;
     this.deviceColumns = new Map();
     this.sessionContexts = new Map();
+    this.lastSessionPresses = new Map();
     for (const device of info?.devices ?? []) {
       if (device?.id && Number.isInteger(device.size?.columns)) {
         this.deviceColumns.set(device.id, device.size.columns);
@@ -86,6 +93,7 @@ export class StreamDeckController {
         break;
       case "willDisappear":
         this.sessionContexts.delete(message.context);
+        this.lastSessionPresses.delete(message.context);
         break;
       case "didReceiveSettings":
         this.handleDidReceiveSettings(message);
@@ -148,28 +156,35 @@ export class StreamDeckController {
       this.alert(context);
       return;
     }
-    // Send exactly the permanent id this key last rendered — never re-resolve the slot, or a
-    // press could target whichever session shifted into it after the image was drawn.
-    // The permanent id resolves to the first current target in cctop's canonical panel order;
-    // a missing id can never retarget the key to an unrelated session.
-    if (entry.renderedCctopSessionId) {
-      this.launch(focusURL(entry.renderedCctopSessionId), context);
-      return;
-    }
-    const state = readDisplayState();
-    if (state?.app_running === true) {
+    const cctopSessionID = this.commandSessionID(entry);
+    if (!cctopSessionID) {
       this.alert(context);
       return;
     }
+    const now = Date.now();
+    const previousPress = this.lastSessionPresses.get(context);
+    const isDoublePress = previousPress?.cctopSessionID === cctopSessionID
+      && now >= previousPress.timestamp
+      && now - previousPress.timestamp <= SESSION_DOUBLE_PRESS_WINDOW_MS;
+    if (isDoublePress) {
+      this.lastSessionPresses.delete(context);
+      this.launch(acknowledgeURL(cctopSessionID), context);
+      return;
+    }
+    this.lastSessionPresses.set(context, { cctopSessionID, timestamp: now });
+    this.launch(focusURL(cctopSessionID), context);
+  }
+
+  commandSessionID(entry) {
+    // Send exactly the permanent id this key last rendered, never whichever session
+    // later shifted into its slot. A missing id cannot retarget an unrelated session.
+    if (entry.renderedCctopSessionId) return entry.renderedCctopSessionId;
+
+    const state = readDisplayState();
+    if (state?.app_running === true) return null;
     // A key first shown while cctop is down has no rendered id. A recent graceful-quit
     // snapshot may still resolve its slot so the press cold-launches that session.
-    const session = commandSessionForSlot(state, entry.slot);
-    const url = session ? focusURL(session.cctopSessionId) : null;
-    if (!url) {
-      this.alert(context);
-      return;
-    }
-    this.launch(url, context);
+    return commandSessionForSlot(state, entry.slot)?.cctopSessionId ?? null;
   }
 
   renderContext(context, entry, state) {

--- a/plugins/streamdeck/com.st0012.cctop.sdPlugin/lib/launcher.mjs
+++ b/plugins/streamdeck/com.st0012.cctop.sdPlugin/lib/launcher.mjs
@@ -7,12 +7,18 @@ export function focusURL(displayID) {
   return `cctop://focus?sid=${encodeURIComponent(displayID)}`;
 }
 
+export function acknowledgeURL(displayID) {
+  if (typeof displayID !== "string" || displayID.length === 0) return null;
+  return `cctop://acknowledge?sid=${encodeURIComponent(displayID)}`;
+}
+
 function isSupportedCommandURL(value) {
   try {
     const url = new URL(value);
     if (url.protocol !== "cctop:") return false;
     if (url.hostname === "toggle") return url.search === "";
-    return url.hostname === "focus" && Boolean(url.searchParams.get("sid"));
+    return ["focus", "acknowledge"].includes(url.hostname)
+      && Boolean(url.searchParams.get("sid"));
   } catch {
     return false;
   }

--- a/plugins/streamdeck/test/protocol.test.mjs
+++ b/plugins/streamdeck/test/protocol.test.mjs
@@ -19,6 +19,7 @@ const {
   defaultSlot,
   parseArgs,
   SESSION_ACTION,
+  SESSION_DOUBLE_PRESS_WINDOW_MS,
   StreamDeckController,
   TOGGLE_ACTION,
 } = await import("../com.st0012.cctop.sdPlugin/lib/controller.mjs");
@@ -191,6 +192,62 @@ test("a session key asks Launch Services to deliver the exact encoded cctop comm
   }]);
   assert.equal(messages(socket, "openUrl").length, 0);
   assert.equal(messages(socket, "showAlert").length, 0);
+});
+
+test("a double press focuses then acknowledges the exact session the key rendered", async () => {
+  writeState();
+  const { controller, socket } = makeController();
+  controller.handleMessage(willAppear("key-1", { row: 0, column: 0 }, { slot: 1 }));
+
+  controller.handleMessage({ event: "keyDown", action: SESSION_ACTION, context: "key-1" });
+  // The source may reorder before the second press; the key still owns the id it rendered.
+  writeState({ sessions: [
+    { cctop_session_id: ID_SECOND, name: "second", status: "working", color: "#DD5353" },
+    { cctop_session_id: ID_FIRST, name: "first", status: "idle", color: "#7DAEA3" },
+  ] });
+  controller.handleMessage({ event: "keyDown", action: SESSION_ACTION, context: "key-1" });
+  await new Promise(setImmediate);
+
+  assert.deepEqual(launches.map((launch) => launch.args[0]), [
+    `cctop://focus?sid=${ID_FIRST}`,
+    `cctop://acknowledge?sid=${ID_FIRST}`,
+  ]);
+  assert.equal(messages(socket, "showAlert").length, 0);
+});
+
+test("presses on separate session keys never combine into a double press", async () => {
+  writeState({ sessions: [
+    { cctop_session_id: ID_FIRST, name: "first target", status: "working", color: "#7EAA6E" },
+    { cctop_session_id: ID_FIRST, name: "second target", status: "idle", color: "#7DAEA3" },
+  ] });
+  const { controller } = makeController();
+  controller.handleMessage(willAppear("key-1", { row: 0, column: 0 }, { slot: 1 }));
+  controller.handleMessage(willAppear("key-2", { row: 0, column: 1 }, { slot: 2 }));
+
+  controller.handleMessage({ event: "keyDown", action: SESSION_ACTION, context: "key-1" });
+  controller.handleMessage({ event: "keyDown", action: SESSION_ACTION, context: "key-2" });
+  await new Promise(setImmediate);
+
+  assert.deepEqual(launches.map((launch) => launch.args[0]), [
+    `cctop://focus?sid=${ID_FIRST}`,
+    `cctop://focus?sid=${ID_FIRST}`,
+  ]);
+});
+
+test("a later press outside the double-press window remains a normal focus", async () => {
+  writeState();
+  const { controller } = makeController();
+  controller.handleMessage(willAppear("key-1", { row: 0, column: 0 }, { slot: 1 }));
+
+  controller.handleMessage({ event: "keyDown", action: SESSION_ACTION, context: "key-1" });
+  await new Promise((resolve) => setTimeout(resolve, SESSION_DOUBLE_PRESS_WINDOW_MS + 25));
+  controller.handleMessage({ event: "keyDown", action: SESSION_ACTION, context: "key-1" });
+  await new Promise(setImmediate);
+
+  assert.deepEqual(launches.map((launch) => launch.args[0]), [
+    `cctop://focus?sid=${ID_FIRST}`,
+    `cctop://focus?sid=${ID_FIRST}`,
+  ]);
 });
 
 test("toggle uses the same direct cctop command boundary", async () => {


### PR DESCRIPTION
### Summary

Add reversible session-triage controls so users can quiet reviewed attention and temporarily remove sessions from operational status without closing, archiving, or permanently hiding them.

### What ships

- Add **Acknowledge** for attention sessions. It turns the current red/attention revision neutral grey while leaving the session open.
- Persist acknowledgements across app restarts.
- Automatically clear acknowledgement when that session receives new activity or enters a new attention revision.
- Add **Drop Until Next Activity**. It removes the current session revision from normal lists, counts, indicators, notifications, Navigate mode, and Stream Deck display state.
- Persist dropped sessions across app restarts.
- Automatically restore a dropped session when new activity arrives.
- Add a **Dropped** view with an explicit **Restore Session** action.
- Keep acknowledged sessions visible in Active/Idle while also making them reachable from an **Ack** view.
- Show compact **Active / Idle / Ack / Dropped** selectors, including zero counts.
- Move lower-priority **Recent / Cleanup** views into the overflow menu.
- Extend keyboard navigation across all six collections.
- Add Stream Deck acknowledgement: one press focuses the session; a second press on the same session within 350 ms acknowledges it.
- Clear Ack and Drop state when a session is permanently hidden.

### Important semantics

- **Ack does not change lifecycle state.** It only records that the current attention event has been reviewed.
- **Drop is temporary and revision-scoped.** It is not Hide, Close, or Archive.
- Both features use cctop's permanent session identity and fail closed when a stable identity is unavailable.
- Newer activity invalidates the stored revision, preventing stale Ack or Drop state from suppressing a later event.
- Partial inventories retain the prior revision when only an older same-session peer can be decoded, preventing transient decode failures from republishing acknowledged or dropped sessions.

### Out of scope

- Notch or menu-bar placement
- Filtering Claude Code-launched Codex workers
- Changes to source session JSON or lifecycle classification

### Validation

- `make test` (1,271 Swift/Node tests plus the release-version guard)
- `swiftlint lint --strict --no-cache` (0 violations)
- `make contract`
- Relevant UI snapshot suites, including Ack, Dropped, and acknowledgement-state coverage
- Regression coverage for a partially unreadable same-ID group in both Ack and Drop paths

The new QA snapshots pass independently. The full snapshot command still hits an existing environment-dependent fixture: `SnapshotTests.testGenerateRecentProjectsReworkProof` expects Ruby's `rdoc` project, while this machine exposes only `cctop` and `irb`.
